### PR TITLE
Добавить MCP-инструмент support-edit

### DIFF
--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -839,6 +839,16 @@ fn configuration_tools() -> Vec<ToolSpec> {
             },
         },
         ToolSpec {
+            name: "unica.support.edit",
+            description: "Toggle 1C vendor support editing capability or per-object support rule.",
+            mutating: true,
+            cache_access: cache_access_for("support-edit", Some(DomainEventKind::ConfigXmlChanged)),
+            handler: ToolHandler::NativeOperation {
+                operation: "support-edit",
+                event: Some(DomainEventKind::ConfigXmlChanged),
+            },
+        },
+        ToolSpec {
             name: "unica.cfe.borrow",
             description: "Borrow configuration objects/forms into an extension.",
             mutating: true,
@@ -1297,6 +1307,7 @@ mod tests {
         assert!(names.contains(&"unica.skd.edit"));
         assert!(names.contains(&"unica.mxl.compile"));
         assert!(names.contains(&"unica.role.validate"));
+        assert!(names.contains(&"unica.support.edit"));
         assert!(names.contains(&"unica.build.load"));
         assert!(names.contains(&"unica.runtime.execute"));
         assert!(names.contains(&"unica.code.definition"));
@@ -1405,6 +1416,7 @@ mod tests {
             "unica.role.compile",
             "unica.role.info",
             "unica.role.validate",
+            "unica.support.edit",
         ];
 
         for tool in tools() {
@@ -1419,6 +1431,7 @@ mod tests {
                 && !tool.name.starts_with("unica.skd.")
                 && !tool.name.starts_with("unica.mxl.")
                 && !tool.name.starts_with("unica.role.")
+                && !tool.name.starts_with("unica.support.")
             {
                 continue;
             }
@@ -1763,6 +1776,277 @@ mod tests {
         assert!(stdout.contains("Поддержка: на замке"));
         assert!(stdout.contains("cfe-*"));
         assert!(!stdout.contains("powershell.exe"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn support_edit_tool_is_mutating_native_operation() {
+        let tool = tools()
+            .into_iter()
+            .find(|tool| tool.name == "unica.support.edit")
+            .expect("support-edit tool exists");
+
+        assert!(tool.mutating);
+        assert_eq!(tool.cache_access.writes, &["metadata_graph"]);
+        match tool.handler {
+            ToolHandler::NativeOperation { operation, event } => {
+                assert_eq!(operation, "support-edit");
+                assert_eq!(event, Some(DomainEventKind::ConfigXmlChanged));
+            }
+            other => {
+                panic!("unica.support.edit should route through native operation, got {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn support_edit_dry_run_does_not_change_parent_configurations() {
+        let (root, workspace, bin_path) = support_test_workspace(
+            "unica-support-edit-dry-run",
+            support_test_parent_configurations_bin(
+                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            ),
+        );
+        let before = std::fs::read_to_string(&bin_path).unwrap();
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("Path".to_string(), Value::String("src".to_string()));
+        args.insert("Capability".to_string(), Value::String("off".to_string()));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.support.edit", &args)
+            .unwrap();
+
+        assert!(result.ok);
+        assert!(result.summary.contains("dry run"));
+        assert_eq!(std::fs::read_to_string(&bin_path).unwrap(), before);
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn support_edit_capability_on_enables_global_editing() {
+        let bin = support_test_parent_configurations_bin(
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "cccccccc-cccc-cccc-cccc-cccccccccccc",
+        )
+        .replace("{6,0,", "{6,1,");
+        let (root, workspace, _bin_path) =
+            support_test_workspace("unica-support-edit-capability-on", bin);
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert("Path".to_string(), Value::String("src".to_string()));
+        args.insert("Capability".to_string(), Value::String("on".to_string()));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.support.edit", &args)
+            .unwrap();
+
+        assert!(result.ok, "{:?}", result.errors);
+        assert!(result.summary.contains("Возможность изменения"));
+        let mut info_args = Map::new();
+        info_args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        info_args.insert("ConfigPath".to_string(), Value::String("src".to_string()));
+        let info = UnicaApplication::new()
+            .call_tool("unica.cf.info", &info_args)
+            .unwrap();
+        assert!(info
+            .stdout
+            .unwrap()
+            .contains("Возможность изменения: включена"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn support_edit_set_editable_updates_object_rule_and_meta_info() {
+        let (root, workspace, _bin_path) = support_test_workspace(
+            "unica-support-edit-set-editable",
+            support_test_parent_configurations_bin(
+                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            ),
+        );
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert(
+            "Path".to_string(),
+            Value::String("src/Catalogs/Items.xml".to_string()),
+        );
+        args.insert("Set".to_string(), Value::String("editable".to_string()));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.support.edit", &args)
+            .unwrap();
+
+        assert!(result.ok, "{:?}", result.errors);
+        assert!(result.summary.contains("редактируется"));
+        let mut info_args = Map::new();
+        info_args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        info_args.insert(
+            "ObjectPath".to_string(),
+            Value::String("src/Catalogs/Items.xml".to_string()),
+        );
+        let info = UnicaApplication::new()
+            .call_tool("unica.meta.info", &info_args)
+            .unwrap();
+        assert!(info
+            .stdout
+            .unwrap()
+            .contains("редактируется с сохранением поддержки"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn support_edit_set_requires_global_capability_on() {
+        let bin = support_test_parent_configurations_bin(
+            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            "cccccccc-cccc-cccc-cccc-cccccccccccc",
+        )
+        .replace("{6,0,", "{6,1,");
+        let (root, workspace, bin_path) =
+            support_test_workspace("unica-support-edit-set-capability-off", bin);
+        let before = std::fs::read_to_string(&bin_path).unwrap();
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert(
+            "Path".to_string(),
+            Value::String("src/Catalogs/Items.xml".to_string()),
+        );
+        args.insert("Set".to_string(), Value::String("editable".to_string()));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.support.edit", &args)
+            .unwrap();
+
+        assert!(!result.ok);
+        assert!(result.errors.join("\n").contains("Capability=on"));
+        assert_eq!(std::fs::read_to_string(&bin_path).unwrap(), before);
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn support_edit_missing_parent_configurations_is_safe_noop() {
+        let root =
+            std::env::temp_dir().join(format!("unica-support-edit-no-bin-{}", std::process::id()));
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(
+            workspace.join("v8project.yaml"),
+            "format: DESIGNER\nsource-set:\n  - name: main\n    type: CONFIGURATION\n    path: src\n",
+        )
+        .unwrap();
+        std::fs::write(
+            src.join("Configuration.xml"),
+            support_test_configuration_xml("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        )
+        .unwrap();
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert("Path".to_string(), Value::String("src".to_string()));
+        args.insert("Capability".to_string(), Value::String("on".to_string()));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.support.edit", &args)
+            .unwrap();
+
+        assert!(result.ok);
+        assert!(result.changes.is_empty());
+        assert!(result.summary.contains("не на поддержке"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn support_edit_set_editable_allows_follow_up_meta_edit() {
+        let (root, workspace, _bin_path) = support_test_workspace(
+            "unica-support-edit-unblocks-guard",
+            support_test_parent_configurations_bin(
+                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            ),
+        );
+        let mut support_args = Map::new();
+        support_args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        support_args.insert("dryRun".to_string(), Value::Bool(false));
+        support_args.insert(
+            "Path".to_string(),
+            Value::String("src/Catalogs/Items.xml".to_string()),
+        );
+        support_args.insert("Set".to_string(), Value::String("editable".to_string()));
+        let support_result = UnicaApplication::new()
+            .call_tool("unica.support.edit", &support_args)
+            .unwrap();
+        assert!(support_result.ok, "{:?}", support_result.errors);
+
+        let object_path = workspace.join("src").join("Catalogs").join("Items.xml");
+        let before = std::fs::read_to_string(&object_path).unwrap();
+        let mut edit_args = Map::new();
+        edit_args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        edit_args.insert("dryRun".to_string(), Value::Bool(false));
+        edit_args.insert(
+            "ObjectPath".to_string(),
+            Value::String("src/Catalogs/Items.xml".to_string()),
+        );
+        edit_args.insert(
+            "Operation".to_string(),
+            Value::String("modify-property".to_string()),
+        );
+        edit_args.insert(
+            "Value".to_string(),
+            Value::String("Name=Changed".to_string()),
+        );
+
+        let edit_result = UnicaApplication::new()
+            .call_tool("unica.meta.edit", &edit_args)
+            .unwrap();
+
+        assert!(edit_result.ok, "{:?}", edit_result.errors);
+        assert_ne!(std::fs::read_to_string(&object_path).unwrap(), before);
+        assert!(std::fs::read_to_string(&object_path)
+            .unwrap()
+            .contains("<Name>Changed</Name>"));
 
         let _ = std::fs::remove_dir_all(root);
     }
@@ -2967,6 +3251,37 @@ mod tests {
     </Properties>
   </Form>
 </MetaDataObject>"#
+    }
+
+    fn support_test_workspace(
+        prefix: &str,
+        parent_configurations_bin: String,
+    ) -> (PathBuf, PathBuf, PathBuf) {
+        let root = std::env::temp_dir().join(format!("{prefix}-{}", std::process::id()));
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        let ext = src.join("Ext");
+        let catalogs = src.join("Catalogs");
+        std::fs::create_dir_all(&ext).unwrap();
+        std::fs::create_dir_all(&catalogs).unwrap();
+        std::fs::write(
+            workspace.join("v8project.yaml"),
+            "format: DESIGNER\nsource-set:\n  - name: main\n    type: CONFIGURATION\n    path: src\n",
+        )
+        .unwrap();
+        std::fs::write(
+            src.join("Configuration.xml"),
+            support_test_configuration_xml("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        )
+        .unwrap();
+        std::fs::write(
+            catalogs.join("Items.xml"),
+            support_test_catalog_xml("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+        )
+        .unwrap();
+        let bin_path = ext.join("ParentConfigurations.bin");
+        std::fs::write(&bin_path, parent_configurations_bin).unwrap();
+        (root, workspace, bin_path)
     }
 
     fn support_test_parent_configurations_bin(

--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -1873,6 +1873,71 @@ mod tests {
     }
 
     #[test]
+    fn support_edit_capability_off_disables_global_editing_and_blocks_set() {
+        let (root, workspace, bin_path) = support_test_workspace(
+            "unica-support-edit-capability-off",
+            support_test_parent_configurations_bin(
+                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            ),
+        );
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert("Path".to_string(), Value::String("src".to_string()));
+        args.insert("Capability".to_string(), Value::String("off".to_string()));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.support.edit", &args)
+            .unwrap();
+
+        assert!(result.ok, "{:?}", result.errors);
+        assert!(result.summary.contains("ВЫКЛЮЧЕНА"));
+        let bin_text = std::fs::read_to_string(&bin_path).unwrap();
+        assert!(bin_text.contains("{6,1,"));
+        assert!(bin_text.contains(",1,0,aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"));
+        assert!(bin_text.contains(",1,0,bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"));
+        assert!(bin_text.contains(",1,0,cccccccc-cccc-cccc-cccc-cccccccccccc"));
+
+        let mut info_args = Map::new();
+        info_args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        info_args.insert("ConfigPath".to_string(), Value::String("src".to_string()));
+        let info = UnicaApplication::new()
+            .call_tool("unica.cf.info", &info_args)
+            .unwrap();
+        assert!(info
+            .stdout
+            .unwrap()
+            .contains("Возможность изменения: выключена"));
+
+        let mut set_args = Map::new();
+        set_args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        set_args.insert("dryRun".to_string(), Value::Bool(false));
+        set_args.insert(
+            "Path".to_string(),
+            Value::String("src/Catalogs/Items.xml".to_string()),
+        );
+        set_args.insert("Set".to_string(), Value::String("editable".to_string()));
+        let set_result = UnicaApplication::new()
+            .call_tool("unica.support.edit", &set_args)
+            .unwrap();
+        assert!(!set_result.ok);
+        assert!(set_result.errors.join("\n").contains("Capability=on"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn support_edit_set_editable_updates_object_rule_and_meta_info() {
         let (root, workspace, _bin_path) = support_test_workspace(
             "unica-support-edit-set-editable",

--- a/crates/unica-coder/src/application/tool_contracts.rs
+++ b/crates/unica-coder/src/application/tool_contracts.rs
@@ -13,6 +13,7 @@ const NATIVE_XML_DSL_ARGS: &[&str] = &[
     "Batch",
     "BodyLimit",
     "BorrowMainAttribute",
+    "Capability",
     "Child",
     "Children",
     "CIPath",
@@ -69,6 +70,7 @@ const NATIVE_XML_DSL_ARGS: &[&str] = &[
     "RightsPath",
     "Raw",
     "Section",
+    "Set",
     "SetDefault",
     "SetMainSKD",
     "ShowDenied",
@@ -78,6 +80,7 @@ const NATIVE_XML_DSL_ARGS: &[&str] = &[
     "TemplateName",
     "TemplatePath",
     "TemplateType",
+    "TargetPath",
     "Type",
     "Value",
     "Vendor",
@@ -87,6 +90,7 @@ const NATIVE_XML_DSL_ARGS: &[&str] = &[
     "batch",
     "bodyLimit",
     "borrowMainAttribute",
+    "capability",
     "child",
     "children",
     "ciPath",
@@ -143,6 +147,7 @@ const NATIVE_XML_DSL_ARGS: &[&str] = &[
     "rightsPath",
     "raw",
     "section",
+    "set",
     "setDefault",
     "setMainSKD",
     "showDenied",
@@ -152,6 +157,7 @@ const NATIVE_XML_DSL_ARGS: &[&str] = &[
     "templateName",
     "templatePath",
     "templateType",
+    "targetPath",
     "type",
     "value",
     "vendor",
@@ -360,6 +366,7 @@ pub fn validate_tool_arguments(
         validate_runtime_arguments(tool.name, args, dry_run)?;
     }
     validate_code_arguments(tool, args, dry_run)?;
+    validate_support_arguments(tool, args, dry_run)?;
 
     if !dry_run {
         for required in required_args(&tool) {
@@ -369,6 +376,73 @@ pub fn validate_tool_arguments(
         }
     }
 
+    Ok(())
+}
+
+fn validate_support_arguments(
+    tool: ToolSpec,
+    args: &Map<String, Value>,
+    dry_run: bool,
+) -> Result<(), String> {
+    if tool.name != "unica.support.edit" {
+        return Ok(());
+    }
+
+    validate_enum_alias_argument(
+        tool.name,
+        args,
+        &["Capability", "capability"],
+        &["on", "off"],
+    )?;
+    validate_enum_alias_argument(
+        tool.name,
+        args,
+        &["Set", "set"],
+        &["editable", "off-support", "locked"],
+    )?;
+
+    if dry_run {
+        return Ok(());
+    }
+
+    if !contains_any(args, &["Path", "path", "TargetPath", "targetPath"]) {
+        return Err(format!("{} requires `Path` argument", tool.name));
+    }
+    let has_capability = contains_any(args, &["Capability", "capability"]);
+    let has_set = contains_any(args, &["Set", "set"]);
+    if has_capability == has_set {
+        return Err(format!(
+            "{} requires exactly one of `Capability` or `Set`",
+            tool.name
+        ));
+    }
+
+    Ok(())
+}
+
+fn contains_any(args: &Map<String, Value>, names: &[&str]) -> bool {
+    names.iter().any(|name| args.contains_key(*name))
+}
+
+fn validate_enum_alias_argument(
+    tool_name: &'static str,
+    args: &Map<String, Value>,
+    names: &[&str],
+    allowed: &[&str],
+) -> Result<(), String> {
+    for name in names {
+        if let Some(value) = args.get(*name) {
+            let Some(value) = value.as_str() else {
+                return Err(format!("{tool_name} argument `{name}` must be string"));
+            };
+            if !allowed.contains(&value) {
+                return Err(format!(
+                    "{tool_name} argument `{name}` must be one of: {}",
+                    allowed.join(", ")
+                ));
+            }
+        }
+    }
     Ok(())
 }
 
@@ -581,6 +655,7 @@ fn write_path_args(tool: ToolSpec) -> &'static [&'static str] {
         ToolHandler::NativeOperation { operation, .. } => match operation {
             "cf-init" | "cfe-init" => &["OutputDir", "outputDir"],
             "cf-edit" => &["ConfigPath", "configPath", "Path", "path"],
+            "support-edit" => &["Path", "path", "TargetPath", "targetPath"],
             "meta-compile" => &["OutputDir", "outputDir"],
             "meta-edit" => &["ObjectPath", "objectPath", "Path", "path"],
             "meta-remove" => &["ConfigDir", "configDir"],
@@ -653,6 +728,7 @@ fn native_source_path_args() -> &'static [&'static str] {
         "SrcDir",
         "SubsystemPath",
         "TemplatePath",
+        "TargetPath",
         "ciPath",
         "configDir",
         "configPath",
@@ -671,6 +747,7 @@ fn native_source_path_args() -> &'static [&'static str] {
         "srcDir",
         "subsystemPath",
         "templatePath",
+        "targetPath",
     ]
 }
 
@@ -858,6 +935,15 @@ fn property_schema_for_tool(tool: &ToolSpec, name: &str) -> Value {
         }
     }
     match tool.name {
+        "unica.support.edit" => match name {
+            "Capability" | "capability" => {
+                return json!({ "type": "string", "enum": ["on", "off"] });
+            }
+            "Set" | "set" => {
+                return json!({ "type": "string", "enum": ["editable", "off-support", "locked"] });
+            }
+            _ => {}
+        },
         "unica.code.graph" => match name {
             "mode" => return json!({ "type": "string", "enum": CODE_GRAPH_MODES }),
             "dir" => return json!({ "type": "string", "enum": CODE_GRAPH_DIRECTIONS }),
@@ -990,6 +1076,40 @@ mod tests {
         let args = Map::new();
 
         validate_tool_arguments(tool, &args, true).unwrap();
+    }
+
+    #[test]
+    fn support_edit_contract_exposes_typed_enums_and_rejects_invalid_payloads() {
+        let tool = tools()
+            .into_iter()
+            .find(|tool| tool.name == "unica.support.edit")
+            .unwrap();
+
+        let schema = input_schema_for_tool(&tool);
+        assert_eq!(schema["additionalProperties"], false);
+        assert_eq!(
+            schema["properties"]["Capability"]["enum"],
+            json!(["on", "off"])
+        );
+        assert_eq!(
+            schema["properties"]["Set"]["enum"],
+            json!(["editable", "off-support", "locked"])
+        );
+        assert!(schema["properties"].get("args").is_none());
+
+        let mut args = Map::new();
+        args.insert("Path".to_string(), json!("src"));
+        args.insert("Capability".to_string(), json!(true));
+        let error = validate_tool_arguments(tool, &args, false).unwrap_err();
+        assert!(error.contains("Capability"));
+        assert!(error.contains("string"));
+
+        let mut args = Map::new();
+        args.insert("Path".to_string(), json!("src"));
+        args.insert("Capability".to_string(), json!("on"));
+        args.insert("Set".to_string(), json!("editable"));
+        let error = validate_tool_arguments(tool, &args, false).unwrap_err();
+        assert!(error.contains("exactly one"));
     }
 
     #[test]

--- a/crates/unica-coder/src/application/tool_contracts.rs
+++ b/crates/unica-coder/src/application/tool_contracts.rs
@@ -388,6 +388,13 @@ fn validate_support_arguments(
         return Ok(());
     }
 
+    validate_unique_alias_group(tool.name, args, &["Capability", "capability"])?;
+    validate_unique_alias_group(tool.name, args, &["Set", "set"])?;
+    validate_unique_alias_group(
+        tool.name,
+        args,
+        &["Path", "path", "TargetPath", "targetPath"],
+    )?;
     validate_enum_alias_argument(
         tool.name,
         args,
@@ -422,6 +429,25 @@ fn validate_support_arguments(
 
 fn contains_any(args: &Map<String, Value>, names: &[&str]) -> bool {
     names.iter().any(|name| args.contains_key(*name))
+}
+
+fn validate_unique_alias_group(
+    tool_name: &str,
+    args: &Map<String, Value>,
+    names: &[&str],
+) -> Result<(), String> {
+    let present = names
+        .iter()
+        .copied()
+        .filter(|name| args.contains_key(*name))
+        .collect::<Vec<_>>();
+    if present.len() > 1 {
+        return Err(format!(
+            "{tool_name} received conflicting aliases: {}",
+            present.join(", ")
+        ));
+    }
+    Ok(())
 }
 
 fn validate_enum_alias_argument(
@@ -1110,6 +1136,33 @@ mod tests {
         args.insert("Set".to_string(), json!("editable"));
         let error = validate_tool_arguments(tool, &args, false).unwrap_err();
         assert!(error.contains("exactly one"));
+
+        let mut args = Map::new();
+        args.insert("Path".to_string(), json!("src"));
+        args.insert("Capability".to_string(), json!("on"));
+        args.insert("capability".to_string(), json!("off"));
+        let error = validate_tool_arguments(tool, &args, false).unwrap_err();
+        assert!(error.contains("conflicting aliases"));
+        assert!(error.contains("Capability"));
+        assert!(error.contains("capability"));
+
+        let mut args = Map::new();
+        args.insert("Path".to_string(), json!("src"));
+        args.insert("Set".to_string(), json!("editable"));
+        args.insert("set".to_string(), json!("locked"));
+        let error = validate_tool_arguments(tool, &args, false).unwrap_err();
+        assert!(error.contains("conflicting aliases"));
+        assert!(error.contains("Set"));
+        assert!(error.contains("set"));
+
+        let mut args = Map::new();
+        args.insert("Path".to_string(), json!("src"));
+        args.insert("TargetPath".to_string(), json!("src/Catalogs/Items.xml"));
+        args.insert("Capability".to_string(), json!("on"));
+        let error = validate_tool_arguments(tool, &args, false).unwrap_err();
+        assert!(error.contains("conflicting aliases"));
+        assert!(error.contains("Path"));
+        assert!(error.contains("TargetPath"));
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/native_operations.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations.rs
@@ -15,6 +15,7 @@ pub(crate) mod registry;
 pub(crate) mod role;
 pub(crate) mod skd;
 pub(crate) mod subsystem;
+pub(crate) mod support;
 pub(crate) mod template;
 
 use crate::domain::workspace::WorkspaceContext;

--- a/crates/unica-coder/src/infrastructure/native_operations/common.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/common.rs
@@ -1625,6 +1625,14 @@ impl SupportState {
             .get(&object_uuid.to_ascii_lowercase())
             .copied()
     }
+
+    pub(crate) fn global_editing_enabled(&self) -> bool {
+        self.global_editing_enabled
+    }
+
+    pub(crate) fn removed(&self) -> bool {
+        self.removed
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/unica-coder/src/infrastructure/native_operations/registry.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/registry.rs
@@ -2,7 +2,7 @@ use crate::domain::workspace::WorkspaceContext;
 use crate::infrastructure::AdapterOutcome;
 use serde_json::{Map, Value};
 
-use super::{cf, cfe, form, help, interface, meta, mxl, role, skd, subsystem, template};
+use super::{cf, cfe, form, help, interface, meta, mxl, role, skd, subsystem, support, template};
 
 pub(crate) fn invoke_read(
     operation: &str,
@@ -42,4 +42,5 @@ pub(crate) fn invoke_mutation(
         .or_else(|| skd::invoke_mutation(operation, tool_name, args, context))
         .or_else(|| mxl::invoke_mutation(operation, tool_name, args, context))
         .or_else(|| role::invoke_mutation(operation, tool_name, args, context))
+        .or_else(|| support::invoke_mutation(operation, tool_name, args, context))
 }

--- a/crates/unica-coder/src/infrastructure/native_operations/support.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/support.rs
@@ -1,0 +1,449 @@
+use crate::domain::workspace::WorkspaceContext;
+use crate::infrastructure::AdapterOutcome;
+use serde_json::{Map, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::common::{
+    absolutize, find_support_config_dir, is_uuid_text, path_arg, read_support_state,
+    support_object_uuid_for_path, support_root_uuid,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SupportCapability {
+    On,
+    Off,
+}
+
+impl SupportCapability {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "on" => Some(Self::On),
+            "off" => Some(Self::Off),
+            _ => None,
+        }
+    }
+
+    fn target_flag(self) -> u8 {
+        match self {
+            Self::On => 0,
+            Self::Off => 1,
+        }
+    }
+
+    fn enabled(self) -> bool {
+        matches!(self, Self::On)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SupportObjectRule {
+    Locked,
+    Editable,
+    OffSupport,
+}
+
+impl SupportObjectRule {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "locked" => Some(Self::Locked),
+            "editable" => Some(Self::Editable),
+            "off-support" => Some(Self::OffSupport),
+            _ => None,
+        }
+    }
+
+    fn flag(self) -> u8 {
+        match self {
+            Self::Locked => 0,
+            Self::Editable => 1,
+            Self::OffSupport => 2,
+        }
+    }
+
+    fn state_text(self) -> &'static str {
+        match self {
+            Self::Locked => "на замке (правка запрещена)",
+            Self::Editable => {
+                "редактируется с сохранением поддержки (объект продолжит получать обновления вендора — возможны конфликты при обновлении)"
+            }
+            Self::OffSupport => "снят с поддержки (обновления вендора по этому объекту прекращаются)",
+        }
+    }
+}
+
+enum SupportEditAction {
+    Capability(SupportCapability),
+    Set(SupportObjectRule),
+}
+
+pub(crate) fn invoke_mutation(
+    operation: &str,
+    _tool_name: &str,
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> Option<AdapterOutcome> {
+    match operation {
+        "support-edit" => Some(edit_support(args, context)),
+        _ => None,
+    }
+}
+
+fn edit_support(args: &Map<String, Value>, context: &WorkspaceContext) -> AdapterOutcome {
+    match edit_support_result(args, context) {
+        Ok(outcome) => outcome,
+        Err(error) => AdapterOutcome {
+            ok: false,
+            summary: "support-edit failed".to_string(),
+            changes: Vec::new(),
+            warnings: Vec::new(),
+            errors: vec![error],
+            artifacts: Vec::new(),
+            stdout: None,
+            stderr: None,
+            command: None,
+        },
+    }
+}
+
+fn edit_support_result(
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> Result<AdapterOutcome, String> {
+    let action = support_edit_action(args)?;
+    let target_path = support_target_path(args, context)?;
+    if !target_path.exists() {
+        return Err(format!("Путь не найден: {}", target_path.display()));
+    }
+    let resolved_path = target_path
+        .canonicalize()
+        .unwrap_or_else(|_| target_path.clone());
+    let Some(config_dir) = find_support_config_dir(&resolved_path) else {
+        return Err(format!(
+            "Не найден корень конфигурации (Configuration.xml) над путём: {}",
+            resolved_path.display()
+        ));
+    };
+    let bin_path = config_dir.join("Ext").join("ParentConfigurations.bin");
+    if !bin_path.exists() {
+        return Ok(noop_outcome(
+            "Конфигурация не на поддержке (Ext/ParentConfigurations.bin отсутствует) — переключать нечего.",
+        ));
+    }
+    let raw = fs::read(&bin_path)
+        .map_err(|err| format!("failed to read {}: {err}", bin_path.display()))?;
+    if raw.len() <= 32 {
+        return Ok(noop_outcome(
+            "Поддержка снята полностью (пустой ParentConfigurations.bin) — переключать нечего.",
+        ));
+    }
+    let text = decode_parent_configurations(&raw)?;
+    let Some(state) = read_support_state(&bin_path) else {
+        return Err("Неизвестный формат ParentConfigurations.bin".to_string());
+    };
+    if state.removed() {
+        return Ok(noop_outcome(
+            "Поддержка снята полностью (пустой ParentConfigurations.bin) — переключать нечего.",
+        ));
+    }
+
+    match action {
+        SupportEditAction::Capability(capability) => {
+            if state.global_editing_enabled() == capability.enabled() {
+                let word = if capability.enabled() {
+                    "включена"
+                } else {
+                    "выключена"
+                };
+                return Ok(noop_outcome(format!(
+                    "Возможность изменения конфигурации уже {word} — изменений нет."
+                )));
+            }
+            apply_capability(&bin_path, &text, capability, &resolved_path)
+        }
+        SupportEditAction::Set(rule) => {
+            if !state.global_editing_enabled() {
+                return Err(format!(
+                    "Возможность изменения конфигурации выключена — пообъектное переключение недоступно.\n  Сначала: support-edit -Path {} -Capability on или unica.support.edit Path={} Capability=on",
+                    resolved_path.display(),
+                    resolved_path.display()
+                ));
+            }
+            let object_uuid = support_object_uuid_for_path(&resolved_path)
+                .or_else(|| support_root_uuid(&config_dir.join("Configuration.xml")))
+                .ok_or_else(|| {
+                    format!(
+                        "Не удалось определить объект по пути: {}",
+                        resolved_path.display()
+                    )
+                })?;
+            apply_object_rule(&bin_path, &text, &object_uuid, rule, &resolved_path)
+        }
+    }
+}
+
+fn support_target_path(
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> Result<PathBuf, String> {
+    path_arg(args, &["Path", "path", "TargetPath", "targetPath"])
+        .map(|path| absolutize(path, &context.cwd))
+        .ok_or_else(|| "missing required argument: Path".to_string())
+}
+
+fn support_edit_action(args: &Map<String, Value>) -> Result<SupportEditAction, String> {
+    let capability = string_arg(args, &["Capability", "capability"]);
+    let set = string_arg(args, &["Set", "set"]);
+    match (capability, set) {
+        (Some(_), Some(_)) | (None, None) => Err(
+            "Укажите ровно одно: Capability=on|off ЛИБО Set=editable|off-support|locked"
+                .to_string(),
+        ),
+        (Some(value), None) => SupportCapability::parse(&value)
+            .map(SupportEditAction::Capability)
+            .ok_or_else(|| "Capability must be one of: on, off".to_string()),
+        (None, Some(value)) => SupportObjectRule::parse(&value)
+            .map(SupportEditAction::Set)
+            .ok_or_else(|| "Set must be one of: editable, off-support, locked".to_string()),
+    }
+}
+
+fn string_arg(args: &Map<String, Value>, names: &[&str]) -> Option<String> {
+    names
+        .iter()
+        .find_map(|name| args.get(*name).and_then(Value::as_str))
+        .map(ToOwned::to_owned)
+}
+
+fn decode_parent_configurations(raw: &[u8]) -> Result<String, String> {
+    let data = raw.strip_prefix(&[0xEF, 0xBB, 0xBF]).unwrap_or(raw);
+    String::from_utf8(data.to_vec())
+        .map_err(|err| format!("ParentConfigurations.bin is not UTF-8: {err}"))
+}
+
+fn apply_capability(
+    bin_path: &Path,
+    text: &str,
+    capability: SupportCapability,
+    target_path: &Path,
+) -> Result<AdapterOutcome, String> {
+    let target = capability.target_flag();
+    let mut updated = replace_global_flag(text, target)?;
+    updated = replace_vendor_rule_flags(&updated, target);
+    let object_count = replace_all_object_rule_flags(&mut updated, target);
+    write_parent_configurations(bin_path, &updated)?;
+
+    let summary = if capability.enabled() {
+        "Возможность изменения конфигурации ВКЛЮЧЕНА"
+    } else {
+        "Возможность изменения конфигурации ВЫКЛЮЧЕНА"
+    };
+    let stdout = if capability.enabled() {
+        format!(
+            "{summary}. Все объекты поставщика — на замке.\nВключайте редактирование точечно: support-edit -Path <объект> -Set editable\n"
+        )
+    } else {
+        format!("{summary}. Вся конфигурация стала read-only; пообъектные правила сброшены.\n")
+    };
+
+    Ok(AdapterOutcome {
+        ok: true,
+        summary: summary.to_string(),
+        changes: vec![
+            format!("updated {}", bin_path.display()),
+            format!("set global editing flag to {target}"),
+            format!("reset object support rules: {object_count}"),
+        ],
+        warnings: if capability.enabled() {
+            vec![
+                "Все объекты поставщика оставлены на замке; включайте editable/off-support точечно."
+                    .to_string(),
+            ]
+        } else {
+            Vec::new()
+        },
+        errors: Vec::new(),
+        artifacts: vec![
+            bin_path.display().to_string(),
+            target_path.display().to_string(),
+        ],
+        stdout: Some(stdout),
+        stderr: None,
+        command: None,
+    })
+}
+
+fn apply_object_rule(
+    bin_path: &Path,
+    text: &str,
+    object_uuid: &str,
+    rule: SupportObjectRule,
+    target_path: &Path,
+) -> Result<AdapterOutcome, String> {
+    let mut updated = text.to_string();
+    let changed = replace_object_rule_flags(&mut updated, object_uuid, rule.flag());
+    if changed == 0 {
+        let message = format!(
+            "Объект (uuid {object_uuid}) не на поддержке (своё добавление или не найден в bin) — переключать нечего."
+        );
+        return Ok(noop_outcome(message));
+    }
+    write_parent_configurations(bin_path, &updated)?;
+    let summary = format!("Объект uuid {object_uuid} → {}.", rule.state_text());
+    Ok(AdapterOutcome {
+        ok: true,
+        summary: summary.clone(),
+        changes: vec![
+            format!("updated {}", bin_path.display()),
+            format!("set object {object_uuid} support rule to {}", rule.flag()),
+            format!("updated support records: {changed}"),
+        ],
+        warnings: if matches!(rule, SupportObjectRule::Editable) {
+            vec![
+                "Объект продолжит получать обновления вендора; при обновлении возможны конфликты."
+                    .to_string(),
+            ]
+        } else {
+            Vec::new()
+        },
+        errors: Vec::new(),
+        artifacts: vec![
+            bin_path.display().to_string(),
+            target_path.display().to_string(),
+        ],
+        stdout: Some(format!(
+            "{summary}\nЗаписей в bin изменено: {changed}. Цель: {}\n",
+            target_path.display()
+        )),
+        stderr: None,
+        command: None,
+    })
+}
+
+fn noop_outcome(message: impl Into<String>) -> AdapterOutcome {
+    let message = message.into();
+    AdapterOutcome {
+        ok: true,
+        summary: message.clone(),
+        changes: Vec::new(),
+        warnings: Vec::new(),
+        errors: Vec::new(),
+        artifacts: Vec::new(),
+        stdout: Some(format!("{message}\n")),
+        stderr: None,
+        command: None,
+    }
+}
+
+fn write_parent_configurations(path: &Path, text: &str) -> Result<(), String> {
+    let mut bytes = Vec::with_capacity(text.len() + 3);
+    bytes.extend_from_slice(&[0xEF, 0xBB, 0xBF]);
+    bytes.extend_from_slice(text.as_bytes());
+    fs::write(path, bytes).map_err(|err| format!("failed to write {}: {err}", path.display()))
+}
+
+fn replace_global_flag(text: &str, target: u8) -> Result<String, String> {
+    let prefix = "{6,";
+    let Some(rest) = text.strip_prefix(prefix) else {
+        return Err("Неизвестный формат ParentConfigurations.bin".to_string());
+    };
+    let Some(comma) = rest.find(',') else {
+        return Err("Неизвестный формат ParentConfigurations.bin".to_string());
+    };
+    Ok(format!("{prefix}{target}{}", &rest[comma..]))
+}
+
+fn replace_vendor_rule_flags(text: &str, target: u8) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut i = 0usize;
+    while i < text.len() {
+        if let Some((flag_start, flag_end)) = vendor_flag_span(text, i) {
+            result.push_str(&text[i..flag_start]);
+            result.push(char::from(b'0' + target));
+            i = flag_end;
+            continue;
+        }
+        let ch = text[i..].chars().next().expect("valid char boundary");
+        result.push(ch);
+        i += ch.len_utf8();
+    }
+    result
+}
+
+fn vendor_flag_span(text: &str, start: usize) -> Option<(usize, usize)> {
+    let bytes = text.as_bytes();
+    if start + 36 >= bytes.len() {
+        return None;
+    }
+    let first_uuid = text.get(start..start + 36)?;
+    if !is_uuid_text(first_uuid) || bytes.get(start + 36) != Some(&b',') {
+        return None;
+    }
+    let flag_start = start + 37;
+    let mut flag_end = flag_start;
+    while bytes
+        .get(flag_end)
+        .is_some_and(|byte| byte.is_ascii_digit())
+    {
+        flag_end += 1;
+    }
+    if flag_end == flag_start || bytes.get(flag_end) != Some(&b',') {
+        return None;
+    }
+    let second_uuid_start = flag_end + 1;
+    let second_uuid = text.get(second_uuid_start..second_uuid_start + 36)?;
+    if !is_uuid_text(second_uuid) {
+        return None;
+    }
+    Some((flag_start, flag_end))
+}
+
+fn replace_all_object_rule_flags(text: &mut String, target: u8) -> usize {
+    let mut bytes = text.as_bytes().to_vec();
+    let mut count = 0usize;
+    let mut i = 0usize;
+    while i + 40 <= bytes.len() {
+        if matches!(bytes[i], b'0'..=b'2')
+            && bytes.get(i + 1..i + 4) == Some(b",0,")
+            && text.get(i + 4..i + 40).is_some_and(is_uuid_text)
+        {
+            bytes[i] = b'0' + target;
+            count += 1;
+            i += 40;
+            continue;
+        }
+        i += 1;
+    }
+    if count > 0 {
+        *text = String::from_utf8(bytes).expect("single-byte digit replacement preserves UTF-8");
+    }
+    count
+}
+
+fn replace_object_rule_flags(text: &mut String, object_uuid: &str, target: u8) -> usize {
+    let target_uuid = object_uuid.to_ascii_lowercase();
+    let mut bytes = text.as_bytes().to_vec();
+    let mut count = 0usize;
+    let mut i = 0usize;
+    while i + 40 <= bytes.len() {
+        if matches!(bytes[i], b'0'..=b'2') && bytes.get(i + 1..i + 4) == Some(b",0,") {
+            let uuid_start = i + 4;
+            let uuid_end = uuid_start + 36;
+            if let Some(uuid) = text.get(uuid_start..uuid_end) {
+                if is_uuid_text(uuid)
+                    && uuid.as_bytes().eq_ignore_ascii_case(target_uuid.as_bytes())
+                {
+                    bytes[i] = b'0' + target;
+                    count += 1;
+                    i = uuid_end;
+                    continue;
+                }
+            }
+        }
+        i += 1;
+    }
+    if count > 0 {
+        *text = String::from_utf8(bytes).expect("single-byte digit replacement preserves UTF-8");
+    }
+    count
+}

--- a/plugins/unica/README.md
+++ b/plugins/unica/README.md
@@ -26,7 +26,7 @@ The `skills/` directory contains operation skills and scenario references for 1C
 - `mxl-*`, `role-*`, `skd-*`, `subsystem-*`, `interface-*`, `template-*`, `web-test`, `img-grid`
 - `code-search`, `code-diagnostics`, `code-review`, `query-optimize`, `test-authoring`
 - `api-design`, `platform-help`, `bsp-patterns`, `integration-implement`, `autonomous-server`, `log-analysis`
-- `background-jobs`, `data-exchange`, `db-performance`, `security-auth-crypto`, `data-separation`, `release-support`
+- `background-jobs`, `data-exchange`, `db-performance`, `security-auth-crypto`, `data-separation`, `release-support`, `support-edit`
 
 ## Local Codex Install
 

--- a/plugins/unica/provenance/skill-upstreams.json
+++ b/plugins/unica/provenance/skill-upstreams.json
@@ -100,6 +100,24 @@
           "decisionReason": "Reviewed cbde49 drift as EOL normalization, raw PowerShell wrapper/guidance churn, shared donor docs, or donor-only capabilities outside the current Unica packaged surface; no prompt-visible Unica skill or typed MCP behavior change is required."
         },
         {
+          "skill": "support-edit",
+          "status": "ported-to-unica",
+          "notes": "Ported donor support-edit semantics into typed Unica MCP/native Rust: Capability=on/off toggles global editing capability and resets object rules using Ext/ParentConfigurations.bin semantics; Set=editable/off-support/locked changes a resolved object's support rule. This replaces downstream raw support metadata fallback with an explicit audited Unica tool.",
+          "upstreamPaths": [
+            ".claude/skills/support-edit/**"
+          ],
+          "localPaths": [
+            "plugins/unica/skills/support-edit"
+          ],
+          "contractPaths": [
+            "crates/unica-coder/src/application/mod.rs",
+            "crates/unica-coder/src/application/tool_contracts.rs",
+            "crates/unica-coder/src/infrastructure/native_operations/support.rs"
+          ],
+          "baselineCommit": "78b5b73fa7f835462dc4073ae7a9fc841e7c62fb",
+          "decision": "ported"
+        },
+        {
           "skill": "cfe-borrow",
           "status": "ported-to-unica",
           "notes": "Reviewed and ported donor cfe-borrow functional drift through cbde49efdaeec190432fdf4a53201a87e83c69de in native Rust: BorrowMainAttribute path enrichment, deep tabular-section paths, DefinedType Type XML, Field path collection, idempotent form metadata, and preserved Module.bsl.",

--- a/plugins/unica/skills/support-edit/SKILL.md
+++ b/plugins/unica/skills/support-edit/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: support-edit
+description: "Изменение состояния поддержки 1С. Используй когда нужно явно включить возможность изменения конфигурации поставщика или переключить объект в editable/off-support/locked."
+argument-hint: "-Path <path> -Capability on|off OR -Path <path> -Set editable|off-support|locked"
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Support Edit
+
+## MCP routing
+
+- Preferred path: use MCP `unica` tool `unica.support.edit`.
+- Do not edit `Ext/ParentConfigurations.bin` manually and do not call donor scripts directly.
+- This is a release-support decision. Run `unica.cf.info` / `unica.meta.info` before and after the change and keep evidence in the project.
+- Mutating tools default to dry run. Pass `dryRun: false` only after the user explicitly confirms the support-state change.
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| `Path` | Configuration dump directory, object XML, form XML, or another path inside the source tree |
+| `Capability` | `on` or `off`; toggles global editing capability |
+| `Set` | `editable`, `off-support`, or `locked`; changes the selected object rule |
+| `dryRun` | Default `true` for this mutating tool |
+
+Provide exactly one of `Capability` or `Set`.
+
+## Examples
+
+Enable configuration editing while keeping vendor objects locked:
+
+```json
+{
+  "name": "unica.support.edit",
+  "arguments": {
+    "cwd": "<workspace>",
+    "Path": "src/configuration",
+    "Capability": "on",
+    "dryRun": false
+  }
+}
+```
+
+Allow editing of one object while preserving vendor support:
+
+```json
+{
+  "name": "unica.support.edit",
+  "arguments": {
+    "cwd": "<workspace>",
+    "Path": "src/configuration/Catalogs/Items.xml",
+    "Set": "editable",
+    "dryRun": false
+  }
+}
+```
+
+Remove one object from vendor support:
+
+```json
+{
+  "name": "unica.support.edit",
+  "arguments": {
+    "cwd": "<workspace>",
+    "Path": "src/configuration/Catalogs/Items.xml",
+    "Set": "off-support",
+    "dryRun": false
+  }
+}
+```
+
+## Stop Rules
+
+- If `Capability=on` has not been applied, object-level `Set=*` must fail.
+- If the configuration is not on support or support is already fully removed, the tool returns a safe no-op.
+- If the target object cannot be resolved to a UUID, stop and inspect with `unica.meta.info` or `unica.form.info` before retrying.


### PR DESCRIPTION
## Кратко

Closes #34.

PR переносит `support-edit` в Rust/native MCP и оставляет scope только вокруг управления поддержкой 1С.

## Что изменилось

- Добавлен mutating native MCP-инструмент `unica.support.edit`.
- `dryRun=true` используется по умолчанию.
- Поддержаны действия:
  - `Capability=on|off` для глобальной возможности изменения конфигурации;
  - `Set=editable|off-support|locked` для правила поддержки объекта.
- Добавлен native writer для `ParentConfigurations.bin`.
- Добавлен skill `plugins/unica/skills/support-edit/SKILL.md`.
- Обновлены MCP tool contracts и регистрация native operation.

## Что не входит в PR

- `form.edit` / `form.validate` — вынесено в #36.
- `meta.edit` writer operations — вынесено в #37.
- XML writer / `template.add` BOM и `ChildObjects` — вынесено в #38.
- `role.compile` UUID v4 — вынесено в #39.

## Проверки

- `git diff --check upstream/main...HEAD`
- `cargo fmt --all -- --check`
- `cargo test --package unica-coder` — 141 passed
- `python3 -m unittest discover -s tests/ci` — 101 tests OK, skipped=1
- `cargo clippy --package unica-coder --all-targets --all-features -- -D warnings`

## Контекст

Предыдущий широкий PR #35 закрыт как superseded, потому что смешивал несколько независимых writer-направлений и падал на guardrail, не связанный с `support-edit`.