### PR TITLE
Fix native writer UUID generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
 name = "cc"
 version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +166,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +208,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -324,6 +365,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +433,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +472,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,7 +485,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys",
@@ -481,6 +545,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -568,6 +638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +711,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "ureq",
+ "uuid",
 ]
 
 [[package]]
@@ -692,6 +769,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,6 +796,51 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ sha2 = "0.10"
 roxmltree = "0.20"
 rusqlite = { version = "0.32", features = ["bundled"] }
 ureq = { version = "2.12", features = ["json"] }
+uuid = { version = "1", features = ["v4"] }

--- a/crates/unica-coder/Cargo.toml
+++ b/crates/unica-coder/Cargo.toml
@@ -22,3 +22,4 @@ sha2.workspace = true
 roxmltree.workspace = true
 rusqlite.workspace = true
 ureq.workspace = true
+uuid.workspace = true

--- a/crates/unica-coder/src/infrastructure/native_operations/meta.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta.rs
@@ -8,31 +8,32 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::common::*;
 use super::{
     cf::*, cfe::*, form::*, interface::*, mxl::*, role::*, skd::*, subsystem::*, template::*,
 };
 
-static META_COMPILE_UUID_SEQUENCE: AtomicU64 = AtomicU64::new(1);
-
 pub(crate) fn fresh_meta_compile_uuid() -> String {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
-    let sequence = META_COMPILE_UUID_SEQUENCE.fetch_add(1, Ordering::Relaxed) as u128;
-    let hex = format!("{:032x}", nanos.wrapping_add(sequence));
-    format!(
-        "{}-{}-{}-{}-{}",
-        &hex[0..8],
-        &hex[8..12],
-        &hex[12..16],
-        &hex[16..20],
-        &hex[20..32]
-    )
+    uuid::Uuid::new_v4().to_string()
+}
+
+#[cfg(test)]
+mod uuid_tests {
+    use super::*;
+
+    #[test]
+    fn fresh_meta_compile_uuid_generates_uuid_v4() {
+        let value = fresh_meta_compile_uuid();
+
+        assert!(is_guid(&value), "{value}");
+        assert!(!value.starts_with("00000000-0000-0000-"), "{value}");
+        assert_eq!(value.as_bytes()[14], b'4', "{value}");
+        assert!(
+            matches!(value.as_bytes()[19], b'8' | b'9' | b'a' | b'b'),
+            "{value}"
+        );
+    }
 }
 
 #[derive(Clone)]

--- a/crates/unica-coder/src/infrastructure/native_operations/template.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/template.rs
@@ -348,24 +348,6 @@ pub(crate) fn fresh_uuid() -> String {
     uuid::Uuid::new_v4().to_string()
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn fresh_uuid_generates_uuid_v4() {
-        let value = fresh_uuid();
-
-        assert!(is_valid_uuid(&value), "{value}");
-        assert!(!value.starts_with("00000000-0000-0000-"), "{value}");
-        assert_eq!(value.as_bytes()[14], b'4', "{value}");
-        assert!(
-            matches!(value.as_bytes()[19], b'8' | b'9' | b'a' | b'b'),
-            "{value}"
-        );
-    }
-}
-
 pub(crate) fn template_metadata_xml(
     template_name: &str,
     synonym: &str,
@@ -611,5 +593,23 @@ pub(crate) fn invoke_mutation(
         "template-add" => Some(add_template(args, context)),
         "template-remove" => Some(remove_template(args, context)),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_uuid_generates_uuid_v4() {
+        let value = fresh_uuid();
+
+        assert!(is_valid_uuid(&value), "{value}");
+        assert!(!value.starts_with("00000000-0000-0000-"), "{value}");
+        assert_eq!(value.as_bytes()[14], b'4', "{value}");
+        assert!(
+            matches!(value.as_bytes()[19], b'8' | b'9' | b'a' | b'b'),
+            "{value}"
+        );
     }
 }

--- a/crates/unica-coder/src/infrastructure/native_operations/template.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/template.rs
@@ -8,7 +8,6 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::common::*;
 use super::{cf::*, cfe::*, form::*, interface::*, meta::*, mxl::*, role::*, skd::*, subsystem::*};
@@ -346,19 +345,25 @@ pub(crate) fn full_md_namespace_declarations() -> &'static str {
 }
 
 pub(crate) fn fresh_uuid() -> String {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
-    let hex = format!("{nanos:032x}");
-    format!(
-        "{}-{}-{}-{}-{}",
-        &hex[0..8],
-        &hex[8..12],
-        &hex[12..16],
-        &hex[16..20],
-        &hex[20..32]
-    )
+    uuid::Uuid::new_v4().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_uuid_generates_uuid_v4() {
+        let value = fresh_uuid();
+
+        assert!(is_valid_uuid(&value), "{value}");
+        assert!(!value.starts_with("00000000-0000-0000-"), "{value}");
+        assert_eq!(value.as_bytes()[14], b'4', "{value}");
+        assert!(
+            matches!(value.as_bytes()[19], b'8' | b'9' | b'a' | b'b'),
+            "{value}"
+        );
+    }
 }
 
 pub(crate) fn template_metadata_xml(

--- a/crates/unica-coder/src/infrastructure/native_operations/template.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/template.rs
@@ -603,13 +603,9 @@ mod tests {
     #[test]
     fn fresh_uuid_generates_uuid_v4() {
         let value = fresh_uuid();
+        let uuid = uuid::Uuid::parse_str(&value).expect(&value);
 
-        assert!(is_valid_uuid(&value), "{value}");
-        assert!(!value.starts_with("00000000-0000-0000-"), "{value}");
-        assert_eq!(value.as_bytes()[14], b'4', "{value}");
-        assert!(
-            matches!(value.as_bytes()[19], b'8' | b'9' | b'a' | b'b'),
-            "{value}"
-        );
+        assert!(!uuid.is_nil(), "{value}");
+        assert_eq!(uuid.get_version(), Some(uuid::Version::Random), "{value}");
     }
 }


### PR DESCRIPTION
Replaces native writer UUID generation with uuid::Uuid::new_v4().

Adds unit coverage for meta compile and shared template/subsystem UUID helpers.

Fixes #32