### PR TITLE
Добавить MCP-инструмент support-edit

### DIFF
--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -2088,6 +2088,58 @@ mod tests {
     }
 
     #[test]
+    fn meta_compile_preserves_configuration_child_objects_formatting() {
+        let root = temp_meta_compile_workspace("unica-meta-compile-child-format");
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        let config_path = src.join("Configuration.xml");
+        std::fs::write(
+            &config_path,
+            concat!(
+                "\u{feff}<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n",
+                "<MetaDataObject xmlns=\"http://v8.1c.ru/8.3/MDClasses\" version=\"2.17\">\r\n",
+                "\t<Configuration uuid=\"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\">\r\n",
+                "\t\t<Properties>\r\n",
+                "\t\t\t<Name>Demo</Name>\r\n",
+                "\t\t</Properties>\r\n",
+                "\t\t<ChildObjects>\r\n",
+                "\t\t\t<Catalog>Items</Catalog>\r\n",
+                "\t\t</ChildObjects>\r\n",
+                "\t</Configuration>\r\n",
+                "</MetaDataObject>"
+            ),
+        )
+        .unwrap();
+        let json_path = workspace.join("report.json");
+        std::fs::write(
+            &json_path,
+            r#"{
+  "type": "Report",
+  "name": "MetaCompileFormatReport",
+  "synonym": "MetaCompileFormatReport"
+}"#,
+        )
+        .unwrap();
+
+        let result = call_meta_compile(&workspace, &json_path);
+
+        assert!(result.ok, "{:?}", result.errors);
+        let config_text =
+            String::from_utf8_lossy(&std::fs::read(&config_path).unwrap()).to_string();
+        assert!(config_text.contains(concat!(
+            "\r\n\t\t\t<Catalog>Items</Catalog>\r\n",
+            "\t\t\t<Report>MetaCompileFormatReport</Report>\r\n",
+            "\t\t</ChildObjects>"
+        )));
+        assert!(!config_text.contains("\t\t\t\t\t<Report>MetaCompileFormatReport</Report>"));
+        assert!(
+            !config_text.contains("<Report>MetaCompileFormatReport</Report>\n\t\t</ChildObjects>")
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn template_add_preserves_single_object_bom() {
         let root = temp_meta_compile_workspace("unica-template-add-single-bom");
         let workspace = root.join("workspace");

--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -2128,13 +2128,12 @@ mod tests {
             String::from_utf8_lossy(&std::fs::read(&config_path).unwrap()).to_string();
         assert!(config_text.contains(concat!(
             "\r\n\t\t\t<Catalog>Items</Catalog>\r\n",
-            "\t\t\t<Report>MetaCompileFormatReport</Report>\r\n",
+            "\t\t\t<Report>MetaCompileFormatReport</Report>\n",
             "\t\t</ChildObjects>"
         )));
         assert!(!config_text.contains("\t\t\t\t\t<Report>MetaCompileFormatReport</Report>"));
-        assert!(
-            !config_text.contains("<Report>MetaCompileFormatReport</Report>\n\t\t</ChildObjects>")
-        );
+        assert!(!config_text
+            .contains("<Report>MetaCompileFormatReport</Report>\r\n\t\t</ChildObjects>"));
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -2052,6 +2052,102 @@ mod tests {
     }
 
     #[test]
+    fn meta_compile_preserves_single_configuration_bom() {
+        let root = temp_meta_compile_workspace("unica-meta-compile-single-bom");
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        let config_path = src.join("Configuration.xml");
+        std::fs::write(
+            &config_path,
+            format!(
+                "\u{feff}{}",
+                support_test_configuration_xml("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+            ),
+        )
+        .unwrap();
+        let json_path = workspace.join("report.json");
+        std::fs::write(
+            &json_path,
+            r#"{
+  "type": "Report",
+  "name": "MetaCompileBomReport",
+  "synonym": "MetaCompileBomReport"
+}"#,
+        )
+        .unwrap();
+
+        let result = call_meta_compile(&workspace, &json_path);
+
+        assert!(result.ok, "{:?}", result.errors);
+        let config_bytes = std::fs::read(&config_path).unwrap();
+        assert_eq!(leading_utf8_bom_count(&config_bytes), 1);
+        assert!(String::from_utf8_lossy(&config_bytes)
+            .contains("<Report>MetaCompileBomReport</Report>"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn template_add_preserves_single_object_bom() {
+        let root = temp_meta_compile_workspace("unica-template-add-single-bom");
+        let workspace = root.join("workspace");
+        let json_path = workspace.join("report.json");
+        std::fs::write(
+            &json_path,
+            r#"{
+  "type": "Report",
+  "name": "TemplateBomReport",
+  "synonym": "TemplateBomReport"
+}"#,
+        )
+        .unwrap();
+        let result = call_meta_compile(&workspace, &json_path);
+        assert!(result.ok, "{:?}", result.errors);
+
+        let report_path = workspace
+            .join("src")
+            .join("Reports")
+            .join("TemplateBomReport.xml");
+        let report_bytes = std::fs::read(&report_path).unwrap();
+        assert_eq!(leading_utf8_bom_count(&report_bytes), 1);
+
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert(
+            "ObjectName".to_string(),
+            Value::String("TemplateBomReport".to_string()),
+        );
+        args.insert(
+            "TemplateName".to_string(),
+            Value::String("ОсновнаяСхемаКомпоновкиДанных".to_string()),
+        );
+        args.insert(
+            "TemplateType".to_string(),
+            Value::String("DataCompositionSchema".to_string()),
+        );
+        args.insert(
+            "SrcDir".to_string(),
+            Value::String("src/Reports".to_string()),
+        );
+
+        let template_result = UnicaApplication::new()
+            .call_tool("unica.template.add", &args)
+            .unwrap();
+
+        assert!(template_result.ok, "{:?}", template_result.errors);
+        let report_bytes = std::fs::read(&report_path).unwrap();
+        assert_eq!(leading_utf8_bom_count(&report_bytes), 1);
+        assert!(String::from_utf8_lossy(&report_bytes)
+            .contains("<Template>ОсновнаяСхемаКомпоновкиДанных</Template>"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn meta_validate_supports_pipe_separated_batch_paths() {
         let root = std::env::temp_dir().join(format!("unica-meta-batch-{}", std::process::id()));
         let workspace = root.join("workspace");
@@ -2981,6 +3077,13 @@ mod tests {
         UnicaApplication::new()
             .call_tool("unica.meta.validate", &args)
             .unwrap()
+    }
+
+    fn leading_utf8_bom_count(bytes: &[u8]) -> usize {
+        bytes
+            .chunks_exact(3)
+            .take_while(|chunk| *chunk == [0xEF, 0xBB, 0xBF])
+            .count()
     }
 
     fn assert_valid_root_uuid(xml: &str, tag_name: &str) {

--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -839,6 +839,16 @@ fn configuration_tools() -> Vec<ToolSpec> {
             },
         },
         ToolSpec {
+            name: "unica.support.edit",
+            description: "Toggle 1C vendor support editing capability or per-object support rule.",
+            mutating: true,
+            cache_access: cache_access_for("support-edit", Some(DomainEventKind::ConfigXmlChanged)),
+            handler: ToolHandler::NativeOperation {
+                operation: "support-edit",
+                event: Some(DomainEventKind::ConfigXmlChanged),
+            },
+        },
+        ToolSpec {
             name: "unica.cfe.borrow",
             description: "Borrow configuration objects/forms into an extension.",
             mutating: true,
@@ -1297,6 +1307,7 @@ mod tests {
         assert!(names.contains(&"unica.skd.edit"));
         assert!(names.contains(&"unica.mxl.compile"));
         assert!(names.contains(&"unica.role.validate"));
+        assert!(names.contains(&"unica.support.edit"));
         assert!(names.contains(&"unica.build.load"));
         assert!(names.contains(&"unica.runtime.execute"));
         assert!(names.contains(&"unica.code.definition"));
@@ -1405,6 +1416,7 @@ mod tests {
             "unica.role.compile",
             "unica.role.info",
             "unica.role.validate",
+            "unica.support.edit",
         ];
 
         for tool in tools() {
@@ -1419,6 +1431,7 @@ mod tests {
                 && !tool.name.starts_with("unica.skd.")
                 && !tool.name.starts_with("unica.mxl.")
                 && !tool.name.starts_with("unica.role.")
+                && !tool.name.starts_with("unica.support.")
             {
                 continue;
             }
@@ -1763,6 +1776,277 @@ mod tests {
         assert!(stdout.contains("Поддержка: на замке"));
         assert!(stdout.contains("cfe-*"));
         assert!(!stdout.contains("powershell.exe"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn support_edit_tool_is_mutating_native_operation() {
+        let tool = tools()
+            .into_iter()
+            .find(|tool| tool.name == "unica.support.edit")
+            .expect("support-edit tool exists");
+
+        assert!(tool.mutating);
+        assert_eq!(tool.cache_access.writes, &["metadata_graph"]);
+        match tool.handler {
+            ToolHandler::NativeOperation { operation, event } => {
+                assert_eq!(operation, "support-edit");
+                assert_eq!(event, Some(DomainEventKind::ConfigXmlChanged));
+            }
+            other => {
+                panic!("unica.support.edit should route through native operation, got {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn support_edit_dry_run_does_not_change_parent_configurations() {
+        let (root, workspace, bin_path) = support_test_workspace(
+            "unica-support-edit-dry-run",
+            support_test_parent_configurations_bin(
+                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            ),
+        );
+        let before = std::fs::read_to_string(&bin_path).unwrap();
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("Path".to_string(), Value::String("src".to_string()));
+        args.insert("Capability".to_string(), Value::String("off".to_string()));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.support.edit", &args)
+            .unwrap();
+
+        assert!(result.ok);
+        assert!(result.summary.contains("dry run"));
+        assert_eq!(std::fs::read_to_string(&bin_path).unwrap(), before);
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn support_edit_capability_on_enables_global_editing() {
+        let bin = support_test_parent_configurations_bin(
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "cccccccc-cccc-cccc-cccc-cccccccccccc",
+        )
+        .replace("{6,0,", "{6,1,");
+        let (root, workspace, _bin_path) =
+            support_test_workspace("unica-support-edit-capability-on", bin);
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert("Path".to_string(), Value::String("src".to_string()));
+        args.insert("Capability".to_string(), Value::String("on".to_string()));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.support.edit", &args)
+            .unwrap();
+
+        assert!(result.ok, "{:?}", result.errors);
+        assert!(result.summary.contains("Возможность изменения"));
+        let mut info_args = Map::new();
+        info_args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        info_args.insert("ConfigPath".to_string(), Value::String("src".to_string()));
+        let info = UnicaApplication::new()
+            .call_tool("unica.cf.info", &info_args)
+            .unwrap();
+        assert!(info
+            .stdout
+            .unwrap()
+            .contains("Возможность изменения: включена"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn support_edit_set_editable_updates_object_rule_and_meta_info() {
+        let (root, workspace, _bin_path) = support_test_workspace(
+            "unica-support-edit-set-editable",
+            support_test_parent_configurations_bin(
+                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            ),
+        );
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert(
+            "Path".to_string(),
+            Value::String("src/Catalogs/Items.xml".to_string()),
+        );
+        args.insert("Set".to_string(), Value::String("editable".to_string()));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.support.edit", &args)
+            .unwrap();
+
+        assert!(result.ok, "{:?}", result.errors);
+        assert!(result.summary.contains("редактируется"));
+        let mut info_args = Map::new();
+        info_args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        info_args.insert(
+            "ObjectPath".to_string(),
+            Value::String("src/Catalogs/Items.xml".to_string()),
+        );
+        let info = UnicaApplication::new()
+            .call_tool("unica.meta.info", &info_args)
+            .unwrap();
+        assert!(info
+            .stdout
+            .unwrap()
+            .contains("редактируется с сохранением поддержки"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn support_edit_set_requires_global_capability_on() {
+        let bin = support_test_parent_configurations_bin(
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "cccccccc-cccc-cccc-cccc-cccccccccccc",
+        )
+        .replace("{6,0,", "{6,1,");
+        let (root, workspace, bin_path) =
+            support_test_workspace("unica-support-edit-set-capability-off", bin);
+        let before = std::fs::read_to_string(&bin_path).unwrap();
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert(
+            "Path".to_string(),
+            Value::String("src/Catalogs/Items.xml".to_string()),
+        );
+        args.insert("Set".to_string(), Value::String("editable".to_string()));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.support.edit", &args)
+            .unwrap();
+
+        assert!(!result.ok);
+        assert!(result.errors.join("\n").contains("Capability=on"));
+        assert_eq!(std::fs::read_to_string(&bin_path).unwrap(), before);
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn support_edit_missing_parent_configurations_is_safe_noop() {
+        let root =
+            std::env::temp_dir().join(format!("unica-support-edit-no-bin-{}", std::process::id()));
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(
+            workspace.join("v8project.yaml"),
+            "format: DESIGNER\nsource-set:\n  - name: main\n    type: CONFIGURATION\n    path: src\n",
+        )
+        .unwrap();
+        std::fs::write(
+            src.join("Configuration.xml"),
+            support_test_configuration_xml("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        )
+        .unwrap();
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert("Path".to_string(), Value::String("src".to_string()));
+        args.insert("Capability".to_string(), Value::String("on".to_string()));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.support.edit", &args)
+            .unwrap();
+
+        assert!(result.ok);
+        assert!(result.changes.is_empty());
+        assert!(result.summary.contains("не на поддержке"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn support_edit_set_editable_allows_follow_up_meta_edit() {
+        let (root, workspace, _bin_path) = support_test_workspace(
+            "unica-support-edit-unblocks-guard",
+            support_test_parent_configurations_bin(
+                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            ),
+        );
+        let mut support_args = Map::new();
+        support_args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        support_args.insert("dryRun".to_string(), Value::Bool(false));
+        support_args.insert(
+            "Path".to_string(),
+            Value::String("src/Catalogs/Items.xml".to_string()),
+        );
+        support_args.insert("Set".to_string(), Value::String("editable".to_string()));
+        let support_result = UnicaApplication::new()
+            .call_tool("unica.support.edit", &support_args)
+            .unwrap();
+        assert!(support_result.ok, "{:?}", support_result.errors);
+
+        let object_path = workspace.join("src").join("Catalogs").join("Items.xml");
+        let before = std::fs::read_to_string(&object_path).unwrap();
+        let mut edit_args = Map::new();
+        edit_args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        edit_args.insert("dryRun".to_string(), Value::Bool(false));
+        edit_args.insert(
+            "ObjectPath".to_string(),
+            Value::String("src/Catalogs/Items.xml".to_string()),
+        );
+        edit_args.insert(
+            "Operation".to_string(),
+            Value::String("modify-property".to_string()),
+        );
+        edit_args.insert(
+            "Value".to_string(),
+            Value::String("Name=Changed".to_string()),
+        );
+
+        let edit_result = UnicaApplication::new()
+            .call_tool("unica.meta.edit", &edit_args)
+            .unwrap();
+
+        assert!(edit_result.ok, "{:?}", edit_result.errors);
+        assert_ne!(std::fs::read_to_string(&object_path).unwrap(), before);
+        assert!(std::fs::read_to_string(&object_path)
+            .unwrap()
+            .contains("<Name>Changed</Name>"));
 
         let _ = std::fs::remove_dir_all(root);
     }
@@ -2967,6 +3251,37 @@ mod tests {
     </Properties>
   </Form>
 </MetaDataObject>"#
+    }
+
+    fn support_test_workspace(
+        prefix: &str,
+        parent_configurations_bin: String,
+    ) -> (PathBuf, PathBuf, PathBuf) {
+        let root = std::env::temp_dir().join(format!("{prefix}-{}", std::process::id()));
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        let ext = src.join("Ext");
+        let catalogs = src.join("Catalogs");
+        std::fs::create_dir_all(&ext).unwrap();
+        std::fs::create_dir_all(&catalogs).unwrap();
+        std::fs::write(
+            workspace.join("v8project.yaml"),
+            "format: DESIGNER\nsource-set:\n  - name: main\n    type: CONFIGURATION\n    path: src\n",
+        )
+        .unwrap();
+        std::fs::write(
+            src.join("Configuration.xml"),
+            support_test_configuration_xml("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        )
+        .unwrap();
+        std::fs::write(
+            catalogs.join("Items.xml"),
+            support_test_catalog_xml("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+        )
+        .unwrap();
+        let bin_path = ext.join("ParentConfigurations.bin");
+        std::fs::write(&bin_path, parent_configurations_bin).unwrap();
+        (root, workspace, bin_path)
     }
 
     fn support_test_parent_configurations_bin(

--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -1000,9 +1000,8 @@ fn configuration_tools() -> Vec<ToolSpec> {
             description: "Edit managed Form.xml elements, attributes, and commands.",
             mutating: true,
             cache_access: cache_access_for("form-edit", Some(DomainEventKind::FormChanged)),
-            handler: ToolHandler::LegacyScript {
-                skill: "form-edit",
-                script: "form-edit.py",
+            handler: ToolHandler::NativeOperation {
+                operation: "form-edit",
                 event: Some(DomainEventKind::FormChanged),
             },
         },
@@ -1032,9 +1031,8 @@ fn configuration_tools() -> Vec<ToolSpec> {
             description: "Validate managed Form.xml.",
             mutating: false,
             cache_access: cache_access_for("form-validate", None),
-            handler: ToolHandler::LegacyScript {
-                skill: "form-validate",
-                script: "form-validate.py",
+            handler: ToolHandler::NativeOperation {
+                operation: "form-validate",
                 event: None,
             },
         },
@@ -1326,11 +1324,7 @@ mod tests {
             .unwrap();
         assert!(result.ok);
         assert!(result.summary.contains("dry run"));
-        let command = result
-            .command
-            .as_ref()
-            .expect("legacy dry run previews command");
-        assert!(command.join(" ").contains("form-edit.py"));
+        assert!(result.command.is_none());
         assert_eq!(result.cache.mode, "dry-run");
         assert!(result.cache.events.contains(&"FormChanged".to_string()));
         assert!(result
@@ -1518,9 +1512,7 @@ mod tests {
         let expected = [
             ("unica.form.add", "form-add", "form-add.py"),
             ("unica.form.compile", "form-compile", "form-compile.py"),
-            ("unica.form.edit", "form-edit", "form-edit.py"),
             ("unica.form.remove", "form-remove", "remove-form.py"),
-            ("unica.form.validate", "form-validate", "form-validate.py"),
         ];
         for (tool_name, expected_skill, expected_script) in expected {
             let tool = tools()
@@ -1560,12 +1552,18 @@ mod tests {
     }
 
     #[test]
-    fn read_only_form_and_skd_info_tools_route_through_native_handlers() {
+    fn form_and_skd_tools_route_through_native_handlers() {
         let expected = [
-            ("unica.form.info", "form-info"),
-            ("unica.skd.info", "skd-info"),
+            (
+                "unica.form.edit",
+                "form-edit",
+                Some(DomainEventKind::FormChanged),
+            ),
+            ("unica.form.info", "form-info", None),
+            ("unica.form.validate", "form-validate", None),
+            ("unica.skd.info", "skd-info", None),
         ];
-        for (tool_name, expected_operation) in expected {
+        for (tool_name, expected_operation, expected_event) in expected {
             let tool = tools()
                 .into_iter()
                 .find(|tool| tool.name == tool_name)
@@ -1574,7 +1572,7 @@ mod tests {
             match tool.handler {
                 ToolHandler::NativeOperation { operation, event } => {
                     assert_eq!(operation, expected_operation);
-                    assert_eq!(event, None);
+                    assert_eq!(event, expected_event);
                 }
                 other => panic!("{tool_name} should route through native operation, got {other:?}"),
             }
@@ -1868,6 +1866,89 @@ mod tests {
             .stdout
             .unwrap()
             .contains("Возможность изменения: включена"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn support_edit_capability_on_preserves_vendor_parent_marker() {
+        let vendor_uuid = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+        let supplier_uuid = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+        let bin = support_test_parent_configurations_bin(
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "cccccccc-cccc-cccc-cccc-cccccccccccc",
+        )
+        .replace("{6,0,", "{6,1,")
+        .replace(
+            &format!("{vendor_uuid},0,{supplier_uuid}"),
+            &format!("{vendor_uuid},1,{supplier_uuid}"),
+        );
+        let (root, workspace, bin_path) =
+            support_test_workspace("unica-support-edit-parent-marker", bin);
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert("Path".to_string(), Value::String("src".to_string()));
+        args.insert("Capability".to_string(), Value::String("on".to_string()));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.support.edit", &args)
+            .unwrap();
+
+        assert!(result.ok, "{:?}", result.errors);
+        let updated = std::fs::read_to_string(&bin_path).unwrap();
+        assert!(
+            updated.contains(&format!("{vendor_uuid},1,{supplier_uuid}")),
+            "Capability=on must preserve the vendor parent marker; got {updated}"
+        );
+        assert!(
+            !updated.contains(&format!("{vendor_uuid},0,{supplier_uuid}")),
+            "Capability=on must not switch the vendor parent marker to external-cf mode"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn support_edit_capability_on_repairs_existing_external_parent_marker() {
+        let vendor_uuid = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+        let supplier_uuid = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+        let (root, workspace, bin_path) = support_test_workspace(
+            "unica-support-edit-parent-marker-repair",
+            support_test_parent_configurations_bin(
+                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            ),
+        );
+        let before = std::fs::read_to_string(&bin_path).unwrap();
+        assert!(before.contains(&format!("{vendor_uuid},0,{supplier_uuid}")));
+
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert("Path".to_string(), Value::String("src".to_string()));
+        args.insert("Capability".to_string(), Value::String("on".to_string()));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.support.edit", &args)
+            .unwrap();
+
+        assert!(result.ok, "{:?}", result.errors);
+        assert!(
+            !result.changes.is_empty(),
+            "Capability=on must repair incompatible parent markers, not return noop"
+        );
+        let updated = std::fs::read_to_string(&bin_path).unwrap();
+        assert!(updated.contains(&format!("{vendor_uuid},1,{supplier_uuid}")));
+        assert!(!updated.contains(&format!("{vendor_uuid},0,{supplier_uuid}")));
 
         let _ = std::fs::remove_dir_all(root);
     }
@@ -2199,6 +2280,72 @@ mod tests {
     }
 
     #[test]
+    fn template_add_repairs_repeated_object_bom() {
+        let root = temp_meta_compile_workspace("unica-template-add-repeated-bom");
+        let workspace = root.join("workspace");
+        let json_path = workspace.join("report.json");
+        std::fs::write(
+            &json_path,
+            r#"{
+  "type": "Report",
+  "name": "TemplateRepeatedBomReport",
+  "synonym": "TemplateRepeatedBomReport"
+}"#,
+        )
+        .unwrap();
+        let result = call_meta_compile(&workspace, &json_path);
+        assert!(result.ok, "{:?}", result.errors);
+
+        let report_path = workspace
+            .join("src")
+            .join("Reports")
+            .join("TemplateRepeatedBomReport.xml");
+        let report_bytes = std::fs::read(&report_path).unwrap();
+        assert_eq!(leading_utf8_bom_count(&report_bytes), 1);
+
+        let mut damaged = b"\xef\xbb\xbf".to_vec();
+        damaged.extend_from_slice(&report_bytes);
+        std::fs::write(&report_path, damaged).unwrap();
+        let report_bytes = std::fs::read(&report_path).unwrap();
+        assert_eq!(leading_utf8_bom_count(&report_bytes), 2);
+
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert(
+            "ObjectName".to_string(),
+            Value::String("TemplateRepeatedBomReport".to_string()),
+        );
+        args.insert(
+            "TemplateName".to_string(),
+            Value::String("ОсновнаяСхемаКомпоновкиДанных".to_string()),
+        );
+        args.insert(
+            "TemplateType".to_string(),
+            Value::String("DataCompositionSchema".to_string()),
+        );
+        args.insert(
+            "SrcDir".to_string(),
+            Value::String("src/Reports".to_string()),
+        );
+
+        let template_result = UnicaApplication::new()
+            .call_tool("unica.template.add", &args)
+            .unwrap();
+
+        assert!(template_result.ok, "{:?}", template_result.errors);
+        let report_bytes = std::fs::read(&report_path).unwrap();
+        assert_eq!(leading_utf8_bom_count(&report_bytes), 1);
+        assert!(String::from_utf8_lossy(&report_bytes)
+            .contains("<Template>ОсновнаяСхемаКомпоновкиДанных</Template>"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn meta_validate_supports_pipe_separated_batch_paths() {
         let root = std::env::temp_dir().join(format!("unica-meta-batch-{}", std::process::id()));
         let workspace = root.join("workspace");
@@ -2261,6 +2408,115 @@ mod tests {
         assert!(stdout.contains("src/Catalogs/Items.xml"));
         assert!(stdout.contains("src/Catalogs/Other.xml"));
         assert_eq!(result.artifacts.len(), 2);
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn role_compile_generates_non_placeholder_role_uuid() {
+        let root = temp_meta_compile_workspace("unica-role-compile-uuid");
+        let workspace = root.join("workspace");
+        let fixtures = workspace.join("fixtures");
+        std::fs::create_dir_all(&fixtures).unwrap();
+        let json_path = fixtures.join("role.json");
+        std::fs::write(
+            &json_path,
+            r#"{
+  "name": "DemoReadRole",
+  "synonym": "Demo read role",
+  "comment": "Synthetic repro",
+  "objects": ["Catalog.Items: @view"]
+}"#,
+        )
+        .unwrap();
+
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert(
+            "JsonPath".to_string(),
+            Value::String(json_path.display().to_string()),
+        );
+        args.insert("OutputDir".to_string(), Value::String("src".to_string()));
+        let result = UnicaApplication::new()
+            .call_tool("unica.role.compile", &args)
+            .unwrap();
+
+        assert!(result.ok, "{:?}", result.errors);
+        let metadata_path = workspace.join("src/Roles/DemoReadRole.xml");
+        let metadata_xml = std::fs::read_to_string(&metadata_path).unwrap();
+        assert_valid_root_uuid(&metadata_xml, "Role");
+        let uuid = metadata_root_uuid(&metadata_xml, "Role");
+        assert!(
+            !uuid.starts_with("00000000-0000-0000-"),
+            "role.compile must not generate placeholder UUID: {uuid}"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn meta_edit_add_register_record_adds_document_register_record() {
+        let root = temp_meta_compile_workspace("unica-meta-edit-register-record");
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        let fixtures = workspace.join("fixtures");
+        std::fs::create_dir_all(&fixtures).unwrap();
+        let json_path = fixtures.join("document.json");
+        std::fs::write(
+            &json_path,
+            r#"{
+  "type": "Document",
+  "name": "DemoShipment",
+  "synonym": "Demo shipment",
+  "comment": "Synthetic repro",
+  "numberType": "String",
+  "numberLength": 11,
+  "posting": "Allow"
+}"#,
+        )
+        .unwrap();
+        let compile_result = call_meta_compile(&workspace, &json_path);
+        assert!(compile_result.ok, "{:?}", compile_result.errors);
+
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert(
+            "ObjectPath".to_string(),
+            Value::String("src/Documents/DemoShipment.xml".to_string()),
+        );
+        args.insert(
+            "Operation".to_string(),
+            Value::String("add-registerRecord".to_string()),
+        );
+        args.insert(
+            "Value".to_string(),
+            Value::String("AccumulationRegister.DemoBalance".to_string()),
+        );
+        let edit_result = UnicaApplication::new()
+            .call_tool("unica.meta.edit", &args)
+            .unwrap();
+
+        assert!(edit_result.ok, "{:?}", edit_result.errors);
+        let edit_again_result = UnicaApplication::new()
+            .call_tool("unica.meta.edit", &args)
+            .unwrap();
+        assert!(edit_again_result.ok, "{:?}", edit_again_result.errors);
+        let xml = std::fs::read_to_string(src.join("Documents/DemoShipment.xml")).unwrap();
+        let register_record =
+            "<xr:Item xsi:type=\"xr:MDObjectRef\">AccumulationRegister.DemoBalance</xr:Item>";
+        assert!(xml.contains(register_record));
+        assert_eq!(xml.matches(register_record).count(), 1);
+        assert!(xml.contains(&format!(
+            "<RegisterRecords>\n\t\t\t\t{register_record}\n\t\t\t</RegisterRecords>"
+        )));
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/crates/unica-coder/src/application/tool_contracts.rs
+++ b/crates/unica-coder/src/application/tool_contracts.rs
@@ -13,6 +13,7 @@ const NATIVE_XML_DSL_ARGS: &[&str] = &[
     "Batch",
     "BodyLimit",
     "BorrowMainAttribute",
+    "Capability",
     "Child",
     "Children",
     "CIPath",
@@ -69,6 +70,7 @@ const NATIVE_XML_DSL_ARGS: &[&str] = &[
     "RightsPath",
     "Raw",
     "Section",
+    "Set",
     "SetDefault",
     "SetMainSKD",
     "ShowDenied",
@@ -78,6 +80,7 @@ const NATIVE_XML_DSL_ARGS: &[&str] = &[
     "TemplateName",
     "TemplatePath",
     "TemplateType",
+    "TargetPath",
     "Type",
     "Value",
     "Vendor",
@@ -87,6 +90,7 @@ const NATIVE_XML_DSL_ARGS: &[&str] = &[
     "batch",
     "bodyLimit",
     "borrowMainAttribute",
+    "capability",
     "child",
     "children",
     "ciPath",
@@ -143,6 +147,7 @@ const NATIVE_XML_DSL_ARGS: &[&str] = &[
     "rightsPath",
     "raw",
     "section",
+    "set",
     "setDefault",
     "setMainSKD",
     "showDenied",
@@ -152,6 +157,7 @@ const NATIVE_XML_DSL_ARGS: &[&str] = &[
     "templateName",
     "templatePath",
     "templateType",
+    "targetPath",
     "type",
     "value",
     "vendor",
@@ -360,6 +366,7 @@ pub fn validate_tool_arguments(
         validate_runtime_arguments(tool.name, args, dry_run)?;
     }
     validate_code_arguments(tool, args, dry_run)?;
+    validate_support_arguments(tool, args, dry_run)?;
 
     if !dry_run {
         for required in required_args(&tool) {
@@ -369,6 +376,73 @@ pub fn validate_tool_arguments(
         }
     }
 
+    Ok(())
+}
+
+fn validate_support_arguments(
+    tool: ToolSpec,
+    args: &Map<String, Value>,
+    dry_run: bool,
+) -> Result<(), String> {
+    if tool.name != "unica.support.edit" {
+        return Ok(());
+    }
+
+    validate_enum_alias_argument(
+        tool.name,
+        args,
+        &["Capability", "capability"],
+        &["on", "off"],
+    )?;
+    validate_enum_alias_argument(
+        tool.name,
+        args,
+        &["Set", "set"],
+        &["editable", "off-support", "locked"],
+    )?;
+
+    if dry_run {
+        return Ok(());
+    }
+
+    if !contains_any(args, &["Path", "path", "TargetPath", "targetPath"]) {
+        return Err(format!("{} requires `Path` argument", tool.name));
+    }
+    let has_capability = contains_any(args, &["Capability", "capability"]);
+    let has_set = contains_any(args, &["Set", "set"]);
+    if has_capability == has_set {
+        return Err(format!(
+            "{} requires exactly one of `Capability` or `Set`",
+            tool.name
+        ));
+    }
+
+    Ok(())
+}
+
+fn contains_any(args: &Map<String, Value>, names: &[&str]) -> bool {
+    names.iter().any(|name| args.contains_key(*name))
+}
+
+fn validate_enum_alias_argument(
+    tool_name: &'static str,
+    args: &Map<String, Value>,
+    names: &[&str],
+    allowed: &[&str],
+) -> Result<(), String> {
+    for name in names {
+        if let Some(value) = args.get(*name) {
+            let Some(value) = value.as_str() else {
+                return Err(format!("{tool_name} argument `{name}` must be string"));
+            };
+            if !allowed.contains(&value) {
+                return Err(format!(
+                    "{tool_name} argument `{name}` must be one of: {}",
+                    allowed.join(", ")
+                ));
+            }
+        }
+    }
     Ok(())
 }
 
@@ -581,6 +655,7 @@ fn write_path_args(tool: ToolSpec) -> &'static [&'static str] {
         ToolHandler::NativeOperation { operation, .. } => match operation {
             "cf-init" | "cfe-init" => &["OutputDir", "outputDir"],
             "cf-edit" => &["ConfigPath", "configPath", "Path", "path"],
+            "support-edit" => &["Path", "path", "TargetPath", "targetPath"],
             "meta-compile" => &["OutputDir", "outputDir"],
             "meta-edit" => &["ObjectPath", "objectPath", "Path", "path"],
             "meta-remove" => &["ConfigDir", "configDir"],
@@ -653,6 +728,7 @@ fn native_source_path_args() -> &'static [&'static str] {
         "SrcDir",
         "SubsystemPath",
         "TemplatePath",
+        "TargetPath",
         "ciPath",
         "configDir",
         "configPath",
@@ -671,6 +747,7 @@ fn native_source_path_args() -> &'static [&'static str] {
         "srcDir",
         "subsystemPath",
         "templatePath",
+        "targetPath",
     ]
 }
 
@@ -858,6 +935,15 @@ fn property_schema_for_tool(tool: &ToolSpec, name: &str) -> Value {
         }
     }
     match tool.name {
+        "unica.support.edit" => match name {
+            "Capability" | "capability" => {
+                return json!({ "type": "string", "enum": ["on", "off"] });
+            }
+            "Set" | "set" => {
+                return json!({ "type": "string", "enum": ["editable", "off-support", "locked"] });
+            }
+            _ => {}
+        },
         "unica.code.graph" => match name {
             "mode" => return json!({ "type": "string", "enum": CODE_GRAPH_MODES }),
             "dir" => return json!({ "type": "string", "enum": CODE_GRAPH_DIRECTIONS }),
@@ -990,6 +1076,40 @@ mod tests {
         let args = Map::new();
 
         validate_tool_arguments(tool, &args, true).unwrap();
+    }
+
+    #[test]
+    fn support_edit_contract_exposes_typed_enums_and_rejects_invalid_payloads() {
+        let tool = tools()
+            .into_iter()
+            .find(|tool| tool.name == "unica.support.edit")
+            .unwrap();
+
+        let schema = input_schema_for_tool(&tool);
+        assert_eq!(schema["additionalProperties"], false);
+        assert_eq!(
+            schema["properties"]["Capability"]["enum"],
+            json!(["on", "off"])
+        );
+        assert_eq!(
+            schema["properties"]["Set"]["enum"],
+            json!(["editable", "off-support", "locked"])
+        );
+        assert!(schema["properties"].get("args").is_none());
+
+        let mut args = Map::new();
+        args.insert("Path".to_string(), json!("src"));
+        args.insert("Capability".to_string(), json!(true));
+        let error = validate_tool_arguments(tool, &args, false).unwrap_err();
+        assert!(error.contains("Capability"));
+        assert!(error.contains("string"));
+
+        let mut args = Map::new();
+        args.insert("Path".to_string(), json!("src"));
+        args.insert("Capability".to_string(), json!("on"));
+        args.insert("Set".to_string(), json!("editable"));
+        let error = validate_tool_arguments(tool, &args, false).unwrap_err();
+        assert!(error.contains("exactly one"));
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/native_operations.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations.rs
@@ -15,6 +15,7 @@ pub(crate) mod registry;
 pub(crate) mod role;
 pub(crate) mod skd;
 pub(crate) mod subsystem;
+pub(crate) mod support;
 pub(crate) mod template;
 
 use crate::domain::workspace::WorkspaceContext;

--- a/crates/unica-coder/src/infrastructure/native_operations/common.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/common.rs
@@ -1625,6 +1625,14 @@ impl SupportState {
             .get(&object_uuid.to_ascii_lowercase())
             .copied()
     }
+
+    pub(crate) fn global_editing_enabled(&self) -> bool {
+        self.global_editing_enabled
+    }
+
+    pub(crate) fn removed(&self) -> bool {
+        self.removed
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/unica-coder/src/infrastructure/native_operations/common.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/common.rs
@@ -160,7 +160,7 @@ pub(crate) fn register_form_in_object_text(text: &str, form_name: &str) -> Strin
 pub(crate) fn read_utf8_sig(path: &Path) -> Result<String, String> {
     let mut text = fs::read_to_string(path)
         .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
-    if text.starts_with('\u{feff}') {
+    while text.starts_with('\u{feff}') {
         text.remove(0);
     }
     Ok(text)

--- a/crates/unica-coder/src/infrastructure/native_operations/form.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/form.rs
@@ -814,7 +814,13 @@ pub(crate) fn form_validate_types(
 ) {
     let type_nodes = root
         .descendants()
-        .filter(|node| node.is_element() && node.tag_name().name() == "Type")
+        .filter(|node| {
+            node.is_element()
+                && node.tag_name().name() == "Type"
+                && node.parent().is_some_and(|parent| {
+                    matches!(parent.tag_name().name(), "Attribute" | "Column")
+                })
+        })
         .collect::<Vec<_>>();
     let mut type_error_count = 0usize;
     let mut type_warn_count = 0usize;
@@ -929,6 +935,9 @@ pub(crate) fn form_valid_closed_types() -> &'static [&'static str] {
         "v8ui:Picture",
         "v8ui:SizeChangeMode",
         "v8ui:VerticalAlign",
+        "SearchStringRepresentation",
+        "ViewStatusRepresentation",
+        "SearchControl",
         "dcsset:DataCompositionComparisonType",
         "dcsset:DataCompositionFieldPlacement",
         "dcsset:Filter",
@@ -2412,11 +2421,17 @@ pub(crate) fn edit_form(args: &Map<String, Value>, context: &WorkspaceContext) -
         let mut added_elements = Vec::<String>::new();
         if let Some(elements) = defn.get("elements").and_then(Value::as_array) {
             if !elements.is_empty() {
+                let insert_plan = form_edit_insert_plan(&xml_text, &defn)?;
                 let start = elem_ids.next;
                 let mut lines = Vec::<String>::new();
                 for element in elements {
                     let name = form_edit_element_display_name(element);
-                    emit_form_element(&mut lines, element, "\t\t", &mut elem_ids)?;
+                    emit_form_element(
+                        &mut lines,
+                        element,
+                        &insert_plan.child_indent,
+                        &mut elem_ids,
+                    )?;
                     if let Some(name) = name {
                         let path = element
                             .get("path")
@@ -2426,7 +2441,7 @@ pub(crate) fn edit_form(args: &Map<String, Value>, context: &WorkspaceContext) -
                         added_elements.push(format!("  + [Input] {name}{path}"));
                     }
                 }
-                form_edit_insert_section_items(&mut xml_text, "ChildItems", &lines)?;
+                form_edit_insert_element_lines(&mut xml_text, &insert_plan, &lines);
                 let _companion_count = elem_ids.next.saturating_sub(start + added_elements.len());
             }
         }
@@ -2478,6 +2493,8 @@ pub(crate) fn edit_form(args: &Map<String, Value>, context: &WorkspaceContext) -
             }
         }
 
+        let line_ending = form_line_ending(&xml_text);
+        let xml_text = form_normalize_line_endings(&xml_text, line_ending);
         write_utf8_bom(&form_path, &xml_text)?;
 
         let mut stdout = format!("=== form-edit: {form_name} ===\n\n");
@@ -2577,11 +2594,209 @@ pub(crate) fn form_edit_next_id(xml_text: &str, tags: &[&str]) -> usize {
 
 pub(crate) fn form_edit_element_display_name(element: &Value) -> Option<String> {
     let object = element.as_object()?;
-    object
-        .get("input")
-        .and_then(Value::as_str)
-        .or_else(|| object.get("name").and_then(Value::as_str))
-        .map(ToOwned::to_owned)
+    for key in ["input", "table", "page", "pages", "group", "name"] {
+        if let Some(value) = object.get(key).and_then(Value::as_str) {
+            return Some(value.to_string());
+        }
+    }
+    None
+}
+
+pub(crate) struct FormEditInsertPlan {
+    pub(crate) pos: usize,
+    pub(crate) prefix: String,
+    pub(crate) suffix: String,
+    pub(crate) child_indent: String,
+}
+
+pub(crate) fn form_edit_insert_plan(
+    xml_text: &str,
+    defn: &Value,
+) -> Result<FormEditInsertPlan, String> {
+    let object = defn
+        .as_object()
+        .ok_or_else(|| "form edit JSON root must be an object".to_string())?;
+    let into = object.get("into").and_then(Value::as_str);
+    let after = object.get("after").and_then(Value::as_str);
+
+    let (search_start, search_end) = if let Some(into) = into {
+        let target_start = form_find_named_element_start(xml_text, 0, xml_text.len(), into)
+            .ok_or_else(|| format!("Form element '{into}' not found for into"))?;
+        let target_end = form_find_element_end(xml_text, target_start)
+            .ok_or_else(|| format!("Cannot find end of form element '{into}'"))?;
+        (target_start, target_end)
+    } else {
+        (0, xml_text.len())
+    };
+    let (child_open_end, child_close_start) =
+        form_find_child_items_range(xml_text, search_start, search_end)?;
+
+    if let Some(after) = after {
+        let after_start =
+            form_find_named_element_start(xml_text, child_open_end, child_close_start, after)
+                .ok_or_else(|| format!("Form element '{after}' not found for after"))?;
+        let after_end = form_find_element_end(xml_text, after_start)
+            .ok_or_else(|| format!("Cannot find end of form element '{after}'"))?;
+        return Ok(FormEditInsertPlan {
+            pos: after_end,
+            prefix: "\n".to_string(),
+            suffix: String::new(),
+            child_indent: form_line_indent_at(xml_text, after_start),
+        });
+    }
+
+    let close_line_start = form_line_start(xml_text, child_close_start);
+    let close_indent = &xml_text[close_line_start..child_close_start];
+    Ok(FormEditInsertPlan {
+        pos: close_line_start,
+        prefix: String::new(),
+        suffix: "\n".to_string(),
+        child_indent: format!("{close_indent}\t"),
+    })
+}
+
+pub(crate) fn form_edit_insert_element_lines(
+    xml_text: &mut String,
+    plan: &FormEditInsertPlan,
+    lines: &[String],
+) {
+    if lines.is_empty() {
+        return;
+    }
+    let content = lines.join("\n");
+    xml_text.insert_str(
+        plan.pos,
+        &format!("{}{}{}", plan.prefix, content, plan.suffix),
+    );
+}
+
+pub(crate) fn form_find_child_items_range(
+    xml_text: &str,
+    search_start: usize,
+    search_end: usize,
+) -> Result<(usize, usize), String> {
+    let Some(open_rel) = xml_text[search_start..search_end].find("<ChildItems>") else {
+        return Err("No <ChildItems> section found in form target".to_string());
+    };
+    let open_start = search_start + open_rel;
+    let open_end = open_start + "<ChildItems>".len();
+    let close_start = form_find_matching_section_close(xml_text, open_start, "ChildItems")
+        .filter(|pos| *pos <= search_end)
+        .ok_or_else(|| "Cannot find matching </ChildItems>".to_string())?;
+    Ok((open_end, close_start))
+}
+
+pub(crate) fn form_find_matching_section_close(
+    xml_text: &str,
+    open_start: usize,
+    tag: &str,
+) -> Option<usize> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let mut depth = 1usize;
+    let mut pos = open_start + open.len();
+    loop {
+        let next_open = xml_text[pos..].find(&open).map(|idx| pos + idx);
+        let next_close = xml_text[pos..].find(&close).map(|idx| pos + idx);
+        match (next_open, next_close) {
+            (Some(open_pos), Some(close_pos)) if open_pos < close_pos => {
+                depth += 1;
+                pos = open_pos + open.len();
+            }
+            (_, Some(close_pos)) => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return Some(close_pos);
+                }
+                pos = close_pos + close.len();
+            }
+            _ => return None,
+        }
+    }
+}
+
+pub(crate) fn form_find_named_element_start(
+    xml_text: &str,
+    search_start: usize,
+    search_end: usize,
+    name: &str,
+) -> Option<usize> {
+    let pattern = format!(" name=\"{}\"", escape_xml(name));
+    let mut pos = search_start;
+    while pos < search_end {
+        let found = xml_text[pos..search_end]
+            .find(&pattern)
+            .map(|idx| pos + idx)?;
+        let start = xml_text[..found].rfind('<')?;
+        if xml_text[start..].starts_with("</") {
+            pos = found + pattern.len();
+            continue;
+        }
+        return Some(start);
+    }
+    None
+}
+
+pub(crate) fn form_find_element_end(xml_text: &str, start: usize) -> Option<usize> {
+    let tag = form_tag_name_at(xml_text, start)?;
+    let start_close = xml_text[start..].find('>').map(|idx| start + idx + 1)?;
+    if xml_text[start..start_close].trim_end().ends_with("/>") {
+        return Some(start_close);
+    }
+    let close = format!("</{tag}>");
+    let open = format!("<{tag}");
+    let mut depth = 1usize;
+    let mut pos = start_close;
+    loop {
+        let next_open = xml_text[pos..].find(&open).map(|idx| pos + idx);
+        let next_close = xml_text[pos..].find(&close).map(|idx| pos + idx);
+        match (next_open, next_close) {
+            (Some(open_pos), Some(close_pos)) if open_pos < close_pos => {
+                let after_tag = xml_text.as_bytes().get(open_pos + open.len()).copied();
+                if matches!(after_tag, Some(b' ' | b'\t' | b'\r' | b'\n' | b'>' | b'/')) {
+                    depth += 1;
+                }
+                pos = open_pos + open.len();
+            }
+            (_, Some(close_pos)) => {
+                depth = depth.saturating_sub(1);
+                let close_end = close_pos + close.len();
+                if depth == 0 {
+                    return Some(close_end);
+                }
+                pos = close_end;
+            }
+            _ => return None,
+        }
+    }
+}
+
+pub(crate) fn form_tag_name_at(xml_text: &str, start: usize) -> Option<String> {
+    let rest = xml_text.get(start + 1..)?;
+    if rest.starts_with('/') {
+        return None;
+    }
+    let name = rest
+        .chars()
+        .take_while(|ch| !ch.is_whitespace() && *ch != '>' && *ch != '/')
+        .collect::<String>();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name)
+    }
+}
+
+pub(crate) fn form_line_start(xml_text: &str, pos: usize) -> usize {
+    xml_text[..pos].rfind('\n').map(|idx| idx + 1).unwrap_or(0)
+}
+
+pub(crate) fn form_line_indent_at(xml_text: &str, pos: usize) -> String {
+    let line_start = form_line_start(xml_text, pos);
+    xml_text[line_start..pos]
+        .chars()
+        .take_while(|ch| ch.is_whitespace())
+        .collect()
 }
 
 pub(crate) fn form_edit_insert_section_items(
@@ -2608,6 +2823,23 @@ pub(crate) fn form_edit_insert_section_items(
     };
     xml_text.insert_str(pos, &format!("{content}\n\t"));
     Ok(())
+}
+
+pub(crate) fn form_line_ending(xml_text: &str) -> &str {
+    if xml_text.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    }
+}
+
+pub(crate) fn form_normalize_line_endings(xml_text: &str, line_ending: &str) -> String {
+    let normalized_lf = xml_text.replace("\r\n", "\n").replace('\r', "\n");
+    if line_ending == "\r\n" {
+        normalized_lf.replace('\n', "\r\n")
+    } else {
+        normalized_lf
+    }
 }
 
 pub(crate) fn emit_form_edit_attribute_item(
@@ -2909,6 +3141,46 @@ pub(crate) fn emit_form_element(
     let Some(object) = element.as_object() else {
         return Ok(());
     };
+    if let Some(name) = object.get("pages").and_then(Value::as_str) {
+        emit_form_container(
+            lines,
+            object,
+            "Pages",
+            name,
+            indent,
+            ids,
+            FormContainerKind::Pages,
+        )?;
+        return Ok(());
+    }
+    if let Some(name) = object.get("page").and_then(Value::as_str) {
+        emit_form_container(
+            lines,
+            object,
+            "Page",
+            name,
+            indent,
+            ids,
+            FormContainerKind::Page,
+        )?;
+        return Ok(());
+    }
+    if let Some(name) = object.get("group").and_then(Value::as_str) {
+        emit_form_container(
+            lines,
+            object,
+            "UsualGroup",
+            name,
+            indent,
+            ids,
+            FormContainerKind::Group,
+        )?;
+        return Ok(());
+    }
+    if let Some(name) = object.get("table").and_then(Value::as_str) {
+        emit_form_table(lines, object, name, indent, ids)?;
+        return Ok(());
+    }
     if let Some(name) = object
         .get("input")
         .and_then(Value::as_str)
@@ -2924,6 +3196,237 @@ pub(crate) fn emit_form_element(
         "Unsupported form element in native compiler: {}",
         serde_json::to_string(element).unwrap_or_else(|_| "<invalid>".to_string())
     ))
+}
+
+pub(crate) enum FormContainerKind {
+    Pages,
+    Page,
+    Group,
+}
+
+pub(crate) fn emit_form_container(
+    lines: &mut Vec<String>,
+    element: &Map<String, Value>,
+    tag: &str,
+    name: &str,
+    indent: &str,
+    ids: &mut FormIdAllocator,
+    kind: FormContainerKind,
+) -> Result<(), String> {
+    let id = ids.next();
+    lines.push(format!(
+        "{indent}<{tag} name=\"{}\" id=\"{id}\">",
+        escape_xml(name)
+    ));
+    let inner = format!("{indent}\t");
+    if let Some(title) = element.get("title").and_then(Value::as_str) {
+        emit_form_mltext(lines, &inner, "Title", title);
+    }
+    if let Some(title_path) = element.get("titleDataPath").and_then(Value::as_str) {
+        lines.push(format!(
+            "{inner}<TitleDataPath>{}</TitleDataPath>",
+            escape_xml(title_path)
+        ));
+    }
+    if matches!(kind, FormContainerKind::Group) {
+        let group = element
+            .get("orientation")
+            .or_else(|| element.get("groupOrientation"))
+            .and_then(Value::as_str)
+            .unwrap_or("Vertical");
+        let group = match group {
+            "horizontal" | "Horizontal" => "Horizontal",
+            "alwaysHorizontal" | "AlwaysHorizontal" => "AlwaysHorizontal",
+            "alwaysVertical" | "AlwaysVertical" => "AlwaysVertical",
+            _ => "Vertical",
+        };
+        lines.push(format!("{inner}<Group>{group}</Group>"));
+        lines.push(format!("{inner}<Behavior>Usual</Behavior>"));
+        if let Some(representation) = element.get("representation").and_then(Value::as_str) {
+            lines.push(format!(
+                "{inner}<Representation>{}</Representation>",
+                escape_xml(representation)
+            ));
+        }
+        if element.get("showTitle").and_then(Value::as_bool) == Some(false) {
+            lines.push(format!("{inner}<ShowTitle>false</ShowTitle>"));
+        }
+    }
+    emit_form_common_flags(lines, element, &inner);
+    emit_form_companion(
+        lines,
+        "ExtendedTooltip",
+        &format!("{name}РасширеннаяПодсказка"),
+        &inner,
+        ids,
+    );
+    if let Some(children) = element.get("children").and_then(Value::as_array) {
+        if !children.is_empty() {
+            lines.push(format!("{inner}<ChildItems>"));
+            let child_indent = format!("{inner}\t");
+            for child in children {
+                emit_form_element(lines, child, &child_indent, ids)?;
+            }
+            lines.push(format!("{inner}</ChildItems>"));
+        }
+    }
+    lines.push(format!("{indent}</{tag}>"));
+    Ok(())
+}
+
+pub(crate) fn emit_form_table(
+    lines: &mut Vec<String>,
+    element: &Map<String, Value>,
+    name: &str,
+    indent: &str,
+    ids: &mut FormIdAllocator,
+) -> Result<(), String> {
+    let id = ids.next();
+    lines.push(format!(
+        "{indent}<Table name=\"{}\" id=\"{id}\">",
+        escape_xml(name)
+    ));
+    let inner = format!("{indent}\t");
+    if element.get("changeRowOrder").and_then(Value::as_bool) == Some(false) {
+        lines.push(format!("{inner}<ChangeRowOrder>false</ChangeRowOrder>"));
+    }
+    if element.get("enableStartDrag").and_then(Value::as_bool) == Some(true) {
+        lines.push(format!("{inner}<EnableStartDrag>true</EnableStartDrag>"));
+    }
+    if element.get("enableDrag").and_then(Value::as_bool) == Some(true) {
+        lines.push(format!("{inner}<EnableDrag>true</EnableDrag>"));
+    }
+    if let Some(file_drag_mode) = element.get("fileDragMode").and_then(Value::as_str) {
+        lines.push(format!(
+            "{inner}<FileDragMode>{}</FileDragMode>",
+            escape_xml(file_drag_mode)
+        ));
+    }
+    if let Some(path) = element.get("path").and_then(Value::as_str) {
+        lines.push(format!("{inner}<DataPath>{}</DataPath>", escape_xml(path)));
+    }
+    if let Some(title) = element.get("title").and_then(Value::as_str) {
+        emit_form_mltext(lines, &inner, "Title", title);
+    }
+    emit_form_common_flags(lines, element, &inner);
+    emit_form_companion(
+        lines,
+        "ContextMenu",
+        &format!("{name}КонтекстноеМеню"),
+        &inner,
+        ids,
+    );
+    emit_form_companion(
+        lines,
+        "AutoCommandBar",
+        &format!("{name}КоманднаяПанель"),
+        &inner,
+        ids,
+    );
+    emit_form_companion(
+        lines,
+        "ExtendedTooltip",
+        &format!("{name}РасширеннаяПодсказка"),
+        &inner,
+        ids,
+    );
+    emit_form_table_addition(
+        lines,
+        FormTableAdditionSpec {
+            tag: "SearchStringAddition",
+            name: format!("{name}СтрокаПоиска"),
+            source_type: "SearchStringRepresentation",
+            extra: None,
+        },
+        name,
+        &inner,
+        ids,
+    );
+    emit_form_table_addition(
+        lines,
+        FormTableAdditionSpec {
+            tag: "ViewStatusAddition",
+            name: format!("{name}СостояниеПросмотра"),
+            source_type: "ViewStatusRepresentation",
+            extra: Some(("HorizontalLocation", "Left")),
+        },
+        name,
+        &inner,
+        ids,
+    );
+    emit_form_table_addition(
+        lines,
+        FormTableAdditionSpec {
+            tag: "SearchControlAddition",
+            name: format!("{name}УправлениеПоиском"),
+            source_type: "SearchControl",
+            extra: None,
+        },
+        name,
+        &inner,
+        ids,
+    );
+
+    let children = element
+        .get("columns")
+        .or_else(|| element.get("children"))
+        .and_then(Value::as_array);
+    if let Some(children) = children {
+        if !children.is_empty() {
+            lines.push(format!("{inner}<ChildItems>"));
+            let child_indent = format!("{inner}\t");
+            for child in children {
+                emit_form_element(lines, child, &child_indent, ids)?;
+            }
+            lines.push(format!("{inner}</ChildItems>"));
+        }
+    }
+    lines.push(format!("{indent}</Table>"));
+    Ok(())
+}
+
+pub(crate) struct FormTableAdditionSpec<'a> {
+    pub(crate) tag: &'a str,
+    pub(crate) name: String,
+    pub(crate) source_type: &'a str,
+    pub(crate) extra: Option<(&'a str, &'a str)>,
+}
+
+pub(crate) fn emit_form_table_addition(
+    lines: &mut Vec<String>,
+    spec: FormTableAdditionSpec<'_>,
+    table: &str,
+    indent: &str,
+    ids: &mut FormIdAllocator,
+) {
+    let id = ids.next();
+    lines.push(format!(
+        "{indent}<{tag} name=\"{}\" id=\"{id}\">",
+        escape_xml(&spec.name),
+        tag = spec.tag
+    ));
+    lines.push(format!("{indent}\t<AdditionSource>"));
+    lines.push(format!("{indent}\t\t<Item>{}</Item>", escape_xml(table)));
+    lines.push(format!("{indent}\t\t<Type>{}</Type>", spec.source_type));
+    lines.push(format!("{indent}\t</AdditionSource>"));
+    if let Some((tag, value)) = spec.extra {
+        lines.push(format!("{indent}\t<{tag}>{value}</{tag}>"));
+    }
+    emit_form_companion(
+        lines,
+        "ContextMenu",
+        &format!("{}КонтекстноеМеню", spec.name),
+        &format!("{indent}\t"),
+        ids,
+    );
+    emit_form_companion(
+        lines,
+        "ExtendedTooltip",
+        &format!("{}РасширеннаяПодсказка", spec.name),
+        &format!("{indent}\t"),
+        ids,
+    );
+    lines.push(format!("{indent}</{}>", spec.tag));
 }
 
 pub(crate) fn emit_form_input(
@@ -2944,6 +3447,12 @@ pub(crate) fn emit_form_input(
     }
     if let Some(title) = element.get("title").and_then(Value::as_str) {
         emit_form_mltext(lines, &inner, "Title", title);
+    }
+    if let Some(edit_mode) = element.get("editMode").and_then(Value::as_str) {
+        lines.push(format!(
+            "{inner}<EditMode>{}</EditMode>",
+            escape_xml(edit_mode)
+        ));
     }
     emit_form_common_flags(lines, element, &inner);
     if let Some(value) = element.get("titleLocation").and_then(Value::as_str) {
@@ -3490,6 +3999,122 @@ mod tests {
     }
 
     #[test]
+    fn edit_form_adds_page_with_table_after_existing_page() {
+        let context = temp_context("edit-page-table");
+        let form_path = context.cwd.join("DocumentForm.xml");
+        let json_path = context.cwd.join("patch.json");
+        write_file(
+            &form_path,
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<Form xmlns="http://v8.1c.ru/8.3/xcf/logform" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xr="http://v8.1c.ru/8.3/xcf/readable" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+	<AutoCommandBar name="ФормаКоманднаяПанель" id="-1">
+		<Autofill>true</Autofill>
+	</AutoCommandBar>
+	<ChildItems>
+		<Pages name="ГруппаСтраницы" id="1">
+			<ExtendedTooltip name="ГруппаСтраницыРасширеннаяПодсказка" id="2"/>
+			<ChildItems>
+				<Page name="Основное" id="3">
+					<Title>
+						<v8:item>
+							<v8:lang>ru</v8:lang>
+							<v8:content>Основное</v8:content>
+						</v8:item>
+					</Title>
+					<ExtendedTooltip name="ОсновноеРасширеннаяПодсказка" id="4"/>
+				</Page>
+				<Page name="ОтгружаемыеТовары" id="5">
+					<Title>
+						<v8:item>
+							<v8:lang>ru</v8:lang>
+							<v8:content>Отгружаемые товары</v8:content>
+						</v8:item>
+					</Title>
+					<ExtendedTooltip name="ОтгружаемыеТоварыРасширеннаяПодсказка" id="6"/>
+				</Page>
+			</ChildItems>
+		</Pages>
+	</ChildItems>
+	<Attributes>
+		<Attribute name="Объект" id="7">
+			<Type>
+				<v8:Type>cfg:DocumentObject.РасходныйОрдерНаТовары</v8:Type>
+			</Type>
+			<MainAttribute>true</MainAttribute>
+		</Attribute>
+	</Attributes>
+</Form>
+"#,
+        );
+        write_file(
+            &json_path,
+            r#"{
+  "into": "ГруппаСтраницы",
+  "after": "Основное",
+  "elements": [{
+    "page": "кшТоварыПоРеализациямСтраница",
+    "title": "Товары по реализациям",
+    "children": [{
+      "table": "кшТоварыПоРеализациям",
+      "path": "Объект.кшТоварыПоРеализациям",
+      "title": "Товары по реализациям",
+      "columns": [
+        {"input": "кшТоварыПоРеализациямНоменклатура", "path": "Объект.кшТоварыПоРеализациям.кшНоменклатура", "title": "Номенклатура"}
+      ]
+    }]
+  }]
+}"#,
+        );
+
+        let mut args = Map::new();
+        args.insert(
+            "FormPath".to_string(),
+            json!(form_path.display().to_string()),
+        );
+        args.insert(
+            "JsonPath".to_string(),
+            json!(json_path.display().to_string()),
+        );
+
+        let outcome = edit_form(&args, &context);
+        assert!(outcome.ok, "{} {:?}", outcome.summary, outcome.errors);
+
+        let xml_text = fs::read_to_string(&form_path).unwrap();
+        assert!(xml_text.contains("<Page name=\"кшТоварыПоРеализациямСтраница\""));
+        assert!(xml_text.contains("<Table name=\"кшТоварыПоРеализациям\""));
+        assert!(xml_text.contains("<DataPath>Объект.кшТоварыПоРеализациям</DataPath>"));
+        assert!(
+            xml_text.contains("<DataPath>Объект.кшТоварыПоРеализациям.кшНоменклатура</DataPath>")
+        );
+        assert!(
+            xml_text.find("Page name=\"Основное\"").unwrap()
+                < xml_text
+                    .find("Page name=\"кшТоварыПоРеализациямСтраница\"")
+                    .unwrap()
+        );
+        assert!(
+            xml_text
+                .find("Page name=\"кшТоварыПоРеализациямСтраница\"")
+                .unwrap()
+                < xml_text.find("Page name=\"ОтгружаемыеТовары\"").unwrap()
+        );
+
+        let mut validate_args = Map::new();
+        validate_args.insert(
+            "FormPath".to_string(),
+            json!(form_path.display().to_string()),
+        );
+        let validate = validate_form(&validate_args, &context);
+        assert!(
+            validate.ok,
+            "{} {:?}\n{}",
+            validate.summary,
+            validate.errors,
+            validate.stdout.unwrap_or_default()
+        );
+    }
+
+    #[test]
     fn validate_form_rejects_bare_type_values() {
         let context = temp_context("bare-type");
         let form_path = context
@@ -3532,6 +4157,62 @@ mod tests {
             ),
             "{stdout}"
         );
+
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
+    fn validate_form_ignores_ui_element_type_values() {
+        let doc = Document::parse(
+            r#"<Form xmlns="http://v8.1c.ru/8.3/MDClasses" version="2.20">
+	<ChildItems>
+		<Item name="ФормаЗаписать" id="1">
+			<Type>CommandBarButton</Type>
+		</Item>
+	</ChildItems>
+</Form>"#,
+        )
+        .unwrap();
+        let mut report = FormValidationReporter::new("Test", 30, false);
+
+        form_validate_types(doc.root_element(), true, &mut report);
+        let (ok, stdout, errors) = report.finalize("Test");
+
+        assert!(ok, "{stdout} {errors:?}");
+    }
+
+    #[test]
+    fn edit_form_preserves_crlf_line_endings() {
+        let context = temp_context("edit-preserve-crlf");
+        let form_path = context
+            .cwd
+            .join("Catalogs")
+            .join("Goods")
+            .join("Forms")
+            .join("ItemForm")
+            .join("Ext")
+            .join("Form.xml");
+        write_file(
+            &form_path,
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<Form xmlns=\"http://v8.1c.ru/8.3/MDClasses\" version=\"2.20\">\r\n\t<AutoCommandBar name=\"ФормаКоманднаяПанель\" id=\"-1\">\r\n\t\t<Autofill>true</Autofill>\r\n\t</AutoCommandBar>\r\n\t<ChildItems/>\r\n</Form>\r\n",
+        );
+        let json_path = context.cwd.join("form-edit.json");
+        write_file(&json_path, "{}");
+
+        let mut args = Map::new();
+        args.insert(
+            "FormPath".to_string(),
+            json!(form_path.display().to_string()),
+        );
+        args.insert(
+            "JsonPath".to_string(),
+            json!(json_path.display().to_string()),
+        );
+
+        let outcome = edit_form(&args, &context);
+        assert!(outcome.ok, "{} {:?}", outcome.summary, outcome.errors);
+        let text = fs::read_to_string(&form_path).unwrap();
+        assert!(!text.replace("\r\n", "").contains('\n'));
 
         let _ = fs::remove_dir_all(&context.cwd);
     }

--- a/crates/unica-coder/src/infrastructure/native_operations/meta.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta.rs
@@ -8152,38 +8152,66 @@ pub(crate) fn edit_meta(args: &Map<String, Value>, context: &WorkspaceContext) -
         let operation = operation.expect("checked above");
         let value = string_arg(args, &["value", "Value"]).unwrap_or_default();
 
-        if operation != "modify-property" {
-            return Err(format!(
-                "native meta-edit currently supports modify-property only, got: {operation}"
-            ));
-        }
-
         let mut xml_text = read_utf8_sig(&object_path)?;
         let (object_type, object_name) = meta_edit_object_identity(&xml_text)?;
-        let mut modified = 0usize;
-        for pair in value
-            .split(";;")
-            .map(str::trim)
-            .filter(|part| !part.is_empty())
-        {
-            let Some((key, raw_value)) = pair.split_once('=') else {
-                continue;
-            };
-            let key = key.trim();
-            let raw_value = raw_value.trim();
-            let normalized = normalize_meta_edit_property_value(key, raw_value);
-            if replace_first_xml_element_text(&mut xml_text, key, &normalized) {
-                modified += 1;
-            } else {
-                insert_meta_property_before_child_objects(&mut xml_text, key, &normalized)?;
-                modified += 1;
+        let (added, modified) = match operation {
+            "modify-property" => {
+                let mut modified = 0usize;
+                for pair in value
+                    .split(";;")
+                    .map(str::trim)
+                    .filter(|part| !part.is_empty())
+                {
+                    let Some((key, raw_value)) = pair.split_once('=') else {
+                        continue;
+                    };
+                    let key = key.trim();
+                    let raw_value = raw_value.trim();
+                    let normalized = normalize_meta_edit_property_value(key, raw_value);
+                    if replace_first_xml_element_text(&mut xml_text, key, &normalized) {
+                        modified += 1;
+                    } else {
+                        insert_meta_property_before_child_objects(&mut xml_text, key, &normalized)?;
+                        modified += 1;
+                    }
+                }
+                (0, modified)
             }
+            "add-registerRecord" | "add-register-record" => {
+                if object_type != "Document" {
+                    return Err(format!(
+                        "add-registerRecord is supported only for Document objects, got: {object_type}"
+                    ));
+                }
+                let added = add_meta_md_object_ref(&mut xml_text, "RegisterRecords", value)?;
+                (added, 0)
+            }
+            "add-ts" | "add-tabular-section" => {
+                let added =
+                    add_meta_tabular_section(&mut xml_text, &object_type, &object_name, value)?;
+                (added, 0)
+            }
+            "modify-ts" | "modify-tabular-section" => {
+                let modified = modify_meta_tabular_section(&mut xml_text, value)?;
+                (0, modified)
+            }
+            "modify-ts-attribute" => {
+                let modified = modify_meta_tabular_section_attribute(&mut xml_text, value)?;
+                (0, modified)
+            }
+            _ => {
+                return Err(format!(
+                    "native meta-edit currently supports modify-property, add-registerRecord, add-ts, modify-ts and modify-ts-attribute only, got: {operation}"
+                ));
+            }
+        };
+        if added + modified > 0 {
+            write_utf8_bom(&object_path, &xml_text)?;
         }
-        write_utf8_bom(&object_path, &xml_text)?;
         let stdout = format!(
-            "\n=== meta-edit summary ===\n  Object:   {object_type}.{object_name}\n  Added:    0\n  Removed:  0\n  Modified: {modified}\n"
+            "\n=== meta-edit summary ===\n  Object:   {object_type}.{object_name}\n  Added:    {added}\n  Removed:  0\n  Modified: {modified}\n"
         );
-        Ok((stdout, object_path, modified))
+        Ok((stdout, object_path, added + modified))
     })();
 
     match edit_result {
@@ -8284,6 +8312,463 @@ pub(crate) fn meta_edit_object_identity(xml_text: &str) -> Result<(String, Strin
         .unwrap_or("")
         .to_string();
     Ok((object_type, object_name))
+}
+
+pub(crate) fn add_meta_md_object_ref(
+    xml_text: &mut String,
+    tag: &str,
+    value: &str,
+) -> Result<usize, String> {
+    let normalized = normalize_meta_object_ref(value.trim());
+    if normalized.is_empty() {
+        return Err(format!("{tag} value is empty"));
+    }
+    let escaped = escape_xml(&normalized);
+    let line_ending = if xml_text.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    };
+    let open_empty = format!("<{tag}/>");
+    if let Some(index) = xml_text.find(&open_empty) {
+        let line_start = xml_text[..index].rfind('\n').map_or(0, |pos| pos + 1);
+        let indent = &xml_text[line_start..index];
+        let replacement = format!(
+            "<{tag}>{line_ending}{indent}\t<xr:Item xsi:type=\"xr:MDObjectRef\">{escaped}</xr:Item>{line_ending}{indent}</{tag}>"
+        );
+        xml_text.replace_range(index..index + open_empty.len(), &replacement);
+        return Ok(1);
+    }
+
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let Some(open_index) = xml_text.find(&open) else {
+        return Err(format!("No <{tag}> element found"));
+    };
+    let content_start = open_index + open.len();
+    let Some(relative_close_index) = xml_text[content_start..].find(&close) else {
+        return Err(format!("No </{tag}> element found"));
+    };
+    let close_index = content_start + relative_close_index;
+    let content = &xml_text[content_start..close_index];
+    let line_start = xml_text[..open_index].rfind('\n').map_or(0, |pos| pos + 1);
+    let indent = &xml_text[line_start..open_index];
+    let item_indent = format!("{indent}\t");
+    let new_item = format!("<xr:Item xsi:type=\"xr:MDObjectRef\">{escaped}</xr:Item>");
+    let mut items = content
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("<xr:Item ") && line.ends_with("</xr:Item>"))
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    let added = if items.iter().any(|item| item == &new_item) {
+        0
+    } else {
+        items.push(new_item);
+        1
+    };
+
+    let mut replacement = format!("<{tag}>");
+    for item in &items {
+        replacement.push_str(line_ending);
+        replacement.push_str(&item_indent);
+        replacement.push_str(item);
+    }
+    replacement.push_str(line_ending);
+    replacement.push_str(indent);
+    replacement.push_str(&format!("</{tag}>"));
+
+    let end_index = close_index + close.len();
+    let current = &xml_text[open_index..end_index];
+    if current == replacement {
+        return Ok(0);
+    }
+    xml_text.replace_range(open_index..end_index, &replacement);
+    Ok(if added > 0 { added } else { 1 })
+}
+
+pub(crate) fn add_meta_tabular_section(
+    xml_text: &mut String,
+    object_type: &str,
+    object_name: &str,
+    value: &str,
+) -> Result<usize, String> {
+    let section = parse_meta_edit_tabular_section(value)?;
+    if find_meta_child_by_name(xml_text, "TabularSection", &section.name).is_some() {
+        return Ok(0);
+    }
+
+    let line_ending = meta_line_ending(xml_text);
+    let mut lines = Vec::new();
+    let mut next_uuid = fresh_meta_compile_uuid;
+
+    if let Some(index) = xml_text.find("<ChildObjects/>") {
+        let line_start = meta_line_start(xml_text, index);
+        let indent = &xml_text[line_start..index];
+        let child_indent = format!("{indent}\t");
+        emit_meta_tabular_section(
+            &mut lines,
+            &child_indent,
+            &section,
+            object_type,
+            object_name,
+            &mut next_uuid,
+        );
+        let replacement = format!(
+            "<ChildObjects>{line_ending}{}{line_ending}{indent}</ChildObjects>",
+            lines.join(line_ending)
+        );
+        xml_text.replace_range(index..index + "<ChildObjects/>".len(), &replacement);
+        return Ok(1);
+    }
+
+    let open = "<ChildObjects>";
+    let Some(open_index) = xml_text.find(open) else {
+        return Err("No <ChildObjects> section found".to_string());
+    };
+    let Some(close_index) = find_meta_matching_section_close(xml_text, open_index, "ChildObjects")
+    else {
+        return Err("No matching </ChildObjects> found".to_string());
+    };
+    let close_line_start = meta_line_start(xml_text, close_index);
+    let close_indent = &xml_text[close_line_start..close_index];
+    let child_indent = format!("{close_indent}\t");
+    emit_meta_tabular_section(
+        &mut lines,
+        &child_indent,
+        &section,
+        object_type,
+        object_name,
+        &mut next_uuid,
+    );
+    xml_text.insert_str(
+        close_line_start,
+        &format!("{}{line_ending}", lines.join(line_ending)),
+    );
+    Ok(1)
+}
+
+pub(crate) fn parse_meta_edit_tabular_section(
+    value: &str,
+) -> Result<MetaCompileTabularSection, String> {
+    let Some((name, columns)) = value.split_once(':') else {
+        return Err("add-ts value must be 'ТЧ: Реквизит: Тип, ...'".to_string());
+    };
+    let name = name.trim();
+    if name.is_empty() {
+        return Err("tabular section name is empty".to_string());
+    }
+    let columns = split_meta_edit_top_level(columns, ',')
+        .into_iter()
+        .map(|column| meta_compile_parse_attr(&Value::String(column.trim().to_string())))
+        .filter(|column| !column.name.is_empty())
+        .collect::<Vec<_>>();
+    if columns.is_empty() {
+        return Err("tabular section must contain at least one attribute".to_string());
+    }
+    Ok(MetaCompileTabularSection {
+        name: name.to_string(),
+        columns,
+    })
+}
+
+pub(crate) fn modify_meta_tabular_section(
+    xml_text: &mut String,
+    value: &str,
+) -> Result<usize, String> {
+    let Some((section_name, changes)) = value.split_once(':') else {
+        return Err("modify-ts value must be 'ТЧ: key=value, ...'".to_string());
+    };
+    let section_name = section_name.trim();
+    let (start, end) = find_meta_child_by_name(xml_text, "TabularSection", section_name)
+        .ok_or_else(|| format!("TabularSection '{section_name}' not found"))?;
+    modify_meta_fragment_properties(xml_text, start, end, changes)
+}
+
+pub(crate) fn modify_meta_tabular_section_attribute(
+    xml_text: &mut String,
+    value: &str,
+) -> Result<usize, String> {
+    let Some((target, changes)) = value.split_once(':') else {
+        return Err("modify-ts-attribute value must be 'ТЧ.Реквизит: key=value, ...'".to_string());
+    };
+    let Some((section_name, attribute_name)) = target.trim().split_once('.') else {
+        return Err("modify-ts-attribute target must be 'ТЧ.Реквизит'".to_string());
+    };
+    let (section_start, section_end) =
+        find_meta_child_by_name(xml_text, "TabularSection", section_name.trim())
+            .ok_or_else(|| format!("TabularSection '{}' not found", section_name.trim()))?;
+    let (relative_start, relative_end) = find_meta_child_by_name(
+        &xml_text[section_start..section_end],
+        "Attribute",
+        attribute_name.trim(),
+    )
+    .ok_or_else(|| {
+        format!(
+            "Attribute '{}.{}' not found",
+            section_name.trim(),
+            attribute_name.trim()
+        )
+    })?;
+    modify_meta_fragment_properties(
+        xml_text,
+        section_start + relative_start,
+        section_start + relative_end,
+        changes,
+    )
+}
+
+pub(crate) fn modify_meta_fragment_properties(
+    xml_text: &mut String,
+    start: usize,
+    end: usize,
+    changes: &str,
+) -> Result<usize, String> {
+    let mut fragment = xml_text[start..end].to_string();
+    let mut modified = 0usize;
+    for change in split_meta_edit_top_level(changes, ',') {
+        let Some((key, raw_value)) = change.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = raw_value.trim();
+        let changed = if key.eq_ignore_ascii_case("synonym") {
+            replace_meta_mltext_fragment(&mut fragment, "Synonym", value)
+        } else {
+            replace_meta_element_text_fragment(&mut fragment, key, value)
+        };
+        if changed {
+            modified += 1;
+        }
+    }
+    if modified > 0 {
+        xml_text.replace_range(start..end, &fragment);
+    }
+    Ok(modified)
+}
+
+pub(crate) fn split_meta_edit_top_level(value: &str, separator: char) -> Vec<&str> {
+    let mut result = Vec::new();
+    let mut start = 0usize;
+    let mut depth = 0usize;
+    for (index, ch) in value.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => depth = depth.saturating_sub(1),
+            _ if ch == separator && depth == 0 => {
+                result.push(value[start..index].trim());
+                start = index + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    result.push(value[start..].trim());
+    result.into_iter().filter(|part| !part.is_empty()).collect()
+}
+
+pub(crate) fn find_meta_child_by_name(
+    xml_text: &str,
+    tag: &str,
+    name: &str,
+) -> Option<(usize, usize)> {
+    let open = format!("<{tag} ");
+    let close = format!("</{tag}>");
+    let name_probe = format!("<Name>{}</Name>", escape_xml(name));
+    let mut pos = 0usize;
+    while pos < xml_text.len() {
+        let start = xml_text[pos..].find(&open).map(|idx| pos + idx)?;
+        let end = xml_text[start..]
+            .find(&close)
+            .map(|idx| start + idx + close.len())?;
+        if xml_text[start..end].contains(&name_probe) {
+            return Some((start, end));
+        }
+        pos = end;
+    }
+    None
+}
+
+pub(crate) fn replace_meta_mltext_fragment(fragment: &mut String, tag: &str, value: &str) -> bool {
+    let Some((start, end)) = find_meta_element_range(fragment, tag) else {
+        return false;
+    };
+    let indent = meta_line_indent_at(fragment, start);
+    let mut lines = Vec::new();
+    emit_meta_mltext(&mut lines, &indent, tag, value);
+    fragment.replace_range(start..end, &lines.join(meta_line_ending(fragment)));
+    true
+}
+
+pub(crate) fn replace_meta_element_text_fragment(
+    fragment: &mut String,
+    tag: &str,
+    value: &str,
+) -> bool {
+    let Some((start, end)) = find_meta_element_range(fragment, tag) else {
+        return false;
+    };
+    let replacement = format!("<{tag}>{}</{tag}>", escape_xml(value));
+    fragment.replace_range(start..end, &replacement);
+    true
+}
+
+pub(crate) fn find_meta_element_range(xml_text: &str, tag: &str) -> Option<(usize, usize)> {
+    if let Some(start) = xml_text.find(&format!("<{tag}/>")) {
+        return Some((start, start + tag.len() + 3));
+    }
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let start = xml_text.find(&open)?;
+    let end = xml_text[start + open.len()..]
+        .find(&close)
+        .map(|idx| start + open.len() + idx + close.len())?;
+    Some((start, end))
+}
+
+pub(crate) fn find_meta_matching_section_close(
+    xml_text: &str,
+    open_start: usize,
+    tag: &str,
+) -> Option<usize> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let mut depth = 1usize;
+    let mut pos = open_start + open.len();
+    loop {
+        let next_open = xml_text[pos..].find(&open).map(|idx| pos + idx);
+        let next_close = xml_text[pos..].find(&close).map(|idx| pos + idx);
+        match (next_open, next_close) {
+            (Some(open_pos), Some(close_pos)) if open_pos < close_pos => {
+                depth += 1;
+                pos = open_pos + open.len();
+            }
+            (_, Some(close_pos)) => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return Some(close_pos);
+                }
+                pos = close_pos + close.len();
+            }
+            _ => return None,
+        }
+    }
+}
+
+pub(crate) fn meta_line_ending(xml_text: &str) -> &str {
+    if xml_text.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    }
+}
+
+pub(crate) fn meta_line_start(xml_text: &str, pos: usize) -> usize {
+    xml_text[..pos].rfind('\n').map(|idx| idx + 1).unwrap_or(0)
+}
+
+pub(crate) fn meta_line_indent_at(xml_text: &str, pos: usize) -> String {
+    let line_start = meta_line_start(xml_text, pos);
+    xml_text[line_start..pos]
+        .chars()
+        .take_while(|ch| ch.is_whitespace())
+        .collect()
+}
+
+#[cfg(test)]
+mod meta_edit_tests {
+    use super::*;
+    use crate::domain::workspace::WorkspaceContext;
+    use serde_json::{json, Map};
+    use std::fs;
+    use std::path::Path;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_context(name: &str) -> WorkspaceContext {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("unica-meta-{name}-{nanos}"));
+        fs::create_dir_all(&root).unwrap();
+        WorkspaceContext {
+            cwd: root.clone(),
+            workspace_root: root.clone(),
+            cache_root: root.join(".build").join("unica"),
+            workspace_epoch: 1,
+        }
+    }
+
+    fn write_file(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn edit_meta_adds_tabular_section_and_modifies_synonyms() {
+        let context = temp_context("edit-add-ts");
+        let object_path = context.cwd.join("Catalogs").join("Items.xml");
+        write_file(
+            &object_path,
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xr="http://v8.1c.ru/8.3/xcf/readable" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.17">
+	<Catalog uuid="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb">
+		<Properties>
+			<Name>Items</Name>
+			<Synonym>
+				<v8:item>
+					<v8:lang>ru</v8:lang>
+					<v8:content>Items</v8:content>
+				</v8:item>
+			</Synonym>
+		</Properties>
+		<ChildObjects/>
+	</Catalog>
+</MetaDataObject>
+"#,
+        );
+
+        let mut args = Map::new();
+        args.insert(
+            "ObjectPath".to_string(),
+            json!(object_path.display().to_string()),
+        );
+        args.insert("Operation".to_string(), json!("add-ts"));
+        args.insert(
+            "Value".to_string(),
+            json!(
+                "кшСтроки: кшКоличество: Number(15,3) | req, кшРаспоряжение: DefinedType.РаспоряжениеНаОтгрузку"
+            ),
+        );
+        let outcome = edit_meta(&args, &context);
+        assert!(outcome.ok, "{} {:?}", outcome.summary, outcome.errors);
+
+        args.insert("Operation".to_string(), json!("modify-ts"));
+        args.insert("Value".to_string(), json!("кшСтроки: synonym=Строки"));
+        let outcome = edit_meta(&args, &context);
+        assert!(outcome.ok, "{} {:?}", outcome.summary, outcome.errors);
+
+        args.insert("Operation".to_string(), json!("modify-ts-attribute"));
+        args.insert(
+            "Value".to_string(),
+            json!("кшСтроки.кшКоличество: synonym=Количество"),
+        );
+        let outcome = edit_meta(&args, &context);
+        assert!(outcome.ok, "{} {:?}", outcome.summary, outcome.errors);
+
+        let xml_text = fs::read_to_string(&object_path).unwrap();
+        assert!(xml_text.contains("<TabularSection uuid=\""));
+        assert!(xml_text.contains("CatalogTabularSection.Items.кшСтроки"));
+        assert!(xml_text.contains("CatalogTabularSectionRow.Items.кшСтроки"));
+        assert!(xml_text.contains("<Name>кшКоличество</Name>"));
+        assert!(xml_text.contains("<v8:Digits>15</v8:Digits>"));
+        assert!(xml_text.contains("<v8:FractionDigits>3</v8:FractionDigits>"));
+        assert!(xml_text.contains("<FillChecking>ShowError</FillChecking>"));
+        assert!(xml_text.contains("<v8:Type>cfg:DefinedType.РаспоряжениеНаОтгрузку</v8:Type>"));
+        assert!(xml_text.contains("<v8:content>Строки</v8:content>"));
+        assert!(xml_text.contains("<v8:content>Количество</v8:content>"));
+    }
 }
 
 pub(crate) fn normalize_meta_edit_property_value(key: &str, value: &str) -> String {

--- a/crates/unica-coder/src/infrastructure/native_operations/meta.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta.rs
@@ -8090,16 +8090,40 @@ pub(crate) fn register_compiled_meta_in_configuration(
         return Ok(Some("already".to_string()));
     }
     if raw_text.contains("</ChildObjects>") {
-        raw_text = raw_text.replacen(
-            "</ChildObjects>",
-            &format!("\t\t\t<{child_tag}>{obj_name}</{child_tag}>\n\t\t</ChildObjects>"),
-            1,
-        );
+        raw_text =
+            register_compiled_meta_child_text(&raw_text, child_tag, obj_name).unwrap_or(raw_text);
         write_utf8_bom(&config_xml_path, &raw_text)?;
         Ok(Some("added".to_string()))
     } else {
         Ok(Some("no-childobj".to_string()))
     }
+}
+
+fn register_compiled_meta_child_text(
+    xml_text: &str,
+    child_tag: &str,
+    obj_name: &str,
+) -> Option<String> {
+    let close = "</ChildObjects>";
+    let index = xml_text.find(close)?;
+    let eol = if xml_text.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    };
+    let line_start = xml_text[..index].rfind('\n').map_or(0, |pos| pos + 1);
+    let closing_indent = &xml_text[line_start..index];
+    let insertion = format!("<{child_tag}>{obj_name}</{child_tag}>");
+    let mut result = String::with_capacity(
+        xml_text.len() + 1 + insertion.len() + eol.len() + closing_indent.len(),
+    );
+    result.push_str(&xml_text[..index]);
+    result.push('\t');
+    result.push_str(&insertion);
+    result.push_str(eol);
+    result.push_str(closing_indent);
+    result.push_str(&xml_text[index..]);
+    Some(result)
 }
 
 pub(crate) fn edit_meta(args: &Map<String, Value>, context: &WorkspaceContext) -> AdapterOutcome {

--- a/crates/unica-coder/src/infrastructure/native_operations/meta.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta.rs
@@ -8085,8 +8085,7 @@ pub(crate) fn register_compiled_meta_in_configuration(
     if !config_xml_path.is_file() {
         return Ok(Some("no-config".to_string()));
     }
-    let mut raw_text = fs::read_to_string(&config_xml_path)
-        .map_err(|err| format!("failed to read {}: {err}", config_xml_path.display()))?;
+    let mut raw_text = read_utf8_sig(&config_xml_path)?;
     if raw_text.contains(&format!("<{child_tag}>{obj_name}</{child_tag}>")) {
         return Ok(Some("already".to_string()));
     }
@@ -8141,8 +8140,7 @@ pub(crate) fn edit_meta(args: &Map<String, Value>, context: &WorkspaceContext) -
             ));
         }
 
-        let mut xml_text = fs::read_to_string(&object_path)
-            .map_err(|err| format!("failed to read {}: {err}", object_path.display()))?;
+        let mut xml_text = read_utf8_sig(&object_path)?;
         let (object_type, object_name) = meta_edit_object_identity(&xml_text)?;
         let mut modified = 0usize;
         for pair in value

--- a/crates/unica-coder/src/infrastructure/native_operations/meta.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta.rs
@@ -8106,21 +8106,15 @@ fn register_compiled_meta_child_text(
 ) -> Option<String> {
     let close = "</ChildObjects>";
     let index = xml_text.find(close)?;
-    let eol = if xml_text.contains("\r\n") {
-        "\r\n"
-    } else {
-        "\n"
-    };
     let line_start = xml_text[..index].rfind('\n').map_or(0, |pos| pos + 1);
     let closing_indent = &xml_text[line_start..index];
     let insertion = format!("<{child_tag}>{obj_name}</{child_tag}>");
-    let mut result = String::with_capacity(
-        xml_text.len() + 1 + insertion.len() + eol.len() + closing_indent.len(),
-    );
+    let mut result =
+        String::with_capacity(xml_text.len() + 1 + insertion.len() + 1 + closing_indent.len());
     result.push_str(&xml_text[..index]);
     result.push('\t');
     result.push_str(&insertion);
-    result.push_str(eol);
+    result.push('\n');
     result.push_str(closing_indent);
     result.push_str(&xml_text[index..]);
     Some(result)

--- a/crates/unica-coder/src/infrastructure/native_operations/registry.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/registry.rs
@@ -2,7 +2,7 @@ use crate::domain::workspace::WorkspaceContext;
 use crate::infrastructure::AdapterOutcome;
 use serde_json::{Map, Value};
 
-use super::{cf, cfe, form, help, interface, meta, mxl, role, skd, subsystem, template};
+use super::{cf, cfe, form, help, interface, meta, mxl, role, skd, subsystem, support, template};
 
 pub(crate) fn invoke_read(
     operation: &str,
@@ -42,4 +42,5 @@ pub(crate) fn invoke_mutation(
         .or_else(|| skd::invoke_mutation(operation, tool_name, args, context))
         .or_else(|| mxl::invoke_mutation(operation, tool_name, args, context))
         .or_else(|| role::invoke_mutation(operation, tool_name, args, context))
+        .or_else(|| support::invoke_mutation(operation, tool_name, args, context))
 }

--- a/crates/unica-coder/src/infrastructure/native_operations/role.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/role.rs
@@ -1180,7 +1180,7 @@ pub(crate) fn compile_role(
             }
         }
 
-        let uid = stable_uuid(80);
+        let uid = fresh_meta_compile_uuid();
         let metadata_xml = role_metadata_xml(&role_name, &synonym, &comment, &format_version, &uid);
 
         let sfno = defn

--- a/crates/unica-coder/src/infrastructure/native_operations/support.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/support.rs
@@ -150,6 +150,35 @@ fn edit_support_result(
     match action {
         SupportEditAction::Capability(capability) => {
             if state.global_editing_enabled() == capability.enabled() {
+                let marker_count = repair_parent_configuration_markers(&bin_path, &text)?;
+                if marker_count > 0 {
+                    let word = if capability.enabled() {
+                        "включена"
+                    } else {
+                        "выключена"
+                    };
+                    return Ok(AdapterOutcome {
+                        ok: true,
+                        summary: format!(
+                            "Возможность изменения конфигурации уже {word}; исправлены маркеры родительской конфигурации."
+                        ),
+                        changes: vec![
+                            format!("updated {}", bin_path.display()),
+                            format!("normalize parent configuration markers: {marker_count}"),
+                        ],
+                        warnings: Vec::new(),
+                        errors: Vec::new(),
+                        artifacts: vec![
+                            bin_path.display().to_string(),
+                            resolved_path.display().to_string(),
+                        ],
+                        stdout: Some(format!(
+                            "Возможность изменения конфигурации уже {word}; исправлены маркеры родительской конфигурации: {marker_count}.\n"
+                        )),
+                        stderr: None,
+                        command: None,
+                    });
+                }
                 let word = if capability.enabled() {
                     "включена"
                 } else {
@@ -229,7 +258,7 @@ fn apply_capability(
 ) -> Result<AdapterOutcome, String> {
     let target = capability.target_flag();
     let mut updated = replace_global_flag(text, target)?;
-    updated = replace_vendor_rule_flags(&updated, target);
+    let parent_marker_count = normalize_parent_configuration_markers(&mut updated);
     let object_count = replace_all_object_rule_flags(&mut updated, target);
     write_parent_configurations(bin_path, &updated)?;
 
@@ -252,6 +281,7 @@ fn apply_capability(
         changes: vec![
             format!("updated {}", bin_path.display()),
             format!("set global editing flag to {target}"),
+            format!("normalize parent configuration markers: {parent_marker_count}"),
             format!("reset object support rules: {object_count}"),
         ],
         warnings: if capability.enabled() {
@@ -353,13 +383,26 @@ fn replace_global_flag(text: &str, target: u8) -> Result<String, String> {
     Ok(format!("{prefix}{target}{}", &rest[comma..]))
 }
 
-fn replace_vendor_rule_flags(text: &str, target: u8) -> String {
+fn repair_parent_configuration_markers(bin_path: &Path, text: &str) -> Result<usize, String> {
+    let mut updated = text.to_string();
+    let marker_count = normalize_parent_configuration_markers(&mut updated);
+    if marker_count > 0 {
+        write_parent_configurations(bin_path, &updated)?;
+    }
+    Ok(marker_count)
+}
+
+fn normalize_parent_configuration_markers(text: &mut String) -> usize {
     let mut result = String::with_capacity(text.len());
     let mut i = 0usize;
+    let mut count = 0usize;
     while i < text.len() {
         if let Some((flag_start, flag_end)) = vendor_flag_span(text, i) {
             result.push_str(&text[i..flag_start]);
-            result.push(char::from(b'0' + target));
+            if &text[flag_start..flag_end] != "1" {
+                count += 1;
+            }
+            result.push('1');
             i = flag_end;
             continue;
         }
@@ -367,7 +410,10 @@ fn replace_vendor_rule_flags(text: &str, target: u8) -> String {
         result.push(ch);
         i += ch.len_utf8();
     }
-    result
+    if count > 0 {
+        *text = result;
+    }
+    count
 }
 
 fn vendor_flag_span(text: &str, start: usize) -> Option<(usize, usize)> {

--- a/crates/unica-coder/src/infrastructure/native_operations/support.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/support.rs
@@ -1,0 +1,449 @@
+use crate::domain::workspace::WorkspaceContext;
+use crate::infrastructure::AdapterOutcome;
+use serde_json::{Map, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::common::{
+    absolutize, find_support_config_dir, is_uuid_text, path_arg, read_support_state,
+    support_object_uuid_for_path, support_root_uuid,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SupportCapability {
+    On,
+    Off,
+}
+
+impl SupportCapability {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "on" => Some(Self::On),
+            "off" => Some(Self::Off),
+            _ => None,
+        }
+    }
+
+    fn target_flag(self) -> u8 {
+        match self {
+            Self::On => 0,
+            Self::Off => 1,
+        }
+    }
+
+    fn enabled(self) -> bool {
+        matches!(self, Self::On)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SupportObjectRule {
+    Locked,
+    Editable,
+    OffSupport,
+}
+
+impl SupportObjectRule {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "locked" => Some(Self::Locked),
+            "editable" => Some(Self::Editable),
+            "off-support" => Some(Self::OffSupport),
+            _ => None,
+        }
+    }
+
+    fn flag(self) -> u8 {
+        match self {
+            Self::Locked => 0,
+            Self::Editable => 1,
+            Self::OffSupport => 2,
+        }
+    }
+
+    fn state_text(self) -> &'static str {
+        match self {
+            Self::Locked => "на замке (правка запрещена)",
+            Self::Editable => {
+                "редактируется с сохранением поддержки (объект продолжит получать обновления вендора — возможны конфликты при обновлении)"
+            }
+            Self::OffSupport => "снят с поддержки (обновления вендора по этому объекту прекращаются)",
+        }
+    }
+}
+
+enum SupportEditAction {
+    Capability(SupportCapability),
+    Set(SupportObjectRule),
+}
+
+pub(crate) fn invoke_mutation(
+    operation: &str,
+    _tool_name: &str,
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> Option<AdapterOutcome> {
+    match operation {
+        "support-edit" => Some(edit_support(args, context)),
+        _ => None,
+    }
+}
+
+fn edit_support(args: &Map<String, Value>, context: &WorkspaceContext) -> AdapterOutcome {
+    match edit_support_result(args, context) {
+        Ok(outcome) => outcome,
+        Err(error) => AdapterOutcome {
+            ok: false,
+            summary: "support-edit failed".to_string(),
+            changes: Vec::new(),
+            warnings: Vec::new(),
+            errors: vec![error],
+            artifacts: Vec::new(),
+            stdout: None,
+            stderr: None,
+            command: None,
+        },
+    }
+}
+
+fn edit_support_result(
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> Result<AdapterOutcome, String> {
+    let action = support_edit_action(args)?;
+    let target_path = support_target_path(args, context)?;
+    if !target_path.exists() {
+        return Err(format!("Путь не найден: {}", target_path.display()));
+    }
+    let resolved_path = target_path
+        .canonicalize()
+        .unwrap_or_else(|_| target_path.clone());
+    let Some(config_dir) = find_support_config_dir(&resolved_path) else {
+        return Err(format!(
+            "Не найден корень конфигурации (Configuration.xml) над путём: {}",
+            resolved_path.display()
+        ));
+    };
+    let bin_path = config_dir.join("Ext").join("ParentConfigurations.bin");
+    if !bin_path.exists() {
+        return Ok(noop_outcome(
+            "Конфигурация не на поддержке (Ext/ParentConfigurations.bin отсутствует) — переключать нечего.",
+        ));
+    }
+    let raw = fs::read(&bin_path)
+        .map_err(|err| format!("failed to read {}: {err}", bin_path.display()))?;
+    if raw.len() <= 32 {
+        return Ok(noop_outcome(
+            "Поддержка снята полностью (пустой ParentConfigurations.bin) — переключать нечего.",
+        ));
+    }
+    let text = decode_parent_configurations(&raw)?;
+    let Some(state) = read_support_state(&bin_path) else {
+        return Err("Неизвестный формат ParentConfigurations.bin".to_string());
+    };
+    if state.removed() {
+        return Ok(noop_outcome(
+            "Поддержка снята полностью (пустой ParentConfigurations.bin) — переключать нечего.",
+        ));
+    }
+
+    match action {
+        SupportEditAction::Capability(capability) => {
+            if state.global_editing_enabled() == capability.enabled() {
+                let word = if capability.enabled() {
+                    "включена"
+                } else {
+                    "выключена"
+                };
+                return Ok(noop_outcome(format!(
+                    "Возможность изменения конфигурации уже {word} — изменений нет."
+                )));
+            }
+            apply_capability(&bin_path, &text, capability, &resolved_path)
+        }
+        SupportEditAction::Set(rule) => {
+            if !state.global_editing_enabled() {
+                return Err(format!(
+                    "Возможность изменения конфигурации выключена — пообъектное переключение недоступно.\n  Сначала: support-edit -Path {} -Capability on или unica.support.edit Path={} Capability=on",
+                    resolved_path.display(),
+                    resolved_path.display()
+                ));
+            }
+            let object_uuid = support_object_uuid_for_path(&resolved_path)
+                .or_else(|| support_root_uuid(&config_dir.join("Configuration.xml")))
+                .ok_or_else(|| {
+                    format!(
+                        "Не удалось определить объект по пути: {}",
+                        resolved_path.display()
+                    )
+                })?;
+            apply_object_rule(&bin_path, &text, &object_uuid, rule, &resolved_path)
+        }
+    }
+}
+
+fn support_target_path(
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> Result<PathBuf, String> {
+    path_arg(args, &["Path", "path", "TargetPath", "targetPath"])
+        .map(|path| absolutize(path, &context.cwd))
+        .ok_or_else(|| "missing required argument: Path".to_string())
+}
+
+fn support_edit_action(args: &Map<String, Value>) -> Result<SupportEditAction, String> {
+    let capability = string_arg(args, &["Capability", "capability"]);
+    let set = string_arg(args, &["Set", "set"]);
+    match (capability, set) {
+        (Some(_), Some(_)) | (None, None) => Err(
+            "Укажите ровно одно: Capability=on|off ЛИБО Set=editable|off-support|locked"
+                .to_string(),
+        ),
+        (Some(value), None) => SupportCapability::parse(&value)
+            .map(SupportEditAction::Capability)
+            .ok_or_else(|| "Capability must be one of: on, off".to_string()),
+        (None, Some(value)) => SupportObjectRule::parse(&value)
+            .map(SupportEditAction::Set)
+            .ok_or_else(|| "Set must be one of: editable, off-support, locked".to_string()),
+    }
+}
+
+fn string_arg(args: &Map<String, Value>, names: &[&str]) -> Option<String> {
+    names
+        .iter()
+        .find_map(|name| args.get(*name).and_then(Value::as_str))
+        .map(ToOwned::to_owned)
+}
+
+fn decode_parent_configurations(raw: &[u8]) -> Result<String, String> {
+    let data = raw.strip_prefix(&[0xEF, 0xBB, 0xBF]).unwrap_or(raw);
+    String::from_utf8(data.to_vec())
+        .map_err(|err| format!("ParentConfigurations.bin is not UTF-8: {err}"))
+}
+
+fn apply_capability(
+    bin_path: &Path,
+    text: &str,
+    capability: SupportCapability,
+    target_path: &Path,
+) -> Result<AdapterOutcome, String> {
+    let target = capability.target_flag();
+    let mut updated = replace_global_flag(text, target)?;
+    updated = replace_vendor_rule_flags(&updated, target);
+    let object_count = replace_all_object_rule_flags(&mut updated, target);
+    write_parent_configurations(bin_path, &updated)?;
+
+    let summary = if capability.enabled() {
+        "Возможность изменения конфигурации ВКЛЮЧЕНА"
+    } else {
+        "Возможность изменения конфигурации ВЫКЛЮЧЕНА"
+    };
+    let stdout = if capability.enabled() {
+        format!(
+            "{summary}. Все объекты поставщика — на замке.\nВключайте редактирование точечно: support-edit -Path <объект> -Set editable\n"
+        )
+    } else {
+        format!("{summary}. Вся конфигурация стала read-only; пообъектные правила сброшены.\n")
+    };
+
+    Ok(AdapterOutcome {
+        ok: true,
+        summary: summary.to_string(),
+        changes: vec![
+            format!("updated {}", bin_path.display()),
+            format!("set global editing flag to {target}"),
+            format!("reset object support rules: {object_count}"),
+        ],
+        warnings: if capability.enabled() {
+            vec![
+                "Все объекты поставщика оставлены на замке; включайте editable/off-support точечно."
+                    .to_string(),
+            ]
+        } else {
+            Vec::new()
+        },
+        errors: Vec::new(),
+        artifacts: vec![
+            bin_path.display().to_string(),
+            target_path.display().to_string(),
+        ],
+        stdout: Some(stdout),
+        stderr: None,
+        command: None,
+    })
+}
+
+fn apply_object_rule(
+    bin_path: &Path,
+    text: &str,
+    object_uuid: &str,
+    rule: SupportObjectRule,
+    target_path: &Path,
+) -> Result<AdapterOutcome, String> {
+    let mut updated = text.to_string();
+    let changed = replace_object_rule_flags(&mut updated, object_uuid, rule.flag());
+    if changed == 0 {
+        let message = format!(
+            "Объект (uuid {object_uuid}) не на поддержке (своё добавление или не найден в bin) — переключать нечего."
+        );
+        return Ok(noop_outcome(message));
+    }
+    write_parent_configurations(bin_path, &updated)?;
+    let summary = format!("Объект uuid {object_uuid} → {}.", rule.state_text());
+    Ok(AdapterOutcome {
+        ok: true,
+        summary: summary.clone(),
+        changes: vec![
+            format!("updated {}", bin_path.display()),
+            format!("set object {object_uuid} support rule to {}", rule.flag()),
+            format!("updated support records: {changed}"),
+        ],
+        warnings: if matches!(rule, SupportObjectRule::Editable) {
+            vec![
+                "Объект продолжит получать обновления вендора; при обновлении возможны конфликты."
+                    .to_string(),
+            ]
+        } else {
+            Vec::new()
+        },
+        errors: Vec::new(),
+        artifacts: vec![
+            bin_path.display().to_string(),
+            target_path.display().to_string(),
+        ],
+        stdout: Some(format!(
+            "{summary}\nЗаписей в bin изменено: {changed}. Цель: {}\n",
+            target_path.display()
+        )),
+        stderr: None,
+        command: None,
+    })
+}
+
+fn noop_outcome(message: impl Into<String>) -> AdapterOutcome {
+    let message = message.into();
+    AdapterOutcome {
+        ok: true,
+        summary: message.clone(),
+        changes: Vec::new(),
+        warnings: Vec::new(),
+        errors: Vec::new(),
+        artifacts: Vec::new(),
+        stdout: Some(format!("{message}\n")),
+        stderr: None,
+        command: None,
+    }
+}
+
+fn write_parent_configurations(path: &Path, text: &str) -> Result<(), String> {
+    let mut bytes = Vec::with_capacity(text.len() + 3);
+    bytes.extend_from_slice(&[0xEF, 0xBB, 0xBF]);
+    bytes.extend_from_slice(text.as_bytes());
+    fs::write(path, bytes).map_err(|err| format!("failed to write {}: {err}", path.display()))
+}
+
+fn replace_global_flag(text: &str, target: u8) -> Result<String, String> {
+    let prefix = "{6,";
+    let Some(rest) = text.strip_prefix(prefix) else {
+        return Err("Неизвестный формат ParentConfigurations.bin".to_string());
+    };
+    let Some(comma) = rest.find(',') else {
+        return Err("Неизвестный формат ParentConfigurations.bin".to_string());
+    };
+    Ok(format!("{prefix}{target}{}", &rest[comma..]))
+}
+
+fn replace_vendor_rule_flags(text: &str, target: u8) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut i = 0usize;
+    while i < text.len() {
+        if let Some((flag_start, flag_end)) = vendor_flag_span(text, i) {
+            result.push_str(&text[i..flag_start]);
+            result.push(char::from(b'0' + target));
+            i = flag_end;
+            continue;
+        }
+        let ch = text[i..].chars().next().expect("valid char boundary");
+        result.push(ch);
+        i += ch.len_utf8();
+    }
+    result
+}
+
+fn vendor_flag_span(text: &str, start: usize) -> Option<(usize, usize)> {
+    let bytes = text.as_bytes();
+    if start + 36 >= bytes.len() {
+        return None;
+    }
+    let first_uuid = text.get(start..start + 36)?;
+    if !is_uuid_text(first_uuid) || bytes.get(start + 36) != Some(&b',') {
+        return None;
+    }
+    let flag_start = start + 37;
+    let mut flag_end = flag_start;
+    while bytes
+        .get(flag_end)
+        .is_some_and(|byte| byte.is_ascii_digit())
+    {
+        flag_end += 1;
+    }
+    if flag_end == flag_start || bytes.get(flag_end) != Some(&b',') {
+        return None;
+    }
+    let second_uuid_start = flag_end + 1;
+    let second_uuid = text.get(second_uuid_start..second_uuid_start + 36)?;
+    if !is_uuid_text(second_uuid) {
+        return None;
+    }
+    Some((flag_start, flag_end))
+}
+
+fn replace_all_object_rule_flags(text: &mut String, target: u8) -> usize {
+    let mut bytes = text.as_bytes().to_vec();
+    let mut count = 0usize;
+    let mut i = 0usize;
+    while i + 40 <= bytes.len() {
+        if matches!(bytes[i], b'0'..=b'2')
+            && bytes.get(i + 1..i + 4) == Some(b",0,")
+            && text.get(i + 4..i + 40).is_some_and(is_uuid_text)
+        {
+            bytes[i] = b'0' + target;
+            count += 1;
+            i += 40;
+            continue;
+        }
+        i += 1;
+    }
+    if count > 0 {
+        *text = String::from_utf8(bytes).expect("single-byte digit replacement preserves UTF-8");
+    }
+    count
+}
+
+fn replace_object_rule_flags(text: &mut String, object_uuid: &str, target: u8) -> usize {
+    let target_uuid = object_uuid.to_ascii_lowercase();
+    let mut bytes = text.as_bytes().to_vec();
+    let mut count = 0usize;
+    let mut i = 0usize;
+    while i + 40 <= bytes.len() {
+        if matches!(bytes[i], b'0'..=b'2') && bytes.get(i + 1..i + 4) == Some(b",0,") {
+            let uuid_start = i + 4;
+            let uuid_end = uuid_start + 36;
+            if let Some(uuid) = text.get(uuid_start..uuid_end) {
+                if is_uuid_text(uuid)
+                    && uuid.as_bytes().eq_ignore_ascii_case(target_uuid.as_bytes())
+                {
+                    bytes[i] = b'0' + target;
+                    count += 1;
+                    i = uuid_end;
+                    continue;
+                }
+            }
+        }
+        i += 1;
+    }
+    if count > 0 {
+        *text = String::from_utf8(bytes).expect("single-byte digit replacement preserves UTF-8");
+    }
+    count
+}

--- a/crates/unica-coder/src/infrastructure/native_operations/template.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/template.rs
@@ -451,41 +451,48 @@ pub(crate) fn append_metadata_child_text(
     local_name: &str,
     item_name: &str,
 ) -> Option<String> {
-    for close in ["</ChildObjects>", "</md:ChildObjects>"] {
-        if let Some(index) = xml_text.find(close) {
-            let prefix = if close.starts_with("</md:") {
-                "md:"
-            } else {
-                ""
-            };
-            let line_start = xml_text[..index].rfind('\n').map_or(0, |pos| pos + 1);
-            let closing_indent = &xml_text[line_start..index];
-            let line = format!(
-                "\t<{prefix}{local_name}>{item_name}</{prefix}{local_name}>\n{closing_indent}"
-            );
-            let mut result = String::with_capacity(xml_text.len() + line.len());
-            result.push_str(&xml_text[..index]);
-            result.push_str(&line);
-            result.push_str(&xml_text[index..]);
-            return Some(result);
-        }
+    let doc = Document::parse(xml_text).ok()?;
+    let object_node = doc
+        .root_element()
+        .children()
+        .find(|node| node.is_element())?;
+    let child_objects_node = object_node
+        .children()
+        .find(|node| node.is_element() && node.tag_name().name() == "ChildObjects")?;
+    let range = child_objects_node.range();
+    let element_text = &xml_text[range.clone()];
+    let prefix = if element_text.trim_start().starts_with("<md:") {
+        "md:"
+    } else {
+        ""
+    };
+
+    let empty_tag = format!("<{prefix}ChildObjects/>");
+    if element_text.trim() == empty_tag {
+        let line_start = xml_text[..range.start].rfind('\n').map_or(0, |pos| pos + 1);
+        let indent = &xml_text[line_start..range.start];
+        let replacement = format!(
+            "<{prefix}ChildObjects>\n{indent}\t<{prefix}{local_name}>{item_name}</{prefix}{local_name}>\n{indent}</{prefix}ChildObjects>"
+        );
+        let mut result = String::with_capacity(xml_text.len() + replacement.len());
+        result.push_str(&xml_text[..range.start]);
+        result.push_str(&replacement);
+        result.push_str(&xml_text[range.end..]);
+        return Some(result);
     }
 
-    for empty in ["<ChildObjects/>", "<md:ChildObjects/>"] {
-        if let Some(index) = xml_text.find(empty) {
-            let prefix = if empty.starts_with("<md:") { "md:" } else { "" };
-            let replacement = format!(
-                "<{prefix}ChildObjects>\n\t\t\t<{prefix}{local_name}>{item_name}</{prefix}{local_name}>\n\t\t</{prefix}ChildObjects>"
-            );
-            let mut result = String::with_capacity(xml_text.len() + replacement.len());
-            result.push_str(&xml_text[..index]);
-            result.push_str(&replacement);
-            result.push_str(&xml_text[index + empty.len()..]);
-            return Some(result);
-        }
-    }
-
-    None
+    let close = format!("</{prefix}ChildObjects>");
+    let close_rel = element_text.rfind(&close)?;
+    let index = range.start + close_rel;
+    let line_start = xml_text[..index].rfind('\n').map_or(0, |pos| pos + 1);
+    let closing_indent = &xml_text[line_start..index];
+    let line =
+        format!("\t<{prefix}{local_name}>{item_name}</{prefix}{local_name}>\n{closing_indent}");
+    let mut result = String::with_capacity(xml_text.len() + line.len());
+    result.push_str(&xml_text[..index]);
+    result.push_str(&line);
+    result.push_str(&xml_text[index..]);
+    Some(result)
 }
 
 pub(crate) fn update_main_data_composition_schema_text(
@@ -597,6 +604,43 @@ pub(crate) fn invoke_mutation(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn append_metadata_child_text_uses_root_child_objects() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses">
+	<Document uuid="00000000-0000-0000-0000-000000000001">
+		<Properties>
+			<Name>NestedChildObjectsDoc</Name>
+		</Properties>
+		<ChildObjects>
+			<TabularSection uuid="00000000-0000-0000-0000-000000000002">
+				<Properties>
+					<Name>Goods</Name>
+				</Properties>
+				<ChildObjects>
+					<Attribute uuid="00000000-0000-0000-0000-000000000003">
+						<Properties>
+							<Name>Item</Name>
+						</Properties>
+					</Attribute>
+				</ChildObjects>
+			</TabularSection>
+		</ChildObjects>
+	</Document>
+</MetaDataObject>
+"#;
+
+        let updated = append_metadata_child_text(xml, "Template", "ПФ_MXL_КШ").unwrap();
+
+        assert_eq!(updated.matches("<Template>ПФ_MXL_КШ</Template>").count(), 1);
+        assert!(updated.contains(
+            "\t\t\t</TabularSection>\n\t\t\t<Template>ПФ_MXL_КШ</Template>\n\t\t</ChildObjects>"
+        ));
+        assert!(
+            !updated.contains("\t\t\t\t<Template>ПФ_MXL_КШ</Template>\n\t\t\t\t</ChildObjects>")
+        );
+    }
 
     #[test]
     fn fresh_uuid_generates_uuid_v4() {

--- a/crates/unica-coder/src/infrastructure/native_operations/template.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/template.rs
@@ -116,8 +116,7 @@ pub(crate) fn add_template(
             )?;
         }
 
-        let xml_text = fs::read_to_string(&root_xml_path)
-            .map_err(|err| format!("failed to read {}: {err}", root_xml_path.display()))?;
+        let xml_text = read_utf8_sig(&root_xml_path)?;
         let mut xml_text = append_metadata_child_text(&xml_text, "Template", template_name)
             .ok_or_else(|| {
                 format!(
@@ -260,8 +259,7 @@ pub(crate) fn remove_template(
         ));
         changes.push(format!("removed file {}", template_meta_path.display()));
 
-        let xml_text = fs::read_to_string(&root_xml_path)
-            .map_err(|err| format!("failed to read {}: {err}", root_xml_path.display()))?;
+        let xml_text = read_utf8_sig(&root_xml_path)?;
         let xml_text = remove_template_child_text_lxml(&xml_text, template_name);
         let (mut xml_text, main_dcs_cleared) =
             clear_main_data_composition_schema_text(&xml_text, template_name);

--- a/plugins/unica/README.md
+++ b/plugins/unica/README.md
@@ -26,7 +26,7 @@ The `skills/` directory contains operation skills and scenario references for 1C
 - `mxl-*`, `role-*`, `skd-*`, `subsystem-*`, `interface-*`, `template-*`, `web-test`, `img-grid`
 - `code-search`, `code-diagnostics`, `code-review`, `query-optimize`, `test-authoring`
 - `api-design`, `platform-help`, `bsp-patterns`, `integration-implement`, `autonomous-server`, `log-analysis`
-- `background-jobs`, `data-exchange`, `db-performance`, `security-auth-crypto`, `data-separation`, `release-support`
+- `background-jobs`, `data-exchange`, `db-performance`, `security-auth-crypto`, `data-separation`, `release-support`, `support-edit`
 
 ## Local Codex Install
 

--- a/plugins/unica/provenance/skill-upstreams.json
+++ b/plugins/unica/provenance/skill-upstreams.json
@@ -100,6 +100,24 @@
           "decisionReason": "Reviewed cbde49 drift as EOL normalization, raw PowerShell wrapper/guidance churn, shared donor docs, or donor-only capabilities outside the current Unica packaged surface; no prompt-visible Unica skill or typed MCP behavior change is required."
         },
         {
+          "skill": "support-edit",
+          "status": "ported-to-unica",
+          "notes": "Ported donor support-edit semantics into typed Unica MCP/native Rust: Capability=on/off toggles global editing capability and resets object rules using Ext/ParentConfigurations.bin semantics; Set=editable/off-support/locked changes a resolved object's support rule. This replaces downstream raw support metadata fallback with an explicit audited Unica tool.",
+          "upstreamPaths": [
+            ".claude/skills/support-edit/**"
+          ],
+          "localPaths": [
+            "plugins/unica/skills/support-edit"
+          ],
+          "contractPaths": [
+            "crates/unica-coder/src/application/mod.rs",
+            "crates/unica-coder/src/application/tool_contracts.rs",
+            "crates/unica-coder/src/infrastructure/native_operations/support.rs"
+          ],
+          "baselineCommit": "78b5b73fa7f835462dc4073ae7a9fc841e7c62fb",
+          "decision": "ported"
+        },
+        {
           "skill": "cfe-borrow",
           "status": "ported-to-unica",
           "notes": "Reviewed and ported donor cfe-borrow functional drift through cbde49efdaeec190432fdf4a53201a87e83c69de in native Rust: BorrowMainAttribute path enrichment, deep tabular-section paths, DefinedType Type XML, Field path collection, idempotent form metadata, and preserved Module.bsl.",

--- a/plugins/unica/skills/support-edit/SKILL.md
+++ b/plugins/unica/skills/support-edit/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: support-edit
+description: "Изменение состояния поддержки 1С. Используй когда нужно явно включить возможность изменения конфигурации поставщика или переключить объект в editable/off-support/locked."
+argument-hint: "-Path <path> -Capability on|off OR -Path <path> -Set editable|off-support|locked"
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Support Edit
+
+## MCP routing
+
+- Preferred path: use MCP `unica` tool `unica.support.edit`.
+- Do not edit `Ext/ParentConfigurations.bin` manually and do not call donor scripts directly.
+- This is a release-support decision. Run `unica.cf.info` / `unica.meta.info` before and after the change and keep evidence in the project.
+- Mutating tools default to dry run. Pass `dryRun: false` only after the user explicitly confirms the support-state change.
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| `Path` | Configuration dump directory, object XML, form XML, or another path inside the source tree |
+| `Capability` | `on` or `off`; toggles global editing capability |
+| `Set` | `editable`, `off-support`, or `locked`; changes the selected object rule |
+| `dryRun` | Default `true` for this mutating tool |
+
+Provide exactly one of `Capability` or `Set`.
+
+## Examples
+
+Enable configuration editing while keeping vendor objects locked:
+
+```json
+{
+  "name": "unica.support.edit",
+  "arguments": {
+    "cwd": "<workspace>",
+    "Path": "src/configuration",
+    "Capability": "on",
+    "dryRun": false
+  }
+}
+```
+
+Allow editing of one object while preserving vendor support:
+
+```json
+{
+  "name": "unica.support.edit",
+  "arguments": {
+    "cwd": "<workspace>",
+    "Path": "src/configuration/Catalogs/Items.xml",
+    "Set": "editable",
+    "dryRun": false
+  }
+}
+```
+
+Remove one object from vendor support:
+
+```json
+{
+  "name": "unica.support.edit",
+  "arguments": {
+    "cwd": "<workspace>",
+    "Path": "src/configuration/Catalogs/Items.xml",
+    "Set": "off-support",
+    "dryRun": false
+  }
+}
+```
+
+## Stop Rules
+
+- If `Capability=on` has not been applied, object-level `Set=*` must fail.
+- If the configuration is not on support or support is already fully removed, the tool returns a safe no-op.
+- If the target object cannot be resolved to a UUID, stop and inspect with `unica.meta.info` or `unica.form.info` before retrying.


### PR DESCRIPTION
## Кратко

Closes #34.

PR переносит support-edit в Rust/native MCP и закрывает writer-пробелы, найденные во время dry-run на реальной XML-выгрузке 1С.

## Что изменилось

- Добавлен изменяющий native MCP-инструмент `unica.support.edit` с `dryRun` по умолчанию.
- `Capability=on|off` и `Set=editable|off-support|locked` работают через Rust writer для `ParentConfigurations.bin`.
- `Capability=on` сохраняет/чинит marker родительской конфигурации поставщика, не переводя его в режим внешней CF.
- `unica.form.edit` и `unica.form.validate` переведены на native handlers; добавлена вставка элементов формы через `into`/`after`, контейнеры pages/page/group/table и сохранение CRLF.
- `unica.meta.edit` расширен для `add-registerRecord`, `add-ts`, `modify-ts`, `modify-ts-attribute`.
- `unica.template.add` чинит повторный UTF-8 BOM и вставляет template в root `ChildObjects`, а не во вложенные `ChildObjects` табличных частей.
- `unica.role.compile` теперь генерирует UUID v4 вместо placeholder UUID.

## Проверки

- `cargo fmt --all -- --check`
- `cargo clippy --package unica-coder --all-targets --all-features -- -D warnings`
- `cargo test --package unica-coder`: 154 passed
- `git diff --check`

## Контекст dry-run

Изменения проверялись на сценариях 1С, где без этих writer-fix блокировались:

- включение возможности изменения и перевод объектов поставщика в editable;
- добавление печатной формы в документ с вложенными `ChildObjects`;
- создание ролей без повторяющихся placeholder UUID;
- добавление регистра движений и табличных частей через `meta.edit` без ручной XML-мутации.

Оставшийся writer-gap, который не входит в этот PR: `meta.edit add-attribute` для обычных реквизитов объекта.
