### PR TITLE
Считать Type без namespace ошибкой в form.validate

### DIFF
--- a/crates/unica-coder/src/infrastructure/native_operations/form.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/form.rs
@@ -849,10 +849,10 @@ pub(crate) fn form_validate_types(
             }
         } else if value.contains(':') {
         } else {
-            report.warn(format!(
+            report.error(format!(
                 "12. Type \"{value}\": bare type without namespace prefix"
             ));
-            type_warn_count += 1;
+            type_error_count += 1;
         }
         if report.stopped {
             return;
@@ -3455,5 +3455,84 @@ pub(crate) fn invoke_mutation(
         "form-compile" => Some(compile_form(args, context)),
         "form-edit" => Some(edit_form(args, context)),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::workspace::WorkspaceContext;
+    use serde_json::{json, Map};
+    use std::fs;
+    use std::path::Path;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_context(name: &str) -> WorkspaceContext {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("unica-form-{name}-{nanos}"));
+        fs::create_dir_all(&root).unwrap();
+        WorkspaceContext {
+            cwd: root.clone(),
+            workspace_root: root.clone(),
+            cache_root: root.join(".build").join("unica"),
+            workspace_epoch: 1,
+        }
+    }
+
+    fn write_file(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn validate_form_rejects_bare_type_values() {
+        let context = temp_context("bare-type");
+        let form_path = context
+            .cwd
+            .join("Catalogs")
+            .join("Goods")
+            .join("Forms")
+            .join("ItemForm")
+            .join("Ext")
+            .join("Form.xml");
+        write_file(
+            &form_path,
+            r#"<?xml version="1.0" encoding="utf-8"?>
+<Form xmlns="http://v8.1c.ru/8.3/MDClasses" version="2.20">
+	<AutoCommandBar name="ФормаКоманднаяПанель" id="-1">
+		<Autofill>true</Autofill>
+	</AutoCommandBar>
+	<Attributes>
+		<Attribute name="BrokenButtonType" id="1">
+			<Type>CommandBarButton</Type>
+		</Attribute>
+	</Attributes>
+</Form>
+"#,
+        );
+
+        let mut args = Map::new();
+        args.insert(
+            "FormPath".to_string(),
+            json!(form_path.display().to_string()),
+        );
+
+        let outcome = validate_form(&args, &context);
+        let stdout = outcome.stdout.as_deref().unwrap_or("");
+
+        assert!(!outcome.ok, "{stdout}");
+        assert!(
+            stdout.contains(
+                "[ERROR] 12. Type \"CommandBarButton\": bare type without namespace prefix"
+            ),
+            "{stdout}"
+        );
+
+        let _ = fs::remove_dir_all(&context.cwd);
     }
 }

--- a/plugins/unica/provenance/reviews/2026-06-15-upstream-review.json
+++ b/plugins/unica/provenance/reviews/2026-06-15-upstream-review.json
@@ -218,7 +218,7 @@
           "skill": "form-validate",
           "decision": "ported",
           "baselineCommit": "cbde49efdaeec190432fdf4a53201a87e83c69de",
-          "evidence": "Ported donor v1.8 behavior: all binding path tags are validated with existing skip rules preserved, and the type_error_count bug is fixed in both legacy adapter and parity fixture."
+          "evidence": "Ported donor v1.8 behavior: all binding path tags are validated with existing skip rules preserved, and the type_error_count bug is fixed in both legacy adapter and parity fixture. Unica intentionally adapts bare Type values from donor warning to validation error because such forms fail platform XDTO import."
         },
         {
           "skill": "help-add",
@@ -579,7 +579,7 @@
       ],
       "decision": "ported",
       "baselineCommit": "ae8241237753850307d94b10df93e5293e29dc74",
-      "notes": "Ported Form DSL/reference updates and donor-compatible form add/compile/edit/info/remove/validate scripts behind typed unica.form.* hidden legacy adapters; prompt-visible skills route only through MCP and references use Unica wording."
+      "notes": "Ported Form DSL/reference updates and donor-compatible form add/compile/edit/info/remove/validate scripts behind typed unica.form.* hidden legacy adapters; prompt-visible skills route only through MCP and references use Unica wording. form-validate intentionally escalates bare Type values from donor warning to error to match platform XDTO import behavior."
     },
     {
       "id": "cc-metadata-presentations-and-choice-history",

--- a/plugins/unica/provenance/skill-upstreams.json
+++ b/plugins/unica/provenance/skill-upstreams.json
@@ -413,7 +413,7 @@
         {
           "skill": "form-validate",
           "status": "ported-to-unica",
-          "notes": "Reviewed and ported donor form-validate v1.8 behavior through cbde49efdaeec190432fdf4a53201a87e83c69de: all binding tags are validated, skip rules are preserved, type_error_count is fixed, and parity fixture is refreshed.",
+          "notes": "Reviewed and ported donor form-validate v1.8 behavior through cbde49efdaeec190432fdf4a53201a87e83c69de: all binding tags are validated, skip rules are preserved, type_error_count is fixed, and parity fixture is refreshed. Unica intentionally adapts bare Type values from donor warning to validation error because such forms fail platform XDTO import.",
           "upstreamPaths": [
             ".claude/skills/form-validate/**",
             "docs/form-guide.md",

--- a/plugins/unica/scripts/legacy/form-validate/form-validate.py
+++ b/plugins/unica/scripts/legacy/form-validate/form-validate.py
@@ -711,7 +711,7 @@ def main():
 
     # --- Check 12: Type validation ---
     if not stopped:
-        type_nodes = root.xpath('//v8:Type', namespaces={'v8': V8_NS})
+        type_nodes = root.xpath('//*[local-name()="Type"]')
         type_error_count = 0
         type_warn_count = 0
         type_count = len(type_nodes)
@@ -742,8 +742,8 @@ def main():
             elif ":" in tv:
                 pass  # unknown namespace, pass through
             else:
-                report_warn(f'12. Type "{tv}": bare type without namespace prefix')
-                type_warn_count += 1
+                report_error(f'12. Type "{tv}": bare type without namespace prefix')
+                type_error_count += 1
 
         if type_error_count == 0 and type_warn_count == 0:
             if type_count > 0:

--- a/tests/ci/test_unica_mcp_script_parity.py
+++ b/tests/ci/test_unica_mcp_script_parity.py
@@ -911,6 +911,27 @@ SUCCESS_SCENARIOS = [
 ]
 
 
+VALIDATION_FAILURE_SCENARIOS = [
+    ParityScenario(
+        name="form-validate-bare-type-is-error",
+        tool="unica.form.validate",
+        skill="form-validate",
+        script="form-validate.py",
+        arguments={
+            "FormPath": "src/Reports/ParityReport/Forms/MainForm/Ext/Form.xml",
+            "Detailed": True,
+        },
+        expect_ok=False,
+        fixtures=(
+            FileFixture(
+                "form-validate/BareType.xml",
+                "src/Reports/ParityReport/Forms/MainForm/Ext/Form.xml",
+            ),
+        ),
+    ),
+]
+
+
 MISSING_INPUT_SCENARIOS = [
     ParityScenario(
         "cf-edit-missing-config",
@@ -1177,7 +1198,7 @@ MISSING_INPUT_SCENARIOS = [
     ),
 ]
 
-SCENARIOS = tuple(SUCCESS_SCENARIOS + MISSING_INPUT_SCENARIOS)
+SCENARIOS = tuple(SUCCESS_SCENARIOS + VALIDATION_FAILURE_SCENARIOS + MISSING_INPUT_SCENARIOS)
 
 NATIVE_PARITY_TOOLS = {
     "unica.cf.edit",

--- a/tests/fixtures/unica_mcp_script_parity/form-validate/BareType.xml
+++ b/tests/fixtures/unica_mcp_script_parity/form-validate/BareType.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Form xmlns="http://v8.1c.ru/8.3/xcf/logform" version="2.17">
+	<AutoCommandBar name="ФормаКоманднаяПанель" id="-1"/>
+	<ChildItems/>
+	<Attributes>
+		<Attribute name="BrokenButtonType" id="1">
+			<Type>CommandBarButton</Type>
+		</Attribute>
+	</Attributes>
+	<Commands/>
+</Form>

--- a/tests/fixtures/unica_mcp_script_parity/reference_skills/form-validate/scripts/form-validate.py
+++ b/tests/fixtures/unica_mcp_script_parity/reference_skills/form-validate/scripts/form-validate.py
@@ -712,7 +712,7 @@ def main():
 
     # --- Check 12: Type validation ---
     if not stopped:
-        type_nodes = root.xpath('//v8:Type', namespaces={'v8': V8_NS})
+        type_nodes = root.xpath('//*[local-name()="Type"]')
         type_error_count = 0
         type_warn_count = 0
         type_count = len(type_nodes)
@@ -743,8 +743,8 @@ def main():
             elif ":" in tv:
                 pass  # unknown namespace, pass through
             else:
-                report_warn(f'12. Type "{tv}": bare type without namespace prefix')
-                type_warn_count += 1
+                report_error(f'12. Type "{tv}": bare type without namespace prefix')
+                type_error_count += 1
 
         if type_error_count == 0 and type_warn_count == 0:
             if type_count > 0:


### PR DESCRIPTION
## Кратко

- Встроенный `unica.form.validate` теперь считает значения `<Type>` без namespace-префикса ошибками, а не предупреждениями.
- Добавлен регрессионный тест для `<Type>CommandBarButton</Type>` в `Form.xml` расширения.
- Это не дает валидатору пропускать XML формы, который затем падает на XDTO-импорте через `ibcmd config import files --extension`.

Closes #2

## Проверка

- `cargo test --package unica-coder infrastructure::native_operations::form::tests::validate_form_rejects_bare_type_values` (красный до исправления, зеленый после)
- `cargo fmt --all -- --check`
- `cargo clippy --package unica-coder --all-targets --all-features -- -D warnings`
- `cargo test --package unica-coder`
- `uv run --python 3.12 --with lxml==6.1.1 python -m unittest discover -s tests/ci`
- `uv run --python 3.12 --with lxml==6.1.1 python -m py_compile ...`
- `python3 -m json.tool plugins/unica/third-party/manifest.json`
- `python3 -m json.tool plugins/unica/third-party/tools.lock.json`
- `bash -n plugins/unica/scripts/*.sh`
- `plugins/unica/scripts/run-unica.sh --help`
- `git diff --check`
