### PR TITLE
[codex] Improve PR CI gating

### DIFF
--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -20,9 +20,42 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  classify-changes:
+    name: Classify CI scope
+    runs-on: ubuntu-latest
+    outputs:
+      release_artifacts: ${{ steps.scope.outputs.release_artifacts }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: scope
+        name: Decide release artifact scope
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "release_artifacts=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          changed_files="$(git diff --name-only FETCH_HEAD...HEAD)"
+          printf '%s\n' "$changed_files"
+
+          release_artifacts="$(printf '%s\n' "$changed_files" | python scripts/ci/classify-workflow-changes.py)"
+          echo "release_artifacts=$release_artifacts" >> "$GITHUB_OUTPUT"
+
   verify-source:
     name: Verify source guardrails
     runs-on: ubuntu-latest
@@ -69,7 +102,10 @@ jobs:
   build-tools:
     name: Build tools (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
-    needs: verify-source
+    needs:
+      - verify-source
+      - classify-changes
+    if: ${{ github.event_name != 'pull_request' || needs.classify-changes.outputs.release_artifacts == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -142,17 +178,11 @@ jobs:
             dist/unica-codex-marketplace-${{ matrix.target }}.zip
           if-no-files-found: error
 
-      - name: Publish release assets
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            dist/unica-codex-marketplace-${{ matrix.target }}.tar.gz
-            dist/unica-codex-marketplace-${{ matrix.target }}.zip
-
   installer:
-    name: Publish installer script
+    name: Package installer script
     runs-on: ubuntu-latest
+    needs: classify-changes
+    if: ${{ github.event_name != 'pull_request' || needs.classify-changes.outputs.release_artifacts == 'true' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -168,8 +198,49 @@ jobs:
           path: dist/install-unica.sh
           if-no-files-found: error
 
-      - name: Publish installer asset
-        if: startsWith(github.ref, 'refs/tags/')
+  publish-release-assets:
+    name: Publish release assets (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    needs: package
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - linux-x64
+          - win-x64
+          - darwin-arm64
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: unica-codex-marketplace-${{ matrix.target }}
+          path: dist/${{ matrix.target }}
+
+      - name: Publish release assets
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/install-unica.sh
+          files: |
+            dist/${{ matrix.target }}/unica-codex-marketplace-${{ matrix.target }}.tar.gz
+            dist/${{ matrix.target }}/unica-codex-marketplace-${{ matrix.target }}.zip
+
+  publish-installer-asset:
+    name: Publish installer asset
+    runs-on: ubuntu-latest
+    needs: installer
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: unica-installer
+          path: dist/installer
+
+      - name: Publish installer asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/installer/install-unica.sh

--- a/scripts/ci/classify-workflow-changes.py
+++ b/scripts/ci/classify-workflow-changes.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Classify changed paths for the Unica GitHub Actions workflow."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterable
+from typing import TextIO
+
+
+RELEASE_ARTIFACT_PATHS = {
+    ".agents/plugins/marketplace.json",
+    ".github/workflows/unica-plugin-release.yml",
+    "Cargo.toml",
+    "Cargo.lock",
+    "crates/unica-coder/Cargo.toml",
+    "plugins/unica/.codex-plugin/plugin.json",
+    "plugins/unica/.mcp.json",
+    "plugins/unica/third-party/tools.lock.json",
+    "plugins/unica/third-party/manifest.json",
+    "scripts/ci/build-unica-tools.py",
+    "scripts/ci/package-unica-plugin.py",
+    "scripts/install-unica.sh",
+}
+
+
+def normalize_path(path: str) -> str:
+    path = path.strip()
+    if path.startswith("./"):
+        return path[2:]
+    return path
+
+
+def needs_release_artifacts(paths: Iterable[str]) -> bool:
+    return any(normalize_path(path) in RELEASE_ARTIFACT_PATHS for path in paths)
+
+
+def classify_stdin(stdin: TextIO) -> str:
+    return "true" if needs_release_artifacts(stdin) else "false"
+
+
+def main() -> None:
+    print(classify_stdin(sys.stdin))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ci/test_classify_workflow_changes.py
+++ b/tests/ci/test_classify_workflow_changes.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def load_classifier_module():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "classify-workflow-changes.py"
+    spec = importlib.util.spec_from_file_location("classify_workflow_changes", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ClassifyWorkflowChangesTests(unittest.TestCase):
+    def test_release_artifacts_are_needed_for_package_surface_changes(self) -> None:
+        module = load_classifier_module()
+
+        release_paths = [
+            ".agents/plugins/marketplace.json",
+            ".github/workflows/unica-plugin-release.yml",
+            "Cargo.toml",
+            "Cargo.lock",
+            "crates/unica-coder/Cargo.toml",
+            "plugins/unica/.codex-plugin/plugin.json",
+            "plugins/unica/.mcp.json",
+            "plugins/unica/third-party/tools.lock.json",
+            "plugins/unica/third-party/manifest.json",
+            "scripts/ci/build-unica-tools.py",
+            "scripts/ci/package-unica-plugin.py",
+            "scripts/install-unica.sh",
+        ]
+
+        for path in release_paths:
+            with self.subTest(path=path):
+                self.assertTrue(module.needs_release_artifacts([path]))
+
+    def test_release_artifacts_are_not_needed_for_source_only_pr_changes(self) -> None:
+        module = load_classifier_module()
+
+        source_only_paths = [
+            "crates/unica-coder/src/application.rs",
+            "plugins/unica/skills/meta-compile/SKILL.md",
+            "plugins/unica/references/tooling/internal-package.md",
+            "spec/architecture/invariants.md",
+            "tests/ci/test_unica_workflow.py",
+            "tests/fixtures/unica_mcp_script_parity/meta-catalog.json",
+        ]
+
+        self.assertFalse(module.needs_release_artifacts(source_only_paths))
+
+    def test_cli_prints_boolean_from_stdin_paths(self) -> None:
+        module = load_classifier_module()
+
+        with tempfile.TemporaryFile("w+", encoding="utf-8") as stdin:
+            stdin.write("tests/ci/test_unica_workflow.py\nscripts/install-unica.sh\n")
+            stdin.seek(0)
+
+            self.assertEqual(module.classify_stdin(stdin), "true")

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -57,12 +57,45 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
             with self.subTest(token=token):
                 self.assertIn(token, text)
 
+    def test_pull_request_runs_cancel_stale_commits(self) -> None:
+        text = self.workflow_text()
+
+        self.assertIn("concurrency:", text)
+        self.assertIn("group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}", text)
+        self.assertIn("cancel-in-progress: ${{ github.event_name == 'pull_request' }}", text)
+
+    def test_workflow_is_read_only_by_default(self) -> None:
+        text = self.workflow_text()
+
+        self.assertIn("permissions:\n  contents: read", text)
+        self.assertNotIn("permissions:\n  contents: write\n\njobs:", text)
+
+    def test_release_artifact_builds_are_gated_on_prs(self) -> None:
+        text = self.workflow_text()
+
+        self.assertIn("classify-changes:", text)
+        self.assertIn("release_artifacts: ${{ steps.scope.outputs.release_artifacts }}", text)
+        self.assertIn("if: ${{ github.event_name != 'pull_request' || needs.classify-changes.outputs.release_artifacts == 'true' }}", text)
+        self.assertIn("python scripts/ci/classify-workflow-changes.py", text)
+
     def test_build_tools_waits_for_source_verification_and_sets_up_rust(self) -> None:
         text = self.workflow_text()
         self.assertIn("build-tools:", text)
-        self.assertIn("needs: verify-source", text)
+        self.assertIn("needs:\n      - verify-source\n      - classify-changes", text)
         self.assertIn("uses: dtolnay/rust-toolchain@stable", text)
         self.assertIn("python scripts/ci/build-unica-tools.py", text)
+
+    def test_release_publishing_is_separate_from_packaging(self) -> None:
+        text = self.workflow_text()
+
+        package_job = text[text.index("  package:") : text.index("  publish-release-assets:")]
+        self.assertNotIn("softprops/action-gh-release", package_job)
+        self.assertNotIn("contents: write", package_job)
+
+        self.assertIn("publish-release-assets:", text)
+        self.assertIn("publish-installer-asset:", text)
+        self.assertIn("if: startsWith(github.ref, 'refs/tags/')", text)
+        self.assertIn("permissions:\n      contents: write", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR tightens pull request CI so ordinary source-only changes still get the full source guardrail suite, while release/package artifact builds run only when the PR touches artifact-sensitive surfaces.

## Root Cause

The previous workflow mixed three concerns in one unconditional PR path: source verification, three-platform marketplace artifact builds, and release asset publishing. That made normal PR commits wait on heavyweight macOS/Windows/Linux packaging work and also granted `contents: write` at workflow scope even though PR jobs do not need it.

## Changes

- Keep `verify-source` as the full PR gate for Python, JSON, shell, Rust formatting, clippy, and tests.
- Add PR concurrency so stale commits cancel instead of occupying runners.
- Default workflow permissions to `contents: read`.
- Gate release artifact jobs behind a tested changed-path classifier.
- Move GitHub Release publishing into tag-only jobs with job-local `contents: write`.
- Add CI tests that lock the workflow policy and classifier behavior.

## Validation

- `python3 -m unittest discover -s tests/ci`
- `python3 -m py_compile scripts/ci/*.py tests/ci/*.py`
- `bash -n plugins/unica/scripts/*.sh`
- JSON manifest validation for plugin, MCP, tools lock, and placeholder manifest
- YAML parse via Ruby Psych
- `cargo fmt --all -- --check`
- `cargo clippy --package unica-coder --all-targets --all-features -- -D warnings`
- `cargo test --package unica-coder`
- `git diff --check`
