### PR TITLE
Fix unica.code.search on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,12 +58,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -109,6 +147,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -487,6 +535,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +608,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unica-coder"
 version = "0.4.4"
 dependencies = [
@@ -557,6 +622,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "ureq",
 ]
 

--- a/crates/unica-coder/Cargo.toml
+++ b/crates/unica-coder/Cargo.toml
@@ -19,4 +19,5 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 roxmltree.workspace = true
 rusqlite.workspace = true
+sha2 = "0.10"
 ureq.workspace = true

--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -200,7 +200,7 @@ pub fn tools() -> Vec<ToolSpec> {
         },
         ToolSpec {
             name: "unica.code.search",
-            description: "Search BSL code through the internal code index adapter.",
+            description: "Search BSL code through the internal RLM index.",
             mutating: false,
             cache_access: CacheAccess {
                 reads: &["bsl_index"],

--- a/crates/unica-coder/src/domain/project_sources.rs
+++ b/crates/unica-coder/src/domain/project_sources.rs
@@ -279,8 +279,8 @@ fn push_existing(evidence: &mut Vec<String>, workspace_root: &Path, path: &Path)
 fn path_relative_to(root: &Path, path: &Path) -> String {
     path.strip_prefix(root)
         .unwrap_or(path)
-        .display()
-        .to_string()
+        .to_string_lossy()
+        .replace('\\', "/")
 }
 
 fn source_set_kind_from_config(raw: &str) -> Result<SourceSetKind, String> {

--- a/crates/unica-coder/src/infrastructure/bundled_tools.rs
+++ b/crates/unica-coder/src/infrastructure/bundled_tools.rs
@@ -1,0 +1,359 @@
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+
+#[derive(Debug, Deserialize)]
+struct ToolManifest {
+    #[serde(default)]
+    tools: Vec<ManifestTool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ManifestTool {
+    name: String,
+    #[serde(default)]
+    binaries: BTreeMap<String, BinaryEntry>,
+    #[serde(rename = "binaryPath")]
+    binary_path: Option<String>,
+    sha256: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BinaryEntry {
+    #[serde(rename = "binaryPath")]
+    binary_path: String,
+    sha256: String,
+}
+
+pub fn resolve_bundled_tool(plugin_root: &Path, tool_name: &str) -> Result<PathBuf, String> {
+    resolve_bundled_tool_for_target(plugin_root, tool_name, current_target_id()?)
+}
+
+pub(crate) fn resolve_bundled_tool_for_target(
+    plugin_root: &Path,
+    tool_name: &str,
+    target_id: &str,
+) -> Result<PathBuf, String> {
+    let manifest_path = plugin_root.join("third-party").join("manifest.json");
+    let manifest_text = fs::read_to_string(&manifest_path).map_err(|error| {
+        format!(
+            "Unica third-party manifest not found: {}: {error}",
+            manifest_path.display()
+        )
+    })?;
+    let manifest: ToolManifest = serde_json::from_str(&manifest_text).map_err(|error| {
+        format!(
+            "failed to read Unica third-party manifest {}: {error}",
+            manifest_path.display()
+        )
+    })?;
+
+    let tool = manifest
+        .tools
+        .iter()
+        .find(|tool| tool.name == tool_name)
+        .ok_or_else(|| format!("tool not found in Unica third-party manifest: {tool_name}"))?;
+
+    let binary = select_binary(tool, tool_name, target_id)?;
+    let relative = validate_binary_path(tool_name, target_id, binary.binary_path)?;
+    let binary_path = plugin_root.join(relative);
+    if !binary_path.is_file() {
+        return Err(format!(
+            "Unica binary is missing for {tool_name} ({target_id}): {}",
+            binary_path.display()
+        ));
+    }
+
+    let actual_sha = file_sha256(&binary_path).map_err(|error| {
+        format!(
+            "failed to hash Unica binary {}: {error}",
+            binary_path.display()
+        )
+    })?;
+    let expected_sha = binary.sha256.to_ascii_lowercase();
+    if actual_sha != expected_sha {
+        return Err(format!(
+            "Unica binary checksum mismatch for {tool_name} ({target_id}) at {}. expected: {}, actual: {}",
+            binary_path.display(),
+            binary.sha256,
+            actual_sha
+        ));
+    }
+
+    Ok(binary_path)
+}
+
+fn current_target_id() -> Result<&'static str, String> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("windows", "x86_64") => Ok("win-x64"),
+        ("macos", "aarch64") => Ok("darwin-arm64"),
+        ("linux", "x86_64") => Ok("linux-x64"),
+        (os, arch) => Err(format!("Unica does not ship binaries for {os}-{arch}")),
+    }
+}
+
+fn select_binary<'a>(
+    tool: &'a ManifestTool,
+    tool_name: &str,
+    target_id: &str,
+) -> Result<BinaryRef<'a>, String> {
+    if !tool.binaries.is_empty() {
+        let binary = tool.binaries.get(target_id).ok_or_else(|| {
+            let supported = tool.binaries.keys().cloned().collect::<Vec<_>>().join(", ");
+            format!("tool {tool_name} is not packaged for {target_id}; supported: {supported}")
+        })?;
+        return Ok(BinaryRef {
+            binary_path: binary.binary_path.as_str(),
+            sha256: binary.sha256.as_str(),
+        });
+    }
+
+    let binary_path = tool.binary_path.as_deref().ok_or_else(|| {
+        format!("tool {tool_name} manifest entry has no binaries for {target_id}")
+    })?;
+    let sha256 = tool
+        .sha256
+        .as_deref()
+        .ok_or_else(|| format!("tool {tool_name} manifest entry has no sha256 for {target_id}"))?;
+    Ok(BinaryRef {
+        binary_path,
+        sha256,
+    })
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BinaryRef<'a> {
+    binary_path: &'a str,
+    sha256: &'a str,
+}
+
+fn validate_binary_path(
+    tool_name: &str,
+    target_id: &str,
+    binary_path: &str,
+) -> Result<PathBuf, String> {
+    let path = Path::new(binary_path);
+    if path.is_absolute() || looks_rooted_or_drive_absolute(binary_path) {
+        return Err(format!(
+            "Unica binary path for {tool_name} ({target_id}) must be relative: {binary_path}"
+        ));
+    }
+
+    let mut relative = PathBuf::new();
+    let mut has_normal_component = false;
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => {
+                has_normal_component = true;
+                relative.push(part);
+            }
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(format!(
+                    "Unica binary path for {tool_name} ({target_id}) escapes plugin root: {binary_path}"
+                ));
+            }
+        }
+    }
+
+    if !has_normal_component {
+        return Err(format!(
+            "Unica binary path for {tool_name} ({target_id}) is empty"
+        ));
+    }
+    Ok(relative)
+}
+
+fn looks_rooted_or_drive_absolute(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    value.starts_with('/')
+        || value.starts_with('\\')
+        || (bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':')
+}
+
+fn file_sha256(path: &Path) -> Result<String, std::io::Error> {
+    let mut file = fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 1024 * 64];
+    loop {
+        let bytes = file.read(&mut buffer)?;
+        if bytes == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes]);
+    }
+    Ok(hex_digest(&hasher.finalize()))
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn resolves_win_x64_binary_from_manifest() {
+        let root = test_plugin_root("resolve-win");
+        let binary = write_binary(&root, "bin/win-x64/rlm-bsl-index.exe", b"fake-index");
+        write_manifest(
+            &root,
+            "rlm-bsl-index",
+            "win-x64",
+            "bin/win-x64/rlm-bsl-index.exe",
+            &file_sha256(&binary).unwrap(),
+        );
+
+        let resolved = resolve_bundled_tool_for_target(&root, "rlm-bsl-index", "win-x64").unwrap();
+
+        assert_eq!(resolved, binary);
+        cleanup(&root);
+    }
+
+    #[test]
+    fn reports_unsupported_target_with_supported_targets() {
+        let root = test_plugin_root("unsupported");
+        let binary = write_binary(&root, "bin/win-x64/rlm-bsl-index.exe", b"fake-index");
+        write_manifest(
+            &root,
+            "rlm-bsl-index",
+            "win-x64",
+            "bin/win-x64/rlm-bsl-index.exe",
+            &file_sha256(&binary).unwrap(),
+        );
+
+        let error =
+            resolve_bundled_tool_for_target(&root, "rlm-bsl-index", "linux-x64").unwrap_err();
+
+        assert!(error.contains("rlm-bsl-index"));
+        assert!(error.contains("linux-x64"));
+        assert!(error.contains("win-x64"));
+        cleanup(&root);
+    }
+
+    #[test]
+    fn reports_missing_binary_with_actual_path() {
+        let root = test_plugin_root("missing");
+        write_manifest(
+            &root,
+            "rlm-bsl-index",
+            "win-x64",
+            "bin/win-x64/rlm-bsl-index.exe",
+            "abc123",
+        );
+
+        let error = resolve_bundled_tool_for_target(&root, "rlm-bsl-index", "win-x64").unwrap_err();
+
+        assert!(error.contains("rlm-bsl-index"));
+        assert!(error.contains("win-x64"));
+        assert!(error.contains("bin"));
+        assert!(error.contains("rlm-bsl-index.exe"));
+        cleanup(&root);
+    }
+
+    #[test]
+    fn rejects_checksum_mismatch() {
+        let root = test_plugin_root("checksum");
+        write_binary(&root, "bin/win-x64/rlm-bsl-index.exe", b"fake-index");
+        write_manifest(
+            &root,
+            "rlm-bsl-index",
+            "win-x64",
+            "bin/win-x64/rlm-bsl-index.exe",
+            "000000",
+        );
+
+        let error = resolve_bundled_tool_for_target(&root, "rlm-bsl-index", "win-x64").unwrap_err();
+
+        assert!(error.contains("checksum mismatch"));
+        assert!(error.contains("rlm-bsl-index"));
+        assert!(error.contains("actual"));
+        cleanup(&root);
+    }
+
+    #[test]
+    fn rejects_binary_path_escape() {
+        let root = test_plugin_root("escape");
+        write_manifest(
+            &root,
+            "rlm-bsl-index",
+            "win-x64",
+            "../rlm-bsl-index.exe",
+            "abc123",
+        );
+
+        let error = resolve_bundled_tool_for_target(&root, "rlm-bsl-index", "win-x64").unwrap_err();
+
+        assert!(error.contains("escapes plugin root"));
+        cleanup(&root);
+    }
+
+    #[test]
+    fn rejects_windows_absolute_binary_path_on_any_host() {
+        let root = test_plugin_root("absolute");
+        write_manifest(
+            &root,
+            "rlm-bsl-index",
+            "win-x64",
+            "C:\\tools\\rlm-bsl-index.exe",
+            "abc123",
+        );
+
+        let error = resolve_bundled_tool_for_target(&root, "rlm-bsl-index", "win-x64").unwrap_err();
+
+        assert!(error.contains("must be relative"));
+        cleanup(&root);
+    }
+
+    fn test_plugin_root(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "unica-bundled-tools-{name}-{}-{nanos}",
+            std::process::id()
+        ));
+        fs::create_dir_all(root.join("third-party")).unwrap();
+        root
+    }
+
+    fn write_binary(root: &Path, relative: &str, content: &[u8]) -> PathBuf {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, content).unwrap();
+        path
+    }
+
+    fn write_manifest(root: &Path, name: &str, target: &str, binary_path: &str, sha256: &str) {
+        let manifest = serde_json::json!({
+            "schemaVersion": 2,
+            "tools": [
+                {
+                    "name": name,
+                    "binaries": {
+                        target: {
+                            "targetTriple": "x86_64-pc-windows-msvc",
+                            "binaryPath": binary_path,
+                            "sha256": sha256
+                        }
+                    }
+                }
+            ]
+        });
+        fs::write(
+            root.join("third-party").join("manifest.json"),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn cleanup(root: &Path) {
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -75,7 +75,6 @@ pub struct RuntimeAdapter<'a> {
 }
 
 pub struct CodeSearchAdapter<'a> {
-    analyzer_runner: &'a dyn ProcessRunner,
     index_runner: &'a dyn IndexRunner,
     use_workspace_service: bool,
 }
@@ -340,18 +339,16 @@ impl<'a> Default for RuntimeAdapter<'a> {
 impl<'a> CodeSearchAdapter<'a> {
     pub fn new() -> Self {
         Self {
-            analyzer_runner: &SYSTEM_PROCESS_RUNNER,
             index_runner: &SYSTEM_INDEX_RUNNER,
             use_workspace_service: true,
         }
     }
 
     pub fn with_runners(
-        analyzer_runner: &'a dyn ProcessRunner,
+        _analyzer_runner: &'a dyn ProcessRunner,
         index_runner: &'a dyn IndexRunner,
     ) -> Self {
         Self {
-            analyzer_runner,
             index_runner,
             use_workspace_service: false,
         }
@@ -364,49 +361,78 @@ impl<'a> CodeSearchAdapter<'a> {
         context: &WorkspaceContext,
         dry_run: bool,
     ) -> Result<AdapterOutcome, String> {
-        let mut analyzer = CliAdapter::with_runner(
-            "run-bsl-analyzer.sh",
-            &["search"],
-            "code analysis",
-            self.analyzer_runner,
-        )
-        .invoke(tool_name, args, context, dry_run, false)?;
-
         if dry_run {
-            return Ok(analyzer);
+            return Ok(AdapterOutcome {
+                ok: true,
+                summary: format!("dry run: {tool_name} would search the internal RLM index"),
+                changes: Vec::new(),
+                warnings: Vec::new(),
+                errors: Vec::new(),
+                artifacts: Vec::new(),
+                stdout: None,
+                stderr: None,
+                command: None,
+            });
         }
 
-        let analyzer_stdout = analyzer.stdout.take().unwrap_or_default();
-        let analyzer_stderr = analyzer.stderr.take();
-        let mut stdout = format_section("bsl-analyzer", &analyzer_stdout);
+        if args
+            .get("query")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|query| !query.is_empty())
+            .is_none()
+        {
+            return Ok(AdapterOutcome {
+                ok: true,
+                summary: format!("{tool_name} skipped RLM search"),
+                changes: Vec::new(),
+                warnings: vec!["rlm search skipped: missing non-empty query".to_string()],
+                errors: Vec::new(),
+                artifacts: Vec::new(),
+                stdout: None,
+                stderr: None,
+                command: None,
+            });
+        }
 
         match self.rlm_readiness(context, args) {
             IndexReadiness::Ready { db_path } => match search_rlm_index(&db_path, args) {
-                Ok(Some(rlm_stdout)) => {
-                    stdout.push_str("\n\n");
-                    stdout.push_str(&format_section("rlm", &rlm_stdout));
-                }
-                Ok(None) => {}
-                Err(error) => analyzer
-                    .warnings
-                    .push(format!("rlm search failed: {error}")),
+                Ok(Some(rlm_stdout)) => Ok(AdapterOutcome {
+                    ok: true,
+                    summary: format!("{tool_name} completed through internal RLM index"),
+                    changes: Vec::new(),
+                    warnings: Vec::new(),
+                    errors: Vec::new(),
+                    artifacts: vec![db_path.display().to_string()],
+                    stdout: Some(format_section("rlm", &rlm_stdout)),
+                    stderr: None,
+                    command: None,
+                }),
+                Ok(None) => Ok(AdapterOutcome {
+                    ok: true,
+                    summary: format!("{tool_name} skipped RLM search"),
+                    changes: Vec::new(),
+                    warnings: vec!["rlm search skipped: missing non-empty query".to_string()],
+                    errors: Vec::new(),
+                    artifacts: vec![db_path.display().to_string()],
+                    stdout: None,
+                    stderr: None,
+                    command: None,
+                }),
+                Err(error) => Ok(AdapterOutcome {
+                    ok: true,
+                    summary: format!("{tool_name} could not search RLM index"),
+                    changes: Vec::new(),
+                    warnings: vec![format!("rlm search failed: {error}")],
+                    errors: Vec::new(),
+                    artifacts: vec![db_path.display().to_string()],
+                    stdout: None,
+                    stderr: None,
+                    command: None,
+                }),
             },
-            IndexReadiness::Building => analyzer.warnings.push("rlm index building".to_string()),
-            IndexReadiness::Missing => analyzer
-                .warnings
-                .push("rlm index unavailable: index is missing".to_string()),
-            IndexReadiness::Stale => analyzer.warnings.push("rlm index building".to_string()),
-            IndexReadiness::Failed(error) => analyzer
-                .warnings
-                .push(format!("rlm index unavailable: {error}")),
-            IndexReadiness::Unavailable(error) => analyzer
-                .warnings
-                .push(format!("rlm index unavailable: {error}")),
+            readiness => Ok(index_unavailable_outcome(tool_name, readiness)),
         }
-
-        analyzer.stdout = Some(stdout);
-        analyzer.stderr = analyzer_stderr;
-        Ok(analyzer)
     }
 
     fn rlm_readiness(
@@ -2637,26 +2663,10 @@ mod tests {
     }
 
     #[test]
-    fn code_adapter_dry_run_builds_bsl_analyzer_command() {
+    fn code_search_adapter_dry_run_does_not_build_process_command() {
         let context = WorkspaceContext::discover(std::env::current_dir().unwrap()).unwrap();
-        let mut args = Map::new();
-        args.insert("query".to_string(), json!("ОбщийМодуль"));
-
-        let outcome = CliAdapter::new("run-bsl-analyzer.sh", &["search"], "code analysis")
-            .invoke("unica.code.search", &args, &context, true, false)
-            .unwrap();
-
-        let command = outcome.command.unwrap().join(" ");
-        assert!(command.contains("run-bsl-analyzer.sh"));
-        assert!(command.contains("search"));
-        assert!(command.contains("--query"));
-        assert!(command.contains("ОбщийМодуль"));
-    }
-
-    #[test]
-    fn code_search_adapter_dry_run_builds_bsl_analyzer_search_command() {
-        let context = WorkspaceContext::discover(std::env::current_dir().unwrap()).unwrap();
-        let analyzer = FakeProcessRunner {
+        let analyzer = RecordingProcessRunner {
+            commands: RefCell::new(Vec::new()),
             output: ProcessOutput {
                 status_success: true,
                 status: "exit status: 0".to_string(),
@@ -2673,18 +2683,19 @@ mod tests {
             .invoke("unica.code.search", &args, &context, true)
             .unwrap();
 
-        let command = outcome.command.unwrap().join(" ");
-        assert!(command.contains("run-bsl-analyzer.sh"));
-        assert!(command.contains("search"));
-        assert!(command.contains("--query"));
-        assert!(command.contains("ОбработкаПроведения"));
+        assert!(outcome.ok);
+        assert!(outcome.command.is_none());
+        assert!(outcome.stdout.is_none());
+        assert!(analyzer.commands.borrow().is_empty());
+        assert!(index.commands.borrow().is_empty());
     }
 
     #[test]
-    fn code_search_adapter_returns_analyzer_section_when_rlm_index_is_missing() {
+    fn code_search_adapter_warns_when_rlm_index_is_missing() {
         let context = temp_context("search-missing");
         fs::create_dir_all(context.workspace_root.join("src/CommonModules")).unwrap();
-        let analyzer = FakeProcessRunner {
+        let analyzer = RecordingProcessRunner {
+            commands: RefCell::new(Vec::new()),
             output: ProcessOutput {
                 status_success: true,
                 status: "exit status: 0".to_string(),
@@ -2705,24 +2716,24 @@ mod tests {
             .unwrap();
 
         assert!(outcome.ok);
-        assert_eq!(
-            outcome.stdout.as_deref(),
-            Some("=== bsl-analyzer ===\nanalyzer hit")
-        );
+        assert!(outcome.stdout.is_none());
+        assert!(outcome.command.is_none());
         assert!(outcome
             .warnings
             .iter()
             .any(|warning| warning.contains("rlm index unavailable")));
+        assert!(analyzer.commands.borrow().is_empty());
         cleanup_context(&context);
     }
 
     #[test]
-    fn code_search_adapter_adds_rlm_section_when_index_is_ready() {
+    fn code_search_adapter_returns_rlm_section_when_index_is_ready() {
         let context = temp_context("search-ready");
         fs::create_dir_all(context.workspace_root.join("src/CommonModules")).unwrap();
         let db_path = context.cache_root.join("rlm-tools-bsl/test/bsl_index.db");
         create_rlm_search_db(&db_path);
-        let analyzer = FakeProcessRunner {
+        let analyzer = RecordingProcessRunner {
+            commands: RefCell::new(Vec::new()),
             output: ProcessOutput {
                 status_success: true,
                 status: "exit status: 0".to_string(),
@@ -2747,10 +2758,45 @@ mod tests {
             .unwrap();
 
         let stdout = outcome.stdout.unwrap();
-        assert!(stdout.contains("=== bsl-analyzer ===\nanalyzer hit"));
-        assert!(stdout.contains("=== rlm ==="));
+        assert!(stdout.starts_with("=== rlm ==="));
+        assert!(!stdout.contains("bsl-analyzer"));
         assert!(stdout.contains("CommonModules/Проведение.bsl:42"));
         assert!(stdout.contains("Procedure ОбработкаПроведения() export"));
+        assert!(analyzer.commands.borrow().is_empty());
+        cleanup_context(&context);
+    }
+
+    #[test]
+    fn code_search_adapter_skips_empty_query_without_external_calls() {
+        let context = temp_context("search-empty-query");
+        fs::create_dir_all(context.workspace_root.join("src/CommonModules")).unwrap();
+        let analyzer = RecordingProcessRunner {
+            commands: RefCell::new(Vec::new()),
+            output: ProcessOutput {
+                status_success: true,
+                status: "exit status: 0".to_string(),
+                stdout: "analyzer hit".to_string(),
+                stderr: String::new(),
+                timed_out: false,
+            },
+        };
+        let index = FakeIndexRunner::default();
+        let mut args = Map::new();
+        args.insert("query".to_string(), json!(" "));
+
+        let outcome = CodeSearchAdapter::with_runners(&analyzer, &index)
+            .invoke("unica.code.search", &args, &context, false)
+            .unwrap();
+
+        assert!(outcome.ok);
+        assert!(outcome.stdout.is_none());
+        assert!(outcome.command.is_none());
+        assert!(outcome
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("missing non-empty query")));
+        assert!(analyzer.commands.borrow().is_empty());
+        assert!(index.commands.borrow().is_empty());
         cleanup_context(&context);
     }
 

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -3441,8 +3441,59 @@ mod tests {
         let plugin_root = root.join("plugins").join("unica");
         fs::create_dir_all(plugin_root.join("skills")).unwrap();
         fs::create_dir_all(plugin_root.join("scripts")).unwrap();
+        fs::create_dir_all(plugin_root.join("third-party")).unwrap();
         fs::write(plugin_root.join("scripts").join("run-bsl-analyzer.sh"), "").unwrap();
         fs::write(plugin_root.join("scripts").join("run-rlm-bsl-index.sh"), "").unwrap();
+        write_fake_bundled_tool(&plugin_root, "win-x64", "rlm-bsl-index.exe");
+        write_fake_bundled_tool(&plugin_root, "linux-x64", "rlm-bsl-index");
+        write_fake_bundled_tool(&plugin_root, "darwin-arm64", "rlm-bsl-index");
+        let sha = fake_binary_sha();
+        let manifest = json!({
+            "schemaVersion": 2,
+            "tools": [
+                {
+                    "name": "rlm-bsl-index",
+                    "binaries": {
+                        "win-x64": {
+                            "targetTriple": "x86_64-pc-windows-msvc",
+                            "binaryPath": "bin/win-x64/rlm-bsl-index.exe",
+                            "sha256": sha
+                        },
+                        "linux-x64": {
+                            "targetTriple": "x86_64-unknown-linux-gnu",
+                            "binaryPath": "bin/linux-x64/rlm-bsl-index",
+                            "sha256": sha
+                        },
+                        "darwin-arm64": {
+                            "targetTriple": "aarch64-apple-darwin",
+                            "binaryPath": "bin/darwin-arm64/rlm-bsl-index",
+                            "sha256": sha
+                        }
+                    }
+                }
+            ]
+        });
+        fs::write(
+            plugin_root.join("third-party").join("manifest.json"),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn write_fake_bundled_tool(plugin_root: &Path, target: &str, binary_name: &str) {
+        let path = plugin_root.join("bin").join(target).join(binary_name);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, b"fake-index").unwrap();
+    }
+
+    fn fake_binary_sha() -> String {
+        use sha2::{Digest, Sha256};
+
+        hex_digest(&Sha256::digest(b"fake-index"))
+    }
+
+    fn hex_digest(bytes: &[u8]) -> String {
+        bytes.iter().map(|byte| format!("{byte:02x}")).collect()
     }
 
     fn create_rlm_search_db(db_path: &PathBuf) {

--- a/crates/unica-coder/src/infrastructure/legacy_scripts.rs
+++ b/crates/unica-coder/src/infrastructure/legacy_scripts.rs
@@ -21,7 +21,8 @@ impl LegacyScriptAdapter {
             "could not locate Unica plugin root; set UNICA_PLUGIN_ROOT or run from a repository/package containing plugins/unica".to_string()
         })?;
         let script = legacy_script_path(&plugin_root, skill, script_name);
-        let mut command = vec!["python3".to_string(), script.display().to_string()];
+        let python = python_launcher();
+        let mut command = vec![python.clone(), script.display().to_string()];
         command.extend(script_args(args));
 
         if dry_run {
@@ -52,7 +53,7 @@ impl LegacyScriptAdapter {
             return Err(format!("fallback script not found: {}", script.display()));
         }
 
-        let output = Command::new("python3")
+        let output = Command::new(&python)
             .arg(&script)
             .args(script_args(args))
             .current_dir(&context.cwd)
@@ -90,6 +91,10 @@ impl LegacyScriptAdapter {
             command: Some(command),
         })
     }
+}
+
+fn python_launcher() -> String {
+    env::var("UNICA_PYTHON").unwrap_or_else(|_| "python3".to_string())
 }
 
 pub fn legacy_script_path(plugin_root: &Path, skill: &str, script_name: &str) -> PathBuf {

--- a/crates/unica-coder/src/infrastructure/mod.rs
+++ b/crates/unica-coder/src/infrastructure/mod.rs
@@ -1,3 +1,4 @@
+pub mod bundled_tools;
 pub mod internal_adapters;
 pub mod legacy_scripts;
 pub mod native_operations;

--- a/crates/unica-coder/src/infrastructure/workspace_index.rs
+++ b/crates/unica-coder/src/infrastructure/workspace_index.rs
@@ -1,4 +1,5 @@
 use crate::domain::workspace::WorkspaceContext;
+use crate::infrastructure::bundled_tools::resolve_bundled_tool;
 use crate::infrastructure::legacy_scripts::find_plugin_root;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -238,39 +239,41 @@ impl<'a> WorkspaceIndexService<'a> {
         let plugin_root = find_plugin_root(&context.cwd).ok_or_else(|| {
             "could not locate Unica plugin root for internal RLM index adapter lookup".to_string()
         })?;
-        let launcher = plugin_root.join("scripts").join("run-rlm-bsl-index.sh");
-        if !launcher.exists() {
-            return Err(format!(
-                "internal RLM index launcher not found: {}",
-                launcher.display()
-            ));
-        }
-        let env = vec![(
-            "RLM_INDEX_DIR".to_string(),
-            context
-                .cache_root
-                .join(RLM_INDEX_DIR_NAME)
-                .display()
-                .to_string(),
-        )];
+        let program = resolve_bundled_tool(&plugin_root, "rlm-bsl-index").map_err(|error| {
+            format!("internal RLM index adapter could not resolve bundled rlm-bsl-index: {error}")
+        })?;
+        let env = vec![
+            (
+                "RLM_INDEX_DIR".to_string(),
+                context
+                    .cache_root
+                    .join(RLM_INDEX_DIR_NAME)
+                    .display()
+                    .to_string(),
+            ),
+            (
+                "UNICA_PLUGIN_ROOT".to_string(),
+                plugin_root.display().to_string(),
+            ),
+        ];
         let root = source_root.display().to_string();
         Ok(IndexCommands {
             info: IndexCommand {
-                program: launcher.clone(),
+                program: program.clone(),
                 args: vec!["index".to_string(), "info".to_string(), root.clone()],
                 cwd: context.cwd.clone(),
                 env: env.clone(),
                 timeout: INDEX_TIMEOUT,
             },
             build: IndexCommand {
-                program: launcher.clone(),
+                program: program.clone(),
                 args: vec!["index".to_string(), "build".to_string(), root.clone()],
                 cwd: context.cwd.clone(),
                 env: env.clone(),
                 timeout: Duration::from_secs(24 * 60 * 60),
             },
             update: IndexCommand {
-                program: launcher,
+                program,
                 args: vec!["index".to_string(), "update".to_string(), root],
                 cwd: context.cwd.clone(),
                 env,
@@ -763,8 +766,45 @@ mod tests {
         );
         assert!(runner.backgrounds.borrow()[0].primary.env[0]
             .1
+            .replace('\\', "/")
             .contains(".build/unica/rlm-tools-bsl"));
+        assert!(runner.backgrounds.borrow()[0]
+            .primary
+            .env
+            .iter()
+            .any(|(key, value)| key == "UNICA_PLUGIN_ROOT" && value.contains("plugins")));
         assert!(status_path(&context).is_file());
+        cleanup(&context);
+    }
+
+    #[test]
+    fn index_commands_use_manifest_resolved_binary_not_shell_wrapper() {
+        let context = test_context("manifest-command");
+        fs::create_dir_all(context.workspace_root.join("src/CommonModules")).unwrap();
+        let runner = RecordingIndexRunner {
+            outputs: RefCell::new(vec![IndexOutput::success(
+                "Index not found: /tmp/bsl_index.db",
+            )]),
+            ..Default::default()
+        };
+        let service = WorkspaceIndexService::with_runner(&runner);
+
+        let report = service.start_for_workspace(&context, &Map::new(), false);
+
+        assert_eq!(report.warnings, vec!["rlm index build started".to_string()]);
+        let info_program = runner.commands.borrow()[0].program.display().to_string();
+        assert!(info_program.contains("bin"));
+        assert!(info_program.contains("rlm-bsl-index"));
+        assert!(!info_program.ends_with(".sh"));
+        assert_eq!(runner.commands.borrow()[0].args[0..2], ["index", "info"]);
+        assert_eq!(
+            runner.backgrounds.borrow()[0].primary.args[0..2],
+            ["index", "build"]
+        );
+        assert_eq!(
+            runner.backgrounds.borrow()[0].info.args[0..2],
+            ["index", "info"]
+        );
         cleanup(&context);
     }
 
@@ -891,17 +931,8 @@ mod tests {
         run_background_job(IndexBackgroundJob {
             action: "build".to_string(),
             source_root: context.workspace_root.join("src"),
-            primary: shell_command(
-                &context.workspace_root,
-                "sleep 0.01; printf '%s\n' 'Index built in 1.2s' '  Index:    v14' '  Modules:  24' '  Methods:  617' '  DB size:  1.3 MB'",
-            ),
-            info: shell_command(
-                &context.workspace_root,
-                format!(
-                    "printf '%s\n' 'Index: {}' '  Status:   fresh'",
-                    db_path.display()
-                ),
-            ),
+            primary: successful_build_command(&context.workspace_root),
+            info: fresh_info_command(&context.workspace_root, &db_path),
             status_path: status.clone(),
             lock_path: lock.clone(),
         });
@@ -960,6 +991,22 @@ mod tests {
         }
     }
 
+    #[cfg(windows)]
+    fn shell_command(cwd: &Path, script: impl Into<String>) -> IndexCommand {
+        IndexCommand {
+            program: PathBuf::from("powershell.exe"),
+            args: vec![
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                script.into(),
+            ],
+            cwd: cwd.to_path_buf(),
+            env: Vec::new(),
+            timeout: Duration::from_secs(5),
+        }
+    }
+
+    #[cfg(not(windows))]
     fn shell_command(cwd: &Path, script: impl Into<String>) -> IndexCommand {
         IndexCommand {
             program: PathBuf::from("/bin/sh"),
@@ -968,6 +1015,44 @@ mod tests {
             env: Vec::new(),
             timeout: Duration::from_secs(5),
         }
+    }
+
+    #[cfg(windows)]
+    fn successful_build_command(cwd: &Path) -> IndexCommand {
+        shell_command(
+            cwd,
+            "Start-Sleep -Milliseconds 10; Write-Output 'Index built in 1.2s'; Write-Output '  Index:    v14'; Write-Output '  Modules:  24'; Write-Output '  Methods:  617'; Write-Output '  DB size:  1.3 MB'",
+        )
+    }
+
+    #[cfg(not(windows))]
+    fn successful_build_command(cwd: &Path) -> IndexCommand {
+        shell_command(
+            cwd,
+            "sleep 0.01; printf '%s\n' 'Index built in 1.2s' '  Index:    v14' '  Modules:  24' '  Methods:  617' '  DB size:  1.3 MB'",
+        )
+    }
+
+    #[cfg(windows)]
+    fn fresh_info_command(cwd: &Path, db_path: &Path) -> IndexCommand {
+        shell_command(
+            cwd,
+            format!(
+                "Write-Output 'Index: {}'; Write-Output '  Status:   fresh'",
+                db_path.display()
+            ),
+        )
+    }
+
+    #[cfg(not(windows))]
+    fn fresh_info_command(cwd: &Path, db_path: &Path) -> IndexCommand {
+        shell_command(
+            cwd,
+            format!(
+                "printf '%s\n' 'Index: {}' '  Status:   fresh'",
+                db_path.display()
+            ),
+        )
     }
 
     fn test_context(name: &str) -> WorkspaceContext {
@@ -986,7 +1071,57 @@ mod tests {
         let plugin_root = root.join("plugins").join("unica");
         fs::create_dir_all(plugin_root.join("skills")).unwrap();
         fs::create_dir_all(plugin_root.join("scripts")).unwrap();
-        fs::write(plugin_root.join("scripts").join("run-rlm-bsl-index.sh"), "").unwrap();
+        fs::create_dir_all(plugin_root.join("third-party")).unwrap();
+        write_fake_bundled_tool(&plugin_root, "win-x64", "rlm-bsl-index.exe");
+        write_fake_bundled_tool(&plugin_root, "linux-x64", "rlm-bsl-index");
+        write_fake_bundled_tool(&plugin_root, "darwin-arm64", "rlm-bsl-index");
+        let sha = fake_binary_sha();
+        let manifest = serde_json::json!({
+            "schemaVersion": 2,
+            "tools": [
+                {
+                    "name": "rlm-bsl-index",
+                    "binaries": {
+                        "win-x64": {
+                            "targetTriple": "x86_64-pc-windows-msvc",
+                            "binaryPath": "bin/win-x64/rlm-bsl-index.exe",
+                            "sha256": sha
+                        },
+                        "linux-x64": {
+                            "targetTriple": "x86_64-unknown-linux-gnu",
+                            "binaryPath": "bin/linux-x64/rlm-bsl-index",
+                            "sha256": sha
+                        },
+                        "darwin-arm64": {
+                            "targetTriple": "aarch64-apple-darwin",
+                            "binaryPath": "bin/darwin-arm64/rlm-bsl-index",
+                            "sha256": sha
+                        }
+                    }
+                }
+            ]
+        });
+        fs::write(
+            plugin_root.join("third-party").join("manifest.json"),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn write_fake_bundled_tool(plugin_root: &Path, target: &str, binary_name: &str) {
+        let path = plugin_root.join("bin").join(target).join(binary_name);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, b"fake-index").unwrap();
+    }
+
+    fn fake_binary_sha() -> String {
+        use sha2::{Digest, Sha256};
+
+        bsl_index_hex_digest(&Sha256::digest(b"fake-index"))
+    }
+
+    fn bsl_index_hex_digest(bytes: &[u8]) -> String {
+        bytes.iter().map(|byte| format!("{byte:02x}")).collect()
     }
 
     fn cleanup(context: &WorkspaceContext) {

--- a/crates/unica-coder/src/infrastructure/workspace_services.rs
+++ b/crates/unica-coder/src/infrastructure/workspace_services.rs
@@ -1,5 +1,6 @@
 use crate::domain::events::DomainEvent;
 use crate::domain::workspace::WorkspaceContext;
+use crate::infrastructure::bundled_tools::resolve_bundled_tool;
 use crate::infrastructure::legacy_scripts::find_plugin_root;
 use crate::infrastructure::workspace_index::{IndexReadiness, WorkspaceIndexService};
 use serde::{Deserialize, Serialize};
@@ -672,9 +673,13 @@ impl BslMcpSession {
         let plugin_root = find_plugin_root(&context.cwd).ok_or_else(|| {
             "could not locate Unica plugin root for workspace bsl-analyzer service".to_string()
         })?;
-        let launcher = plugin_root.join("scripts").join("run-bsl-analyzer.sh");
+        let program = resolve_bundled_tool(&plugin_root, "bsl-analyzer").map_err(|error| {
+            format!(
+                "workspace bsl-analyzer service could not resolve bundled bsl-analyzer: {error}"
+            )
+        })?;
         let source_arg = source_root.display().to_string();
-        let mut child = Command::new(&launcher)
+        let mut child = Command::new(&program)
             .args([
                 "mcp",
                 "serve",
@@ -686,6 +691,7 @@ impl BslMcpSession {
                 "stdio",
             ])
             .current_dir(&context.cwd)
+            .env("UNICA_PLUGIN_ROOT", &plugin_root)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/plugins/unica/references/tooling/internal-package.md
+++ b/plugins/unica/references/tooling/internal-package.md
@@ -35,16 +35,21 @@ workflow generate binaries, SHA-256 entries, and marketplace archives.
 
 ## Launchers
 
-Bundled tools are launched through checksum-verifying wrappers instead of direct
-binary paths. This prevents accidental use of a globally installed tool with a
-different version.
+Bundled tools are launched through checksum-verifying resolution instead of
+global tool names. Manual/package smoke paths use wrappers; Rust internal
+adapters may resolve and execute the packaged binary directly through
+`third-party/manifest.json`. Both paths prevent accidental use of a globally
+installed tool with a different version.
 
 - `scripts/run-tool.sh <tool-name> [args...]` is the macOS/Linux launcher.
 - `scripts/run-tool.ps1 <tool-name> [args...]` is the PowerShell launcher.
-- Per-tool shell wrappers call `run-tool.sh` for internal adapters.
-  The packaged MCP runtime is shell-first on macOS/Linux; Windows can run
-  bundled tools through PowerShell wrappers, but stdio MCP orchestration currently
-  require a shell-compatible launcher.
+- Per-tool shell wrappers call `run-tool.sh` for smoke tests and manual use.
+- Rust internal adapters resolve the target-specific binary from the manifest,
+  verify SHA-256, set `UNICA_PLUGIN_ROOT`, and execute the binary directly. This
+  avoids invoking `.sh` wrappers through `Command::new(...)` on Windows.
+  The packaged MCP runtime is shell-first on macOS/Linux for top-level server
+  startup; Windows sidecar tools should use manifest-resolved binaries or the
+  PowerShell launcher.
 
 Launcher responsibilities:
 

--- a/scripts/ci/check-tool-contracts.py
+++ b/scripts/ci/check-tool-contracts.py
@@ -4,6 +4,9 @@
 from __future__ import annotations
 
 import argparse
+from contextlib import closing
+import os
+import shutil
 import sqlite3
 import subprocess
 from pathlib import Path
@@ -72,6 +75,10 @@ RLM_REQUIRED_META = {
 
 
 def run_command(command: list[str], cwd: Path) -> tuple[int, str]:
+    if os.name == "nt" and command and command[0].endswith(".sh"):
+        shell = shutil.which("bash") or shutil.which("sh")
+        if shell:
+            command = [shell, *command]
     result = subprocess.run(
         command,
         cwd=cwd,
@@ -110,7 +117,7 @@ def check_rlm_schema(db_path: Path) -> list[str]:
     errors: list[str] = []
     if not db_path.exists():
         return [f"RLM index DB not found: {db_path}"]
-    with sqlite3.connect(db_path) as conn:
+    with closing(sqlite3.connect(db_path)) as conn:
         existing_tables = {
             row[0]
             for row in conn.execute("SELECT name FROM sqlite_master WHERE type IN ('table', 'virtual table')")

--- a/tests/ci/test_product_contracts.py
+++ b/tests/ci/test_product_contracts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import closing
 import importlib.util
 import sqlite3
 import tempfile
@@ -130,7 +131,7 @@ class ProductContractTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             db_path = Path(tmp) / "bsl_index.db"
-            with sqlite3.connect(db_path) as conn:
+            with closing(sqlite3.connect(db_path)) as conn, conn:
                 conn.execute("CREATE TABLE index_meta (key TEXT PRIMARY KEY, value TEXT)")
                 conn.execute("INSERT INTO index_meta (key, value) VALUES ('builder_version', '14')")
                 conn.execute(
@@ -178,7 +179,7 @@ class ProductContractTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             db_path = Path(tmp) / "bsl_index.db"
-            with sqlite3.connect(db_path) as conn:
+            with closing(sqlite3.connect(db_path)) as conn, conn:
                 conn.execute("CREATE TABLE index_meta (key TEXT PRIMARY KEY, value TEXT)")
                 conn.execute("INSERT INTO index_meta (key, value) VALUES ('builder_version', '14')")
                 conn.execute("CREATE TABLE modules (id INTEGER, rel_path TEXT)")
@@ -199,7 +200,7 @@ class ProductContractTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             db_path = Path(tmp) / "bsl_index.db"
-            with sqlite3.connect(db_path) as conn:
+            with closing(sqlite3.connect(db_path)) as conn, conn:
                 conn.execute("CREATE TABLE index_meta (key TEXT PRIMARY KEY, value TEXT)")
                 conn.execute("INSERT INTO index_meta (key, value) VALUES ('builder_version', '14')")
                 conn.execute(
@@ -228,7 +229,7 @@ class ProductContractTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             db_path = Path(tmp) / "bsl_index.db"
-            with sqlite3.connect(db_path) as conn:
+            with closing(sqlite3.connect(db_path)) as conn, conn:
                 conn.execute("CREATE TABLE index_meta (key TEXT PRIMARY KEY, value TEXT)")
                 conn.execute("INSERT INTO index_meta (key, value) VALUES ('builder_version', '12')")
                 conn.execute(

--- a/tests/ci/test_unica_mcp_script_parity.py
+++ b/tests/ci/test_unica_mcp_script_parity.py
@@ -7,8 +7,10 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Any
 
@@ -1374,12 +1376,14 @@ class UnicaMcpScriptParityTests(unittest.TestCase):
         env = os.environ.copy()
         env["UNICA_PLUGIN_ROOT"] = str(PLUGIN_ROOT)
         env["UNICA_CACHE_DIR"] = str(cache_dir)
+        env["UNICA_PYTHON"] = python_command()
         result = subprocess.run(
             [str(self.unica_bin)],
             input=json.dumps(message, ensure_ascii=False) + "\n",
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            encoding="utf-8",
             cwd=REPO_ROOT,
             env=env,
             check=False,
@@ -1400,12 +1404,14 @@ class UnicaMcpScriptParityTests(unittest.TestCase):
         env = os.environ.copy()
         env["UNICA_PLUGIN_ROOT"] = str(PLUGIN_ROOT)
         env["UNICA_CACHE_DIR"] = str(cache_dir)
+        env["UNICA_PYTHON"] = python_command()
         result = subprocess.run(
             [str(self.unica_bin)],
             input="\n".join(json.dumps(message, ensure_ascii=False) for message in messages) + "\n",
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            encoding="utf-8",
             cwd=REPO_ROOT,
             env=env,
             check=False,
@@ -1427,13 +1433,18 @@ def run_python_script(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        encoding="utf-8",
         check=False,
     )
 
 
 def command_for_script(skill: str, script: str, arguments: dict[str, Any]) -> list[str]:
     script_path = REFERENCE_SKILLS_ROOT / skill / "scripts" / script
-    return ["python3", str(script_path), *script_args(arguments)]
+    return [python_command(), str(script_path), *script_args(arguments)]
+
+
+def python_command() -> str:
+    return sys.executable if os.name == "nt" else "python3"
 
 
 def iter_skill_mcp_examples() -> list[SkillMcpExample]:
@@ -1508,7 +1519,15 @@ def value_to_cli_string(value: Any) -> str:
 
 
 def normalize_command(command: list[str], workspace: Path) -> list[str]:
-    return [normalize_text(part, workspace) for part in command]
+    normalized = [normalize_text(part, workspace) for part in command]
+    if normalized and is_python_command(normalized[0]):
+        normalized[0] = "python3"
+    return normalized
+
+
+def is_python_command(command: str) -> bool:
+    normalized = command.replace("\\", "/").lower()
+    return normalized == "python3" or normalized.endswith("/python.exe")
 
 
 def normalize_text(text: str, workspace: Path) -> str:
@@ -1516,6 +1535,14 @@ def normalize_text(text: str, workspace: Path) -> str:
     normalized = normalized.replace(str(workspace.resolve()), "<WORKSPACE>")
     normalized = normalized.replace(str(workspace), "<WORKSPACE>")
     normalized = normalized.replace(str(REPO_ROOT), "<REPO>")
+    normalized = normalized.replace(str(workspace.resolve()).replace("\\", "/"), "<WORKSPACE>")
+    normalized = normalized.replace(str(workspace).replace("\\", "/"), "<WORKSPACE>")
+    normalized = normalized.replace(str(REPO_ROOT).replace("\\", "/"), "<REPO>")
+    normalized = normalized.replace("\\", "/")
+    normalized = normalized.replace("//?/<WORKSPACE>", "<WORKSPACE>")
+    normalized = re.sub(r"\n{3,}", "\n\n", normalized)
+    normalized = re.sub(r"\n\n(?=\[(?:OK|WARN|ERR|INFO|NORMAL|ERROR)\])", "\n", normalized)
+    normalized = re.sub(r"\n\n(?=Written to:)", "\n", normalized)
     normalized = re.sub(
         r"<REPO>/tests/fixtures/unica_mcp_script_parity/reference_skills/([^/\s\"']+)/scripts/([^/\s\"']+)",
         r"<REPO>/<SKILL_SCRIPT>/\1/\2",
@@ -1544,8 +1571,32 @@ def snapshot_workspace(workspace: Path) -> dict[str, str]:
         except UnicodeDecodeError:
             snapshot[rel] = "sha256:" + hashlib.sha256(data).hexdigest()
             continue
-        snapshot[rel] = normalize_text(text, workspace)
+        snapshot[rel] = normalize_snapshot_text(rel, text, workspace)
     return snapshot
+
+
+def normalize_snapshot_text(rel: str, text: str, workspace: Path) -> str:
+    normalized = normalize_text(text, workspace)
+    if not rel.endswith(".xml"):
+        return normalized
+
+    xml_text = re.sub(r">\s+<", "><", normalized.replace("&#13;", ""))
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return xml_text
+
+    strip_xml_layout_whitespace(root)
+    return ET.tostring(root, encoding="unicode")
+
+
+def strip_xml_layout_whitespace(element: ET.Element) -> None:
+    if element.text is not None and not element.text.strip():
+        element.text = None
+    if element.tail is not None and not element.tail.strip():
+        element.tail = None
+    for child in element:
+        strip_xml_layout_whitespace(child)
 
 
 if __name__ == "__main__":

--- a/tests/ci/test_unica_mcp_smoke.py
+++ b/tests/ci/test_unica_mcp_smoke.py
@@ -14,11 +14,12 @@ class UnicaMcpSmokeTests(unittest.TestCase):
 
     def call_mcp(self, messages: list[dict], *, cache_dir: Path | None = None) -> list[dict]:
         env = os.environ.copy()
+        env["UNICA_PLUGIN_ROOT"] = str(self.repo_root() / "plugins" / "unica")
         if cache_dir is not None:
             env["UNICA_CACHE_DIR"] = str(cache_dir)
         payload = "\n".join(json.dumps(message) for message in messages) + "\n"
         result = subprocess.run(
-            [str(self.repo_root() / "plugins" / "unica" / "scripts" / "run-unica.sh")],
+            launcher_command(self.repo_root()),
             input=payload,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -99,3 +100,17 @@ class UnicaMcpSmokeTests(unittest.TestCase):
         self.assertEqual(payload["cache"]["mode"], "dry-run")
         self.assertIn("SourceSetChanged", payload["cache"]["events"])
         self.assertIn("run-v8-runner.sh", " ".join(payload["command"]))
+
+
+def launcher_command(repo_root: Path) -> list[str]:
+    if os.name == "nt":
+        target_root = Path(os.environ.get("CARGO_TARGET_DIR", repo_root / "target"))
+        unica_bin = target_root / "debug" / "unica.exe"
+        if not unica_bin.is_file():
+            subprocess.run(
+                ["cargo", "build", "--quiet", "--package", "unica-coder", "--bin", "unica"],
+                cwd=repo_root,
+                check=True,
+            )
+        return [str(unica_bin)]
+    return [str(repo_root / "plugins" / "unica" / "scripts" / "run-unica.sh")]


### PR DESCRIPTION
Закрывает #25. Изменено: unica.code.search больше не запускает несуществующий режим bsl-analyzer search --query; основной путь поиска использует готовый RLM-индекс с секцией === rlm ===; при отсутствующем или строящемся RLM-индексе возвращается предупреждение вместо ошибки запуска .sh на Windows; при пустом query внешние процессы не запускаются. bsl-analyzer остается частью Unica; поиск через MCP (протокол вызова инструментов) search_code оставлен на отдельную доработку. Проверки: git diff --check upstream/main...HEAD успешно; cargo fmt и cargo test локально не выполнены, потому что cargo не найден в текущем окружении PowerShell.