### PR TITLE
Исправить запись comment в канонический Comment

### DIFF
--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -2772,6 +2772,52 @@ mod tests {
     }
 
     #[test]
+    fn meta_compile_catalog_comment_emits_single_object_comment() {
+        let root = temp_meta_compile_workspace("unica-meta-compile-catalog-comment");
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        let fixtures = workspace.join("fixtures");
+        std::fs::create_dir_all(&fixtures).unwrap();
+        let json_path = fixtures.join("catalog-comment.json");
+        std::fs::write(
+            &json_path,
+            r#"{
+  "type": "Catalog",
+  "name": "Issue67Catalog",
+  "synonym": "Issue67Catalog",
+  "comment": "TEST-COMMENT"
+}"#,
+        )
+        .unwrap();
+
+        let result = call_meta_compile(&workspace, &json_path);
+
+        assert!(result.ok, "{:?}", result.stderr);
+        let xml_path = src.join("Catalogs").join("Issue67Catalog.xml");
+        assert!(xml_path.is_file());
+        let xml = std::fs::read_to_string(&xml_path).unwrap();
+        assert_eq!(xml.matches("<Comment>TEST-COMMENT</Comment>").count(), 1);
+        let doc = roxmltree::Document::parse(xml.trim_start_matches('\u{feff}')).unwrap();
+        let catalog = doc
+            .root_element()
+            .children()
+            .find(|node| node.is_element() && node.tag_name().name() == "Catalog")
+            .unwrap();
+        let properties = catalog
+            .children()
+            .find(|node| node.is_element() && node.tag_name().name() == "Properties")
+            .unwrap();
+        let comments = properties
+            .children()
+            .filter(|node| node.is_element() && node.tag_name().name() == "Comment")
+            .collect::<Vec<_>>();
+        assert_eq!(comments.len(), 1, "{xml}");
+        assert_eq!(comments[0].text(), Some("TEST-COMMENT"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn template_add_preserves_single_object_bom() {
         let root = temp_meta_compile_workspace("unica-template-add-single-bom");
         let workspace = root.join("workspace");

--- a/crates/unica-coder/src/infrastructure/native_operations/meta.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta.rs
@@ -253,6 +253,64 @@ mod edit_tests {
     }
 
     #[test]
+    fn edit_meta_modify_property_comment_rejects_duplicate_without_mutation() {
+        let context = temp_context("modify-property-comment-duplicate");
+        let object_path = context.cwd.join("Catalogs").join("SampleContracts.xml");
+        let xml = sample_catalog_xml().replace(
+            "<Comment/>",
+            "<Comment>FIRST</Comment>\n\t\t\t<Comment>SECOND</Comment>",
+        );
+        write_file(&object_path, &xml);
+        let before = fs::read(&object_path).unwrap();
+
+        let outcome = edit_meta(
+            &meta_edit_args(&object_path, "modify-property", "Comment=TEST-COMMENT"),
+            &context,
+        );
+
+        assert!(!outcome.ok, "{outcome:?}");
+        assert!(
+            outcome
+                .errors
+                .iter()
+                .any(|error| error.contains("2 direct <Comment>")),
+            "{:?}",
+            outcome.errors
+        );
+        assert_eq!(fs::read(&object_path).unwrap(), before);
+
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
+    fn edit_meta_modify_property_same_comment_is_byte_identical_noop() {
+        let context = temp_context("modify-property-comment-noop");
+        let object_path = context.cwd.join("Catalogs").join("SampleContracts.xml");
+        let xml = meta_edit_lxml_serialized_text(
+            &sample_catalog_xml().replace("<Comment/>", "<Comment>TEST-COMMENT</Comment>"),
+        );
+        fs::create_dir_all(object_path.parent().unwrap()).unwrap();
+        write_utf8_bom(&object_path, &xml).unwrap();
+        let before = fs::read(&object_path).unwrap();
+
+        let outcome = edit_meta(
+            &meta_edit_args(&object_path, "modify-property", "Comment=TEST-COMMENT"),
+            &context,
+        );
+
+        assert!(outcome.ok, "{:?}", outcome.errors);
+        assert!(outcome.changes.is_empty(), "{:?}", outcome.changes);
+        assert_eq!(fs::read(&object_path).unwrap(), before);
+        assert!(outcome
+            .stdout
+            .as_deref()
+            .unwrap_or_default()
+            .contains("No changes"));
+
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
     fn edit_meta_adds_register_record_to_document() {
         let context = temp_context("add-register-record");
         let object_path = context.cwd.join("Documents").join("SampleShipment.xml");
@@ -9422,7 +9480,7 @@ pub(crate) struct MetaEditCounts {
 }
 
 pub(crate) fn edit_meta(args: &Map<String, Value>, context: &WorkspaceContext) -> AdapterOutcome {
-    let edit_result = (|| -> Result<(String, PathBuf, usize), String> {
+    let edit_result = (|| -> Result<(String, PathBuf, bool), String> {
         let definition_file = path_arg(args, &["definitionFile", "DefinitionFile"]);
         let operation = string_arg(args, &["operation", "Operation"]);
         if definition_file.is_some() && operation.is_some() {
@@ -9439,7 +9497,9 @@ pub(crate) fn edit_meta(args: &Map<String, Value>, context: &WorkspaceContext) -
         let object_path = resolve_meta_edit_object_path(&object_path_raw, &context.cwd)?;
         let value = string_arg(args, &["value", "Value"]).unwrap_or_default();
 
-        let mut xml_text = fs::read_to_string(&object_path)
+        let original_bytes = fs::read(&object_path)
+            .map_err(|err| format!("failed to read {}: {err}", object_path.display()))?;
+        let mut xml_text = String::from_utf8(original_bytes.clone())
             .map_err(|err| format!("failed to read {}: {err}", object_path.display()))?;
         if xml_text.starts_with('\u{feff}') {
             xml_text = xml_text.trim_start_matches('\u{feff}').to_string();
@@ -9483,21 +9543,33 @@ pub(crate) fn edit_meta(args: &Map<String, Value>, context: &WorkspaceContext) -
         Document::parse(xml_text.trim_start_matches('\u{feff}'))
             .map_err(|err| format!("XML parse error after meta-edit: {err}"))?;
         let serialized_text = meta_edit_lxml_serialized_text(&xml_text);
-        write_utf8_bom(&object_path, &serialized_text)?;
-        info_lines.push(format!("[INFO] Saved: {}", object_path.display()));
+        let mut serialized_bytes = b"\xef\xbb\xbf".to_vec();
+        serialized_bytes.extend_from_slice(serialized_text.as_bytes());
+        let changed = serialized_bytes != original_bytes;
+        if changed {
+            write_utf8_bom(&object_path, &serialized_text)?;
+            info_lines.push(format!("[INFO] Saved: {}", object_path.display()));
+        } else {
+            counts = MetaEditCounts::default();
+            info_lines.push("[INFO] No changes".to_string());
+        }
         let stdout = format!(
             "{}\n\n=== meta-edit summary ===\n  Object:   {object_type}.{object_name}\n  Added:    {}\n  Removed:  {}\n  Modified: {}\n",
             info_lines.join("\n"),
             counts.added, counts.removed, counts.modified
         );
-        Ok((stdout, object_path, counts.modified))
+        Ok((stdout, object_path, changed))
     })();
 
     match edit_result {
-        Ok((stdout, object_path, _modified)) => AdapterOutcome {
+        Ok((stdout, object_path, changed)) => AdapterOutcome {
             ok: true,
             summary: "unica.meta.edit completed with native metadata editor".to_string(),
-            changes: vec![format!("updated {}", object_path.display())],
+            changes: if changed {
+                vec![format!("updated {}", object_path.display())]
+            } else {
+                Vec::new()
+            },
             warnings: Vec::new(),
             errors: Vec::new(),
             artifacts: vec![object_path.display().to_string()],
@@ -10164,6 +10236,12 @@ pub(crate) fn meta_edit_set_scalar_property(
     let object = meta_edit_object_node(&doc)?;
     let properties = meta_info_child(object, "Properties")
         .ok_or_else(|| "Object has no Properties".to_string())?;
+    let matching_properties = meta_info_children(properties, key).len();
+    if matching_properties > 1 {
+        return Err(format!(
+            "Properties contains {matching_properties} direct <{key}> elements; expected at most one"
+        ));
+    }
     let range = properties.range();
     drop(doc);
 

--- a/crates/unica-coder/src/infrastructure/native_operations/meta.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta.rs
@@ -210,6 +210,49 @@ mod edit_tests {
     }
 
     #[test]
+    fn edit_meta_modify_property_comment_replaces_self_closing_object_comment() {
+        let context = temp_context("modify-property-comment-self-closing");
+        let object_path = context.cwd.join("Catalogs").join("SampleContracts.xml");
+        write_file(&object_path, &sample_catalog_xml());
+
+        let outcome = edit_meta(
+            &meta_edit_args(&object_path, "modify-property", "Comment=TEST-COMMENT"),
+            &context,
+        );
+
+        assert!(outcome.ok, "{:?}", outcome.errors);
+        let updated = fs::read_to_string(&object_path).unwrap();
+        assert!(updated.contains("<Comment>TEST-COMMENT</Comment>"));
+        assert_eq!(updated.matches("<Comment").count(), 1, "{updated}");
+        assert!(!updated.contains("<Comment/>"), "{updated}");
+        Document::parse(updated.trim_start_matches('\u{feff}')).unwrap();
+
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
+    fn edit_meta_modify_property_comment_replaces_existing_object_comment() {
+        let context = temp_context("modify-property-comment-existing");
+        let object_path = context.cwd.join("Catalogs").join("SampleContracts.xml");
+        let xml = sample_catalog_xml().replace("<Comment/>", "<Comment>OLD</Comment>");
+        write_file(&object_path, &xml);
+
+        let outcome = edit_meta(
+            &meta_edit_args(&object_path, "modify-property", "Comment=TEST-COMMENT"),
+            &context,
+        );
+
+        assert!(outcome.ok, "{:?}", outcome.errors);
+        let updated = fs::read_to_string(&object_path).unwrap();
+        assert!(updated.contains("<Comment>TEST-COMMENT</Comment>"));
+        assert!(!updated.contains("<Comment>OLD</Comment>"));
+        assert_eq!(updated.matches("<Comment").count(), 1, "{updated}");
+        Document::parse(updated.trim_start_matches('\u{feff}')).unwrap();
+
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
     fn edit_meta_adds_register_record_to_document() {
         let context = temp_context("add-register-record");
         let object_path = context.cwd.join("Documents").join("SampleShipment.xml");
@@ -6323,9 +6366,7 @@ pub(crate) fn emit_meta_catalog_properties(
     obj_name: &str,
     synonym: &str,
 ) {
-    lines.push(format!("{indent}<Name>{}</Name>", escape_xml(obj_name)));
-    emit_meta_mltext(lines, indent, "Synonym", synonym);
-    lines.push(format!("{indent}<Comment/>"));
+    emit_meta_base_properties(lines, indent, defn, obj_name, synonym);
     let hierarchical = defn.get("hierarchical").and_then(Value::as_bool) == Some(true);
     lines.push(format!(
         "{indent}<Hierarchical>{hierarchical}</Hierarchical>"
@@ -10113,12 +10154,25 @@ pub(crate) fn meta_edit_set_scalar_property(
     key: &str,
     raw_value: &str,
 ) -> Result<(), String> {
-    let normalized = normalize_meta_edit_property_value(key, raw_value);
-    if replace_first_xml_element_text(xml_text, key, &normalized) {
-        Ok(())
-    } else {
-        insert_meta_property_before_child_objects(xml_text, key, &normalized)
+    let key = key.trim();
+    if key.is_empty() {
+        return Err("modify-property requires non-empty key".to_string());
     }
+    let normalized = normalize_meta_edit_property_value(key, raw_value);
+    let doc = Document::parse(xml_text.trim_start_matches('\u{feff}'))
+        .map_err(|err| format!("XML parse error: {err}"))?;
+    let object = meta_edit_object_node(&doc)?;
+    let properties = meta_info_child(object, "Properties")
+        .ok_or_else(|| "Object has no Properties".to_string())?;
+    let range = properties.range();
+    drop(doc);
+
+    let mut properties_text = xml_text[range.clone()].to_string();
+    let child_indent = meta_edit_property_child_indent(&properties_text);
+    let replacement = format!("{child_indent}<{key}>{}</{key}>", escape_xml(&normalized));
+    meta_edit_replace_or_insert_property(&mut properties_text, key, &replacement, &child_indent)?;
+    xml_text.replace_range(range, &properties_text);
+    Ok(())
 }
 
 pub(crate) fn meta_edit_add_child_value(


### PR DESCRIPTION
Closes #67

## Изменения
- `meta.compile` для `Catalog` теперь записывает JSON-поле `comment` в канонический object-level `<Comment>` внутри `<Properties>` без второго `<Comment>`.
- `meta.edit modify-property Comment=...` теперь заменяет существующий object-level `<Comment>` или самозакрытый `<Comment/>`, не создавая дублей.

## Проверки
- `cargo fmt --all -- --check`
- `cargo clippy --package unica-coder --all-targets --all-features -- -D warnings`
- `cargo test --package unica-coder` — 242 пройдено
- `python3.12 -X utf8 -m unittest tests.ci.test_unica_skills tests.ci.test_skill_provenance tests.ci.test_package_unica_plugin` — 72 пройдено, 3 пропущено
- `python3.12 -X utf8 -m compileall -q scripts/ci tests/ci` — 18 файлов скомпилировано
- `git diff --check`

## Известное
Полный `python3.12 -m unittest discover -s tests/ci` и набор проверок parity на локальной Windows-среде падают на существующих расхождениях кодировки, путей и ожидаемых разделителей. Это не связано с изменением #67; GitHub Actions должны подтвердить проверки на целевых окружениях.