### PR TITLE
Fix cf.edit XML serialization formatting

### DIFF
--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -1853,6 +1853,59 @@ mod tests {
     }
 
     #[test]
+    fn cf_edit_add_child_object_does_not_escape_structural_crlf() {
+        let root = std::env::temp_dir().join(format!("unica-cf-child-crlf-{}", std::process::id()));
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        let catalogs = src.join("Catalogs");
+        std::fs::create_dir_all(&catalogs).unwrap();
+        std::fs::write(
+            workspace.join("v8project.yaml"),
+            "format: DESIGNER\nsource-set:\n  - name: main\n    type: CONFIGURATION\n    path: src\n",
+        )
+        .unwrap();
+        let config_path = src.join("Configuration.xml");
+        let crlf_config = support_test_configuration_xml("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+            .replace('\n', "\r\n");
+        std::fs::write(&config_path, crlf_config).unwrap();
+        std::fs::write(
+            catalogs.join("Extra.xml"),
+            support_test_catalog_xml("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+        )
+        .unwrap();
+
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert("ConfigPath".to_string(), Value::String("src".to_string()));
+        args.insert(
+            "Operation".to_string(),
+            Value::String("add-childObject".to_string()),
+        );
+        args.insert(
+            "Value".to_string(),
+            Value::String("Catalog.Extra".to_string()),
+        );
+        args.insert("NoValidate".to_string(), Value::Bool(true));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.cf.edit", &args)
+            .unwrap();
+
+        assert!(result.ok, "{result:?}");
+        let after = std::fs::read_to_string(&config_path).unwrap();
+        assert!(after.starts_with('\u{feff}'));
+        assert!(after.contains("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+        assert!(after.contains("<Catalog>Extra</Catalog>"));
+        assert!(!after.contains("&#13;"), "{after}");
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn meta_info_reports_locked_vendor_support_state_through_unica_boundary() {
         let root = std::env::temp_dir().join(format!("unica-meta-support-{}", std::process::id()));
         let workspace = root.join("workspace");

--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -1896,11 +1896,20 @@ mod tests {
             .unwrap();
 
         assert!(result.ok, "{result:?}");
-        let after = std::fs::read_to_string(&config_path).unwrap();
+        let after_bytes = std::fs::read(&config_path).unwrap();
+        let after = String::from_utf8(after_bytes.clone()).unwrap();
         assert!(after.starts_with('\u{feff}'));
         assert!(after.contains("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
         assert!(after.contains("<Catalog>Extra</Catalog>"));
         assert!(!after.contains("&#13;"), "{after}");
+        assert!(
+            after_bytes
+                .iter()
+                .enumerate()
+                .filter(|(_, byte)| **byte == b'\n')
+                .all(|(index, _)| index > 0 && after_bytes[index - 1] == b'\r'),
+            "{after}"
+        );
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/crates/unica-coder/src/infrastructure/native_operations/cf.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/cf.rs
@@ -1913,7 +1913,8 @@ pub(crate) fn edit_cf(args: &Map<String, Value>, context: &WorkspaceContext) -> 
             .parent()
             .map(Path::to_path_buf)
             .unwrap_or_else(|| context.cwd.clone());
-        let mut text = lxml_parser_normalized_text(&read_utf8_sig(&config_path)?);
+        let source_text = read_utf8_sig(&config_path)?;
+        let mut text = lxml_parser_normalized_text(&source_text);
         if !text.contains("<Configuration") {
             return Err("No <Configuration> element found".to_string());
         }
@@ -2092,7 +2093,10 @@ pub(crate) fn edit_cf(args: &Map<String, Value>, context: &WorkspaceContext) -> 
             }
         }
 
-        write_utf8_bom(&config_path, &lxml_tree_serialized_text(&text))?;
+        write_utf8_bom(
+            &config_path,
+            &lxml_tree_serialized_text_like_source(&text, &source_text),
+        )?;
         stdout.push_str(&format!("[INFO] Saved: {}\n", config_path.display()));
 
         if !bool_arg(args, &["noValidate", "NoValidate"]) {

--- a/crates/unica-coder/src/infrastructure/native_operations/common.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/common.rs
@@ -1176,14 +1176,8 @@ pub(crate) fn ensure_trailing_lf(text: &str) -> String {
 
 pub(crate) fn lxml_tree_serialized_text(text: &str) -> String {
     let mut output = text.to_string();
-    if output.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>") {
-        output = output.replacen(
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
-            1,
-        );
-    }
     output = output.replace(" />", "/>");
+    output = output.replace("\r\n", "\n");
     output = output.replace('\r', "&#13;");
     if !output.ends_with('\n') {
         output.push('\n');

--- a/crates/unica-coder/src/infrastructure/native_operations/common.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/common.rs
@@ -1185,6 +1185,15 @@ pub(crate) fn lxml_tree_serialized_text(text: &str) -> String {
     output
 }
 
+pub(crate) fn lxml_tree_serialized_text_like_source(text: &str, source_text: &str) -> String {
+    let output = lxml_tree_serialized_text(text);
+    if source_text.contains("\r\n") {
+        output.replace('\n', "\r\n")
+    } else {
+        output
+    }
+}
+
 pub(crate) fn lxml_parser_normalized_text(text: &str) -> String {
     text.replace("\r\n", "\n").replace('\r', "\n")
 }

--- a/crates/unica-coder/src/infrastructure/native_operations/form.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/form.rs
@@ -1948,10 +1948,11 @@ pub(crate) fn add_form(args: &Map<String, Value>, context: &WorkspaceContext) ->
 
         let object_xml_full =
             resolve_form_add_object_path(absolutize(object_path_raw, &context.cwd))?;
-        let mut object_text = fs::read_to_string(&object_xml_full)
+        let object_source_text = fs::read_to_string(&object_xml_full)
             .map_err(|err| format!("failed to read {}: {err}", object_xml_full.display()))?
             .trim_start_matches('\u{feff}')
             .to_string();
+        let mut object_text = object_source_text.clone();
         let (object_type, object_name) = detect_form_add_object(&object_text)?;
         let format_version =
             detect_format_version(object_xml_full.parent().unwrap_or(context.cwd.as_path()));
@@ -2025,7 +2026,10 @@ pub(crate) fn add_form(args: &Map<String, Value>, context: &WorkspaceContext) ->
             } else {
                 false
             };
-        write_utf8_bom(&object_xml_full, &lxml_tree_serialized_text(&object_text))?;
+        write_utf8_bom(
+            &object_xml_full,
+            &lxml_tree_serialized_text_like_source(&object_text, &object_source_text),
+        )?;
 
         let obj_dir_name = object_xml_full
             .parent()

--- a/crates/unica-coder/src/infrastructure/native_operations/interface.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/interface.rs
@@ -70,11 +70,12 @@ pub(crate) fn edit_interface(
         }
         ci_path = ci_path.canonicalize().unwrap_or_else(|_| ci_path.clone());
 
-        let mut text = if ci_path.is_file() {
+        let source_text = if ci_path.is_file() {
             read_utf8_sig(&ci_path)?
         } else {
             String::new()
         };
+        let mut text = source_text.clone();
         text = lxml_parser_normalized_text(&text);
         if text.is_empty() {
             text = emit_empty_command_interface_document(&format_version);
@@ -108,7 +109,10 @@ pub(crate) fn edit_interface(
             }
         }
 
-        write_utf8_bom(&ci_path, &lxml_tree_serialized_text(&text))?;
+        write_utf8_bom(
+            &ci_path,
+            &lxml_tree_serialized_text_like_source(&text, &source_text),
+        )?;
         stdout.push_str(&format!("[INFO] Saved: {}\n", ci_path.display()));
 
         if !bool_arg(args, &["noValidate", "NoValidate"]) {

--- a/crates/unica-coder/src/infrastructure/native_operations/template.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/template.rs
@@ -116,7 +116,8 @@ pub(crate) fn add_template(
             )?;
         }
 
-        let xml_text = lxml_parser_normalized_text(&read_utf8_sig(&root_xml_path)?);
+        let source_xml_text = read_utf8_sig(&root_xml_path)?;
+        let xml_text = lxml_parser_normalized_text(&source_xml_text);
         let mut xml_text = append_metadata_child_text(&xml_text, "Template", template_name)
             .ok_or_else(|| {
                 format!(
@@ -137,7 +138,10 @@ pub(crate) fn add_template(
         if !xml_text.ends_with('\n') {
             xml_text.push('\n');
         }
-        write_utf8_bom(&root_xml_path, &lxml_tree_serialized_text(&xml_text))?;
+        write_utf8_bom(
+            &root_xml_path,
+            &lxml_tree_serialized_text_like_source(&xml_text, &source_xml_text),
+        )?;
 
         stdout.push_str(&format!(
             "[OK] Создан макет: {template_name} ({template_type})\n"
@@ -259,7 +263,8 @@ pub(crate) fn remove_template(
         ));
         changes.push(format!("removed file {}", template_meta_path.display()));
 
-        let xml_text = lxml_parser_normalized_text(&read_utf8_sig(&root_xml_path)?);
+        let source_xml_text = read_utf8_sig(&root_xml_path)?;
+        let xml_text = lxml_parser_normalized_text(&source_xml_text);
         let xml_text = remove_template_child_text_lxml(&xml_text, template_name);
         let (mut xml_text, main_dcs_cleared) =
             clear_main_data_composition_schema_text(&xml_text, template_name);
@@ -270,7 +275,10 @@ pub(crate) fn remove_template(
             stdout.push_str("[OK] Очищён MainDataCompositionSchema\n");
             changes.push("cleared MainDataCompositionSchema".to_string());
         }
-        write_utf8_bom(&root_xml_path, &lxml_tree_serialized_text(&xml_text))?;
+        write_utf8_bom(
+            &root_xml_path,
+            &lxml_tree_serialized_text_like_source(&xml_text, &source_xml_text),
+        )?;
         changes.push(format!("updated {}", root_xml_path.display()));
 
         stdout.push_str(&format!(

--- a/tests/ci/test_unica_mcp_script_parity.py
+++ b/tests/ci/test_unica_mcp_script_parity.py
@@ -4733,6 +4733,17 @@ def normalize_text(text: str, workspace: Path) -> str:
     return normalized
 
 
+def normalize_snapshot_text(text: str, workspace: Path) -> str:
+    normalized = normalize_text(text, workspace)
+    normalized = normalized.replace("&#13;\n", "\n")
+    return re.sub(
+        r'(<\?xml\s+version="1\.0"\s+encoding=")utf-8(")',
+        r"\1UTF-8\2",
+        normalized,
+        count=1,
+    )
+
+
 def snapshot_workspace(workspace: Path) -> dict[str, str]:
     snapshot: dict[str, str] = {}
     for path in sorted(workspace.rglob("*")):
@@ -4747,7 +4758,7 @@ def snapshot_workspace(workspace: Path) -> dict[str, str]:
         except UnicodeDecodeError:
             snapshot[rel] = "sha256:" + hashlib.sha256(data).hexdigest()
             continue
-        snapshot[rel] = normalize_text(text, workspace)
+        snapshot[rel] = normalize_snapshot_text(text, workspace)
     return snapshot
 
 


### PR DESCRIPTION
## Summary

- preserve the original XML declaration encoding casing when native edit tools save XML
- stop treating structural CRLF line breaks as text carriage returns during lxml-compatible serialization
- preserve the source XML line-ending style when editing existing XML files
- add a regression test for `unica.cf.edit add-childObject` on CRLF `Configuration.xml`
- adjust parity snapshots so donor-script formatting quirks do not define the native contract

## Root cause

`lxml_tree_serialized_text` was emulating donor lxml output too literally: it forced `encoding=\"UTF-8\"` to `encoding=\"utf-8\"` and escaped every `\r` as `&#13;`. Native edit operations normalize source text before editing, but newly generated XML fragments can still contain CRLF separators. The serializer then turned those structural separators into XML text.

A second review pass found another side effect of the same area: CRLF source files were serialized back as LF-only, causing whole-file diffs. The fix now separates parser-normalized in-memory text from final write-back formatting and restores CRLF output when the edited source used CRLF.

## Validation

- `cargo test -p unica-coder`
- `uv run --with-requirements tests/ci/requirements.txt --with pytest python -m pytest tests/ci/test_unica_mcp_script_parity.py -q`
- `cargo clippy --package unica-coder --all-targets --all-features -- -D warnings`
- `git diff --check`
- manual MCP reproduction for issue #50: `encoding_changed=False`, `escaped_cr_count=0`, `all_lf_are_crlf=True`; remaining diff is localized to the edited `ChildObjects` block

Refs #50