### PR TITLE
Генерировать UUID v4 для role.compile

### DIFF
--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -1908,6 +1908,71 @@ mod tests {
     }
 
     #[test]
+    fn role_compile_preserves_existing_uuid_when_regenerating_role() {
+        let root = temp_meta_compile_workspace("unica-role-compile-idempotent-uuid");
+        let workspace = root.join("workspace");
+        let fixtures = workspace.join("fixtures");
+        std::fs::create_dir_all(&fixtures).unwrap();
+
+        let role_json = fixtures.join("sample-reader.json");
+        std::fs::write(
+            &role_json,
+            r#"{
+  "name": "SampleReader",
+  "synonym": "Sample reader",
+  "comment": "Synthetic repro",
+  "objects": ["Catalog.Items: @view"]
+}"#,
+        )
+        .unwrap();
+
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert(
+            "JsonPath".to_string(),
+            Value::String(role_json.display().to_string()),
+        );
+        args.insert("OutputDir".to_string(), Value::String("src".to_string()));
+        let result = UnicaApplication::new()
+            .call_tool("unica.role.compile", &args)
+            .unwrap();
+
+        assert!(result.ok, "{:?}", result.errors);
+
+        let first_xml =
+            std::fs::read_to_string(workspace.join("src/Roles/SampleReader.xml")).unwrap();
+        let first_uuid = metadata_root_uuid(&first_xml, "Role");
+
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert(
+            "JsonPath".to_string(),
+            Value::String(role_json.display().to_string()),
+        );
+        args.insert("OutputDir".to_string(), Value::String("src".to_string()));
+        let result = UnicaApplication::new()
+            .call_tool("unica.role.compile", &args)
+            .unwrap();
+
+        assert!(result.ok, "{:?}", result.errors);
+
+        let regenerated_xml =
+            std::fs::read_to_string(workspace.join("src/Roles/SampleReader.xml")).unwrap();
+        let regenerated_uuid = metadata_root_uuid(&regenerated_xml, "Role");
+        assert_eq!(first_uuid, regenerated_uuid);
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn meta_compile_creates_constant_with_boolean_type() {
         let root = temp_meta_compile_workspace("unica-meta-compile-constant-bool");
         let workspace = root.join("workspace");

--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -1835,6 +1835,79 @@ mod tests {
     }
 
     #[test]
+    fn role_compile_generates_distinct_non_placeholder_uuid_v4() {
+        let root = temp_meta_compile_workspace("unica-role-compile-uuid-v4");
+        let workspace = root.join("workspace");
+        let fixtures = workspace.join("fixtures");
+        std::fs::create_dir_all(&fixtures).unwrap();
+
+        let reader_json = fixtures.join("sample-reader.json");
+        std::fs::write(
+            &reader_json,
+            r#"{
+  "name": "SampleReader",
+  "synonym": "Sample reader",
+  "comment": "Synthetic repro",
+  "objects": ["Catalog.Items: @view"]
+}"#,
+        )
+        .unwrap();
+        let editor_json = fixtures.join("sample-editor.json");
+        std::fs::write(
+            &editor_json,
+            r#"{
+  "name": "SampleEditor",
+  "synonym": "Sample editor",
+  "comment": "Synthetic repro",
+  "objects": ["Catalog.Items: @view @edit"]
+}"#,
+        )
+        .unwrap();
+
+        for json_path in [&reader_json, &editor_json] {
+            let mut args = Map::new();
+            args.insert(
+                "cwd".to_string(),
+                Value::String(workspace.display().to_string()),
+            );
+            args.insert("dryRun".to_string(), Value::Bool(false));
+            args.insert(
+                "JsonPath".to_string(),
+                Value::String(json_path.display().to_string()),
+            );
+            args.insert("OutputDir".to_string(), Value::String("src".to_string()));
+            let result = UnicaApplication::new()
+                .call_tool("unica.role.compile", &args)
+                .unwrap();
+
+            assert!(result.ok, "{:?}", result.errors);
+        }
+
+        let reader_xml =
+            std::fs::read_to_string(workspace.join("src/Roles/SampleReader.xml")).unwrap();
+        let editor_xml =
+            std::fs::read_to_string(workspace.join("src/Roles/SampleEditor.xml")).unwrap();
+        assert_valid_root_uuid(&reader_xml, "Role");
+        assert_valid_root_uuid(&editor_xml, "Role");
+        let reader_uuid = metadata_root_uuid(&reader_xml, "Role");
+        let editor_uuid = metadata_root_uuid(&editor_xml, "Role");
+        assert_ne!(reader_uuid, editor_uuid);
+        for uuid in [&reader_uuid, &editor_uuid] {
+            assert!(
+                !uuid.starts_with("00000000-0000-0000-"),
+                "role.compile must not generate placeholder UUID: {uuid}"
+            );
+            assert_eq!(
+                uuid.as_bytes().get(14),
+                Some(&b'4'),
+                "UUID must be v4: {uuid}"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn meta_compile_creates_constant_with_boolean_type() {
         let root = temp_meta_compile_workspace("unica-meta-compile-constant-bool");
         let workspace = root.join("workspace");

--- a/crates/unica-coder/src/infrastructure/native_operations/role.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/role.rs
@@ -1180,7 +1180,7 @@ pub(crate) fn compile_role(
             }
         }
 
-        let uid = stable_uuid(80);
+        let uid = fresh_meta_compile_uuid();
         let metadata_xml = role_metadata_xml(&role_name, &synonym, &comment, &format_version, &uid);
 
         let sfno = defn

--- a/crates/unica-coder/src/infrastructure/native_operations/role.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/role.rs
@@ -1180,9 +1180,6 @@ pub(crate) fn compile_role(
             }
         }
 
-        let uid = fresh_meta_compile_uuid();
-        let metadata_xml = role_metadata_xml(&role_name, &synonym, &comment, &format_version, &uid);
-
         let sfno = defn
             .get("setForNewObjects")
             .map(json_value_to_python_lower)
@@ -1272,6 +1269,9 @@ pub(crate) fn compile_role(
 
         let metadata_path = roles_dir.join(format!("{role_name}.xml"));
         let rights_path = roles_dir.join(&role_name).join("Ext").join("Rights.xml");
+        let uid =
+            reusable_existing_role_uuid(&metadata_path).unwrap_or_else(fresh_meta_compile_uuid);
+        let metadata_xml = role_metadata_xml(&role_name, &synonym, &comment, &format_version, &uid);
         fs::create_dir_all(&roles_dir)
             .map_err(|err| format!("failed to create {}: {err}", roles_dir.display()))?;
         if let Some(ext_dir) = rights_path.parent() {
@@ -1359,6 +1359,20 @@ pub(crate) fn compile_role(
             command: None,
         },
     }
+}
+
+fn reusable_existing_role_uuid(metadata_path: &Path) -> Option<String> {
+    let text = fs::read_to_string(metadata_path).ok()?;
+    let doc = Document::parse(text.trim_start_matches('\u{feff}')).ok()?;
+    let role_node = doc
+        .descendants()
+        .find(|node| role_info_element(*node, "Role", None))?;
+    let uuid = role_node.attribute("uuid")?.to_string();
+    (is_valid_uuid(&uuid) && !is_placeholder_uuid(&uuid)).then_some(uuid)
+}
+
+fn is_placeholder_uuid(value: &str) -> bool {
+    value.starts_with("00000000-0000-0000-")
 }
 
 pub(crate) fn role_metadata_xml(


### PR DESCRIPTION
## Кратко

Closes #39.

PR убирает placeholder UUID из `unica.role.compile`: новые роли теперь получают свежий UUID v4.

## Что изменилось

- `role.compile` использует `fresh_meta_compile_uuid()` вместо `stable_uuid(80)`.
- Добавлен regression-тест с двумя синтетическими ролями:
  - `Role.SampleReader`;
  - `Role.SampleEditor`.
- Тест проверяет, что UUID валидные, разные, имеют version nibble `4` и не начинаются с `00000000-0000-0000-`.

## RED/GREEN

- RED: `cargo test --package unica-coder role_compile_generates_distinct_non_placeholder_uuid_v4 -- --nocapture` падал, обе роли получали `00000000-0000-0000-0000-000000000050`.
- GREEN: тот же тест проходит после замены генератора UUID.

## Проверки

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo test --package unica-coder` — 134 passed
- `python3 -m unittest discover -s tests/ci` — 101 tests OK, skipped=1
- `cargo clippy --package unica-coder --all-targets --all-features -- -D warnings`

## Scope

PR не содержит изменений `support-edit`, `form.validate`, `meta.edit` или `template.add`.