### PR TITLE
Fix runtime diagnostics and v8-runner contract

### DIFF
--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -11,7 +11,7 @@ use crate::infrastructure::AdapterOutcome;
 use operation_descriptors::SupportGuardPolicy;
 use ports::{ApplicationPorts, DefaultApplicationPorts};
 use serde::Serialize;
-use serde_json::{Map, Value};
+use serde_json::{json, Map, Value};
 use std::env;
 use std::path::{Path, PathBuf};
 
@@ -65,6 +65,8 @@ pub struct OperationResult {
     pub stderr: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostics: Option<Value>,
 }
 
 pub struct UnicaApplication {
@@ -328,6 +330,7 @@ fn call_tool(
                     stdout: outcome.stdout,
                     stderr: outcome.stderr,
                     command: outcome.command,
+                    diagnostics: None,
                 });
             }
         }
@@ -350,6 +353,7 @@ fn call_tool(
     if spec.mutating && !dry_run && outcome.ok && !events.is_empty() {
         ports.notify_invalidation(&context, &events);
     }
+    let diagnostics = runtime_result_diagnostics(spec, args, &context, &outcome);
 
     Ok(OperationResult {
         ok: outcome.ok,
@@ -362,11 +366,102 @@ fn call_tool(
         stdout: outcome.stdout,
         stderr: outcome.stderr,
         command: outcome.command,
+        diagnostics,
     })
 }
 
 fn should_emit_events(spec: ToolSpec, dry_run: bool, outcome: &AdapterOutcome) -> bool {
     spec.mutating && (dry_run || outcome.ok)
+}
+
+fn runtime_result_diagnostics(
+    spec: ToolSpec,
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+    outcome: &AdapterOutcome,
+) -> Option<Value> {
+    if !matches!(spec.handler, ToolHandler::RuntimeAdapter) || outcome.ok {
+        return None;
+    }
+    let operation = args
+        .get("operation")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let failure_kind = runtime_failure_kind(outcome);
+    let status = runtime_failure_status(outcome, failure_kind);
+    let argv = outcome.command.clone().unwrap_or_default();
+    let executable = argv.first().cloned();
+    Some(json!({
+        "type": "process",
+        "tool": "v8-runner",
+        "operation": operation,
+        "failure_kind": failure_kind,
+        "executable": executable,
+        "argv": argv,
+        "cwd": context.cwd.display().to_string(),
+        "status": status,
+        "exit_code": status.as_deref().and_then(process_exit_code),
+        "timed_out": failure_kind == "timeout",
+        "timeout_seconds": Option::<u64>::None,
+        "timeout_source": "delegated-to-v8-runner",
+        "stdout_tail": result_tail(outcome.stdout.as_deref().unwrap_or_default()),
+        "stderr_tail": result_tail(outcome.stderr.as_deref().unwrap_or_default()),
+        "error": outcome.errors.first(),
+    }))
+}
+
+fn runtime_failure_kind(outcome: &AdapterOutcome) -> &'static str {
+    if outcome
+        .warnings
+        .iter()
+        .any(|warning| warning.contains("failed to spawn"))
+    {
+        "spawn"
+    } else if outcome
+        .warnings
+        .iter()
+        .any(|warning| warning.contains("timed out"))
+    {
+        "timeout"
+    } else {
+        "exit"
+    }
+}
+
+fn runtime_failure_status(outcome: &AdapterOutcome, failure_kind: &str) -> Option<String> {
+    if failure_kind == "spawn" {
+        return None;
+    }
+    if failure_kind == "timeout" {
+        return Some("timeout".to_string());
+    }
+    outcome.warnings.iter().find_map(|warning| {
+        warning
+            .strip_prefix("internal v8-runner runtime adapter exited with status ")
+            .map(str::to_string)
+    })
+}
+
+fn process_exit_code(status: &str) -> Option<i32> {
+    let status = status.trim();
+    if status == "timeout" {
+        return None;
+    }
+    if let Ok(code) = status.parse::<i32>() {
+        return Some(code);
+    }
+    status
+        .rsplit_once(':')
+        .and_then(|(_, tail)| tail.trim().parse::<i32>().ok())
+}
+
+fn result_tail(text: &str) -> String {
+    const TAIL_CHARS: usize = 4096;
+    let char_count = text.chars().count();
+    if char_count <= TAIL_CHARS {
+        return text.to_string();
+    }
+    text.chars().skip(char_count - TAIL_CHARS).collect()
 }
 
 enum SupportGuardCheck {
@@ -1269,6 +1364,132 @@ mod tests {
         assert!(result.ok);
         assert!(result.cache.events.is_empty());
         assert_eq!(result.cache.mode, "read");
+    }
+
+    #[test]
+    fn runtime_failure_result_includes_structured_exit_diagnostics() {
+        let root = test_workspace_root("runtime-exit-diagnostics");
+        let result = call_runtime_with_outcome(
+            &root,
+            AdapterOutcome {
+                ok: false,
+                summary: "unica.runtime.execute failed through internal v8-runner runtime adapter"
+                    .to_string(),
+                changes: Vec::new(),
+                warnings: vec![
+                    "internal v8-runner runtime adapter exited with status exit status: 1"
+                        .to_string(),
+                ],
+                errors: vec!["failed to load configuration: Pwd=<redacted>".to_string()],
+                artifacts: Vec::new(),
+                stdout: Some("started build\nPwd=<redacted>\n".to_string()),
+                stderr: Some("failed to load configuration: Pwd=<redacted>\n".to_string()),
+                command: Some(vec![
+                    "/tmp/unica/plugins/unica/bin/darwin-arm64/v8-runner".to_string(),
+                    "build".to_string(),
+                    "--source-set".to_string(),
+                    "main".to_string(),
+                ]),
+            },
+            "build",
+        );
+
+        let diagnostics = result.diagnostics.unwrap();
+        assert_eq!(diagnostics["tool"], "v8-runner");
+        assert_eq!(diagnostics["operation"], "build");
+        assert_eq!(diagnostics["failure_kind"], "exit");
+        assert_eq!(diagnostics["exit_code"], 1);
+        assert_eq!(diagnostics["timed_out"], false);
+        assert_eq!(diagnostics["argv"][1], "build");
+        assert_eq!(diagnostics["argv"][2], "--source-set");
+        assert_eq!(diagnostics["argv"][3], "main");
+        assert_eq!(diagnostics["cwd"], root.display().to_string());
+        assert!(diagnostics["stdout_tail"]
+            .as_str()
+            .unwrap()
+            .contains("started build"));
+        assert!(!serde_json::to_string(&diagnostics)
+            .unwrap()
+            .contains("super-secret"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn runtime_failure_result_distinguishes_timeout_diagnostics() {
+        let root = test_workspace_root("runtime-timeout-diagnostics");
+        let result = call_runtime_with_outcome(
+            &root,
+            AdapterOutcome {
+                ok: false,
+                summary: "unica.runtime.execute failed through internal v8-runner runtime adapter"
+                    .to_string(),
+                changes: Vec::new(),
+                warnings: vec!["internal v8-runner runtime adapter timed out".to_string()],
+                errors: vec!["internal v8-runner runtime adapter timed out".to_string()],
+                artifacts: Vec::new(),
+                stdout: Some("started loading configuration...\n".to_string()),
+                stderr: Some(String::new()),
+                command: Some(vec![
+                    "/tmp/unica/plugins/unica/bin/darwin-arm64/v8-runner".to_string(),
+                    "load".to_string(),
+                    "--path".to_string(),
+                    "build/config.cf".to_string(),
+                ]),
+            },
+            "load",
+        );
+
+        let diagnostics = result.diagnostics.unwrap();
+        assert_eq!(diagnostics["failure_kind"], "timeout");
+        assert_eq!(diagnostics["timed_out"], true);
+        assert!(diagnostics["timeout_seconds"].is_null());
+        assert_eq!(diagnostics["timeout_source"], "delegated-to-v8-runner");
+        assert!(diagnostics["stdout_tail"]
+            .as_str()
+            .unwrap()
+            .contains("started loading configuration"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn runtime_failure_result_distinguishes_spawn_diagnostics() {
+        let root = test_workspace_root("runtime-spawn-diagnostics");
+        let result = call_runtime_with_outcome(
+            &root,
+            AdapterOutcome {
+                ok: false,
+                summary: "unica.runtime.execute failed through internal v8-runner runtime adapter"
+                    .to_string(),
+                changes: Vec::new(),
+                warnings: vec![
+                    "internal v8-runner runtime adapter failed to spawn process".to_string()
+                ],
+                errors: vec!["failed to execute process: apiToken=<redacted>".to_string()],
+                artifacts: Vec::new(),
+                stdout: None,
+                stderr: Some("failed to execute process: apiToken=<redacted>\n".to_string()),
+                command: Some(vec![
+                    "/tmp/unica/plugins/unica/bin/darwin-arm64/v8-runner".to_string(),
+                    "build".to_string(),
+                ]),
+            },
+            "build",
+        );
+
+        let diagnostics = result.diagnostics.unwrap();
+        assert_eq!(diagnostics["failure_kind"], "spawn");
+        assert_eq!(diagnostics["operation"], "build");
+        assert!(diagnostics["exit_code"].is_null());
+        assert_eq!(diagnostics["timed_out"], false);
+        assert!(diagnostics["status"].is_null());
+        assert!(diagnostics["error"]
+            .as_str()
+            .unwrap()
+            .contains("failed to execute process"));
+        assert!(!serde_json::to_string(&diagnostics)
+            .unwrap()
+            .contains("token-secret"));
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]
@@ -3411,6 +3632,98 @@ mod tests {
   ]
 }}"#
         )
+    }
+
+    struct FixedOutcomePorts {
+        outcome: AdapterOutcome,
+    }
+
+    impl ports::ApplicationPorts for FixedOutcomePorts {
+        fn discover_workspace(&self, cwd: PathBuf) -> Result<WorkspaceContext, String> {
+            Ok(WorkspaceContext {
+                cwd: cwd.clone(),
+                workspace_root: cwd.clone(),
+                cache_root: cwd.join(".build").join("unica"),
+                workspace_epoch: 1,
+            })
+        }
+
+        fn invoke_handler(
+            &self,
+            _spec: ToolSpec,
+            _args: &Map<String, Value>,
+            _context: &WorkspaceContext,
+            _dry_run: bool,
+        ) -> Result<AdapterOutcome, String> {
+            Ok(self.outcome.clone())
+        }
+
+        fn cache_report(
+            &self,
+            context: &WorkspaceContext,
+            events: &[DomainEvent],
+            dry_run: bool,
+            _cache_access: CacheAccess,
+        ) -> Result<CacheReport, String> {
+            Ok(CacheReport {
+                mode: if events.is_empty() {
+                    "read".to_string()
+                } else if dry_run {
+                    "dry-run".to_string()
+                } else {
+                    "applied".to_string()
+                },
+                root: context.cache_root.display().to_string(),
+                workspace_epoch: context.workspace_epoch,
+                events: events
+                    .iter()
+                    .map(|event| event.name().to_string())
+                    .collect(),
+                invalidated: Vec::new(),
+                refreshed: Vec::new(),
+                lazy_rebuilt: Vec::new(),
+                stale: Vec::new(),
+                fresh: Vec::new(),
+            })
+        }
+
+        fn notify_invalidation(&self, _context: &WorkspaceContext, _events: &[DomainEvent]) {}
+    }
+
+    fn call_runtime_with_outcome(
+        workspace: &std::path::Path,
+        outcome: AdapterOutcome,
+        operation: &str,
+    ) -> OperationResult {
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert(
+            "operation".to_string(),
+            Value::String(operation.to_string()),
+        );
+        if operation == "load" {
+            args.insert(
+                "path".to_string(),
+                Value::String("build/config.cf".to_string()),
+            );
+        }
+        UnicaApplication::with_ports(Box::new(FixedOutcomePorts { outcome }))
+            .call_tool("unica.runtime.execute", &args)
+            .unwrap()
+    }
+
+    fn test_workspace_root(prefix: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("{prefix}-{}-{nanos}", std::process::id()));
+        std::fs::create_dir_all(&root).unwrap();
+        root
     }
 
     fn temp_meta_compile_workspace(prefix: &str) -> std::path::PathBuf {

--- a/crates/unica-coder/src/application/tool_contracts.rs
+++ b/crates/unica-coder/src/application/tool_contracts.rs
@@ -236,27 +236,63 @@ const BUILD_ARGS: &[&str] = &[
 ];
 
 const RUNTIME_ARGS: &[&str] = &[
+    "allExtensions",
     "builder",
+    "c",
+    "checkUseModality",
+    "checkUseSynchronousCalls",
     "clientMode",
     "config",
+    "configLogIntegrity",
     "connection",
+    "distributiveModules",
+    "emptyHandlers",
+    "execute",
     "extension",
+    "externalConnection",
+    "externalConnectionServer",
+    "features",
+    "filterTags",
     "format",
+    "force",
+    "fullOutput",
     "fullRebuild",
+    "handlersExistence",
+    "ignoreTags",
+    "incorrectReferences",
     "mcpConfig",
     "mcpPort",
+    "mobileAppClient",
+    "mobileAppServer",
+    "mobileClient",
+    "mobileClientDigiSign",
     "mode",
     "module",
     "object",
+    "objects",
     "operation",
     "output",
     "path",
+    "projects",
+    "rawKeys",
+    "scenarioFilters",
     "server",
     "settings",
     "sourceSet",
+    "sourceSets",
+    "sources",
     "testRunner",
     "testScope",
+    "thickClientManagedApplication",
+    "thickClientOrdinaryApplication",
+    "thickClientServerManagedApplication",
+    "thickClientServerOrdinaryApplication",
     "thinClient",
+    "tool",
+    "unsupportedFunctional",
+    "unreferenceProcedures",
+    "usePrivilegedMode",
+    "webClient",
     "workdir",
 ];
 
@@ -272,13 +308,16 @@ const RUNTIME_OPERATIONS: &[&str] = &[
     "test",
     "launch",
     "extensions",
+    "tools-download",
 ];
 
 const RUNTIME_STRING_ARGS: &[&str] = &[
     "builder",
+    "c",
     "clientMode",
     "config",
     "connection",
+    "execute",
     "extension",
     "format",
     "mcpConfig",
@@ -292,8 +331,133 @@ const RUNTIME_STRING_ARGS: &[&str] = &[
     "sourceSet",
     "testRunner",
     "testScope",
+    "tool",
     "workdir",
 ];
+
+const RUNTIME_ARRAY_ARGS: &[&str] = &[
+    "features",
+    "filterTags",
+    "ignoreTags",
+    "objects",
+    "projects",
+    "rawKeys",
+    "scenarioFilters",
+    "sourceSets",
+];
+
+const RUNTIME_CLIENT_MODES: &[&str] = &["designer", "thin", "thick", "ordinary", "mcp", "mcp-va"];
+const RUNTIME_TEST_RUNNERS: &[&str] = &["yaxunit", "va"];
+const RUNTIME_TEST_SCOPES: &[&str] = &["all", "module"];
+const RUNTIME_TOOLS: &[&str] = &["yaxunit", "vanessa", "client-mcp"];
+const RUNTIME_DUMP_MODES: &[&str] = &["full", "incremental", "partial"];
+const RUNTIME_LOAD_MODES: &[&str] = &["load", "merge"];
+const RUNTIME_SYNTAX_MODES: &[&str] = &["designer-config", "designer-modules", "edt"];
+
+const RUNTIME_CONFIG_INIT_ARGS: &[&str] = &[
+    "operation",
+    "config",
+    "workdir",
+    "connection",
+    "format",
+    "builder",
+    "force",
+];
+const RUNTIME_INIT_ARGS: &[&str] = &["operation", "config", "workdir"];
+const RUNTIME_BUILD_OPERATION_ARGS: &[&str] =
+    &["operation", "config", "workdir", "sourceSet", "fullRebuild"];
+const RUNTIME_DUMP_OPERATION_ARGS: &[&str] = &[
+    "operation",
+    "config",
+    "workdir",
+    "mode",
+    "object",
+    "objects",
+    "sourceSet",
+    "extension",
+];
+const RUNTIME_CONVERT_OPERATION_ARGS: &[&str] =
+    &["operation", "config", "workdir", "sourceSet", "output"];
+const RUNTIME_MAKE_OPERATION_ARGS: &[&str] = &[
+    "operation",
+    "config",
+    "workdir",
+    "output",
+    "sourceSet",
+    "extension",
+];
+const RUNTIME_LOAD_OPERATION_ARGS: &[&str] = &[
+    "operation",
+    "config",
+    "workdir",
+    "path",
+    "mode",
+    "settings",
+    "extension",
+];
+const RUNTIME_SYNTAX_OPERATION_ARGS: &[&str] = &[
+    "operation",
+    "config",
+    "workdir",
+    "mode",
+    "server",
+    "thinClient",
+    "webClient",
+    "mobileClient",
+    "externalConnection",
+    "externalConnectionServer",
+    "thickClientManagedApplication",
+    "thickClientServerManagedApplication",
+    "thickClientOrdinaryApplication",
+    "thickClientServerOrdinaryApplication",
+    "mobileAppClient",
+    "mobileAppServer",
+    "mobileClientDigiSign",
+    "distributiveModules",
+    "unreferenceProcedures",
+    "handlersExistence",
+    "emptyHandlers",
+    "extendedModulesCheck",
+    "checkUseSynchronousCalls",
+    "checkUseModality",
+    "unsupportedFunctional",
+    "configLogIntegrity",
+    "incorrectReferences",
+    "extension",
+    "allExtensions",
+    "projects",
+];
+const RUNTIME_TEST_OPERATION_ARGS: &[&str] = &[
+    "operation",
+    "config",
+    "workdir",
+    "testRunner",
+    "testScope",
+    "module",
+    "fullOutput",
+    "features",
+    "filterTags",
+    "ignoreTags",
+    "scenarioFilters",
+];
+const RUNTIME_LAUNCH_OPERATION_ARGS: &[&str] = &[
+    "operation",
+    "config",
+    "workdir",
+    "clientMode",
+    "mode",
+    "mcpConfig",
+    "mcpPort",
+    "c",
+    "execute",
+    "usePrivilegedMode",
+    "output",
+    "rawKeys",
+];
+const RUNTIME_EXTENSIONS_OPERATION_ARGS: &[&str] =
+    &["operation", "config", "workdir", "sourceSet", "sourceSets"];
+const RUNTIME_TOOLS_DOWNLOAD_OPERATION_ARGS: &[&str] =
+    &["operation", "config", "workdir", "tool", "sources", "force"];
 
 const CODE_ARGS: &[&str] = &[
     "config",
@@ -663,12 +827,16 @@ fn validate_runtime_arguments(
             }
         }
     }
+    for key in RUNTIME_ARRAY_ARGS {
+        validate_string_array_argument(tool_name, args, key)?;
+    }
     if !RUNTIME_OPERATIONS.contains(&operation) {
         return Err(format!(
             "{tool_name} argument `operation` must be one of: {}",
             RUNTIME_OPERATIONS.join(", ")
         ));
     }
+    validate_runtime_operation_payload(tool_name, operation, args)?;
 
     if dry_run {
         return Ok(());
@@ -680,6 +848,7 @@ fn validate_runtime_arguments(
         "syntax" => &["mode"][..],
         "test" => &["testRunner"][..],
         "launch" => &["clientMode"][..],
+        "tools-download" => &["tool"][..],
         _ => &[][..],
     };
     for key in required {
@@ -691,6 +860,197 @@ fn validate_runtime_arguments(
     }
 
     Ok(())
+}
+
+fn validate_string_array_argument(
+    tool_name: &str,
+    args: &Map<String, Value>,
+    key: &str,
+) -> Result<(), String> {
+    let Some(value) = args.get(key) else {
+        return Ok(());
+    };
+    let Some(items) = value.as_array() else {
+        return Err(format!("{tool_name} argument `{key}` must be array"));
+    };
+    for item in items {
+        if !item.is_string() {
+            return Err(format!("{tool_name} argument `{key}` must contain strings"));
+        }
+    }
+    Ok(())
+}
+
+fn validate_runtime_operation_payload(
+    tool_name: &str,
+    operation: &str,
+    args: &Map<String, Value>,
+) -> Result<(), String> {
+    let allowed = runtime_operation_args(operation);
+    for key in args.keys() {
+        if COMMON_ARGS.contains(&key.as_str()) {
+            continue;
+        }
+        if !allowed.contains(&key.as_str()) {
+            return Err(format!(
+                "{tool_name} operation `{operation}` does not accept `{key}`"
+            ));
+        }
+    }
+
+    match operation {
+        "dump" => {
+            validate_enum_argument(tool_name, args, "mode", RUNTIME_DUMP_MODES)?;
+            if args
+                .get("mode")
+                .and_then(Value::as_str)
+                .is_some_and(|mode| mode == "partial")
+                && !args.contains_key("object")
+                && !has_non_empty_array_arg(args, "objects")
+            {
+                return Err(format!(
+                    "{tool_name} operation `dump` with mode `partial` requires `object` or `objects`"
+                ));
+            }
+        }
+        "load" => {
+            if args
+                .get("mode")
+                .and_then(Value::as_str)
+                .is_some_and(|mode| mode == "update")
+            {
+                return Err(format!(
+                    "{tool_name} load --mode update is not supported; use `load` or `merge`"
+                ));
+            }
+            validate_enum_argument(tool_name, args, "mode", RUNTIME_LOAD_MODES)?;
+            if args
+                .get("mode")
+                .and_then(Value::as_str)
+                .is_some_and(|mode| mode == "merge")
+                && !args.contains_key("settings")
+            {
+                return Err(format!(
+                    "{tool_name} operation `load` with mode `merge` requires `settings`"
+                ));
+            }
+            if args.contains_key("settings")
+                && args.get("mode").and_then(Value::as_str) != Some("merge")
+            {
+                return Err(format!(
+                    "{tool_name} operation `load` accepts `settings` only with mode `merge`"
+                ));
+            }
+        }
+        "syntax" => {
+            validate_enum_argument(tool_name, args, "mode", RUNTIME_SYNTAX_MODES)?;
+            let mode = args.get("mode").and_then(Value::as_str);
+            if mode == Some("edt") && contains_any(args, &["extension", "allExtensions"]) {
+                return Err(format!(
+                    "{tool_name} operation `syntax` mode `edt` does not accept extension flags"
+                ));
+            }
+            if matches!(mode, Some("designer-config" | "designer-modules"))
+                && args.contains_key("projects")
+            {
+                return Err(format!(
+                    "{tool_name} operation `syntax` accepts `projects` only with mode `edt`"
+                ));
+            }
+        }
+        "test" => {
+            validate_enum_argument(tool_name, args, "testRunner", RUNTIME_TEST_RUNNERS)?;
+            validate_enum_argument(tool_name, args, "testScope", RUNTIME_TEST_SCOPES)?;
+            match args.get("testRunner").and_then(Value::as_str) {
+                Some("yaxunit") => {
+                    if !args.contains_key("testScope") {
+                        return Err(format!(
+                            "{tool_name} operation `test` with runner `yaxunit` requires `testScope`"
+                        ));
+                    }
+                    if args
+                        .get("testScope")
+                        .and_then(Value::as_str)
+                        .is_some_and(|scope| scope == "module")
+                        && !args.contains_key("module")
+                    {
+                        return Err(format!(
+                            "{tool_name} operation `test` with scope `module` requires `module`"
+                        ));
+                    }
+                }
+                Some("va") if contains_any(args, &["testScope", "module"]) => {
+                    return Err(format!(
+                        "{tool_name} operation `test` runner `va` does not accept `testScope` or `module`"
+                    ));
+                }
+                _ => {}
+            }
+        }
+        "launch" => {
+            validate_enum_argument(tool_name, args, "clientMode", RUNTIME_CLIENT_MODES)?;
+            let client_mode = args.get("clientMode").and_then(Value::as_str);
+            let is_mcp_client = matches!(client_mode, Some("mcp" | "mcp-va"));
+            if is_mcp_client
+                && (contains_any(args, &["c", "execute", "usePrivilegedMode", "output"])
+                    || has_non_empty_array_arg(args, "rawKeys"))
+            {
+                return Err(format!(
+                    "{tool_name} operation `launch` clientMode `mcp` does not accept direct launch flags"
+                ));
+            }
+            if client_mode.is_some()
+                && !is_mcp_client
+                && contains_any(args, &["mcpConfig", "mcpPort"])
+            {
+                return Err(format!(
+                    "{tool_name} operation `launch` direct client modes do not accept MCP flags"
+                ));
+            }
+        }
+        "tools-download" => {
+            validate_enum_argument(tool_name, args, "tool", RUNTIME_TOOLS)?;
+            if args
+                .get("sources")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+                && args
+                    .get("tool")
+                    .and_then(Value::as_str)
+                    .is_some_and(|tool| tool == "vanessa")
+            {
+                return Err(format!(
+                    "{tool_name} operation `tools-download` accepts `sources` only for `yaxunit` or `client-mcp`"
+                ));
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn runtime_operation_args(operation: &str) -> &'static [&'static str] {
+    match operation {
+        "config-init" => RUNTIME_CONFIG_INIT_ARGS,
+        "init" => RUNTIME_INIT_ARGS,
+        "build" => RUNTIME_BUILD_OPERATION_ARGS,
+        "dump" => RUNTIME_DUMP_OPERATION_ARGS,
+        "convert" => RUNTIME_CONVERT_OPERATION_ARGS,
+        "make" => RUNTIME_MAKE_OPERATION_ARGS,
+        "load" => RUNTIME_LOAD_OPERATION_ARGS,
+        "syntax" => RUNTIME_SYNTAX_OPERATION_ARGS,
+        "test" => RUNTIME_TEST_OPERATION_ARGS,
+        "launch" => RUNTIME_LAUNCH_OPERATION_ARGS,
+        "extensions" => RUNTIME_EXTENSIONS_OPERATION_ARGS,
+        "tools-download" => RUNTIME_TOOLS_DOWNLOAD_OPERATION_ARGS,
+        _ => &[],
+    }
+}
+
+fn has_non_empty_array_arg(args: &Map<String, Value>, key: &str) -> bool {
+    args.get(key)
+        .and_then(Value::as_array)
+        .is_some_and(|items| !items.is_empty())
 }
 
 pub fn validate_workspace_paths(
@@ -901,9 +1261,33 @@ fn property_schema(name: &str) -> Value {
             | "createIfMissing"
             | "IsFunction"
             | "isFunction"
+            | "allExtensions"
+            | "checkUseModality"
+            | "checkUseSynchronousCalls"
+            | "configLogIntegrity"
+            | "distributiveModules"
+            | "emptyHandlers"
+            | "externalConnection"
+            | "externalConnectionServer"
+            | "fullOutput"
             | "fullRebuild"
+            | "handlersExistence"
+            | "incorrectReferences"
+            | "mobileAppClient"
+            | "mobileAppServer"
+            | "mobileClient"
+            | "mobileClientDigiSign"
             | "server"
+            | "sources"
+            | "thickClientManagedApplication"
+            | "thickClientOrdinaryApplication"
+            | "thickClientServerManagedApplication"
+            | "thickClientServerOrdinaryApplication"
             | "thinClient"
+            | "unsupportedFunctional"
+            | "unreferenceProcedures"
+            | "usePrivilegedMode"
+            | "webClient"
             | "includeMethods"
             | "ignoreCase"
             | "regex"
@@ -935,6 +1319,14 @@ fn property_schema(name: &str) -> Value {
             | "edgeKinds"
             | "provenance"
             | "sections"
+            | "features"
+            | "filterTags"
+            | "ignoreTags"
+            | "objects"
+            | "projects"
+            | "rawKeys"
+            | "scenarioFilters"
+            | "sourceSets"
     ) {
         "array"
     } else {
@@ -958,11 +1350,12 @@ fn property_schema_for_tool(tool: &ToolSpec, name: &str) -> Value {
             "clientMode" => {
                 return json!({
                     "type": "string",
-                    "enum": ["designer", "thin", "thick", "ordinary", "mcp", "mcp-va"]
+                    "enum": RUNTIME_CLIENT_MODES
                 });
             }
-            "testRunner" => return json!({ "type": "string", "enum": ["yaxunit", "va"] }),
-            "testScope" => return json!({ "type": "string", "enum": ["all", "module"] }),
+            "testRunner" => return json!({ "type": "string", "enum": RUNTIME_TEST_RUNNERS }),
+            "testScope" => return json!({ "type": "string", "enum": RUNTIME_TEST_SCOPES }),
+            "tool" => return json!({ "type": "string", "enum": RUNTIME_TOOLS }),
             _ => {}
         }
     }
@@ -1040,9 +1433,33 @@ fn expected_scalar_type(key: &str) -> Option<&'static str> {
             | "createIfMissing"
             | "IsFunction"
             | "isFunction"
+            | "allExtensions"
+            | "checkUseModality"
+            | "checkUseSynchronousCalls"
+            | "configLogIntegrity"
+            | "distributiveModules"
+            | "emptyHandlers"
+            | "externalConnection"
+            | "externalConnectionServer"
+            | "fullOutput"
             | "fullRebuild"
+            | "handlersExistence"
+            | "incorrectReferences"
+            | "mobileAppClient"
+            | "mobileAppServer"
+            | "mobileClient"
+            | "mobileClientDigiSign"
             | "server"
+            | "sources"
+            | "thickClientManagedApplication"
+            | "thickClientOrdinaryApplication"
+            | "thickClientServerManagedApplication"
+            | "thickClientServerOrdinaryApplication"
             | "thinClient"
+            | "unsupportedFunctional"
+            | "unreferenceProcedures"
+            | "usePrivilegedMode"
+            | "webClient"
             | "includeMethods"
             | "ignoreCase"
             | "regex"
@@ -1074,6 +1491,14 @@ fn expected_scalar_type(key: &str) -> Option<&'static str> {
             | "edgeKinds"
             | "provenance"
             | "sections"
+            | "features"
+            | "filterTags"
+            | "ignoreTags"
+            | "objects"
+            | "projects"
+            | "rawKeys"
+            | "scenarioFilters"
+            | "sourceSets"
     ) {
         Some("array")
     } else {
@@ -1263,6 +1688,57 @@ mod tests {
     }
 
     #[test]
+    fn runtime_contract_rejects_operation_specific_unsupported_payloads() {
+        let tool = tools()
+            .into_iter()
+            .find(|tool| tool.name == "unica.runtime.execute")
+            .unwrap();
+        let cases = vec![
+            (
+                json!({"operation": "build", "extension": "MyExtension"}),
+                "operation `build` does not accept `extension`",
+            ),
+            (
+                json!({"operation": "convert", "path": "src"}),
+                "operation `convert` does not accept `path`",
+            ),
+            (
+                json!({"operation": "test", "testRunner": "yaxunit", "fullRebuild": true}),
+                "operation `test` does not accept `fullRebuild`",
+            ),
+            (
+                json!({"operation": "load", "path": "build/config.cf", "mode": "update"}),
+                "load --mode update is not supported",
+            ),
+            (
+                json!({"operation": "load", "path": "build/config.cf", "mode": "merge"}),
+                "operation `load` with mode `merge` requires `settings`",
+            ),
+            (
+                json!({"operation": "load", "path": "build/config.cf", "settings": "merge-settings.xml"}),
+                "operation `load` accepts `settings` only with mode `merge`",
+            ),
+            (
+                json!({"operation": "dump", "mode": "partial"}),
+                "operation `dump` with mode `partial` requires `object` or `objects`",
+            ),
+            (
+                json!({"operation": "tools-download", "tool": "vanessa", "sources": true}),
+                "operation `tools-download` accepts `sources` only for `yaxunit` or `client-mcp`",
+            ),
+        ];
+
+        for (input, expected) in cases {
+            let args = input.as_object().unwrap().clone();
+            let error = validate_tool_arguments(tool, &args, false).unwrap_err();
+            assert!(
+                error.contains(expected),
+                "expected error containing {expected:?}, got {error:?}"
+            );
+        }
+    }
+
+    #[test]
     fn runtime_schema_exposes_typed_arguments_without_additional_properties() {
         let tool = tools()
             .into_iter()
@@ -1281,10 +1757,26 @@ mod tests {
             .as_array()
             .unwrap()
             .contains(&json!("build")));
+        assert!(schema["properties"]["operation"]["enum"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("tools-download")));
         assert!(schema["properties"]["clientMode"]["enum"]
             .as_array()
             .unwrap()
             .contains(&json!("mcp-va")));
+        assert!(schema["properties"]["tool"]["enum"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("client-mcp")));
+        assert_eq!(schema["properties"]["fullOutput"]["type"], "boolean");
+        assert_eq!(schema["properties"]["objects"]["type"], "array");
+        assert_eq!(schema["properties"]["sourceSets"]["type"], "array");
+        assert_eq!(schema["properties"]["features"]["type"], "array");
+        assert_eq!(schema["properties"]["filterTags"]["type"], "array");
+        assert_eq!(schema["properties"]["ignoreTags"]["type"], "array");
+        assert_eq!(schema["properties"]["scenarioFilters"]["type"], "array");
+        assert_eq!(schema["properties"]["projects"]["type"], "array");
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -2391,6 +2391,126 @@ fn normalize_mcp_http_body(text: &str) -> Result<String, String> {
     Ok(joined)
 }
 
+const RUNTIME_MAPPER_CONFIG_INIT_ARGS: &[&str] = &[
+    "operation",
+    "config",
+    "workdir",
+    "connection",
+    "format",
+    "builder",
+    "force",
+];
+const RUNTIME_MAPPER_INIT_ARGS: &[&str] = &["operation", "config", "workdir"];
+const RUNTIME_MAPPER_BUILD_ARGS: &[&str] =
+    &["operation", "config", "workdir", "sourceSet", "fullRebuild"];
+const RUNTIME_MAPPER_DUMP_ARGS: &[&str] = &[
+    "operation",
+    "config",
+    "workdir",
+    "mode",
+    "object",
+    "objects",
+    "sourceSet",
+    "extension",
+];
+const RUNTIME_MAPPER_CONVERT_ARGS: &[&str] =
+    &["operation", "config", "workdir", "sourceSet", "output"];
+const RUNTIME_MAPPER_MAKE_ARGS: &[&str] = &[
+    "operation",
+    "config",
+    "workdir",
+    "output",
+    "sourceSet",
+    "extension",
+];
+const RUNTIME_MAPPER_LOAD_ARGS: &[&str] = &[
+    "operation",
+    "config",
+    "workdir",
+    "path",
+    "mode",
+    "settings",
+    "extension",
+];
+const RUNTIME_MAPPER_SYNTAX_ARGS: &[&str] = &[
+    "operation",
+    "config",
+    "workdir",
+    "mode",
+    "server",
+    "thinClient",
+    "webClient",
+    "mobileClient",
+    "externalConnection",
+    "externalConnectionServer",
+    "thickClientManagedApplication",
+    "thickClientServerManagedApplication",
+    "thickClientOrdinaryApplication",
+    "thickClientServerOrdinaryApplication",
+    "mobileAppClient",
+    "mobileAppServer",
+    "mobileClientDigiSign",
+    "distributiveModules",
+    "unreferenceProcedures",
+    "handlersExistence",
+    "emptyHandlers",
+    "extendedModulesCheck",
+    "checkUseSynchronousCalls",
+    "checkUseModality",
+    "unsupportedFunctional",
+    "configLogIntegrity",
+    "incorrectReferences",
+    "extension",
+    "allExtensions",
+    "projects",
+];
+const RUNTIME_MAPPER_TEST_ARGS: &[&str] = &[
+    "operation",
+    "config",
+    "workdir",
+    "testRunner",
+    "testScope",
+    "module",
+    "fullOutput",
+    "features",
+    "filterTags",
+    "ignoreTags",
+    "scenarioFilters",
+];
+const RUNTIME_MAPPER_LAUNCH_ARGS: &[&str] = &[
+    "operation",
+    "config",
+    "workdir",
+    "clientMode",
+    "mode",
+    "mcpConfig",
+    "mcpPort",
+    "c",
+    "execute",
+    "usePrivilegedMode",
+    "output",
+    "rawKeys",
+];
+const RUNTIME_MAPPER_EXTENSIONS_ARGS: &[&str] =
+    &["operation", "config", "workdir", "sourceSet", "sourceSets"];
+const RUNTIME_MAPPER_TOOLS_DOWNLOAD_ARGS: &[&str] =
+    &["operation", "config", "workdir", "tool", "sources", "force"];
+const RUNTIME_MAPPER_ARRAY_ARGS: &[&str] = &[
+    "features",
+    "filterTags",
+    "ignoreTags",
+    "objects",
+    "projects",
+    "rawKeys",
+    "scenarioFilters",
+    "sourceSets",
+];
+const RUNTIME_MAPPER_LOAD_MODES: &[&str] = &["load", "merge"];
+const RUNTIME_MAPPER_DUMP_MODES: &[&str] = &["full", "incremental", "partial"];
+const RUNTIME_MAPPER_TEST_RUNNERS: &[&str] = &["yaxunit", "va"];
+const RUNTIME_MAPPER_TEST_SCOPES: &[&str] = &["all", "module"];
+const RUNTIME_MAPPER_TOOLS: &[&str] = &["yaxunit", "vanessa", "client-mcp"];
+
 fn runtime_args(args: &Map<String, Value>, redact: bool) -> Result<Vec<String>, String> {
     if args.contains_key("args") {
         return Err(
@@ -2402,6 +2522,7 @@ fn runtime_args(args: &Map<String, Value>, redact: bool) -> Result<Vec<String>, 
         .get("operation")
         .and_then(Value::as_str)
         .ok_or_else(|| "unica.runtime.execute requires string `operation` argument".to_string())?;
+    validate_runtime_mapper_payload(operation, args)?;
     let mut result = Vec::new();
 
     append_runtime_global_args(&mut result, operation, args, redact);
@@ -2413,18 +2534,19 @@ fn runtime_args(args: &Map<String, Value>, redact: bool) -> Result<Vec<String>, 
             append_arg(&mut result, "--connection", args, "connection", redact);
             append_arg(&mut result, "--format", args, "format", redact);
             append_arg(&mut result, "--builder", args, "builder", redact);
+            append_bool_flag(&mut result, "--force", args, "force");
         }
         "init" => result.push("init".to_string()),
         "build" => {
             result.push("build".to_string());
             append_bool_flag(&mut result, "--full-rebuild", args, "fullRebuild");
             append_arg(&mut result, "--source-set", args, "sourceSet", redact);
-            append_arg(&mut result, "--extension", args, "extension", redact);
         }
         "dump" => {
             result.push("dump".to_string());
             append_arg(&mut result, "--mode", args, "mode", redact);
             append_arg(&mut result, "--object", args, "object", redact);
+            append_array_args(&mut result, "--object", args, "objects", redact);
             append_arg(&mut result, "--source-set", args, "sourceSet", redact);
             append_arg(&mut result, "--extension", args, "extension", redact);
         }
@@ -2432,9 +2554,6 @@ fn runtime_args(args: &Map<String, Value>, redact: bool) -> Result<Vec<String>, 
             result.push("convert".to_string());
             append_arg(&mut result, "--source-set", args, "sourceSet", redact);
             append_arg(&mut result, "--output", args, "output", redact);
-            append_arg(&mut result, "--path", args, "path", redact);
-            append_arg(&mut result, "--format", args, "format", redact);
-            append_arg(&mut result, "--extension", args, "extension", redact);
         }
         "make" => {
             result.push("make".to_string());
@@ -2454,23 +2573,30 @@ fn runtime_args(args: &Map<String, Value>, redact: bool) -> Result<Vec<String>, 
             if let Some(mode) = string_arg(args, "mode", redact) {
                 result.push(mode);
             }
-            append_bool_flag(&mut result, "--server", args, "server");
-            append_bool_flag(&mut result, "--thin-client", args, "thinClient");
+            append_syntax_args(&mut result, args, redact);
         }
         "test" => {
             result.push("test".to_string());
             if let Some(test_runner) = string_arg(args, "testRunner", redact) {
                 result.push(test_runner);
             }
-            append_bool_flag(&mut result, "--full", args, "fullRebuild");
+            append_bool_flag(&mut result, "--full", args, "fullOutput");
             if let Some(test_scope) = string_arg(args, "testScope", redact) {
                 result.push(test_scope);
             }
             if let Some(module) = string_arg(args, "module", redact) {
                 result.push(module);
             }
-            append_arg(&mut result, "--source-set", args, "sourceSet", redact);
-            append_arg(&mut result, "--extension", args, "extension", redact);
+            append_array_args(&mut result, "--feature", args, "features", redact);
+            append_array_args(&mut result, "--filter-tag", args, "filterTags", redact);
+            append_array_args(&mut result, "--ignore-tag", args, "ignoreTags", redact);
+            append_array_args(
+                &mut result,
+                "--scenario-filter",
+                args,
+                "scenarioFilters",
+                redact,
+            );
         }
         "launch" => {
             result.push("launch".to_string());
@@ -2487,14 +2613,25 @@ fn runtime_args(args: &Map<String, Value>, redact: bool) -> Result<Vec<String>, 
                     append_arg(&mut result, "--mcp-port", args, "mcpPort", redact);
                     append_arg(&mut result, "--mcp-config", args, "mcpConfig", redact);
                 }
-                Some(client_mode) => result.push(client_mode.to_string()),
+                Some(client_mode) => {
+                    result.push(client_mode.to_string());
+                    append_launch_direct_args(&mut result, args, redact);
+                }
                 None => {}
             }
         }
         "extensions" => {
             result.push("extensions".to_string());
             append_arg(&mut result, "--name", args, "sourceSet", redact);
-            append_arg(&mut result, "--extension", args, "extension", redact);
+            append_array_args(&mut result, "--name", args, "sourceSets", redact);
+        }
+        "tools-download" => {
+            result.extend(["tools".to_string(), "download".to_string()]);
+            if let Some(tool) = string_arg(args, "tool", redact) {
+                result.push(tool);
+            }
+            append_bool_flag(&mut result, "--sources", args, "sources");
+            append_bool_flag(&mut result, "--force", args, "force");
         }
         other => return Err(format!("unknown runtime operation: {other}")),
     }
@@ -2512,6 +2649,153 @@ fn append_runtime_global_args(
         append_arg(result, "--config", args, "config", redact);
     }
     append_arg(result, "--workdir", args, "workdir", redact);
+}
+
+fn validate_runtime_mapper_payload(
+    operation: &str,
+    args: &Map<String, Value>,
+) -> Result<(), String> {
+    let allowed = runtime_mapper_operation_args(operation)
+        .ok_or_else(|| format!("unknown runtime operation: {operation}"))?;
+    for key in args.keys() {
+        if matches!(key.as_str(), "cwd" | "dryRun" | "confirm") {
+            continue;
+        }
+        if !allowed.contains(&key.as_str()) {
+            return Err(format!("operation `{operation}` does not accept `{key}`"));
+        }
+    }
+    for key in RUNTIME_MAPPER_ARRAY_ARGS {
+        validate_mapper_string_array(args, key)?;
+    }
+
+    match operation {
+        "dump" => {
+            validate_mapper_enum(args, "mode", RUNTIME_MAPPER_DUMP_MODES)?;
+            if args
+                .get("mode")
+                .and_then(Value::as_str)
+                .is_some_and(|mode| mode == "partial")
+                && !args.contains_key("object")
+                && !mapper_has_non_empty_array_arg(args, "objects")
+            {
+                return Err(
+                    "operation `dump` with mode `partial` requires `object` or `objects`"
+                        .to_string(),
+                );
+            }
+        }
+        "load" => {
+            if args
+                .get("mode")
+                .and_then(Value::as_str)
+                .is_some_and(|mode| mode == "update")
+            {
+                return Err(
+                    "load --mode update is not supported; use `load` or `merge`".to_string()
+                );
+            }
+            validate_mapper_enum(args, "mode", RUNTIME_MAPPER_LOAD_MODES)?;
+            if args
+                .get("mode")
+                .and_then(Value::as_str)
+                .is_some_and(|mode| mode == "merge")
+                && !args.contains_key("settings")
+            {
+                return Err("operation `load` with mode `merge` requires `settings`".to_string());
+            }
+            if args.contains_key("settings")
+                && args.get("mode").and_then(Value::as_str) != Some("merge")
+            {
+                return Err(
+                    "operation `load` accepts `settings` only with mode `merge`".to_string()
+                );
+            }
+        }
+        "test" => {
+            validate_mapper_enum(args, "testRunner", RUNTIME_MAPPER_TEST_RUNNERS)?;
+            validate_mapper_enum(args, "testScope", RUNTIME_MAPPER_TEST_SCOPES)?;
+        }
+        "tools-download" => {
+            validate_mapper_enum(args, "tool", RUNTIME_MAPPER_TOOLS)?;
+            if args
+                .get("sources")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+                && args
+                    .get("tool")
+                    .and_then(Value::as_str)
+                    .is_some_and(|tool| tool == "vanessa")
+            {
+                return Err(
+                    "operation `tools-download` accepts `sources` only for `yaxunit` or `client-mcp`"
+                        .to_string(),
+                );
+            }
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+fn runtime_mapper_operation_args(operation: &str) -> Option<&'static [&'static str]> {
+    match operation {
+        "config-init" => Some(RUNTIME_MAPPER_CONFIG_INIT_ARGS),
+        "init" => Some(RUNTIME_MAPPER_INIT_ARGS),
+        "build" => Some(RUNTIME_MAPPER_BUILD_ARGS),
+        "dump" => Some(RUNTIME_MAPPER_DUMP_ARGS),
+        "convert" => Some(RUNTIME_MAPPER_CONVERT_ARGS),
+        "make" => Some(RUNTIME_MAPPER_MAKE_ARGS),
+        "load" => Some(RUNTIME_MAPPER_LOAD_ARGS),
+        "syntax" => Some(RUNTIME_MAPPER_SYNTAX_ARGS),
+        "test" => Some(RUNTIME_MAPPER_TEST_ARGS),
+        "launch" => Some(RUNTIME_MAPPER_LAUNCH_ARGS),
+        "extensions" => Some(RUNTIME_MAPPER_EXTENSIONS_ARGS),
+        "tools-download" => Some(RUNTIME_MAPPER_TOOLS_DOWNLOAD_ARGS),
+        _ => None,
+    }
+}
+
+fn validate_mapper_string_array(args: &Map<String, Value>, key: &str) -> Result<(), String> {
+    let Some(value) = args.get(key) else {
+        return Ok(());
+    };
+    let Some(items) = value.as_array() else {
+        return Err(format!("argument `{key}` must be array"));
+    };
+    for item in items {
+        if !item.is_string() {
+            return Err(format!("argument `{key}` must contain strings"));
+        }
+    }
+    Ok(())
+}
+
+fn validate_mapper_enum(
+    args: &Map<String, Value>,
+    key: &str,
+    allowed: &[&str],
+) -> Result<(), String> {
+    let Some(value) = args.get(key) else {
+        return Ok(());
+    };
+    let Some(value) = value.as_str() else {
+        return Err(format!("argument `{key}` must be string"));
+    };
+    if !allowed.contains(&value) {
+        return Err(format!(
+            "argument `{key}` must be one of: {}",
+            allowed.join(", ")
+        ));
+    }
+    Ok(())
+}
+
+fn mapper_has_non_empty_array_arg(args: &Map<String, Value>, key: &str) -> bool {
+    args.get(key)
+        .and_then(Value::as_array)
+        .is_some_and(|items| !items.is_empty())
 }
 
 fn cli_args(args: &Map<String, Value>, redact: bool) -> Result<Vec<String>, String> {
@@ -2560,6 +2844,79 @@ fn append_arg(
         result.push(flag.to_string());
         result.push(value);
     }
+}
+
+fn append_array_args(
+    result: &mut Vec<String>,
+    flag: &str,
+    args: &Map<String, Value>,
+    key: &str,
+    redact: bool,
+) {
+    let Some(items) = args.get(key).and_then(Value::as_array) else {
+        return;
+    };
+    for item in items {
+        result.push(flag.to_string());
+        result.push(if redact && is_secret_key(key) {
+            "<redacted>".to_string()
+        } else {
+            value_to_cli_string(item)
+        });
+    }
+}
+
+fn append_syntax_args(result: &mut Vec<String>, args: &Map<String, Value>, redact: bool) {
+    for (key, flag) in [
+        ("server", "--server"),
+        ("thinClient", "--thin-client"),
+        ("webClient", "--web-client"),
+        ("mobileClient", "--mobile-client"),
+        ("externalConnection", "--external-connection"),
+        ("externalConnectionServer", "--external-connection-server"),
+        (
+            "thickClientManagedApplication",
+            "--thick-client-managed-application",
+        ),
+        (
+            "thickClientServerManagedApplication",
+            "--thick-client-server-managed-application",
+        ),
+        (
+            "thickClientOrdinaryApplication",
+            "--thick-client-ordinary-application",
+        ),
+        (
+            "thickClientServerOrdinaryApplication",
+            "--thick-client-server-ordinary-application",
+        ),
+        ("mobileAppClient", "--mobile-app-client"),
+        ("mobileAppServer", "--mobile-app-server"),
+        ("mobileClientDigiSign", "--mobile-client-digi-sign"),
+        ("distributiveModules", "--distributive-modules"),
+        ("unreferenceProcedures", "--unreference-procedures"),
+        ("handlersExistence", "--handlers-existence"),
+        ("emptyHandlers", "--empty-handlers"),
+        ("extendedModulesCheck", "--extended-modules-check"),
+        ("checkUseSynchronousCalls", "--check-use-synchronous-calls"),
+        ("checkUseModality", "--check-use-modality"),
+        ("unsupportedFunctional", "--unsupported-functional"),
+        ("configLogIntegrity", "--config-log-integrity"),
+        ("incorrectReferences", "--incorrect-references"),
+        ("allExtensions", "--all-extensions"),
+    ] {
+        append_bool_flag(result, flag, args, key);
+    }
+    append_arg(result, "--extension", args, "extension", redact);
+    append_array_args(result, "--project", args, "projects", redact);
+}
+
+fn append_launch_direct_args(result: &mut Vec<String>, args: &Map<String, Value>, redact: bool) {
+    append_arg(result, "--c", args, "c", redact);
+    append_arg(result, "--execute", args, "execute", redact);
+    append_bool_flag(result, "--use-privileged-mode", args, "usePrivilegedMode");
+    append_arg(result, "--output", args, "output", redact);
+    append_array_args(result, "--raw-key", args, "rawKeys", redact);
 }
 
 fn append_bool_flag(result: &mut Vec<String>, flag: &str, args: &Map<String, Value>, key: &str) {
@@ -2771,7 +3128,7 @@ mod tests {
         let mut test_args = Map::new();
         test_args.insert("operation".to_string(), json!("test"));
         test_args.insert("testRunner".to_string(), json!("yaxunit"));
-        test_args.insert("fullRebuild".to_string(), json!(true));
+        test_args.insert("fullOutput".to_string(), json!(true));
         test_args.insert("testScope".to_string(), json!("module"));
         test_args.insert("module".to_string(), json!("CommonModule.Тесты"));
 
@@ -2885,11 +3242,121 @@ mod tests {
                 }),
                 vec!["extensions", "--name", "MyExtension"],
             ),
+            (
+                json!({
+                    "operation": "dump",
+                    "mode": "partial",
+                    "objects": ["Catalog:Номенклатура", "Document:ЗаказПокупателя"],
+                }),
+                vec![
+                    "dump",
+                    "--mode",
+                    "partial",
+                    "--object",
+                    "Catalog:Номенклатура",
+                    "--object",
+                    "Document:ЗаказПокупателя",
+                ],
+            ),
+            (
+                json!({
+                    "operation": "syntax",
+                    "mode": "edt",
+                    "projects": ["Configuration", "Tests"],
+                }),
+                vec![
+                    "syntax",
+                    "edt",
+                    "--project",
+                    "Configuration",
+                    "--project",
+                    "Tests",
+                ],
+            ),
+            (
+                json!({
+                    "operation": "test",
+                    "testRunner": "va",
+                    "fullOutput": true,
+                    "features": ["features/smoke.feature"],
+                    "filterTags": ["@smoke"],
+                    "ignoreTags": ["@wip"],
+                    "scenarioFilters": ["Open form"],
+                }),
+                vec![
+                    "test",
+                    "va",
+                    "--full",
+                    "--feature",
+                    "features/smoke.feature",
+                    "--filter-tag",
+                    "@smoke",
+                    "--ignore-tag",
+                    "@wip",
+                    "--scenario-filter",
+                    "Open form",
+                ],
+            ),
+            (
+                json!({
+                    "operation": "extensions",
+                    "sourceSets": ["Sales", "Warehouse"],
+                }),
+                vec!["extensions", "--name", "Sales", "--name", "Warehouse"],
+            ),
+            (
+                json!({
+                    "operation": "tools-download",
+                    "tool": "client-mcp",
+                    "sources": true,
+                    "force": true,
+                }),
+                vec!["tools", "download", "client-mcp", "--sources", "--force"],
+            ),
         ];
 
         for (input, expected) in cases {
             let args = input.as_object().unwrap().clone();
             assert_eq!(runtime_args(&args, false).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn runtime_adapter_rejects_operation_specific_unsupported_args() {
+        let cases = vec![
+            (
+                json!({"operation": "build", "extension": "MyExtension"}),
+                "operation `build` does not accept `extension`",
+            ),
+            (
+                json!({"operation": "convert", "path": "src"}),
+                "operation `convert` does not accept `path`",
+            ),
+            (
+                json!({"operation": "test", "testRunner": "yaxunit", "fullRebuild": true}),
+                "operation `test` does not accept `fullRebuild`",
+            ),
+            (
+                json!({"operation": "load", "path": "build/config.cf", "mode": "update"}),
+                "load --mode update is not supported",
+            ),
+            (
+                json!({"operation": "load", "path": "build/config.cf", "settings": "merge-settings.xml"}),
+                "operation `load` accepts `settings` only with mode `merge`",
+            ),
+            (
+                json!({"operation": "dump", "mode": "partial"}),
+                "operation `dump` with mode `partial` requires `object` or `objects`",
+            ),
+        ];
+
+        for (input, expected) in cases {
+            let args = input.as_object().unwrap().clone();
+            let error = runtime_args(&args, false).unwrap_err();
+            assert!(
+                error.contains(expected),
+                "expected error containing {expected:?}, got {error:?}"
+            );
         }
     }
 

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -270,13 +270,36 @@ impl<'a> RuntimeAdapter<'a> {
         }
 
         let process_timeout = None;
-        let output = self.runner.run(&ProcessCommand {
+        let process_command = ProcessCommand {
             program: bundled_tool.program.clone(),
             args: execution_args,
             cwd: context.cwd.clone(),
             timeout: process_timeout,
-        })?;
+        };
+        let output = match self.runner.run(&process_command) {
+            Ok(output) => output,
+            Err(error) => {
+                let error = redact_sensitive_text(&error);
+                return Ok(AdapterOutcome {
+                    ok: false,
+                    summary: format!(
+                        "{tool_name} failed through internal v8-runner runtime adapter"
+                    ),
+                    changes: Vec::new(),
+                    warnings: vec![
+                        "internal v8-runner runtime adapter failed to spawn process".to_string()
+                    ],
+                    errors: vec![error.clone()],
+                    artifacts: Vec::new(),
+                    stdout: None,
+                    stderr: Some(format!("{error}\n")),
+                    command: Some(command),
+                });
+            }
+        };
         let ok = output.status_success;
+        let stdout = redact_sensitive_text(&output.stdout);
+        let stderr = redact_sensitive_text(&output.stderr);
         Ok(AdapterOutcome {
             ok,
             summary: if ok {
@@ -284,7 +307,7 @@ impl<'a> RuntimeAdapter<'a> {
             } else {
                 format!("{tool_name} failed through internal v8-runner runtime adapter")
             },
-            changes: if mutating {
+            changes: if mutating && ok {
                 vec!["internal v8-runner runtime adapter executed".to_string()]
             } else {
                 Vec::new()
@@ -301,14 +324,19 @@ impl<'a> RuntimeAdapter<'a> {
             },
             errors: if ok {
                 Vec::new()
-            } else if output.stderr.trim().is_empty() && output.timed_out {
+            } else if stderr.trim().is_empty() && output.timed_out {
                 vec![process_timeout_error("v8-runner runtime", process_timeout)]
+            } else if stderr.trim().is_empty() {
+                vec![format!(
+                    "internal v8-runner runtime adapter exited with status {}",
+                    output.status
+                )]
             } else {
-                vec![output.stderr.trim().to_string()]
+                vec![stderr.trim().to_string()]
             },
             artifacts: Vec::new(),
-            stdout: Some(output.stdout),
-            stderr: Some(output.stderr),
+            stdout: Some(stdout),
+            stderr: Some(stderr),
             command: Some(command),
         })
     }
@@ -618,6 +646,59 @@ fn process_timeout_error(label: &str, timeout: Option<Duration>) -> String {
         ),
         None => format!("internal {label} adapter timed out"),
     }
+}
+
+fn redact_sensitive_text(text: &str) -> String {
+    let chars = text.chars().collect::<Vec<_>>();
+    let mut output = String::with_capacity(text.len());
+    let mut index = 0;
+    while index < chars.len() {
+        if secret_key_char(chars[index]) {
+            let key_start = index;
+            index += 1;
+            while index < chars.len() && secret_key_char(chars[index]) {
+                index += 1;
+            }
+            let key_end = index;
+            let mut separator = index;
+            while separator < chars.len() && chars[separator].is_whitespace() {
+                separator += 1;
+            }
+            if separator < chars.len() && matches!(chars[separator], '=' | ':') {
+                let mut value_start = separator + 1;
+                while value_start < chars.len() && chars[value_start].is_whitespace() {
+                    value_start += 1;
+                }
+                let key = chars[key_start..key_end].iter().collect::<String>();
+                if is_secret_key(&key) {
+                    for ch in &chars[key_start..value_start] {
+                        output.push(*ch);
+                    }
+                    output.push_str("<redacted>");
+                    index = value_start;
+                    while index < chars.len() && !secret_value_delimiter(chars[index]) {
+                        index += 1;
+                    }
+                    continue;
+                }
+            }
+            for ch in &chars[key_start..key_end] {
+                output.push(*ch);
+            }
+            continue;
+        }
+        output.push(chars[index]);
+        index += 1;
+    }
+    output
+}
+
+fn secret_key_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-')
+}
+
+fn secret_value_delimiter(ch: char) -> bool {
+    matches!(ch, ';' | '&' | ',' | '\n' | '\r' | '}')
 }
 
 fn search_rlm_index(
@@ -2503,6 +2584,7 @@ fn string_arg(args: &Map<String, Value>, key: &str, redact: bool) -> Option<Stri
 fn is_secret_key(key: &str) -> bool {
     let key = key.to_ascii_lowercase();
     key == "connection"
+        || key == "pwd"
         || key.contains("password")
         || key.contains("token")
         || key.contains("secret")
@@ -3786,6 +3868,107 @@ mod tests {
     }
 
     #[test]
+    fn runtime_adapter_redacts_non_zero_process_output() {
+        let context = temp_context("runtime-non-zero-diagnostics");
+        let runner = FakeProcessRunner {
+            output: ProcessOutput {
+                status_success: false,
+                status: "exit status: 1".to_string(),
+                stdout:
+                    "prelude that should not matter\nstarted build\nUsr=admin;Pwd=stdout-secret\n"
+                        .to_string(),
+                stderr: "failed to load configuration: Pwd=stderr-secret\n".to_string(),
+                timed_out: false,
+            },
+        };
+        let mut args = Map::new();
+        args.insert("operation".to_string(), json!("build"));
+        args.insert("sourceSet".to_string(), json!("main"));
+
+        let outcome = RuntimeAdapter::with_runner(&runner)
+            .invoke("unica.runtime.execute", &args, &context, false, true)
+            .unwrap();
+
+        assert!(!outcome.ok);
+        assert!(outcome
+            .command
+            .as_ref()
+            .unwrap()
+            .join(" ")
+            .contains("build --source-set main"));
+        assert!(outcome.stdout.as_deref().unwrap().contains("started build"));
+        assert!(outcome
+            .stderr
+            .as_deref()
+            .unwrap()
+            .contains("failed to load configuration"));
+        let serialized = serde_json::to_string(&outcome).unwrap();
+        assert!(!serialized.contains("stdout-secret"));
+        assert!(!serialized.contains("stderr-secret"));
+        cleanup_context(&context);
+    }
+
+    #[test]
+    fn runtime_adapter_reports_timeout_failure_without_wrapper_budget() {
+        let context = temp_context("runtime-timeout-diagnostics");
+        let runner = FakeProcessRunner {
+            output: ProcessOutput {
+                status_success: false,
+                status: "timeout".to_string(),
+                stdout: "started loading configuration...\n".to_string(),
+                stderr: String::new(),
+                timed_out: true,
+            },
+        };
+        let mut args = Map::new();
+        args.insert("operation".to_string(), json!("load"));
+        args.insert("path".to_string(), json!("build/config.cf"));
+
+        let outcome = RuntimeAdapter::with_runner(&runner)
+            .invoke("unica.runtime.execute", &args, &context, false, true)
+            .unwrap();
+
+        assert!(!outcome.ok);
+        assert!(outcome
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("timed out")));
+        assert!(outcome
+            .stdout
+            .as_deref()
+            .unwrap()
+            .contains("started loading configuration"));
+        assert!(outcome.errors.iter().all(|error| !error.contains("120")));
+        cleanup_context(&context);
+    }
+
+    #[test]
+    fn runtime_adapter_returns_failure_outcome_for_spawn_failure() {
+        let context = temp_context("runtime-spawn-failure-diagnostics");
+        let runner = FailingProcessRunner {
+            error: "failed to execute process: no such file or directory; apiToken=token-secret"
+                .to_string(),
+        };
+        let mut args = Map::new();
+        args.insert("operation".to_string(), json!("build"));
+
+        let outcome = RuntimeAdapter::with_runner(&runner)
+            .invoke("unica.runtime.execute", &args, &context, false, true)
+            .unwrap();
+
+        assert!(!outcome.ok);
+        assert!(outcome.summary.contains("failed"));
+        assert!(outcome
+            .errors
+            .iter()
+            .any(|error| error.contains("failed to execute process")));
+        assert!(!serde_json::to_string(&outcome)
+            .unwrap()
+            .contains("token-secret"));
+        cleanup_context(&context);
+    }
+
+    #[test]
     fn system_process_runner_does_not_timeout_when_timeout_is_none() {
         let output = SYSTEM_PROCESS_RUNNER
             .run(&ProcessCommand {
@@ -3878,6 +4061,16 @@ mod tests {
     impl ProcessRunner for FakeProcessRunner {
         fn run(&self, _command: &ProcessCommand) -> Result<ProcessOutput, String> {
             Ok(self.output.clone())
+        }
+    }
+
+    struct FailingProcessRunner {
+        error: String,
+    }
+
+    impl ProcessRunner for FailingProcessRunner {
+        fn run(&self, _command: &ProcessCommand) -> Result<ProcessOutput, String> {
+            Err(self.error.clone())
         }
     }
 

--- a/plugins/unica/references/tooling/v8project.md
+++ b/plugins/unica/references/tooling/v8project.md
@@ -1,7 +1,7 @@
 # v8project.yaml Contract
 
 `v8project.yaml` is the only project configuration format used by Unica skills.
-Use `V8TR_CONFIG` when the config file is not located at `./v8project.yaml`.
+Use MCP `unica.runtime.execute` argument `config` when the config file is not located at `./v8project.yaml`.
 
 For a new repository with no workspace, use the `v8-runner` skill first. It
 creates `v8project.yaml` through MCP `unica.runtime.execute`, prepares the
@@ -28,11 +28,12 @@ Create or refresh the config through MCP `unica.runtime.execute`:
 ## Minimal Shape
 
 ```yaml
-basePath: '.'
 workPath: 'build'
+execution_timeout: 300000
 format: DESIGNER
 builder: DESIGNER
-connection: '/F/Users/me/1c-bases/dev'
+infobase:
+  connection: 'File=build/ib'
 source-set:
   - name: main
     type: CONFIGURATION
@@ -41,8 +42,22 @@ build:
   partialLoadThreshold: 20
 ```
 
-Server infobase connections use the normal 1C connection string form, for
-example `/Sserver/ref`.
+`infobase.connection` is the current runner key. Do not use legacy top-level
+`connection` in `v8project.yaml`.
+
+`execution_timeout` is the v8-runner operation budget in milliseconds. The
+default is `300000`; v8-runner validates the value in the `1..=86400000` range.
+For a known long operation, change this project config value instead of adding a
+Unica wrapper timeout argument.
+
+Server infobase connections use the normal 1C connection string form in
+`infobase.connection`, for example `Srvr="srv01";Ref="dev";`. IBCMD server
+connections also require the documented `infobase.dbms` block.
+
+`v8project.local.yaml` is loaded automatically next to the primary config. It
+may override local-only `workPath`, `infobase`, `tools`, `tests`, and `mcp`
+settings. It cannot be passed as `config` and must not redefine shared
+`source-set`, `format`, `builder`, or `execution_timeout`.
 
 ## Source-set format discovery
 
@@ -68,12 +83,13 @@ Use the `v8-runner` skill and MCP `unica.runtime.execute` for runtime operations
 | Load XML sources and update DB | `operation=build` |
 | Force full source load | `operation=build`, `fullRebuild=true` |
 | Dump XML sources | `operation=dump`, `mode=full|incremental|partial` |
-| Dump selected objects | `operation=dump`, `mode=partial`, `object=TYPE:NAME` |
-| Load `.cf` / `.cfe` artifact | `operation=load`, `path=<file>`, `mode=load|merge|update` |
+| Dump selected objects | `operation=dump`, `mode=partial`, `object=TYPE:NAME` or `objects=[...]` |
+| Load `.cf` / `.cfe` artifact | `operation=load`, `path=<file>`, `mode=load|merge` |
 | Export `.cf` / `.cfe` artifact | `operation=make`, `output=<file>` |
 | Launch 1C | `operation=launch`, `clientMode=thin|thick|designer|ordinary` |
 | Run syntax checks | `operation=syntax`, `mode=designer-config|designer-modules|edt` |
 | Run tests | `operation=test`, `testRunner=yaxunit|va` |
+| Download configured tools | `operation=tools-download`, `tool=yaxunit|vanessa|client-mcp` |
 
 ## Skill Rules
 
@@ -81,6 +97,8 @@ Use the `v8-runner` skill and MCP `unica.runtime.execute` for runtime operations
 - Resolve the active config as `V8TR_CONFIG` first, then `./v8project.yaml`.
 - If the config is missing, use `operation=config-init` or ask for the connection string.
 - Prefer `source-set` names over ad hoc source directories.
+- Use `execution_timeout` in `v8project.yaml` for long runtime operations; Unica does not expose `timeoutMs` for `unica.runtime.execute`.
+- Do not use `mode=update` for `operation=load`; v8-runner rejects it. Use `mode=load` or `mode=merge` with `settings`.
 - When credentials are absent, try only empty-password `Администратор`, then empty-password `Admin`; if both fail, ask the user.
 - If a command reports a 1C license problem, stop and ask the user to fix licensing. Do not edit license services, HASP settings, registry, or license files.
 - If a runtime flag or debug-server step is missing from `unica.runtime.execute`, treat it as a Unica MCP contract gap. EPF/ERF dump/build flows use external source sets through `unica.runtime.execute`.

--- a/plugins/unica/skills/test-authoring/SKILL.md
+++ b/plugins/unica/skills/test-authoring/SKILL.md
@@ -69,7 +69,6 @@ description: "Проектирование и запуск тестов 1С: tes
       "cwd": "<workspace>",
       "operation": "test",
       "testRunner": "va",
-      "testScope": "all",
       "dryRun": false
     }
   }

--- a/plugins/unica/skills/v8-runner/SKILL.md
+++ b/plugins/unica/skills/v8-runner/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: v8-runner
-description: "Используй когда задача про runtime 1С, информационная база или workspace: v8project.yaml, первый workspace, build/dump/convert source-set, load/make CF/CFE, build/dump/make EPF/ERF external source-set, syntax/tests/launch, extensions. Не используй для точечного чтения или редактирования XML метаданных, форм, СКД, MXL, ролей, подсистем."
-argument-hint: "[config-init|init|build|dump|make|load|syntax|test|launch|extensions] [connection|sourceSet|path|output]"
+description: "Используй когда задача про runtime 1С, информационная база или workspace: v8project.yaml, первый workspace, build/dump/convert source-set, load/make CF/CFE, build/dump/make EPF/ERF external source-set, syntax/tests/launch, extensions, tools-download. Не используй для точечного чтения или редактирования XML метаданных, форм, СКД, MXL, ролей, подсистем."
+argument-hint: "[config-init|init|build|dump|make|load|syntax|test|launch|extensions|tools-download] [connection|sourceSet|path|output]"
 allowed-tools:
   - Bash
   - Read
@@ -33,6 +33,7 @@ allowed-tools:
 | Запустить тесты | `test` | `BuildCompleted` |
 | Запустить клиент/Designer/MCP-клиент | `launch` | без invalidation |
 | Синхронизировать extension properties | `extensions` | `BuildCompleted` |
+| Скачать/обновить runner tools | `tools-download` | без invalidation |
 
 ## Auth/license stop rules
 
@@ -143,9 +144,11 @@ allowed-tools:
 
 ### Локальный overlay
 
-Используй `v8project.local.yaml` для локальных `infobase.connection`, credentials и tool paths. Не добавляй туда `source-set`, `format` или `builder`: эти поля должны жить в основном проектном конфиге.
+Используй `v8project.local.yaml` для локальных `workPath`, `infobase.connection`, credentials, `tools`, `tests` и `mcp`. Не передавай local overlay как `config`. Не добавляй туда `source-set`, `format`, `builder` или `execution_timeout`: эти поля должны жить в основном проектном конфиге.
 
-## Build/load/update
+Для долгих операций меняй `execution_timeout` в `v8project.yaml` (миллисекунды, default `300000`, диапазон `1..=86400000`). Не прокидывай отдельный `timeoutMs` в `unica.runtime.execute`: Unica не владеет таймаутом runner-а.
+
+## Build/load/artifacts
 
 ### Обычный build
 
@@ -212,7 +215,7 @@ allowed-tools:
       "cwd": "<workspace>",
       "operation": "load",
       "path": "build/config.cf",
-      "mode": "update",
+      "mode": "load",
       "dryRun": false
     }
   }
@@ -252,12 +255,14 @@ allowed-tools:
       "operation": "load",
       "path": "build/MyExtension.cfe",
       "extension": "MyExtension",
-      "mode": "update",
+      "mode": "load",
       "dryRun": false
     }
   }
 }
 ```
+
+`operation=load` поддерживает только `mode=load` и `mode=merge`. Для `mode=merge` обязательно передавай `settings`; `mode=update` v8-runner отвергает.
 
 ## Dump/convert/artifacts
 
@@ -294,6 +299,25 @@ allowed-tools:
       "operation": "dump",
       "mode": "partial",
       "object": "Catalog:Номенклатура",
+      "dryRun": false
+    }
+  }
+}
+```
+
+### Partial dump нескольких объектов
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "unica.runtime.execute",
+    "arguments": {
+      "cwd": "<workspace>",
+      "operation": "dump",
+      "mode": "partial",
+      "objects": ["Catalog:Номенклатура", "Document:ЗаказПокупателя"],
       "dryRun": false
     }
   }
@@ -461,6 +485,25 @@ allowed-tools:
 }
 ```
 
+### EDT syntax by projects
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "unica.runtime.execute",
+    "arguments": {
+      "cwd": "<workspace>",
+      "operation": "syntax",
+      "mode": "edt",
+      "projects": ["Configuration", "Tests"],
+      "dryRun": false
+    }
+  }
+}
+```
+
 ### YaXUnit all
 
 ```json
@@ -474,6 +517,7 @@ allowed-tools:
       "operation": "test",
       "testRunner": "yaxunit",
       "testScope": "all",
+      "fullOutput": true,
       "dryRun": false
     }
   }
@@ -512,6 +556,10 @@ allowed-tools:
       "cwd": "<workspace>",
       "operation": "test",
       "testRunner": "va",
+      "features": ["features/smoke.feature"],
+      "filterTags": ["@smoke"],
+      "ignoreTags": ["@wip"],
+      "scenarioFilters": ["Open form"],
       "dryRun": false
     }
   }
@@ -530,6 +578,46 @@ allowed-tools:
       "cwd": "<workspace>",
       "operation": "extensions",
       "sourceSet": "MyExtension",
+      "dryRun": false
+    }
+  }
+}
+```
+
+### Несколько extension source-set
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "unica.runtime.execute",
+    "arguments": {
+      "cwd": "<workspace>",
+      "operation": "extensions",
+      "sourceSets": ["Sales", "Warehouse"],
+      "dryRun": false
+    }
+  }
+}
+```
+
+## Tools
+
+### Download client MCP sources
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "unica.runtime.execute",
+    "arguments": {
+      "cwd": "<workspace>",
+      "operation": "tools-download",
+      "tool": "client-mcp",
+      "sources": true,
+      "force": true,
       "dryRun": false
     }
   }

--- a/plugins/unica/skills/v8-runner/references/command-selection.md
+++ b/plugins/unica/skills/v8-runner/references/command-selection.md
@@ -7,15 +7,24 @@ Use MCP `unica.runtime.execute` and choose `operation` by intent:
 | Missing project config | `operation=config-init`, optional `config`, `connection`, `format`, `builder` |
 | Create runtime state | `operation=init` |
 | Apply source changes to infobase | `operation=build`, optional `sourceSet`, `fullRebuild` |
-| Bring infobase changes back to files | `operation=dump`, optional `mode`, `object`, `sourceSet`, `extension` |
+| Bring infobase changes back to files | `operation=dump`, optional `mode`, `object`, `objects`, `sourceSet`, `extension` |
 | Convert Designer/EDT files | `operation=convert`, optional `sourceSet`, `output` |
 | Export artifact | `operation=make`, required `output`, optional `sourceSet`, `extension` |
-| Load artifact | `operation=load`, required `path`, optional `mode`, `settings`, `extension` |
-| Syntax check | `operation=syntax`, required `mode` |
-| Tests | `operation=test`, required `testRunner`, optional `testScope`, `module` |
-| Client launch | `operation=launch`, required `clientMode` |
-| Extension properties | `operation=extensions`, optional `sourceSet` |
+| Load artifact | `operation=load`, required `path`, optional `mode=load|merge`, `settings`, `extension` |
+| Syntax check | `operation=syntax`, required `mode`, optional Designer flags or EDT `projects` |
+| Tests | `operation=test`, required `testRunner`, optional YaXUnit `testScope`/`module`, `fullOutput`, VA filters |
+| Client launch | `operation=launch`, required `clientMode`, optional MCP or direct launch flags |
+| Extension properties | `operation=extensions`, optional `sourceSet` or `sourceSets` |
+| Download runner tools | `operation=tools-download`, required `tool`, optional `sources`, `force` |
 
 For branch switches, rebases, large object moves, or suspicious incremental state, use `operation=build` with `fullRebuild=true`.
 
 For dumps, inspect the worktree before execution and compare the resulting diff after execution.
+
+Operation-specific guardrails:
+
+- `build` does not accept `extension`; build an extension by selecting its configured `sourceSet`.
+- `convert` does not accept ad hoc `path`, `format`, or `extension`; use configured source-sets.
+- `load` does not support `mode=update`; use `mode=load` or `mode=merge` with `settings`.
+- `test` uses `fullOutput=true` for v8-runner `--full`; it is not a build full rebuild.
+- `tools-download` supports `sources=true` only for `tool=yaxunit` or `tool=client-mcp`.

--- a/plugins/unica/skills/v8-runner/references/config-and-backends.md
+++ b/plugins/unica/skills/v8-runner/references/config-and-backends.md
@@ -4,17 +4,22 @@ Important `v8project.yaml` concepts:
 
 - `format`: `designer` or `edt`.
 - `builder`: `DESIGNER` or `IBCMD`.
+- `execution_timeout`: runner operation budget in milliseconds; default `300000`, valid range `1..=86400000`.
 - `source-set`: ordered configuration and extension source entries.
 - `infobase.connection`: runtime connection string.
+- `infobase.dbms`: required for IBCMD server infobases and invalid for file infobases.
 - `tools.client_mcp.extension`: optional generated tool extension prepared by `build`.
 - external source-set types: `EXTERNAL_DATA_PROCESSORS` publishes `.epf`, `EXTERNAL_REPORTS` publishes `.erf`.
 
-Use `v8project.local.yaml` for local `infobase.connection`, credentials, platform paths, VA paths, and MCP paths. Do not put shared `source-set`, `format`, or `builder` there.
+Use `v8project.local.yaml` for local `workPath`, `infobase`, `tools`, `tests`, and `mcp` values. Do not pass it as the MCP `config` argument. Do not put shared `source-set`, `format`, `builder`, or `execution_timeout` there.
+
+Do not use legacy top-level `connection`; the current schema stores the connection under `infobase.connection`.
 
 Backend guidance:
 
 - Designer format with Designer builder covers init/build/extensions/dump/syntax/tests/make/load.
-- Designer format with IBCMD is narrower and intended mainly for file infobases.
-- EDT format can build through export, run EDT syntax checks, synchronize extensions, and run configured tests.
-- `convert` is a file workflow and does not use the infobase.
+- Designer format with IBCMD supports file infobases and server infobases when `infobase.dbms.kind/server/name` are configured.
+- EDT format can build, run EDT syntax checks, synchronize extensions, and run configured tests, but `syntax edt` uses `projects` rather than Designer module flags.
+- `convert` is a file workflow and accepts only `sourceSet` and `output` from the Unica wrapper.
 - `make` requires a backend that can publish the requested artifact. For external processors/reports, `output` is a publish directory.
+- `load` accepts `mode=load` or `mode=merge`; `mode=merge` requires `settings`. `mode=update` is rejected by v8-runner.

--- a/plugins/unica/skills/v8-runner/references/file-and-artifact-workflows.md
+++ b/plugins/unica/skills/v8-runner/references/file-and-artifact-workflows.md
@@ -6,11 +6,11 @@ Use `dump` with:
 
 - `mode=incremental` for ordinary database-to-source synchronization.
 - `mode=full` for first workspace fill or explicit full export.
-- `mode=partial` plus `object` when the backend supports one-object export.
+- `mode=partial` plus `object` or `objects` when the backend supports scoped export.
 - `sourceSet` or `extension` for scoped export.
 
 Use `convert` for Designer/EDT source conversion. It is repository-aware and does not require an infobase.
 
 Use `make` for `.cf`, `.cfe`, `.epf`, or `.erf` artifacts. Provide `output`; add `sourceSet` or `extension` when the target is not the default source. For external processors/reports, `output` is a publish directory, not a single `.epf`/`.erf` filename.
 
-Use `load` for applying `.cf` or `.cfe` artifacts. v8-runner rejects `.epf` and `.erf` for `load`; external processors/reports are handled through external source-sets with `build`, `dump`, and `make`.
+Use `load` for applying `.cf` or `.cfe` artifacts. Supported modes are `load` and `merge`; `merge` requires `settings`, and `update` is not a supported load mode. v8-runner rejects `.epf` and `.erf` for `load`; external processors/reports are handled through external source-sets with `build`, `dump`, and `make`.

--- a/plugins/unica/skills/v8-runner/references/project-workflows.md
+++ b/plugins/unica/skills/v8-runner/references/project-workflows.md
@@ -1,6 +1,6 @@
 # Project Workflows
 
-`v8project.yaml` is the project contract. `v8project.local.yaml` is for local secrets and paths and must not redefine shared source topology.
+`v8project.yaml` is the project contract. `v8project.local.yaml` is for local secrets and paths and must not redefine shared source topology or `execution_timeout`.
 
 Typical empty workspace order:
 
@@ -13,5 +13,7 @@ Typical empty workspace order:
 `build` also prepares configured client MCP tool extensions when the project has `tools.client_mcp.extension`. Use `fullRebuild=true` if that generated state may be stale.
 
 Use `extensions` when only extension properties need synchronization.
+
+Use `tools-download` when the project needs v8-runner-managed YaXUnit, Vanessa, or client MCP tool payloads refreshed.
 
 Use `launch` with `clientMode=mcp` or `clientMode=mcp-va` for client-side MCP workflows; do not hand-assemble platform launch strings.

--- a/plugins/unica/skills/v8-runner/references/testing.md
+++ b/plugins/unica/skills/v8-runner/references/testing.md
@@ -3,13 +3,15 @@
 Test operations build first, so avoid a separate build unless the user asked for build-only diagnostics.
 
 Use `operation=test`, `testRunner=yaxunit`, `testScope=all` for full YaXUnit.
+Add `fullOutput=true` when you need the runner `--full` output verbosity.
+This is not a source build full rebuild.
 
 Use `operation=test`, `testRunner=yaxunit`, `testScope=module`, and `module=<name>` for narrow module-level tests.
 
-Use `operation=test`, `testRunner=va` for the configured Vanessa Automation profile. Do not invent feature paths without inspecting project test configuration.
+Use `operation=test`, `testRunner=va` for the configured Vanessa Automation profile. Optional VA narrowing arguments are `features`, `filterTags`, `ignoreTags`, and `scenarioFilters`. Do not invent feature paths without inspecting project test configuration.
 
 Use `operation=launch`, `clientMode=mcp-va` for interactive Vanessa Automation scenario authoring and debugging through client MCP.
 
-Syntax validation uses `operation=syntax` with `mode=designer-modules`, `mode=designer-config`, or `mode=edt`.
+Syntax validation uses `operation=syntax` with `mode=designer-modules`, `mode=designer-config`, or `mode=edt`. Designer syntax accepts client/server flags such as `server`, `thinClient`, `webClient`, `mobileClient`, `extension`, and `allExtensions`; EDT syntax accepts `projects`.
 
 Preserve failed test artifacts and report their path when the runner prints one.

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -1077,6 +1077,7 @@ class UnicaSkillRoutingTests(unittest.TestCase):
             r"1c-code-metadata-mcp",
             r"1c-metadata-manage",
             r"deploy_and_test",
+            r'"mode"\s*:\s*"update"',
         ]
         scanned_roots = [self.reference_root(), self.skill_root()]
         for root in scanned_roots:
@@ -1085,6 +1086,36 @@ class UnicaSkillRoutingTests(unittest.TestCase):
                 for pattern in forbidden_patterns:
                     with self.subTest(path=path.relative_to(self.repo_root()), pattern=pattern):
                         self.assertIsNone(re.search(pattern, text))
+
+    def test_v8_runner_docs_track_current_v8project_contract(self) -> None:
+        v8project = (self.reference_root() / "tooling" / "v8project.md").read_text(
+            encoding="utf-8"
+        )
+        v8_runner_docs = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in [
+                self.skill_root() / "v8-runner" / "SKILL.md",
+                self.skill_root()
+                / "v8-runner"
+                / "references"
+                / "config-and-backends.md",
+                self.skill_root()
+                / "v8-runner"
+                / "references"
+                / "command-selection.md",
+                self.skill_root() / "v8-runner" / "references" / "testing.md",
+                self.reference_root() / "tooling" / "v8project.md",
+            ]
+        )
+
+        self.assertIn("execution_timeout", v8project)
+        self.assertIn("infobase:", v8project)
+        self.assertIn("infobase.connection", v8_runner_docs)
+        self.assertIn("tools-download", v8_runner_docs)
+        self.assertIn("fullOutput", v8_runner_docs)
+        self.assertIn("features", v8_runner_docs)
+        self.assertNotRegex(v8project, r"(?m)^connection:")
+        self.assertNotIn("mode=load|merge|update", v8project)
 
     def test_skills_and_references_do_not_expose_restricted_research_sources(self) -> None:
         forbidden_patterns = [


### PR DESCRIPTION
## Summary
- add structured diagnostics to failed `unica.runtime.execute` results from the internal `v8-runner` adapter
- align `unica.runtime.execute` schema, validation, and argv mapping with pinned `v8-runner` 0.5.1 capabilities
- reject operation-specific invalid payloads such as `load --mode update`, `build --extension`, `convert --path`, and VA `testScope`
- expose supported repeated/runtime arguments: `objects`, `sourceSets`, `projects`, VA filters, `fullOutput`, and `tools-download`
- update `v8project.yaml` and v8-runner skills/references for `infobase.connection`, `execution_timeout`, local overlay limits, and current load/test/tool workflows

## Root Cause
Runtime failures were flattened before users could see the process context, and Unica's wrapper/docs had drifted from the actual `v8-runner` contract already pinned in the package. The wrapper accepted or generated stale flags and the skills still showed obsolete examples like `mode: "update"`.

## Verification
- `git diff --check`
- `cargo fmt`
- `cargo clippy -p unica-coder --all-targets -- -D warnings`
- `cargo test -p unica-coder` (222 passed)
- `python3 -m pytest tests/ci -q` (133 passed, 1 skipped)

Closes #47
