### PR TITLE
Исправить UUID в subsystem.compile

### DIFF
--- a/crates/unica-coder/src/infrastructure/native_operations/subsystem.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/subsystem.rs
@@ -1356,6 +1356,9 @@ pub(crate) fn compile_subsystem(
             .unwrap_or_else(|| "false".to_string());
         let explanation = json_string_field(&defn, "explanation").unwrap_or_default();
         let picture = json_string_field(&defn, "picture").unwrap_or_default();
+        let subsystem_uuid = json_string_field(&defn, "uuid")
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(fresh_uuid);
 
         let mut stdout = String::new();
         let mut normalized_count = 0usize;
@@ -1395,7 +1398,10 @@ pub(crate) fn compile_subsystem(
         lines.push(format!(
             "<MetaDataObject xmlns=\"http://v8.1c.ru/8.3/MDClasses\" xmlns:app=\"http://v8.1c.ru/8.2/managed-application/core\" xmlns:cfg=\"http://v8.1c.ru/8.1/data/enterprise/current-config\" xmlns:cmi=\"http://v8.1c.ru/8.2/managed-application/cmi\" xmlns:ent=\"http://v8.1c.ru/8.1/data/enterprise\" xmlns:lf=\"http://v8.1c.ru/8.2/managed-application/logform\" xmlns:style=\"http://v8.1c.ru/8.1/data/ui/style\" xmlns:sys=\"http://v8.1c.ru/8.1/data/ui/fonts/system\" xmlns:v8=\"http://v8.1c.ru/8.1/data/core\" xmlns:v8ui=\"http://v8.1c.ru/8.1/data/ui\" xmlns:web=\"http://v8.1c.ru/8.1/data/ui/colors/web\" xmlns:win=\"http://v8.1c.ru/8.1/data/ui/colors/windows\" xmlns:xen=\"http://v8.1c.ru/8.3/xcf/enums\" xmlns:xpr=\"http://v8.1c.ru/8.3/xcf/predef\" xmlns:xr=\"http://v8.1c.ru/8.3/xcf/readable\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" version=\"{format_version}\">"
         ));
-        lines.push(format!("\t<Subsystem uuid=\"{}\">", stable_uuid(60)));
+        lines.push(format!(
+            "\t<Subsystem uuid=\"{}\">",
+            escape_xml(&subsystem_uuid)
+        ));
         lines.push("\t\t<Properties>".to_string());
         lines.push(format!("\t\t\t<Name>{}</Name>", escape_xml(&obj_name)));
         emit_mltext(&mut lines, "\t\t\t", "Synonym", &synonym);
@@ -1561,7 +1567,7 @@ pub(crate) fn compile_subsystem(
         stdout.push('\n');
         stdout.push_str("=== subsystem-compile summary ===\n");
         stdout.push_str(&format!("  Name:     {obj_name}\n"));
-        stdout.push_str(&format!("  UUID:     {}\n", stable_uuid(60)));
+        stdout.push_str(&format!("  UUID:     {subsystem_uuid}\n"));
         stdout.push_str(&format!("  Content:  {} objects\n", content_items.len()));
         stdout.push_str(&format!("  Children: {}\n", children.len()));
         stdout.push_str(&format!("  File:     {}\n", target_xml.display()));
@@ -1772,5 +1778,92 @@ pub(crate) fn invoke_mutation(
         "subsystem-compile" => Some(compile_subsystem(args, context)),
         "subsystem-edit" => Some(edit_subsystem(args, context)),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::workspace::WorkspaceContext;
+    use serde_json::{json, Map, Value};
+    use std::fs;
+    use std::path::Path;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_context(name: &str) -> WorkspaceContext {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("unica-subsystem-compile-{name}-{nanos}"));
+        fs::create_dir_all(&root).unwrap();
+        WorkspaceContext {
+            cwd: root.clone(),
+            workspace_root: root.clone(),
+            cache_root: root.join(".build").join("unica"),
+            workspace_epoch: 1,
+        }
+    }
+
+    fn compile_args(output_dir: &Path, definition: Value) -> Map<String, Value> {
+        let mut args = Map::new();
+        args.insert(
+            "OutputDir".to_string(),
+            Value::String(output_dir.display().to_string()),
+        );
+        args.insert("Value".to_string(), Value::String(definition.to_string()));
+        args
+    }
+
+    fn subsystem_uuid(output_dir: &Path, name: &str) -> String {
+        let xml_path = output_dir.join("Subsystems").join(format!("{name}.xml"));
+        let xml = fs::read_to_string(&xml_path).unwrap();
+        let marker = "<Subsystem uuid=\"";
+        let start = xml.find(marker).unwrap() + marker.len();
+        let end = xml[start..].find('"').unwrap() + start;
+        xml[start..end].to_string()
+    }
+
+    #[test]
+    fn compile_subsystem_preserves_explicit_uuid() {
+        let context = temp_context("explicit-uuid");
+        let explicit_uuid = "11111111-2222-3333-4444-555555555555";
+        let args = compile_args(
+            &context.cwd,
+            json!({
+                "name": "ExplicitUuidSubsystem",
+                "uuid": explicit_uuid
+            }),
+        );
+
+        let outcome = compile_subsystem(&args, &context);
+
+        assert!(outcome.ok, "{:?}", outcome.errors);
+        assert_eq!(
+            subsystem_uuid(&context.cwd, "ExplicitUuidSubsystem"),
+            explicit_uuid
+        );
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
+    fn compile_subsystem_generates_unique_uuid_when_missing() {
+        let context = temp_context("generated-uuid");
+        for name in ["GeneratedUuidA", "GeneratedUuidB"] {
+            let args = compile_args(
+                &context.cwd,
+                json!({
+                    "name": name
+                }),
+            );
+
+            let outcome = compile_subsystem(&args, &context);
+            assert!(outcome.ok, "{:?}", outcome.errors);
+        }
+
+        let first_uuid = subsystem_uuid(&context.cwd, "GeneratedUuidA");
+        let second_uuid = subsystem_uuid(&context.cwd, "GeneratedUuidB");
+        assert_ne!(first_uuid, second_uuid);
+        let _ = fs::remove_dir_all(&context.cwd);
     }
 }

--- a/crates/unica-coder/src/infrastructure/native_operations/subsystem.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/subsystem.rs
@@ -396,7 +396,7 @@ pub(crate) fn subsystem_edit_add_child(
     }
     let child_xml = child_subs_dir.join(format!("{child_name}.xml"));
     if !child_xml.exists() {
-        write_child_subsystem_stub(&child_xml, &child_name, &model.version, 71)?;
+        write_child_subsystem_stub(&child_xml, &child_name, &model.version)?;
         stdout.push_str(&format!("[INFO] Created stub: {}\n", child_xml.display()));
         artifacts.push(child_xml);
     }
@@ -1497,14 +1497,14 @@ pub(crate) fn compile_subsystem(
                 ));
             }
             let mut seen = Vec::<String>::new();
-            for (idx, child) in children.iter().enumerate() {
+            for child in &children {
                 if seen.iter().any(|value| value == child) {
                     continue;
                 }
                 seen.push(child.clone());
                 let child_xml = child_subs_dir.join(format!("{child}.xml"));
                 if !child_xml.exists() {
-                    write_child_subsystem_stub(&child_xml, child, &format_version, 61 + idx)?;
+                    write_child_subsystem_stub(&child_xml, child, &format_version)?;
                     stdout.push_str(&format!("[OK] Created stub: {}\n", child_xml.display()));
                     artifacts.push(child_xml);
                 }
@@ -1611,17 +1611,14 @@ pub(crate) fn write_child_subsystem_stub(
     child_path: &Path,
     child_name: &str,
     format_version: &str,
-    uuid_index: usize,
 ) -> Result<(), String> {
+    let subsystem_uuid = fresh_uuid();
     let mut lines = Vec::new();
     lines.push("<?xml version=\"1.0\" encoding=\"UTF-8\"?>".to_string());
     lines.push(format!(
         "<MetaDataObject xmlns=\"http://v8.1c.ru/8.3/MDClasses\" xmlns:app=\"http://v8.1c.ru/8.2/managed-application/core\" xmlns:cfg=\"http://v8.1c.ru/8.1/data/enterprise/current-config\" xmlns:cmi=\"http://v8.1c.ru/8.2/managed-application/cmi\" xmlns:ent=\"http://v8.1c.ru/8.1/data/enterprise\" xmlns:lf=\"http://v8.1c.ru/8.2/managed-application/logform\" xmlns:style=\"http://v8.1c.ru/8.1/data/ui/style\" xmlns:sys=\"http://v8.1c.ru/8.1/data/ui/fonts/system\" xmlns:v8=\"http://v8.1c.ru/8.1/data/core\" xmlns:v8ui=\"http://v8.1c.ru/8.1/data/ui\" xmlns:web=\"http://v8.1c.ru/8.1/data/ui/colors/web\" xmlns:win=\"http://v8.1c.ru/8.1/data/ui/colors/windows\" xmlns:xen=\"http://v8.1c.ru/8.3/xcf/enums\" xmlns:xpr=\"http://v8.1c.ru/8.3/xcf/predef\" xmlns:xr=\"http://v8.1c.ru/8.3/xcf/readable\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" version=\"{format_version}\">"
     ));
-    lines.push(format!(
-        "\t<Subsystem uuid=\"{}\">",
-        stable_uuid(uuid_index)
-    ));
+    lines.push(format!("\t<Subsystem uuid=\"{}\">", subsystem_uuid));
     lines.push("\t\t<Properties>".to_string());
     lines.push(format!("\t\t\t<Name>{}</Name>", escape_xml(child_name)));
     lines.push("\t\t\t<Synonym/>".to_string());
@@ -1824,6 +1821,19 @@ mod tests {
         xml[start..end].to_string()
     }
 
+    fn child_subsystem_uuid(output_dir: &Path, parent: &str, child: &str) -> String {
+        let xml_path = output_dir
+            .join("Subsystems")
+            .join(parent)
+            .join("Subsystems")
+            .join(format!("{child}.xml"));
+        let xml = fs::read_to_string(&xml_path).unwrap();
+        let marker = "<Subsystem uuid=\"";
+        let start = xml.find(marker).unwrap() + marker.len();
+        let end = xml[start..].find('"').unwrap() + start;
+        xml[start..end].to_string()
+    }
+
     #[test]
     fn compile_subsystem_preserves_explicit_uuid() {
         let context = temp_context("explicit-uuid");
@@ -1863,6 +1873,31 @@ mod tests {
 
         let first_uuid = subsystem_uuid(&context.cwd, "GeneratedUuidA");
         let second_uuid = subsystem_uuid(&context.cwd, "GeneratedUuidB");
+        assert_ne!(first_uuid, second_uuid);
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
+    fn compile_subsystem_generates_unique_child_stub_uuid_when_missing() {
+        let context = temp_context("generated-child-uuid");
+        for (parent, child) in [
+            ("GeneratedParentA", "GeneratedChildA"),
+            ("GeneratedParentB", "GeneratedChildB"),
+        ] {
+            let args = compile_args(
+                &context.cwd,
+                json!({
+                    "name": parent,
+                    "children": [child]
+                }),
+            );
+
+            let outcome = compile_subsystem(&args, &context);
+            assert!(outcome.ok, "{:?}", outcome.errors);
+        }
+
+        let first_uuid = child_subsystem_uuid(&context.cwd, "GeneratedParentA", "GeneratedChildA");
+        let second_uuid = child_subsystem_uuid(&context.cwd, "GeneratedParentB", "GeneratedChildB");
         assert_ne!(first_uuid, second_uuid);
         let _ = fs::remove_dir_all(&context.cwd);
     }


### PR DESCRIPTION
## Что изменено

Исправляет поведение `unica.subsystem.compile`: writer теперь сохраняет явно переданный `uuid` из JSON DSL. Если `uuid` не передан, генерируется новый уникальный UUID для каждой создаваемой подсистемы.

Fixes #6.

## Почему

Раньше `subsystem.compile` всегда записывал стабильный UUID `00000000-0000-0000-0000-00000000003c`, игнорируя переданное значение. Из-за этого несколько новых подсистем могли получить одинаковый UUID.

## Проверки

- `cargo fmt --check`
- `cargo test --package unica-coder`
- synthetic MCP smoke:
  - explicit UUID `aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee` сохранен в XML;
  - две подсистемы без UUID получили разные UUID.

## Тесты

Добавлены regression tests:

- `compile_subsystem_preserves_explicit_uuid`
- `compile_subsystem_generates_unique_uuid_when_missing`

Комментарий обезличен: без клиентских проектов, локальных путей и customer XML.