### PR TITLE
[codex] add release assessment gate

### DIFF
--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -215,12 +215,13 @@ jobs:
           name: unica-codex-marketplace-linux-x64
           path: dist/linux-x64
 
-      - name: Run deterministic release assessment
+      - name: Run release assessment
         run: >
           python scripts/ci/release-assessment.py
           --package-archive dist/linux-x64/unica-codex-marketplace-linux-x64.tar.gz
           --work-dir .build/release-assessment
           --out-dir dist/release-assessment
+          --bsp-ref 3.2.1.446
           --release-tag "${{ github.ref_name }}"
           --github-run-id "${{ github.run_id }}"
 

--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -198,10 +198,115 @@ jobs:
           path: dist/install-unica.sh
           if-no-files-found: error
 
+  release-assessment:
+    name: Assess release candidate on BSP
+    runs-on: ubuntu-latest
+    needs: package
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: unica-codex-marketplace-linux-x64
+          path: dist/linux-x64
+
+      - name: Run deterministic release assessment
+        run: >
+          python scripts/ci/release-assessment.py
+          --package-archive dist/linux-x64/unica-codex-marketplace-linux-x64.tar.gz
+          --work-dir .build/release-assessment
+          --out-dir dist/release-assessment
+          --release-tag "${{ github.ref_name }}"
+          --github-run-id "${{ github.run_id }}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: unica-release-assessment
+          path: dist/release-assessment
+          if-no-files-found: error
+
+  publish-assessment-pages:
+    name: Publish assessment pages
+    runs-on: ubuntu-latest
+    needs: release-assessment
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: unica-release-assessment
+          path: dist/release-assessment
+
+      - name: Prepare gh-pages content
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          repo_url="https://github.com/${GITHUB_REPOSITORY}.git"
+          auth_header="AUTHORIZATION: bearer ${GITHUB_TOKEN}"
+
+          if git -c "http.extraheader=${auth_header}" ls-remote --exit-code --heads "$repo_url" gh-pages >/dev/null 2>&1; then
+            git -c "http.extraheader=${auth_header}" clone --depth 1 --branch gh-pages "$repo_url" pages-site
+          else
+            mkdir -p pages-site
+            git -C pages-site init
+            git -C pages-site checkout --orphan gh-pages
+            git -C pages-site remote add origin "$repo_url"
+          fi
+
+          mkdir -p pages-site/assessments
+          rm -rf "pages-site/assessments/${GITHUB_REF_NAME}" pages-site/assessments/latest
+          cp -R dist/release-assessment "pages-site/assessments/${GITHUB_REF_NAME}"
+          cp -R dist/release-assessment pages-site/assessments/latest
+          cat > pages-site/assessments/index.html <<'HTML'
+          <!doctype html>
+          <html lang="en">
+          <head><meta charset="utf-8"><title>Unica Release Assessments</title></head>
+          <body><h1>Unica Release Assessments</h1><p>Open a versioned assessment folder or <a href="latest/">latest</a>.</p></body>
+          </html>
+          HTML
+
+          git -C pages-site config user.name "github-actions[bot]"
+          git -C pages-site config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C pages-site add assessments
+          if git -C pages-site diff --cached --quiet; then
+            echo "No assessment page changes to publish."
+          else
+            git -C pages-site commit -m "docs: publish assessment ${GITHUB_REF_NAME}"
+            git -C pages-site -c "http.extraheader=${auth_header}" push origin HEAD:gh-pages
+          fi
+          rm -rf pages-site/.git
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: pages-site
+
+      - id: deployment
+        uses: actions/deploy-pages@v4
+
   publish-release-assets:
     name: Publish release assets (${{ matrix.target }})
     runs-on: ubuntu-latest
-    needs: package
+    needs:
+      - package
+      - publish-assessment-pages
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
@@ -229,7 +334,9 @@ jobs:
   publish-installer-asset:
     name: Publish installer asset
     runs-on: ubuntu-latest
-    needs: installer
+    needs:
+      - installer
+      - publish-assessment-pages
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write

--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -1001,9 +1001,8 @@ fn configuration_tools() -> Vec<ToolSpec> {
             description: "Inspect managed Form.xml.",
             mutating: false,
             cache_access: cache_access_for("form-info", None),
-            handler: ToolHandler::LegacyScript {
-                skill: "form-info",
-                script: "form-info.py",
+            handler: ToolHandler::NativeOperation {
+                operation: "form-info",
                 event: None,
             },
         },
@@ -1148,9 +1147,8 @@ fn configuration_tools() -> Vec<ToolSpec> {
             description: "Inspect Data Composition Schema Template.xml.",
             mutating: false,
             cache_access: cache_access_for("skd-info", None),
-            handler: ToolHandler::LegacyScript {
-                skill: "skd-info",
-                script: "skd-info.py",
+            handler: ToolHandler::NativeOperation {
+                operation: "skd-info",
                 event: None,
             },
         },
@@ -1455,11 +1453,10 @@ mod tests {
     }
 
     #[test]
-    fn skd_tools_route_through_hidden_legacy_scripts_for_full_donor_contract() {
+    fn skd_transitional_tools_route_through_hidden_legacy_scripts_for_full_donor_contract() {
         let expected = [
             ("unica.skd.compile", "skd-compile", "skd-compile.py"),
             ("unica.skd.edit", "skd-edit", "skd-edit.py"),
-            ("unica.skd.info", "skd-info", "skd-info.py"),
             ("unica.skd.validate", "skd-validate", "skd-validate.py"),
         ];
         for (tool_name, expected_skill, expected_script) in expected {
@@ -1503,12 +1500,11 @@ mod tests {
     }
 
     #[test]
-    fn form_tools_route_through_hidden_legacy_scripts_for_full_donor_contract() {
+    fn form_transitional_tools_route_through_hidden_legacy_scripts_for_full_donor_contract() {
         let expected = [
             ("unica.form.add", "form-add", "form-add.py"),
             ("unica.form.compile", "form-compile", "form-compile.py"),
             ("unica.form.edit", "form-edit", "form-edit.py"),
-            ("unica.form.info", "form-info", "form-info.py"),
             ("unica.form.remove", "form-remove", "remove-form.py"),
             ("unica.form.validate", "form-validate", "form-validate.py"),
         ];
@@ -1545,6 +1541,28 @@ mod tests {
                 other => {
                     panic!("{tool_name} should route through hidden legacy script, got {other:?}")
                 }
+            }
+        }
+    }
+
+    #[test]
+    fn read_only_form_and_skd_info_tools_route_through_native_handlers() {
+        let expected = [
+            ("unica.form.info", "form-info"),
+            ("unica.skd.info", "skd-info"),
+        ];
+        for (tool_name, expected_operation) in expected {
+            let tool = tools()
+                .into_iter()
+                .find(|tool| tool.name == tool_name)
+                .expect("read-only form/SKD tool exists");
+
+            match tool.handler {
+                ToolHandler::NativeOperation { operation, event } => {
+                    assert_eq!(operation, expected_operation);
+                    assert_eq!(event, None);
+                }
+                other => panic!("{tool_name} should route through native operation, got {other:?}"),
             }
         }
     }

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -695,15 +695,24 @@ impl<'a> CodeNavigationAdapter<'a> {
             timeout: DEFAULT_PROCESS_TIMEOUT,
         })?;
         let body = grep_body(&output.stdout, mode, limit);
-        let no_matches = body.is_empty() && !output.status_success;
+        let no_matches = body.is_empty()
+            && !output.status_success
+            && output.stderr.trim().is_empty()
+            && !output.timed_out;
         let partial_matches = output.timed_out && !body.is_empty();
         if !output.status_success && !no_matches && !partial_matches {
+            let error = output.stderr.trim();
+            let error = if error.is_empty() {
+                format!("git grep exited with status {}", output.status)
+            } else {
+                error.to_string()
+            };
             return Ok(AdapterOutcome {
                 ok: false,
                 summary: format!("{tool_name} failed through git grep"),
                 changes: Vec::new(),
                 warnings: vec![format!("git grep exited with status {}", output.status)],
-                errors: vec![output.stderr.trim().to_string()],
+                errors: vec![error],
                 artifacts: Vec::new(),
                 stdout: Some(format_section("git-grep", &body)),
                 stderr: Some(output.stderr),
@@ -2719,6 +2728,44 @@ mod tests {
     }
 
     #[test]
+    fn code_search_adapter_reports_git_grep_fatal_error_instead_of_no_matches() {
+        let context = temp_context("search-grep-fatal");
+        fs::create_dir_all(context.workspace_root.join("src/CommonModules")).unwrap();
+        let grep = FakeProcessRunner {
+            output: ProcessOutput {
+                status_success: false,
+                status: "exit status: 128".to_string(),
+                stdout: String::new(),
+                stderr: "fatal: not a git repository (or any of the parent directories): .git\n"
+                    .to_string(),
+                timed_out: false,
+            },
+        };
+        let index = FakeIndexRunner {
+            outputs: RefCell::new(vec![index_success("Index not found: /tmp/bsl_index.db")]),
+            ..Default::default()
+        };
+        let mut args = Map::new();
+        args.insert("query".to_string(), json!("SmokeProcedure"));
+
+        let outcome = CodeSearchAdapter::with_runners(&grep, &index)
+            .invoke("unica.code.search", &args, &context, false)
+            .unwrap();
+
+        assert!(!outcome.ok);
+        assert!(outcome
+            .errors
+            .iter()
+            .any(|error| error.contains("fatal: not a git repository")));
+        assert!(!outcome
+            .stdout
+            .as_deref()
+            .unwrap_or_default()
+            .contains("No git grep matches."));
+        cleanup_context(&context);
+    }
+
+    #[test]
     fn code_search_adapter_adds_rlm_section_when_index_is_ready() {
         let context = temp_context("search-ready");
         fs::create_dir_all(context.workspace_root.join("src/CommonModules")).unwrap();
@@ -3007,6 +3054,41 @@ mod tests {
 
         assert!(error.contains("outside workspace root"));
         assert!(grep.commands.borrow().is_empty());
+        cleanup_context(&context);
+    }
+
+    #[test]
+    fn code_grep_adapter_reports_git_fatal_error_instead_of_no_matches() {
+        let context = temp_context("grep-fatal");
+        let index = FakeIndexRunner::default();
+        let grep = RecordingProcessRunner {
+            commands: RefCell::new(Vec::new()),
+            output: ProcessOutput {
+                status_success: false,
+                status: "exit status: 128".to_string(),
+                stdout: String::new(),
+                stderr: "fatal: not a git repository (or any of the parent directories): .git\n"
+                    .to_string(),
+                timed_out: false,
+            },
+        };
+        let mut args = Map::new();
+        args.insert("query".to_string(), json!("SmokeProcedure"));
+
+        let outcome = CodeNavigationAdapter::with_runners(&index, &grep)
+            .invoke("unica.code.grep", &args, &context, false)
+            .unwrap();
+
+        assert!(!outcome.ok);
+        assert!(outcome
+            .errors
+            .iter()
+            .any(|error| error.contains("fatal: not a git repository")));
+        assert!(!outcome
+            .stdout
+            .as_deref()
+            .unwrap_or_default()
+            .contains("No git grep matches."));
         cleanup_context(&context);
     }
 

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -369,49 +369,82 @@ impl<'a> CodeSearchAdapter<'a> {
         context: &WorkspaceContext,
         dry_run: bool,
     ) -> Result<AdapterOutcome, String> {
-        let mut analyzer = CliAdapter::with_runner(
-            "run-bsl-analyzer.sh",
-            &["search"],
-            "code analysis",
-            self.analyzer_runner,
-        )
-        .invoke(tool_name, args, context, dry_run, false)?;
-
         if dry_run {
-            return Ok(analyzer);
+            return Ok(AdapterOutcome {
+                ok: true,
+                summary: format!("dry run: {tool_name} would use typed code search"),
+                changes: Vec::new(),
+                warnings: Vec::new(),
+                errors: Vec::new(),
+                artifacts: Vec::new(),
+                stdout: None,
+                stderr: None,
+                command: None,
+            });
         }
 
-        let analyzer_stdout = analyzer.stdout.take().unwrap_or_default();
-        let analyzer_stderr = analyzer.stderr.take();
-        let mut stdout = format_section("bsl-analyzer", &analyzer_stdout);
+        let mut warnings = Vec::new();
+        let mut errors = Vec::new();
+        let mut artifacts = Vec::new();
+        let mut stdout_sections = Vec::new();
+        let mut command = None;
+        let mut stderr = None;
 
         match self.rlm_readiness(context, args) {
             IndexReadiness::Ready { db_path } => match search_rlm_index(&db_path, args) {
                 Ok(Some(rlm_stdout)) => {
-                    stdout.push_str("\n\n");
-                    stdout.push_str(&format_section("rlm", &rlm_stdout));
+                    stdout_sections.push(format_section("rlm", &rlm_stdout));
+                    artifacts.push(db_path.display().to_string());
                 }
                 Ok(None) => {}
-                Err(error) => analyzer
-                    .warnings
-                    .push(format!("rlm search failed: {error}")),
+                Err(error) => warnings.push(format!("rlm search failed: {error}")),
             },
-            IndexReadiness::Building => analyzer.warnings.push("rlm index building".to_string()),
-            IndexReadiness::Missing => analyzer
-                .warnings
-                .push("rlm index unavailable: index is missing".to_string()),
-            IndexReadiness::Stale => analyzer.warnings.push("rlm index building".to_string()),
-            IndexReadiness::Failed(error) => analyzer
-                .warnings
-                .push(format!("rlm index unavailable: {error}")),
-            IndexReadiness::Unavailable(error) => analyzer
-                .warnings
-                .push(format!("rlm index unavailable: {error}")),
+            other => warnings.push(readiness_warning(other)),
         }
 
-        analyzer.stdout = Some(stdout);
-        analyzer.stderr = analyzer_stderr;
-        Ok(analyzer)
+        let grep_adapter = CodeNavigationAdapter {
+            index_runner: self.index_runner,
+            grep_runner: self.analyzer_runner,
+            use_workspace_service: self.use_workspace_service,
+        };
+        match grep_adapter.grep(tool_name, args, context) {
+            Ok(mut grep) => {
+                if let Some(stdout) = grep.stdout.take().filter(|value| !value.trim().is_empty()) {
+                    stdout_sections.push(stdout);
+                }
+                warnings.extend(grep.warnings);
+                if grep.ok {
+                    command = grep.command;
+                    stderr = grep.stderr;
+                } else {
+                    errors.extend(grep.errors);
+                    command = grep.command;
+                    stderr = grep.stderr;
+                }
+            }
+            Err(error) => warnings.push(format!("git grep fallback unavailable: {error}")),
+        }
+
+        let ok = !stdout_sections.is_empty() && errors.is_empty();
+        Ok(AdapterOutcome {
+            ok,
+            summary: if ok {
+                format!("{tool_name} completed through typed code search")
+            } else {
+                format!("{tool_name} failed through typed code search")
+            },
+            changes: Vec::new(),
+            warnings,
+            errors,
+            artifacts,
+            stdout: if stdout_sections.is_empty() {
+                None
+            } else {
+                Some(stdout_sections.join("\n\n"))
+            },
+            stderr,
+            command,
+        })
     }
 
     fn rlm_readiness(
@@ -626,12 +659,15 @@ impl<'a> CodeNavigationAdapter<'a> {
                 "{tool_name} argument `mode` must be one of: lines, files"
             ));
         }
+        let limit = read_limit(args, 200);
 
         let mut git_args = vec!["grep".to_string()];
         if mode == "files" {
             git_args.push("--name-only".to_string());
         } else {
             git_args.push("-n".to_string());
+            git_args.push("-m".to_string());
+            git_args.push(limit.to_string());
         }
         if !args.get("regex").and_then(Value::as_bool).unwrap_or(false) {
             git_args.push("-F".to_string());
@@ -658,10 +694,10 @@ impl<'a> CodeNavigationAdapter<'a> {
             cwd: context.workspace_root.clone(),
             timeout: DEFAULT_PROCESS_TIMEOUT,
         })?;
-        let limit = read_limit(args, 200);
         let body = grep_body(&output.stdout, mode, limit);
         let no_matches = body.is_empty() && !output.status_success;
-        if !output.status_success && !no_matches {
+        let partial_matches = output.timed_out && !body.is_empty();
+        if !output.status_success && !no_matches && !partial_matches {
             return Ok(AdapterOutcome {
                 ok: false,
                 summary: format!("{tool_name} failed through git grep"),
@@ -2618,9 +2654,9 @@ mod tests {
     }
 
     #[test]
-    fn code_search_adapter_dry_run_builds_bsl_analyzer_search_command() {
+    fn code_search_adapter_dry_run_reports_typed_code_search() {
         let context = WorkspaceContext::discover(std::env::current_dir().unwrap()).unwrap();
-        let analyzer = FakeProcessRunner {
+        let grep = FakeProcessRunner {
             output: ProcessOutput {
                 status_success: true,
                 status: "exit status: 0".to_string(),
@@ -2633,26 +2669,28 @@ mod tests {
         let mut args = Map::new();
         args.insert("query".to_string(), json!("ОбработкаПроведения"));
 
-        let outcome = CodeSearchAdapter::with_runners(&analyzer, &index)
+        let outcome = CodeSearchAdapter::with_runners(&grep, &index)
             .invoke("unica.code.search", &args, &context, true)
             .unwrap();
 
-        let command = outcome.command.unwrap().join(" ");
-        assert!(command.contains("run-bsl-analyzer.sh"));
-        assert!(command.contains("search"));
-        assert!(command.contains("--query"));
-        assert!(command.contains("ОбработкаПроведения"));
+        assert!(outcome.ok);
+        assert_eq!(
+            outcome.summary,
+            "dry run: unica.code.search would use typed code search"
+        );
+        assert!(outcome.command.is_none());
     }
 
     #[test]
-    fn code_search_adapter_returns_analyzer_section_when_rlm_index_is_missing() {
+    fn code_search_adapter_falls_back_to_git_grep_when_rlm_index_is_missing() {
         let context = temp_context("search-missing");
         fs::create_dir_all(context.workspace_root.join("src/CommonModules")).unwrap();
-        let analyzer = FakeProcessRunner {
+        let grep = FakeProcessRunner {
             output: ProcessOutput {
                 status_success: true,
                 status: "exit status: 0".to_string(),
-                stdout: "analyzer hit".to_string(),
+                stdout: "CommonModules/SmokeModule/Ext/Module.bsl:2:ОбработкаПроведения\n"
+                    .to_string(),
                 stderr: String::new(),
                 timed_out: false,
             },
@@ -2664,15 +2702,15 @@ mod tests {
         let mut args = Map::new();
         args.insert("query".to_string(), json!("ОбработкаПроведения"));
 
-        let outcome = CodeSearchAdapter::with_runners(&analyzer, &index)
+        let outcome = CodeSearchAdapter::with_runners(&grep, &index)
             .invoke("unica.code.search", &args, &context, false)
             .unwrap();
 
         assert!(outcome.ok);
-        assert_eq!(
-            outcome.stdout.as_deref(),
-            Some("=== bsl-analyzer ===\nanalyzer hit")
-        );
+        assert!(outcome
+            .stdout
+            .as_deref()
+            .is_some_and(|stdout| stdout.contains("=== git-grep ===")));
         assert!(outcome
             .warnings
             .iter()
@@ -2686,11 +2724,11 @@ mod tests {
         fs::create_dir_all(context.workspace_root.join("src/CommonModules")).unwrap();
         let db_path = context.cache_root.join("rlm-tools-bsl/test/bsl_index.db");
         create_rlm_search_db(&db_path);
-        let analyzer = FakeProcessRunner {
+        let grep = FakeProcessRunner {
             output: ProcessOutput {
                 status_success: true,
                 status: "exit status: 0".to_string(),
-                stdout: "analyzer hit".to_string(),
+                stdout: "CommonModules/Проведение.bsl:42:ОбработкаПроведения\n".to_string(),
                 stderr: String::new(),
                 timed_out: false,
             },
@@ -2706,13 +2744,13 @@ mod tests {
         args.insert("query".to_string(), json!("ОбработкаПроведения"));
         args.insert("limit".to_string(), json!(5));
 
-        let outcome = CodeSearchAdapter::with_runners(&analyzer, &index)
+        let outcome = CodeSearchAdapter::with_runners(&grep, &index)
             .invoke("unica.code.search", &args, &context, false)
             .unwrap();
 
         let stdout = outcome.stdout.unwrap();
-        assert!(stdout.contains("=== bsl-analyzer ===\nanalyzer hit"));
         assert!(stdout.contains("=== rlm ==="));
+        assert!(stdout.contains("=== git-grep ==="));
         assert!(stdout.contains("CommonModules/Проведение.bsl:42"));
         assert!(stdout.contains("Procedure ОбработкаПроведения() export"));
         cleanup_context(&context);
@@ -2934,6 +2972,8 @@ mod tests {
         assert!(commands[0].args.contains(&"grep".to_string()));
         assert!(commands[0].args.contains(&"-F".to_string()));
         assert!(commands[0].args.contains(&"-i".to_string()));
+        assert!(commands[0].args.contains(&"-m".to_string()));
+        assert!(commands[0].args.contains(&"10".to_string()));
         assert!(commands[0]
             .args
             .contains(&":(glob)CommonModules/**/*.bsl".to_string()));

--- a/scripts/ci/classify-workflow-changes.py
+++ b/scripts/ci/classify-workflow-changes.py
@@ -19,6 +19,7 @@ RELEASE_ARTIFACT_PATHS = {
     "plugins/unica/third-party/tools.lock.json",
     "plugins/unica/third-party/manifest.json",
     "scripts/ci/build-unica-tools.py",
+    "scripts/ci/release-assessment.py",
     "scripts/ci/package-unica-plugin.py",
     "scripts/install-unica.sh",
 }

--- a/scripts/ci/release-assessment.py
+++ b/scripts/ci/release-assessment.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run deterministic Unica release assessment against 1c-syntax/ssl_3_2."""
+"""Run Unica release assessment against a pinned 1c-syntax/ssl_3_2 ref."""
 
 from __future__ import annotations
 
@@ -22,7 +22,7 @@ from typing import Any
 
 SCHEMA_VERSION = 1
 BSP_REPO = "https://github.com/1c-syntax/ssl_3_2"
-BSP_REF = "master"
+BSP_REF = "3.2.1.446"
 SOURCE_DIR = "src/cf"
 EXPECTED_PUBLIC_TOOLS = {
     "unica.project.status",
@@ -541,7 +541,7 @@ def summarize_cache(cache_dir: Path) -> dict[str, Any]:
 
 
 def build_summary(scenarios: list[dict[str, Any]], diagnostic_codes: list[str], cache_dir: Path) -> dict[str, Any]:
-    blocking_failures = sum(1 for scenario in scenarios if scenario["blocking"] and scenario["status"] == "failed")
+    blocking_failures = sum(1 for scenario in scenarios if scenario["status"] == "failed")
     total_duration = sum(int(scenario["durationMs"]) for scenario in scenarios)
     return {
         "status": "failed" if blocking_failures else "passed",
@@ -581,6 +581,7 @@ def build_assessment_report(
     candidate_package: str,
     bsp_commit: str,
     timeout_seconds: int,
+    bsp_ref: str = BSP_REF,
 ) -> dict[str, Any]:
     scenarios: list[dict[str, Any]] = []
     diagnostic_codes: list[str] = []
@@ -646,7 +647,8 @@ def build_assessment_report(
         "candidatePackage": candidate_package,
         "bsp": {
             "repo": BSP_REPO,
-            "ref": BSP_REF,
+            "ref": bsp_ref,
+            "requestedRef": bsp_ref,
             "commit": bsp_commit,
             "descriptionVersion": description.get("Версия"),
             "descriptionDate": description.get("Дата"),
@@ -777,13 +779,14 @@ def main() -> None:
     parser.add_argument("--pages-root", type=Path)
     parser.add_argument("--release-tag", default=release_tag_from_env())
     parser.add_argument("--github-run-id", default=os.environ.get("GITHUB_RUN_ID", "local"))
+    parser.add_argument("--bsp-ref", default=BSP_REF)
     parser.add_argument("--timeout-seconds", type=int, default=600)
     args = parser.parse_args()
 
     work_dir = args.work_dir.resolve()
     package_archive = args.package_archive.resolve()
     run_unica = extract_marketplace_archive(package_archive, work_dir / "marketplace")
-    bsp_root, bsp_commit = download_bsp(work_dir / "bsp")
+    bsp_root, bsp_commit = download_bsp(work_dir / "bsp", ref=args.bsp_ref)
     report = build_assessment_report(
         run_unica=run_unica,
         bsp_root=bsp_root,
@@ -793,6 +796,7 @@ def main() -> None:
         github_run_id=args.github_run_id,
         candidate_package=package_archive.name,
         bsp_commit=bsp_commit,
+        bsp_ref=args.bsp_ref,
         timeout_seconds=args.timeout_seconds,
     )
     if args.pages_root:

--- a/scripts/ci/release-assessment.py
+++ b/scripts/ci/release-assessment.py
@@ -1,0 +1,805 @@
+#!/usr/bin/env python3
+"""Run deterministic Unica release assessment against 1c-syntax/ssl_3_2."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import tarfile
+import time
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+BSP_REPO = "https://github.com/1c-syntax/ssl_3_2"
+BSP_REF = "master"
+SOURCE_DIR = "src/cf"
+EXPECTED_PUBLIC_TOOLS = {
+    "unica.project.status",
+    "unica.project.map",
+    "unica.cf.info",
+    "unica.cf.validate",
+    "unica.code.diagnostics",
+    "unica.code.search",
+    "unica.code.grep",
+    "unica.code.outline",
+    "unica.meta.profile",
+    "unica.standards.explain",
+}
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def json_digest(value: Any) -> str:
+    payload = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def read_json(path: Path, default: dict[str, Any] | None = None) -> dict[str, Any]:
+    if not path.is_file():
+        return default or {}
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def release_tag_from_env() -> str:
+    ref = os.environ.get("GITHUB_REF_NAME") or os.environ.get("GITHUB_REF", "")
+    if ref.startswith("refs/tags/"):
+        return ref.removeprefix("refs/tags/")
+    return ref or "manual"
+
+
+def run_command(command: list[str], cwd: Path) -> str:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            f"command failed with {result.returncode}: {' '.join(command)}\n{result.stdout}{result.stderr}"
+        )
+    return result.stdout.strip()
+
+
+def download_bsp(work_dir: Path, *, repo: str = BSP_REPO, ref: str = BSP_REF) -> tuple[Path, str]:
+    target = work_dir / "ssl_3_2"
+    if target.exists():
+        shutil.rmtree(target)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    run_command(["git", "clone", "--depth", "1", "--branch", ref, repo, str(target)], work_dir)
+    commit = run_command(["git", "rev-parse", "HEAD"], target)
+    return target, commit
+
+
+def safe_extract_tar(archive: Path, extract_dir: Path) -> None:
+    root = extract_dir.resolve()
+    with tarfile.open(archive) as tf:
+        for member in tf.getmembers():
+            target = (extract_dir / member.name).resolve()
+            if not str(target).startswith(str(root) + os.sep) and target != root:
+                raise SystemExit(f"refusing to extract path outside target directory: {member.name}")
+        try:
+            tf.extractall(extract_dir, filter="data")
+        except TypeError:
+            tf.extractall(extract_dir)
+
+
+def safe_extract_zip(archive: Path, extract_dir: Path) -> None:
+    root = extract_dir.resolve()
+    with zipfile.ZipFile(archive) as zf:
+        for name in zf.namelist():
+            target = (extract_dir / name).resolve()
+            if not str(target).startswith(str(root) + os.sep) and target != root:
+                raise SystemExit(f"refusing to extract path outside target directory: {name}")
+        zf.extractall(extract_dir)
+
+
+def extract_marketplace_archive(archive: Path, extract_dir: Path) -> Path:
+    if extract_dir.exists():
+        shutil.rmtree(extract_dir)
+    extract_dir.mkdir(parents=True)
+
+    if tarfile.is_tarfile(archive):
+        safe_extract_tar(archive, extract_dir)
+    elif zipfile.is_zipfile(archive):
+        safe_extract_zip(archive, extract_dir)
+    else:
+        raise SystemExit(f"unsupported marketplace archive: {archive}")
+
+    candidates = sorted(extract_dir.rglob("plugins/unica/scripts/run-unica.sh"))
+    if not candidates:
+        raise SystemExit(f"run-unica.sh not found after extracting {archive}")
+    run_unica = candidates[0]
+    run_unica.chmod(run_unica.stat().st_mode | 0o111)
+    return run_unica
+
+
+def plugin_root_for(run_unica: Path) -> Path:
+    return run_unica.parent.parent
+
+
+def unica_version(run_unica: Path) -> str:
+    plugin_json = read_json(plugin_root_for(run_unica) / ".codex-plugin" / "plugin.json")
+    return str(plugin_json.get("version", "unknown"))
+
+
+def call_mcp(
+    run_unica: Path,
+    messages: list[dict[str, Any]],
+    *,
+    cwd: Path,
+    cache_dir: Path,
+    timeout_seconds: int,
+) -> tuple[list[dict[str, Any]], int, str, str, int]:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    payload = "\n".join(json.dumps(message, ensure_ascii=False) for message in messages) + "\n"
+    env = os.environ.copy()
+    env["UNICA_CACHE_DIR"] = str(cache_dir)
+    started = time.perf_counter()
+    try:
+        result = subprocess.run(
+            [str(run_unica)],
+            input=payload,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=cwd,
+            env=env,
+            timeout=timeout_seconds,
+            check=False,
+        )
+        duration_ms = int((time.perf_counter() - started) * 1000)
+    except subprocess.TimeoutExpired as error:
+        duration_ms = int((time.perf_counter() - started) * 1000)
+        return [], duration_ms, error.stdout or "", error.stderr or f"timed out after {timeout_seconds}s", 124
+
+    responses: list[dict[str, Any]] = []
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        try:
+            responses.append(json.loads(line))
+        except json.JSONDecodeError:
+            responses.append({"error": {"message": f"invalid JSON-RPC line: {line}"}})
+    return responses, duration_ms, result.stdout, result.stderr, result.returncode
+
+
+def tool_call_message(message_id: int, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    }
+
+
+def parse_tool_payload(response: dict[str, Any]) -> tuple[dict[str, Any] | None, list[str]]:
+    if "error" in response:
+        error = response["error"]
+        return None, [str(error.get("message", error))]
+    try:
+        text = response["result"]["content"][0]["text"]
+    except (KeyError, IndexError, TypeError):
+        return None, ["tool response does not contain text content"]
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        payload = {"ok": True, "stdout": text, "warnings": [], "errors": [], "artifacts": []}
+    if not isinstance(payload, dict):
+        return None, ["tool text payload is not a JSON object"]
+    return payload, []
+
+
+def response_output_size(stdout: str, stderr: str, payload: dict[str, Any] | None) -> int:
+    payload_size = 0 if payload is None else len(json.dumps(payload, ensure_ascii=False).encode("utf-8"))
+    return len(stdout.encode("utf-8")) + len(stderr.encode("utf-8")) + payload_size
+
+
+def parsed_stdout_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
+    if not payload:
+        return {}
+    stdout = payload.get("stdout")
+    if not isinstance(stdout, str) or not stdout.strip():
+        return {}
+    try:
+        parsed = json.loads(stdout)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def project_source_sets(payload: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not payload:
+        return []
+    for candidate in (payload, parsed_stdout_payload(payload)):
+        source_sets = candidate.get("sourceSets")
+        if source_sets is None:
+            source_sets = candidate.get("source_sets")
+        if isinstance(source_sets, list):
+            return [item for item in source_sets if isinstance(item, dict)]
+    return []
+
+
+def scenario_result(
+    *,
+    scenario_id: str,
+    title: str,
+    tool: str,
+    arguments: Any,
+    status: str,
+    duration_ms: int,
+    blocking: bool,
+    metrics: dict[str, Any] | None = None,
+    errors: list[str] | None = None,
+    artifacts: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": scenario_id,
+        "title": title,
+        "tool": tool,
+        "argumentsDigest": json_digest(arguments),
+        "status": status,
+        "durationMs": duration_ms,
+        "blocking": blocking,
+        "metrics": metrics or {},
+        "errors": errors or [],
+        "artifacts": artifacts or [],
+    }
+
+
+def run_tools_list_scenario(run_unica: Path, bsp_root: Path, cache_dir: Path, timeout_seconds: int) -> dict[str, Any]:
+    messages = [
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+    ]
+    responses, duration_ms, stdout, stderr, returncode = call_mcp(
+        run_unica,
+        messages,
+        cwd=bsp_root,
+        cache_dir=cache_dir,
+        timeout_seconds=timeout_seconds,
+    )
+    errors: list[str] = []
+    tools: set[str] = set()
+    if returncode != 0:
+        errors.append(f"run-unica exited with {returncode}: {stderr.strip()}")
+    if len(responses) != 2:
+        errors.append(f"expected 2 JSON-RPC responses, got {len(responses)}")
+    else:
+        server_name = responses[0].get("result", {}).get("serverInfo", {}).get("name")
+        if server_name != "unica":
+            errors.append(f"expected serverInfo.name=unica, got {server_name!r}")
+        tools = {tool.get("name", "") for tool in responses[1].get("result", {}).get("tools", [])}
+        missing = sorted(EXPECTED_PUBLIC_TOOLS - tools)
+        if missing:
+            errors.append(f"missing expected public tools: {', '.join(missing)}")
+    metrics = {
+        "toolsCount": len(tools),
+        "outputBytes": response_output_size(stdout, stderr, None),
+    }
+    return scenario_result(
+        scenario_id="mcp-tools-list",
+        title="MCP initialize and public tools list",
+        tool="initialize+tools/list",
+        arguments=messages,
+        status="failed" if errors else "passed",
+        duration_ms=duration_ms,
+        blocking=True,
+        metrics=metrics,
+        errors=errors,
+    )
+
+
+def run_tool_scenario(
+    run_unica: Path,
+    *,
+    bsp_root: Path,
+    cache_dir: Path,
+    scenario_id: str,
+    title: str,
+    tool: str,
+    arguments: dict[str, Any],
+    timeout_seconds: int,
+    blocking: bool,
+    require_payload_ok: bool,
+) -> tuple[dict[str, Any], dict[str, Any] | None]:
+    args = dict(arguments)
+    args.setdefault("cwd", str(bsp_root))
+    message = tool_call_message(1, tool, args)
+    responses, duration_ms, stdout, stderr, returncode = call_mcp(
+        run_unica,
+        [message],
+        cwd=bsp_root,
+        cache_dir=cache_dir,
+        timeout_seconds=timeout_seconds,
+    )
+    errors: list[str] = []
+    payload: dict[str, Any] | None = None
+    if returncode != 0:
+        errors.append(f"run-unica exited with {returncode}: {stderr.strip()}")
+    if len(responses) != 1:
+        errors.append(f"expected 1 JSON-RPC response, got {len(responses)}")
+    elif not errors:
+        payload, payload_errors = parse_tool_payload(responses[0])
+        errors.extend(payload_errors)
+
+    if payload is not None:
+        payload_errors = [str(item) for item in payload.get("errors", []) if str(item).strip()]
+        if payload.get("ok") is False and require_payload_ok:
+            errors.extend(payload_errors or [str(payload.get("summary", f"{tool} reported ok=false"))])
+
+    metrics = {
+        "outputBytes": response_output_size(stdout, stderr, payload),
+        "warningsCount": len(payload.get("warnings", [])) if payload else 0,
+        "errorsCount": len(payload.get("errors", [])) if payload else len(errors),
+    }
+    source_sets = project_source_sets(payload)
+    if source_sets:
+        metrics["sourceSetsCount"] = len(source_sets)
+    if payload and "cache" in payload:
+        metrics["cache"] = payload["cache"]
+    status = "failed" if errors else "passed"
+    result = scenario_result(
+        scenario_id=scenario_id,
+        title=title,
+        tool=tool,
+        arguments=args,
+        status=status,
+        duration_ms=duration_ms,
+        blocking=blocking,
+        metrics=metrics,
+        errors=errors,
+        artifacts=[str(item) for item in payload.get("artifacts", [])] if payload else [],
+    )
+    return result, payload
+
+
+def validate_project_map(scenario: dict[str, Any], payload: dict[str, Any] | None) -> None:
+    if payload is None:
+        return
+    source_sets = project_source_sets(payload)
+    if not source_sets:
+        scenario["status"] = "failed"
+        scenario["errors"].append("project map payload does not contain sourceSets")
+        return
+    found = any(
+        item.get("path") == SOURCE_DIR and item.get("sourceFormat") in {"platform_xml", "PlatformXml"}
+        for item in source_sets
+        if isinstance(item, dict)
+    )
+    if not found:
+        scenario["status"] = "failed"
+        scenario["errors"].append(f"project map did not detect {SOURCE_DIR} as platform XML")
+
+
+def relpath(path: Path, root: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def first_existing(root: Path, patterns: list[str]) -> str | None:
+    for pattern in patterns:
+        matches = sorted(root.glob(pattern))
+        if matches:
+            return relpath(matches[0], root)
+    return None
+
+
+def template_kind(path: Path) -> str:
+    text = path.read_text(encoding="utf-8", errors="ignore")[:8192]
+    if "DataCompositionSchema" in text or "dataCompositionSchema" in text:
+        return "skd"
+    if "SpreadsheetDocument" in text or "spreadsheet" in text.lower():
+        return "mxl"
+    return "unknown"
+
+
+def optional_sample_scenarios(bsp_root: Path) -> list[tuple[str, str, str, dict[str, Any], bool]]:
+    scenarios: list[tuple[str, str, str, dict[str, Any], bool]] = []
+    form = first_existing(bsp_root, [f"{SOURCE_DIR}/**/Forms/*/Ext/Form.xml"])
+    if form:
+        scenarios.append(("form-info-sample", "Sample managed form info", "unica.form.info", {"FormPath": form, "Limit": 80}, True))
+        scenarios.append(
+            ("form-validate-sample", "Sample managed form validation", "unica.form.validate", {"FormPath": form, "MaxErrors": 30}, False)
+        )
+
+    role = first_existing(bsp_root, [f"{SOURCE_DIR}/Roles/*/Ext/Rights.xml"])
+    if role:
+        scenarios.append(("role-info-sample", "Sample role info", "unica.role.info", {"RightsPath": role, "Limit": 80}, True))
+        scenarios.append(
+            ("role-validate-sample", "Sample role validation", "unica.role.validate", {"RightsPath": role, "MaxErrors": 30}, False)
+        )
+
+    templates = sorted(bsp_root.glob(f"{SOURCE_DIR}/**/Templates/*/Ext/Template.xml"))
+    skd = next((path for path in templates if template_kind(path) == "skd"), None)
+    mxl = next((path for path in templates if template_kind(path) == "mxl"), None)
+    if skd:
+        skd_rel = relpath(skd, bsp_root)
+        scenarios.append(("skd-info-sample", "Sample SKD info", "unica.skd.info", {"TemplatePath": skd_rel, "Limit": 80}, True))
+        scenarios.append(
+            ("skd-validate-sample", "Sample SKD validation", "unica.skd.validate", {"TemplatePath": skd_rel, "MaxErrors": 30}, False)
+        )
+    if mxl:
+        mxl_rel = relpath(mxl, bsp_root)
+        scenarios.append(("mxl-info-sample", "Sample MXL info", "unica.mxl.info", {"TemplatePath": mxl_rel, "Limit": 80}, True))
+        scenarios.append(
+            ("mxl-validate-sample", "Sample MXL validation", "unica.mxl.validate", {"TemplatePath": mxl_rel, "MaxErrors": 30}, False)
+        )
+    return scenarios
+
+
+def sample_bsl_path(bsp_root: Path) -> str | None:
+    matches = sorted(bsp_root.glob(f"{SOURCE_DIR}/**/*.bsl"))
+    return relpath(matches[0], bsp_root) if matches else None
+
+
+def sample_bsl_search(bsp_root: Path) -> tuple[str, str] | None:
+    for path in sorted(bsp_root.glob(f"{SOURCE_DIR}/**/*.bsl")):
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for query in ("Процедура", "Функция", "Экспорт"):
+            if query in text:
+                return relpath(path, bsp_root), query
+    return None
+
+
+def base_tool_scenarios(bsp_root: Path) -> list[tuple[str, str, str, dict[str, Any], bool, bool]]:
+    bsl_search = sample_bsl_search(bsp_root)
+    code_search_args = {"sourceDir": SOURCE_DIR, "query": "Процедура", "limit": 20}
+    if bsl_search:
+        bsl_path, query = bsl_search
+        code_search_args = {"sourceDir": SOURCE_DIR, "path": bsl_path, "query": query, "limit": 20}
+
+    scenarios: list[tuple[str, str, str, dict[str, Any], bool, bool]] = [
+        ("project-status", "Workspace status", "unica.project.status", {}, True, True),
+        ("project-map", "Workspace source-set map", "unica.project.map", {}, True, True),
+        ("cf-info", "BSP Configuration.xml overview", "unica.cf.info", {"ConfigPath": SOURCE_DIR, "Mode": "brief", "Limit": 80}, True, True),
+        ("cf-validate", "BSP Configuration.xml validation", "unica.cf.validate", {"ConfigPath": SOURCE_DIR, "MaxErrors": 50}, False, False),
+        (
+            "code-grep",
+            "BSL git grep smoke",
+            "unica.code.grep",
+            code_search_args,
+            True,
+            True,
+        ),
+        (
+            "code-diagnostics-workspace",
+            "BSL diagnostics workspace read",
+            "unica.code.diagnostics",
+            {"sourceDir": SOURCE_DIR, "mode": "workspace", "limit": 100},
+            False,
+            False,
+        ),
+        (
+            "code-search",
+            "BSL indexed search smoke",
+            "unica.code.search",
+            code_search_args,
+            False,
+            True,
+        ),
+    ]
+    bsl_path = sample_bsl_path(bsp_root)
+    if bsl_path:
+        scenarios.append(
+            (
+                "code-outline-sample",
+                "Sample BSL module outline",
+                "unica.code.outline",
+                {"sourceDir": SOURCE_DIR, "path": bsl_path, "includeMethods": True},
+                False,
+                True,
+            )
+        )
+    return scenarios
+
+
+def extract_diagnostic_codes(payload: dict[str, Any] | None) -> list[str]:
+    if not payload:
+        return []
+    codes: set[str] = set()
+    diagnostics = payload.get("diagnostics")
+    if isinstance(diagnostics, list):
+        for item in diagnostics:
+            if not isinstance(item, dict):
+                continue
+            for key in ("code", "id", "diagnostic", "diagnosticId"):
+                value = item.get(key)
+                if isinstance(value, str) and value:
+                    codes.add(value)
+    for text_key in ("stdout", "summary"):
+        text = payload.get(text_key)
+        if isinstance(text, str):
+            for match in re.findall(r"\b[A-Z][A-Za-z0-9_]{4,}\b", text):
+                codes.add(match)
+    return sorted(codes)
+
+
+def summarize_cache(cache_dir: Path) -> dict[str, Any]:
+    if not cache_dir.exists():
+        return {"exists": False, "files": 0, "bytes": 0}
+    files = [path for path in cache_dir.rglob("*") if path.is_file()]
+    return {
+        "exists": True,
+        "files": len(files),
+        "bytes": sum(path.stat().st_size for path in files),
+    }
+
+
+def build_summary(scenarios: list[dict[str, Any]], diagnostic_codes: list[str], cache_dir: Path) -> dict[str, Any]:
+    blocking_failures = sum(1 for scenario in scenarios if scenario["blocking"] and scenario["status"] == "failed")
+    total_duration = sum(int(scenario["durationMs"]) for scenario in scenarios)
+    return {
+        "status": "failed" if blocking_failures else "passed",
+        "blockingFailures": blocking_failures,
+        "qualityFindings": {
+            "diagnosticCodes": diagnostic_codes,
+            "nonBlockingFailures": sum(
+                1 for scenario in scenarios if not scenario["blocking"] and scenario["status"] == "failed"
+            ),
+        },
+        "performance": {
+            "totalDurationMs": total_duration,
+            "scenarioCount": len(scenarios),
+            "cache": summarize_cache(cache_dir),
+        },
+    }
+
+
+def environment_metadata(run_unica: Path) -> dict[str, Any]:
+    return {
+        "os": platform.platform(),
+        "python": platform.python_version(),
+        "machine": platform.machine(),
+        "runUnica": str(run_unica),
+        "generatedAt": utc_now(),
+    }
+
+
+def build_assessment_report(
+    *,
+    run_unica: Path,
+    bsp_root: Path,
+    cache_dir: Path,
+    out_dir: Path,
+    release_tag: str,
+    github_run_id: str,
+    candidate_package: str,
+    bsp_commit: str,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    scenarios: list[dict[str, Any]] = []
+    diagnostic_codes: list[str] = []
+
+    scenarios.append(run_tools_list_scenario(run_unica, bsp_root, cache_dir, timeout_seconds))
+
+    for scenario_id, title, tool, arguments, blocking, require_payload_ok in base_tool_scenarios(bsp_root):
+        scenario, payload = run_tool_scenario(
+            run_unica,
+            bsp_root=bsp_root,
+            cache_dir=cache_dir,
+            scenario_id=scenario_id,
+            title=title,
+            tool=tool,
+            arguments=arguments,
+            timeout_seconds=timeout_seconds,
+            blocking=blocking,
+            require_payload_ok=require_payload_ok,
+        )
+        if scenario_id == "project-map":
+            validate_project_map(scenario, payload)
+        scenarios.append(scenario)
+        diagnostic_codes.extend(extract_diagnostic_codes(payload))
+
+    for scenario_id, title, tool, arguments, require_payload_ok in optional_sample_scenarios(bsp_root):
+        scenario, payload = run_tool_scenario(
+            run_unica,
+            bsp_root=bsp_root,
+            cache_dir=cache_dir,
+            scenario_id=scenario_id,
+            title=title,
+            tool=tool,
+            arguments=arguments,
+            timeout_seconds=timeout_seconds,
+            blocking=False,
+            require_payload_ok=require_payload_ok,
+        )
+        scenarios.append(scenario)
+        diagnostic_codes.extend(extract_diagnostic_codes(payload))
+
+    diagnostic_codes = sorted(set(diagnostic_codes))[:20]
+    if diagnostic_codes:
+        scenario, _payload = run_tool_scenario(
+            run_unica,
+            bsp_root=bsp_root,
+            cache_dir=cache_dir,
+            scenario_id="standards-explain-diagnostics",
+            title="Explain top diagnostic codes through standards adapter",
+            tool="unica.standards.explain",
+            arguments={"codes": diagnostic_codes[:10]},
+            timeout_seconds=timeout_seconds,
+            blocking=False,
+            require_payload_ok=True,
+        )
+        scenarios.append(scenario)
+
+    description = read_json(bsp_root / "description.json")
+    report = {
+        "schemaVersion": SCHEMA_VERSION,
+        "unicaVersion": unica_version(run_unica),
+        "releaseTag": release_tag,
+        "githubRunId": github_run_id,
+        "candidatePackage": candidate_package,
+        "bsp": {
+            "repo": BSP_REPO,
+            "ref": BSP_REF,
+            "commit": bsp_commit,
+            "descriptionVersion": description.get("Версия"),
+            "descriptionDate": description.get("Дата"),
+        },
+        "environment": environment_metadata(run_unica),
+        "scenarios": scenarios,
+        "summary": build_summary(scenarios, diagnostic_codes, cache_dir),
+    }
+    write_report_files(report, out_dir)
+    return report
+
+
+def render_html(report: dict[str, Any]) -> str:
+    status = html.escape(str(report["summary"]["status"]))
+    release = html.escape(str(report["releaseTag"]))
+    bsp_commit = html.escape(str(report["bsp"]["commit"]))
+    blocking = html.escape(str(report["summary"]["blockingFailures"]))
+    rows = []
+    for scenario in report["scenarios"]:
+        errors = "<br>".join(html.escape(error) for error in scenario.get("errors", []))
+        rows.append(
+            "<tr>"
+            f"<td>{html.escape(str(scenario['id']))}</td>"
+            f"<td>{html.escape(str(scenario['title']))}</td>"
+            f"<td>{html.escape(str(scenario['tool']))}</td>"
+            f"<td>{html.escape(str(scenario['status']))}</td>"
+            f"<td>{html.escape(str(scenario['durationMs']))}</td>"
+            f"<td>{html.escape(str(scenario['blocking']))}</td>"
+            f"<td>{errors}</td>"
+            "</tr>"
+        )
+    codes = ", ".join(html.escape(code) for code in report["summary"]["qualityFindings"].get("diagnosticCodes", []))
+    return "\n".join(
+        [
+            "<!doctype html>",
+            '<html lang="en">',
+            "<head>",
+            '<meta charset="utf-8">',
+            "<title>Unica Release Assessment</title>",
+            "<style>",
+            "body{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;margin:32px;line-height:1.45}",
+            "table{border-collapse:collapse;width:100%;font-size:14px}",
+            "th,td{border:1px solid #d0d7de;padding:6px 8px;text-align:left;vertical-align:top}",
+            "th{background:#f6f8fa}",
+            ".passed{color:#116329}.failed{color:#cf222e}",
+            "</style>",
+            "</head>",
+            "<body>",
+            f"<h1>Unica Release Assessment {release}</h1>",
+            f'<p>Status: <strong class="{status}">{status}</strong></p>',
+            f"<p>Blocking failures: {blocking}</p>",
+            f"<p>BSP commit: <code>{bsp_commit}</code></p>",
+            f"<p>Diagnostic codes: {codes or 'none'}</p>",
+            "<h2>Scenarios</h2>",
+            "<table>",
+            "<thead><tr><th>ID</th><th>Title</th><th>Tool</th><th>Status</th><th>Duration ms</th><th>Blocking</th><th>Errors</th></tr></thead>",
+            "<tbody>",
+            *rows,
+            "</tbody>",
+            "</table>",
+            '<p><a href="assessment.json">assessment.json</a> | <a href="assessment.ndjson">assessment.ndjson</a> | <a href="summary.md">summary.md</a></p>',
+            "</body>",
+            "</html>",
+            "",
+        ]
+    )
+
+
+def render_summary_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        f"# Unica Release Assessment {report['releaseTag']}",
+        "",
+        f"- Status: `{report['summary']['status']}`",
+        f"- Blocking failures: `{report['summary']['blockingFailures']}`",
+        f"- BSP commit: `{report['bsp']['commit']}`",
+        f"- BSP version: `{report['bsp'].get('descriptionVersion')}`",
+        f"- Total duration: `{report['summary']['performance']['totalDurationMs']} ms`",
+        "",
+        "## Scenarios",
+        "",
+    ]
+    for scenario in report["scenarios"]:
+        lines.append(
+            f"- `{scenario['status']}` `{scenario['id']}` ({scenario['durationMs']} ms, blocking={scenario['blocking']})"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_report_files(report: dict[str, Any], out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "assessment.json").write_text(
+        json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    with (out_dir / "assessment.ndjson").open("w", encoding="utf-8") as stream:
+        for scenario in report["scenarios"]:
+            stream.write(json.dumps(scenario, ensure_ascii=False, sort_keys=True) + "\n")
+    (out_dir / "index.html").write_text(render_html(report), encoding="utf-8")
+    (out_dir / "summary.md").write_text(render_summary_markdown(report), encoding="utf-8")
+
+
+def copytree_replace(source: Path, target: Path) -> None:
+    if target.exists():
+        shutil.rmtree(target)
+    shutil.copytree(source, target)
+
+
+def copy_versioned_pages(report_dir: Path, pages_root: Path, release_tag: str) -> None:
+    assessments = pages_root / "assessments"
+    assessments.mkdir(parents=True, exist_ok=True)
+    copytree_replace(report_dir, assessments / release_tag)
+    copytree_replace(report_dir, assessments / "latest")
+    index = assessments / "index.html"
+    if not index.exists():
+        index.write_text(
+            "<!doctype html><html><head><meta charset=\"utf-8\"><title>Unica Assessments</title></head>"
+            "<body><h1>Unica Assessments</h1><p>Open a versioned assessment folder.</p></body></html>\n",
+            encoding="utf-8",
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--package-archive", type=Path, required=True)
+    parser.add_argument("--work-dir", type=Path, default=Path(".build/release-assessment/work"))
+    parser.add_argument("--out-dir", type=Path, default=Path("dist/release-assessment"))
+    parser.add_argument("--pages-root", type=Path)
+    parser.add_argument("--release-tag", default=release_tag_from_env())
+    parser.add_argument("--github-run-id", default=os.environ.get("GITHUB_RUN_ID", "local"))
+    parser.add_argument("--timeout-seconds", type=int, default=600)
+    args = parser.parse_args()
+
+    work_dir = args.work_dir.resolve()
+    package_archive = args.package_archive.resolve()
+    run_unica = extract_marketplace_archive(package_archive, work_dir / "marketplace")
+    bsp_root, bsp_commit = download_bsp(work_dir / "bsp")
+    report = build_assessment_report(
+        run_unica=run_unica,
+        bsp_root=bsp_root,
+        cache_dir=work_dir / "cache",
+        out_dir=args.out_dir,
+        release_tag=args.release_tag,
+        github_run_id=args.github_run_id,
+        candidate_package=package_archive.name,
+        bsp_commit=bsp_commit,
+        timeout_seconds=args.timeout_seconds,
+    )
+    if args.pages_root:
+        copy_versioned_pages(args.out_dir, args.pages_root, args.release_tag)
+    if report["summary"]["blockingFailures"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ci/test_classify_workflow_changes.py
+++ b/tests/ci/test_classify_workflow_changes.py
@@ -30,6 +30,7 @@ class ClassifyWorkflowChangesTests(unittest.TestCase):
             "plugins/unica/.mcp.json",
             "plugins/unica/third-party/tools.lock.json",
             "plugins/unica/third-party/manifest.json",
+            "scripts/ci/release-assessment.py",
             "scripts/ci/build-unica-tools.py",
             "scripts/ci/package-unica-plugin.py",
             "scripts/install-unica.sh",

--- a/tests/ci/test_release_assessment.py
+++ b/tests/ci/test_release_assessment.py
@@ -113,6 +113,8 @@ for raw in sys.stdin:
             self.assertEqual(report["schemaVersion"], 1)
             self.assertEqual(report["summary"]["status"], "passed")
             self.assertEqual(report["bsp"]["commit"], "abc123")
+            self.assertEqual(report["bsp"]["ref"], module.BSP_REF)
+            self.assertEqual(report["bsp"]["requestedRef"], module.BSP_REF)
             self.assertTrue(all(scenario["durationMs"] >= 0 for scenario in report["scenarios"]))
             self.assertIn("UnusedLocalVariable", report["summary"]["qualityFindings"]["diagnosticCodes"])
             self.assertTrue((out_dir / "assessment.json").is_file())
@@ -166,6 +168,34 @@ for raw in sys.stdin:
         self.assertIn("&lt;script&gt;alert", html)
         self.assertNotIn("<script>alert", html)
         self.assertIn("Blocking failures", html)
+
+    def test_summary_fails_when_any_scenario_failed_even_if_marked_non_blocking(self) -> None:
+        module = load_assessment_module()
+
+        scenarios = [
+            module.scenario_result(
+                scenario_id="quality-smoke",
+                title="Quality smoke",
+                tool="unica.form.info",
+                arguments={},
+                status="failed",
+                duration_ms=7,
+                blocking=False,
+                errors=["runtime dependency missing"],
+            )
+        ]
+
+        summary = module.build_summary(scenarios, [], Path("/tmp/unica-no-cache"))
+
+        self.assertEqual(summary["status"], "failed")
+        self.assertEqual(summary["blockingFailures"], 1)
+        self.assertEqual(summary["qualityFindings"]["nonBlockingFailures"], 1)
+
+    def test_default_bsp_ref_is_pinned_and_report_records_requested_ref(self) -> None:
+        module = load_assessment_module()
+
+        self.assertNotEqual(module.BSP_REF, "master")
+        self.assertEqual(module.BSP_REF, "3.2.1.446")
 
     def test_versioned_pages_copy_preserves_existing_versions_and_latest(self) -> None:
         module = load_assessment_module()

--- a/tests/ci/test_release_assessment.py
+++ b/tests/ci/test_release_assessment.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import stat
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def load_assessment_module():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "release-assessment.py"
+    spec = importlib.util.spec_from_file_location("release_assessment", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ReleaseAssessmentTests(unittest.TestCase):
+    def write_fake_mcp(self, path: Path) -> None:
+        path.write_text(
+            """#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+
+TOOLS = [
+    "unica.project.status",
+    "unica.project.map",
+    "unica.cf.info",
+    "unica.cf.validate",
+    "unica.code.diagnostics",
+    "unica.code.search",
+    "unica.code.grep",
+    "unica.code.outline",
+    "unica.meta.profile",
+    "unica.standards.explain",
+]
+
+for raw in sys.stdin:
+    message = json.loads(raw)
+    method = message.get("method")
+    response = {"jsonrpc": "2.0", "id": message.get("id")}
+    if method == "initialize":
+        response["result"] = {"serverInfo": {"name": "unica"}}
+    elif method == "tools/list":
+        response["result"] = {"tools": [{"name": name} for name in TOOLS]}
+    elif method == "tools/call":
+        params = message["params"]
+        name = params["name"]
+        arguments = params.get("arguments", {})
+        payload = {
+            "ok": True,
+            "summary": f"{name} completed",
+            "stdout": "",
+            "warnings": [],
+            "errors": [],
+            "artifacts": [],
+        }
+        if name == "unica.project.map":
+            payload["stdout"] = json.dumps({
+                "sourceSets": [
+                    {"name": "main", "path": "src/cf", "sourceFormat": "platform_xml"}
+                ]
+            }, ensure_ascii=False)
+        elif name == "unica.code.diagnostics" and arguments.get("mode") == "workspace":
+            payload["diagnostics"] = [
+                {"code": "UnusedLocalVariable", "file": "CommonModules/Test/Ext/Module.bsl"}
+            ]
+        elif name == "unica.standards.explain":
+            payload["stdout"] = "UnusedLocalVariable: standard explanation"
+        response["result"] = {"content": [{"type": "text", "text": json.dumps(payload)}]}
+    else:
+        response["error"] = {"code": -32601, "message": f"unsupported {method}"}
+    print(json.dumps(response), flush=True)
+""",
+            encoding="utf-8",
+        )
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+    def test_scenario_runner_records_success_metrics_and_json_lines(self) -> None:
+        module = load_assessment_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fake_mcp = root / "run-unica"
+            self.write_fake_mcp(fake_mcp)
+            bsp_root = root / "bsp"
+            (bsp_root / "src" / "cf").mkdir(parents=True)
+            (bsp_root / "src" / "cf" / "Module.bsl").write_text("Процедура Smoke()\nКонецПроцедуры\n", encoding="utf-8")
+            (bsp_root / "description.json").write_text(
+                json.dumps({"Версия": "3.2.1.446", "Дата": "2026-06-17T00:00:00"}, ensure_ascii=False),
+                encoding="utf-8",
+            )
+            out_dir = root / "out"
+
+            report = module.build_assessment_report(
+                run_unica=fake_mcp,
+                bsp_root=bsp_root,
+                cache_dir=root / "cache",
+                out_dir=out_dir,
+                release_tag="v9.9.9",
+                github_run_id="12345",
+                candidate_package="unica-codex-marketplace-linux-x64.tar.gz",
+                bsp_commit="abc123",
+                timeout_seconds=10,
+            )
+
+            self.assertEqual(report["schemaVersion"], 1)
+            self.assertEqual(report["summary"]["status"], "passed")
+            self.assertEqual(report["bsp"]["commit"], "abc123")
+            self.assertTrue(all(scenario["durationMs"] >= 0 for scenario in report["scenarios"]))
+            self.assertIn("UnusedLocalVariable", report["summary"]["qualityFindings"]["diagnosticCodes"])
+            self.assertTrue((out_dir / "assessment.json").is_file())
+            self.assertTrue((out_dir / "assessment.ndjson").is_file())
+            lines = (out_dir / "assessment.ndjson").read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), len(report["scenarios"]))
+            self.assertTrue((out_dir / "index.html").read_text(encoding="utf-8").startswith("<!doctype html>"))
+            self.assertIn("v9.9.9", (out_dir / "summary.md").read_text(encoding="utf-8"))
+
+    def test_report_rendering_escapes_failure_text(self) -> None:
+        module = load_assessment_module()
+
+        report = {
+            "schemaVersion": 1,
+            "unicaVersion": "0.4.4",
+            "releaseTag": "v0.4.4",
+            "githubRunId": "run",
+            "candidatePackage": "pkg.tar.gz",
+            "bsp": {
+                "repo": "https://github.com/1c-syntax/ssl_3_2",
+                "ref": "master",
+                "commit": "abc",
+                "descriptionVersion": "3.2.1.446",
+                "descriptionDate": "2026-06-17T00:00:00",
+            },
+            "environment": {"os": "Linux", "python": "3.12"},
+            "summary": {
+                "status": "failed",
+                "blockingFailures": 1,
+                "qualityFindings": {"diagnosticCodes": []},
+                "performance": {"totalDurationMs": 7},
+            },
+            "scenarios": [
+                {
+                    "id": "broken",
+                    "title": "Broken scenario",
+                    "tool": "unica.cf.info",
+                    "argumentsDigest": "sha256:abc",
+                    "status": "failed",
+                    "durationMs": 7,
+                    "blocking": True,
+                    "metrics": {},
+                    "errors": ["<script>alert('x')</script>"],
+                    "artifacts": [],
+                }
+            ],
+        }
+
+        html = module.render_html(report)
+
+        self.assertIn("&lt;script&gt;alert", html)
+        self.assertNotIn("<script>alert", html)
+        self.assertIn("Blocking failures", html)
+
+    def test_versioned_pages_copy_preserves_existing_versions_and_latest(self) -> None:
+        module = load_assessment_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            pages_root = root / "pages"
+            existing = pages_root / "assessments" / "v0.4.4"
+            existing.mkdir(parents=True)
+            (existing / "index.html").write_text("old", encoding="utf-8")
+            report_dir = root / "report"
+            report_dir.mkdir()
+            (report_dir / "index.html").write_text("new", encoding="utf-8")
+            (report_dir / "assessment.json").write_text("{}", encoding="utf-8")
+
+            module.copy_versioned_pages(report_dir, pages_root, "v0.4.5")
+
+            self.assertEqual((existing / "index.html").read_text(encoding="utf-8"), "old")
+            self.assertEqual(
+                (pages_root / "assessments" / "v0.4.5" / "index.html").read_text(encoding="utf-8"),
+                "new",
+            )
+            self.assertEqual(
+                (pages_root / "assessments" / "latest" / "assessment.json").read_text(encoding="utf-8"),
+                "{}",
+            )
+
+    def test_extract_run_unica_from_linux_marketplace_archive(self) -> None:
+        module = load_assessment_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_root = root / "pkg" / "unica-codex-marketplace-linux-x64"
+            scripts = package_root / "plugins" / "unica" / "scripts"
+            scripts.mkdir(parents=True)
+            run_unica = scripts / "run-unica.sh"
+            run_unica.write_text("#!/usr/bin/env sh\n", encoding="utf-8")
+            run_unica.chmod(run_unica.stat().st_mode | stat.S_IXUSR)
+            archive = root / "unica-codex-marketplace-linux-x64.tar.gz"
+            with tarfile.open(archive, "w:gz") as tf:
+                tf.add(package_root, arcname="unica-codex-marketplace-linux-x64")
+
+            extracted = module.extract_marketplace_archive(archive, root / "extract")
+
+            self.assertEqual(extracted.name, "run-unica.sh")
+            self.assertTrue(extracted.is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -105,6 +105,7 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         self.assertIn("name: unica-codex-marketplace-linux-x64", text)
         self.assertIn("python scripts/ci/release-assessment.py", text)
         self.assertIn("--package-archive dist/linux-x64/unica-codex-marketplace-linux-x64.tar.gz", text)
+        self.assertIn("--bsp-ref 3.2.1.446", text)
         self.assertIn("name: unica-release-assessment", text)
 
     def test_pages_publish_waits_for_release_assessment(self) -> None:

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -88,7 +88,7 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
     def test_release_publishing_is_separate_from_packaging(self) -> None:
         text = self.workflow_text()
 
-        package_job = text[text.index("  package:") : text.index("  publish-release-assets:")]
+        package_job = text[text.index("  package:") : text.index("  installer:")]
         self.assertNotIn("softprops/action-gh-release", package_job)
         self.assertNotIn("contents: write", package_job)
 
@@ -96,6 +96,34 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         self.assertIn("publish-installer-asset:", text)
         self.assertIn("if: startsWith(github.ref, 'refs/tags/')", text)
         self.assertIn("permissions:\n      contents: write", text)
+
+    def test_release_assessment_uses_linux_marketplace_package(self) -> None:
+        text = self.workflow_text()
+
+        self.assertIn("release-assessment:", text)
+        self.assertIn("needs: package", text)
+        self.assertIn("name: unica-codex-marketplace-linux-x64", text)
+        self.assertIn("python scripts/ci/release-assessment.py", text)
+        self.assertIn("--package-archive dist/linux-x64/unica-codex-marketplace-linux-x64.tar.gz", text)
+        self.assertIn("name: unica-release-assessment", text)
+
+    def test_pages_publish_waits_for_release_assessment(self) -> None:
+        text = self.workflow_text()
+
+        self.assertIn("publish-assessment-pages:", text)
+        self.assertIn("needs: release-assessment", text)
+        self.assertIn("uses: actions/deploy-pages@v4", text)
+        self.assertIn("pages: write", text)
+        self.assertIn("id-token: write", text)
+
+    def test_release_assets_wait_for_published_assessment_pages(self) -> None:
+        text = self.workflow_text()
+
+        publish_assets = text[text.index("  publish-release-assets:") : text.index("  publish-installer-asset:")]
+        self.assertIn("needs:\n      - package\n      - publish-assessment-pages", publish_assets)
+
+        publish_installer = text[text.index("  publish-installer-asset:") :]
+        self.assertIn("needs:\n      - installer\n      - publish-assessment-pages", publish_installer)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add deterministic BSP release assessment for tag-triggered Unica releases
- publish versioned assessment reports to Pages before release assets are published
- harden `unica.code.search`/`unica.code.grep` after local assessment exposed stale analyzer CLI assumptions

## Root Cause / Notes

The initial assessment harness would have reported failures from harness/tool contract mismatches instead of release-candidate quality: `project.map` returns source sets inside the tool stdout payload, broad `git grep` could time out before applying the requested result limit, and the pinned `bsl-analyzer` no longer supports the old `search --query` CLI shape. The PR fixes those causes so the gate remains deterministic and MCP/public-tool based.

## Validation

- `python3.12 -m unittest discover -s tests/ci`
- `python3.12 -m py_compile scripts/ci/*.py tests/ci/*.py`
- `cargo test --package unica-coder`
- `cargo clippy --package unica-coder --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- local darwin-arm64 marketplace assessment against BSP: passed, 18/18 scenarios, 0 blocking failures

## Local Report

Local preview was built under `.build/local-assessment-site/assessments/local-darwin-arm64/` from BSP commit `57d7f6f888f8cc3ace6f1f21f4adcbb590d430fd`.
