### PR TITLE
Стабилизировать XML writer и template.add

### DIFF
--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -1768,6 +1768,219 @@ mod tests {
     }
 
     #[test]
+    fn meta_compile_preserves_single_configuration_bom() {
+        let root = temp_meta_compile_workspace("unica-meta-compile-single-bom");
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        let config_path = src.join("Configuration.xml");
+        std::fs::write(
+            &config_path,
+            format!(
+                "\u{feff}{}",
+                support_test_configuration_xml("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+            ),
+        )
+        .unwrap();
+        let json_path = workspace.join("report.json");
+        std::fs::write(
+            &json_path,
+            r#"{
+  "type": "Report",
+  "name": "MetaCompileBomReport",
+  "synonym": "MetaCompileBomReport"
+}"#,
+        )
+        .unwrap();
+
+        let result = call_meta_compile(&workspace, &json_path);
+
+        assert!(result.ok, "{:?}", result.errors);
+        let config_bytes = std::fs::read(&config_path).unwrap();
+        assert_eq!(leading_utf8_bom_count(&config_bytes), 1);
+        assert!(String::from_utf8_lossy(&config_bytes)
+            .contains("<Report>MetaCompileBomReport</Report>"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn meta_compile_preserves_configuration_child_objects_formatting() {
+        let root = temp_meta_compile_workspace("unica-meta-compile-child-format");
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        let config_path = src.join("Configuration.xml");
+        std::fs::write(
+            &config_path,
+            concat!(
+                "\u{feff}<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n",
+                "<MetaDataObject xmlns=\"http://v8.1c.ru/8.3/MDClasses\" version=\"2.17\">\r\n",
+                "\t<Configuration uuid=\"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\">\r\n",
+                "\t\t<Properties>\r\n",
+                "\t\t\t<Name>Demo</Name>\r\n",
+                "\t\t</Properties>\r\n",
+                "\t\t<ChildObjects>\r\n",
+                "\t\t\t<Catalog>Items</Catalog>\r\n",
+                "\t\t</ChildObjects>\r\n",
+                "\t</Configuration>\r\n",
+                "</MetaDataObject>"
+            ),
+        )
+        .unwrap();
+        let json_path = workspace.join("report.json");
+        std::fs::write(
+            &json_path,
+            r#"{
+  "type": "Report",
+  "name": "MetaCompileFormatReport",
+  "synonym": "MetaCompileFormatReport"
+}"#,
+        )
+        .unwrap();
+
+        let result = call_meta_compile(&workspace, &json_path);
+
+        assert!(result.ok, "{:?}", result.errors);
+        let config_text =
+            String::from_utf8_lossy(&std::fs::read(&config_path).unwrap()).to_string();
+        assert!(config_text.contains(concat!(
+            "\r\n\t\t\t<Catalog>Items</Catalog>\r\n",
+            "\t\t\t<Report>MetaCompileFormatReport</Report>\n",
+            "\t\t</ChildObjects>"
+        )));
+        assert!(!config_text.contains("\t\t\t\t\t<Report>MetaCompileFormatReport</Report>"));
+        assert!(!config_text
+            .contains("<Report>MetaCompileFormatReport</Report>\r\n\t\t</ChildObjects>"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn template_add_preserves_single_object_bom() {
+        let root = temp_meta_compile_workspace("unica-template-add-single-bom");
+        let workspace = root.join("workspace");
+        let json_path = workspace.join("report.json");
+        std::fs::write(
+            &json_path,
+            r#"{
+  "type": "Report",
+  "name": "TemplateBomReport",
+  "synonym": "TemplateBomReport"
+}"#,
+        )
+        .unwrap();
+        let result = call_meta_compile(&workspace, &json_path);
+        assert!(result.ok, "{:?}", result.errors);
+
+        let report_path = workspace
+            .join("src")
+            .join("Reports")
+            .join("TemplateBomReport.xml");
+        let report_bytes = std::fs::read(&report_path).unwrap();
+        assert_eq!(leading_utf8_bom_count(&report_bytes), 1);
+
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert(
+            "ObjectName".to_string(),
+            Value::String("TemplateBomReport".to_string()),
+        );
+        args.insert(
+            "TemplateName".to_string(),
+            Value::String("ОсновнаяСхемаКомпоновкиДанных".to_string()),
+        );
+        args.insert(
+            "TemplateType".to_string(),
+            Value::String("DataCompositionSchema".to_string()),
+        );
+        args.insert(
+            "SrcDir".to_string(),
+            Value::String("src/Reports".to_string()),
+        );
+
+        let template_result = UnicaApplication::new()
+            .call_tool("unica.template.add", &args)
+            .unwrap();
+
+        assert!(template_result.ok, "{:?}", template_result.errors);
+        let report_bytes = std::fs::read(&report_path).unwrap();
+        assert_eq!(leading_utf8_bom_count(&report_bytes), 1);
+        assert!(String::from_utf8_lossy(&report_bytes)
+            .contains("<Template>ОсновнаяСхемаКомпоновкиДанных</Template>"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn template_add_repairs_repeated_object_bom() {
+        let root = temp_meta_compile_workspace("unica-template-add-repeated-bom");
+        let workspace = root.join("workspace");
+        let json_path = workspace.join("report.json");
+        std::fs::write(
+            &json_path,
+            r#"{
+  "type": "Report",
+  "name": "TemplateRepeatedBomReport",
+  "synonym": "TemplateRepeatedBomReport"
+}"#,
+        )
+        .unwrap();
+        let result = call_meta_compile(&workspace, &json_path);
+        assert!(result.ok, "{:?}", result.errors);
+
+        let report_path = workspace
+            .join("src")
+            .join("Reports")
+            .join("TemplateRepeatedBomReport.xml");
+        let report_bytes = std::fs::read(&report_path).unwrap();
+        assert_eq!(leading_utf8_bom_count(&report_bytes), 1);
+
+        let mut damaged = b"\xef\xbb\xbf".to_vec();
+        damaged.extend_from_slice(&report_bytes);
+        std::fs::write(&report_path, damaged).unwrap();
+        let report_bytes = std::fs::read(&report_path).unwrap();
+        assert_eq!(leading_utf8_bom_count(&report_bytes), 2);
+
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert(
+            "ObjectName".to_string(),
+            Value::String("TemplateRepeatedBomReport".to_string()),
+        );
+        args.insert(
+            "TemplateName".to_string(),
+            Value::String("ОсновнаяСхемаКомпоновкиДанных".to_string()),
+        );
+        args.insert(
+            "TemplateType".to_string(),
+            Value::String("DataCompositionSchema".to_string()),
+        );
+        args.insert(
+            "SrcDir".to_string(),
+            Value::String("src/Reports".to_string()),
+        );
+
+        let template_result = UnicaApplication::new()
+            .call_tool("unica.template.add", &args)
+            .unwrap();
+
+        assert!(template_result.ok, "{:?}", template_result.errors);
+        let report_bytes = std::fs::read(&report_path).unwrap();
+        assert_eq!(leading_utf8_bom_count(&report_bytes), 1);
+        assert!(String::from_utf8_lossy(&report_bytes)
+            .contains("<Template>ОсновнаяСхемаКомпоновкиДанных</Template>"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn meta_validate_supports_pipe_separated_batch_paths() {
         let root = std::env::temp_dir().join(format!("unica-meta-batch-{}", std::process::id()));
         let workspace = root.join("workspace");
@@ -2697,6 +2910,13 @@ mod tests {
         UnicaApplication::new()
             .call_tool("unica.meta.validate", &args)
             .unwrap()
+    }
+
+    fn leading_utf8_bom_count(bytes: &[u8]) -> usize {
+        bytes
+            .chunks_exact(3)
+            .take_while(|chunk| *chunk == [0xEF, 0xBB, 0xBF])
+            .count()
     }
 
     fn assert_valid_root_uuid(xml: &str, tag_name: &str) {

--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -1797,8 +1797,9 @@ mod tests {
         assert!(result.ok, "{:?}", result.errors);
         let config_bytes = std::fs::read(&config_path).unwrap();
         assert_eq!(leading_utf8_bom_count(&config_bytes), 1);
-        assert!(String::from_utf8_lossy(&config_bytes)
-            .contains("<Report>MetaCompileBomReport</Report>"));
+        let config_text = String::from_utf8_lossy(&config_bytes).to_string();
+        assert!(config_text.contains("<Report>MetaCompileBomReport</Report>"));
+        roxmltree::Document::parse(config_text.trim_start_matches('\u{feff}')).unwrap();
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/crates/unica-coder/src/infrastructure/native_operations/common.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/common.rs
@@ -160,7 +160,7 @@ pub(crate) fn register_form_in_object_text(text: &str, form_name: &str) -> Strin
 pub(crate) fn read_utf8_sig(path: &Path) -> Result<String, String> {
     let mut text = fs::read_to_string(path)
         .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
-    if text.starts_with('\u{feff}') {
+    while text.starts_with('\u{feff}') {
         text.remove(0);
     }
     Ok(text)
@@ -1212,6 +1212,7 @@ pub(crate) fn output_dir_arg(
 pub(crate) fn write_utf8_bom(path: &Path, content: &str) -> Result<(), String> {
     let mut file = fs::File::create(path)
         .map_err(|err| format!("failed to write {}: {err}", path.display()))?;
+    let content = content.trim_start_matches('\u{feff}');
     file.write_all(b"\xef\xbb\xbf")
         .and_then(|_| file.write_all(content.as_bytes()))
         .map_err(|err| format!("failed to write {}: {err}", path.display()))

--- a/crates/unica-coder/src/infrastructure/native_operations/meta.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta.rs
@@ -8085,22 +8085,39 @@ pub(crate) fn register_compiled_meta_in_configuration(
     if !config_xml_path.is_file() {
         return Ok(Some("no-config".to_string()));
     }
-    let mut raw_text = fs::read_to_string(&config_xml_path)
-        .map_err(|err| format!("failed to read {}: {err}", config_xml_path.display()))?;
+    let mut raw_text = read_utf8_sig(&config_xml_path)?;
     if raw_text.contains(&format!("<{child_tag}>{obj_name}</{child_tag}>")) {
         return Ok(Some("already".to_string()));
     }
     if raw_text.contains("</ChildObjects>") {
-        raw_text = raw_text.replacen(
-            "</ChildObjects>",
-            &format!("\t\t\t<{child_tag}>{obj_name}</{child_tag}>\n\t\t</ChildObjects>"),
-            1,
-        );
+        raw_text =
+            register_compiled_meta_child_text(&raw_text, child_tag, obj_name).unwrap_or(raw_text);
         write_utf8_bom(&config_xml_path, &raw_text)?;
         Ok(Some("added".to_string()))
     } else {
         Ok(Some("no-childobj".to_string()))
     }
+}
+
+fn register_compiled_meta_child_text(
+    xml_text: &str,
+    child_tag: &str,
+    obj_name: &str,
+) -> Option<String> {
+    let close = "</ChildObjects>";
+    let index = xml_text.find(close)?;
+    let line_start = xml_text[..index].rfind('\n').map_or(0, |pos| pos + 1);
+    let closing_indent = &xml_text[line_start..index];
+    let insertion = format!("<{child_tag}>{obj_name}</{child_tag}>");
+    let mut result =
+        String::with_capacity(xml_text.len() + 1 + insertion.len() + 1 + closing_indent.len());
+    result.push_str(&xml_text[..index]);
+    result.push('\t');
+    result.push_str(&insertion);
+    result.push('\n');
+    result.push_str(closing_indent);
+    result.push_str(&xml_text[index..]);
+    Some(result)
 }
 
 pub(crate) fn edit_meta(args: &Map<String, Value>, context: &WorkspaceContext) -> AdapterOutcome {

--- a/crates/unica-coder/src/infrastructure/native_operations/meta.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta.rs
@@ -8107,11 +8107,27 @@ fn register_compiled_meta_child_text(
     let close = "</ChildObjects>";
     let index = xml_text.find(close)?;
     let line_start = xml_text[..index].rfind('\n').map_or(0, |pos| pos + 1);
-    let closing_indent = &xml_text[line_start..index];
+    let before_close_on_line = &xml_text[line_start..index];
+    let closing_indent = if before_close_on_line.chars().all(|ch| ch == '\t' || ch == ' ') {
+        before_close_on_line
+    } else {
+        let open_index = xml_text[..index].rfind("<ChildObjects")?;
+        let open_line_start = xml_text[..open_index].rfind('\n').map_or(0, |pos| pos + 1);
+        let open_indent = &xml_text[open_line_start..open_index];
+        if open_indent.chars().all(|ch| ch == '\t' || ch == ' ') {
+            open_indent
+        } else {
+            ""
+        }
+    };
     let insertion = format!("<{child_tag}>{obj_name}</{child_tag}>");
     let mut result =
         String::with_capacity(xml_text.len() + 1 + insertion.len() + 1 + closing_indent.len());
     result.push_str(&xml_text[..index]);
+    if !before_close_on_line.chars().all(|ch| ch == '\t' || ch == ' ') {
+        result.push('\n');
+        result.push_str(closing_indent);
+    }
     result.push('\t');
     result.push_str(&insertion);
     result.push('\n');

--- a/crates/unica-coder/src/infrastructure/native_operations/template.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/template.rs
@@ -116,8 +116,7 @@ pub(crate) fn add_template(
             )?;
         }
 
-        let xml_text = fs::read_to_string(&root_xml_path)
-            .map_err(|err| format!("failed to read {}: {err}", root_xml_path.display()))?;
+        let xml_text = read_utf8_sig(&root_xml_path)?;
         let mut xml_text = append_metadata_child_text(&xml_text, "Template", template_name)
             .ok_or_else(|| {
                 format!(
@@ -260,8 +259,7 @@ pub(crate) fn remove_template(
         ));
         changes.push(format!("removed file {}", template_meta_path.display()));
 
-        let xml_text = fs::read_to_string(&root_xml_path)
-            .map_err(|err| format!("failed to read {}: {err}", root_xml_path.display()))?;
+        let xml_text = read_utf8_sig(&root_xml_path)?;
         let xml_text = remove_template_child_text_lxml(&xml_text, template_name);
         let (mut xml_text, main_dcs_cleared) =
             clear_main_data_composition_schema_text(&xml_text, template_name);
@@ -453,41 +451,48 @@ pub(crate) fn append_metadata_child_text(
     local_name: &str,
     item_name: &str,
 ) -> Option<String> {
-    for close in ["</ChildObjects>", "</md:ChildObjects>"] {
-        if let Some(index) = xml_text.find(close) {
-            let prefix = if close.starts_with("</md:") {
-                "md:"
-            } else {
-                ""
-            };
-            let line_start = xml_text[..index].rfind('\n').map_or(0, |pos| pos + 1);
-            let closing_indent = &xml_text[line_start..index];
-            let line = format!(
-                "\t<{prefix}{local_name}>{item_name}</{prefix}{local_name}>\n{closing_indent}"
-            );
-            let mut result = String::with_capacity(xml_text.len() + line.len());
-            result.push_str(&xml_text[..index]);
-            result.push_str(&line);
-            result.push_str(&xml_text[index..]);
-            return Some(result);
-        }
+    let doc = Document::parse(xml_text).ok()?;
+    let object_node = doc
+        .root_element()
+        .children()
+        .find(|node| node.is_element())?;
+    let child_objects_node = object_node
+        .children()
+        .find(|node| node.is_element() && node.tag_name().name() == "ChildObjects")?;
+    let range = child_objects_node.range();
+    let element_text = &xml_text[range.clone()];
+    let prefix = if element_text.trim_start().starts_with("<md:") {
+        "md:"
+    } else {
+        ""
+    };
+
+    let empty_tag = format!("<{prefix}ChildObjects/>");
+    if element_text.trim() == empty_tag {
+        let line_start = xml_text[..range.start].rfind('\n').map_or(0, |pos| pos + 1);
+        let indent = &xml_text[line_start..range.start];
+        let replacement = format!(
+            "<{prefix}ChildObjects>\n{indent}\t<{prefix}{local_name}>{item_name}</{prefix}{local_name}>\n{indent}</{prefix}ChildObjects>"
+        );
+        let mut result = String::with_capacity(xml_text.len() + replacement.len());
+        result.push_str(&xml_text[..range.start]);
+        result.push_str(&replacement);
+        result.push_str(&xml_text[range.end..]);
+        return Some(result);
     }
 
-    for empty in ["<ChildObjects/>", "<md:ChildObjects/>"] {
-        if let Some(index) = xml_text.find(empty) {
-            let prefix = if empty.starts_with("<md:") { "md:" } else { "" };
-            let replacement = format!(
-                "<{prefix}ChildObjects>\n\t\t\t<{prefix}{local_name}>{item_name}</{prefix}{local_name}>\n\t\t</{prefix}ChildObjects>"
-            );
-            let mut result = String::with_capacity(xml_text.len() + replacement.len());
-            result.push_str(&xml_text[..index]);
-            result.push_str(&replacement);
-            result.push_str(&xml_text[index + empty.len()..]);
-            return Some(result);
-        }
-    }
-
-    None
+    let close = format!("</{prefix}ChildObjects>");
+    let close_rel = element_text.rfind(&close)?;
+    let index = range.start + close_rel;
+    let line_start = xml_text[..index].rfind('\n').map_or(0, |pos| pos + 1);
+    let closing_indent = &xml_text[line_start..index];
+    let line =
+        format!("\t<{prefix}{local_name}>{item_name}</{prefix}{local_name}>\n{closing_indent}");
+    let mut result = String::with_capacity(xml_text.len() + line.len());
+    result.push_str(&xml_text[..index]);
+    result.push_str(&line);
+    result.push_str(&xml_text[index..]);
+    Some(result)
 }
 
 pub(crate) fn update_main_data_composition_schema_text(
@@ -599,6 +604,43 @@ pub(crate) fn invoke_mutation(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn append_metadata_child_text_uses_root_child_objects() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses">
+	<Document uuid="00000000-0000-0000-0000-000000000001">
+		<Properties>
+			<Name>NestedChildObjectsDoc</Name>
+		</Properties>
+		<ChildObjects>
+			<TabularSection uuid="00000000-0000-0000-0000-000000000002">
+				<Properties>
+					<Name>Goods</Name>
+				</Properties>
+				<ChildObjects>
+					<Attribute uuid="00000000-0000-0000-0000-000000000003">
+						<Properties>
+							<Name>Item</Name>
+						</Properties>
+					</Attribute>
+				</ChildObjects>
+			</TabularSection>
+		</ChildObjects>
+	</Document>
+</MetaDataObject>
+"#;
+
+        let updated = append_metadata_child_text(xml, "Template", "ПФ_MXL_КШ").unwrap();
+
+        assert_eq!(updated.matches("<Template>ПФ_MXL_КШ</Template>").count(), 1);
+        assert!(updated.contains(
+            "\t\t\t</TabularSection>\n\t\t\t<Template>ПФ_MXL_КШ</Template>\n\t\t</ChildObjects>"
+        ));
+        assert!(
+            !updated.contains("\t\t\t\t<Template>ПФ_MXL_КШ</Template>\n\t\t\t\t</ChildObjects>")
+        );
+    }
 
     #[test]
     fn fresh_uuid_generates_uuid_v4() {


### PR DESCRIPTION
## Summary

- Исправлена нормализация UTF-8 BOM при чтении/записи XML writer: повторные leading BOM больше не размножаются.
- `meta.compile` регистрирует новый объект в `Configuration.xml` без двойного BOM и с корректным отступом внутри `ChildObjects`.
- `template.add` теперь вставляет `<Template>` в root `ChildObjects` объекта, а не в первый вложенный `ChildObjects` табличной части.

Closes #38

## RED/GREEN evidence

- RED: `cargo test --package unica-coder --lib` падал на 5 новых сценариях: `meta_compile_preserves_single_configuration_bom`, `meta_compile_preserves_configuration_child_objects_formatting`, `template_add_preserves_single_object_bom`, `template_add_repairs_repeated_object_bom`, `append_metadata_child_text_uses_root_child_objects`.
- GREEN: тот же `cargo test --package unica-coder --lib` прошёл: 138 passed.

## Test Plan

- `cargo fmt --all -- --check`
- `git diff --check`
- `python3 -m unittest discover -s tests/ci` — 101 tests OK, skipped=1
- `cargo test --package unica-coder` — 138 unit tests passed; main/doc tests 0
- `cargo clippy --package unica-coder --all-targets --all-features -- -D warnings`

## Scope

- В PR нет изменений `support`, `role.compile`, `form.validate` и расширения операций `meta.edit`.
