### PR TITLE
fix(cf): единый registry metadata kinds и атомарная проверка batch

### DIFF
--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -1901,6 +1901,173 @@ mod tests {
         args
     }
 
+    #[test]
+    fn cf_edit_definition_file_rejects_invalid_child_object_before_sidecar_writes() {
+        let mut violations = Vec::new();
+
+        for (sidecar_operation, sidecar_value, sidecar_name, child_operation, child_value, error) in [
+            (
+                "set-panels",
+                json!({"top": ["open"]}),
+                "ClientApplicationInterface.xml",
+                "add-childObject",
+                "SyntheticMetadata.Unknown",
+                "Unknown type 'SyntheticMetadata'",
+            ),
+            (
+                "set-panels",
+                json!({"top": ["open"]}),
+                "ClientApplicationInterface.xml",
+                "remove-childObject",
+                "SyntheticMetadata.Unknown",
+                "Unknown type 'SyntheticMetadata'",
+            ),
+            (
+                "set-home-page",
+                json!({"template": "OneColumn", "left": ["CommonForm.Demo"]}),
+                "HomePageWorkArea.xml",
+                "add-childObject",
+                "SyntheticMetadata.Unknown",
+                "Unknown type 'SyntheticMetadata'",
+            ),
+            (
+                "set-home-page",
+                json!({"template": "OneColumn", "left": ["CommonForm.Demo"]}),
+                "HomePageWorkArea.xml",
+                "remove-childObject",
+                "SyntheticMetadata.Unknown",
+                "Unknown type 'SyntheticMetadata'",
+            ),
+            (
+                "set-panels",
+                json!({"top": ["open"]}),
+                "ClientApplicationInterface.xml",
+                "add-childObject",
+                "Catalog.",
+                "Invalid format 'Catalog.', expected 'Type.Name'",
+            ),
+            (
+                "set-panels",
+                json!({"top": ["open"]}),
+                "ClientApplicationInterface.xml",
+                "remove-childObject",
+                "Catalog.",
+                "Invalid format 'Catalog.', expected 'Type.Name'",
+            ),
+        ] {
+            let (root, workspace, _) = support_test_workspace(
+                &format!("unica-cf-edit-unknown-kind-atomic-{sidecar_operation}-{child_operation}"),
+                String::new(),
+            );
+            let config_path = workspace.join("src/Configuration.xml");
+            let definition_path =
+                workspace.join(format!("{sidecar_operation}-{child_operation}.json"));
+            std::fs::write(
+                &definition_path,
+                serde_json::to_string(&json!([
+                    {"operation": sidecar_operation, "value": sidecar_value},
+                    {"operation": child_operation, "value": child_value}
+                ]))
+                .unwrap(),
+            )
+            .unwrap();
+            let config_before = std::fs::read(&config_path).unwrap();
+            let definition_before = std::fs::read(&definition_path).unwrap();
+            let sidecar_path = workspace.join("src/Ext").join(sidecar_name);
+            let sidecar_before = b"sidecar content before failed batch";
+            std::fs::write(&sidecar_path, sidecar_before).unwrap();
+
+            let mut args = Map::new();
+            args.insert(
+                "cwd".to_string(),
+                Value::String(workspace.display().to_string()),
+            );
+            args.insert("dryRun".to_string(), Value::Bool(false));
+            args.insert("ConfigPath".to_string(), Value::String("src".to_string()));
+            args.insert(
+                "DefinitionFile".to_string(),
+                Value::String(definition_path.display().to_string()),
+            );
+            args.insert("NoValidate".to_string(), Value::Bool(true));
+
+            let result = UnicaApplication::new()
+                .call_tool("unica.cf.edit", &args)
+                .unwrap();
+
+            let case = format!("{sidecar_operation} -> {child_operation} {child_value}");
+            if result.ok {
+                violations.push(format!("{case}: batch unexpectedly succeeded"));
+            }
+            if !result.errors.join("\n").contains(error) {
+                violations.push(format!("{case}: wrong error: {result:?}"));
+            }
+            if std::fs::read(&config_path).unwrap() != config_before {
+                violations.push(format!("{case}: Configuration.xml changed"));
+            }
+            if std::fs::read(&definition_path).unwrap() != definition_before {
+                violations.push(format!("{case}: definition file changed"));
+            }
+            if std::fs::read(&sidecar_path).unwrap() != sidecar_before {
+                violations.push(format!(
+                    "{case}: failed batch changed {}",
+                    sidecar_path.display()
+                ));
+            }
+
+            let _ = std::fs::remove_dir_all(root);
+        }
+
+        assert!(
+            violations.is_empty(),
+            "failed batches must leave all affected files byte-identical: {violations:#?}"
+        );
+    }
+
+    #[test]
+    fn cf_edit_definition_file_keeps_valid_ordered_child_object_batch() {
+        let (root, workspace, _) =
+            support_test_workspace("unica-cf-edit-known-kind-batch", String::new());
+        let definition_path = workspace.join("ordered-batch.json");
+        std::fs::write(
+            &definition_path,
+            serde_json::to_string(&json!([
+                {"operation": "set-panels", "value": {"top": ["open"]}},
+                {"operation": "remove-childObject", "value": "Catalog.Items"},
+                {"operation": "add-childObject", "value": "Catalog.Items"}
+            ]))
+            .unwrap(),
+        )
+        .unwrap();
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert("ConfigPath".to_string(), Value::String("src".to_string()));
+        args.insert(
+            "DefinitionFile".to_string(),
+            Value::String(definition_path.display().to_string()),
+        );
+        args.insert("NoValidate".to_string(), Value::Bool(true));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.cf.edit", &args)
+            .unwrap();
+
+        assert!(result.ok, "{result:?}");
+        assert!(workspace
+            .join("src/Ext/ClientApplicationInterface.xml")
+            .is_file());
+        assert!(
+            std::fs::read_to_string(workspace.join("src/Configuration.xml"))
+                .unwrap()
+                .contains("<Catalog>Items</Catalog>")
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
     fn cf_edit_issue55_config_xml(child_indent: &str) -> String {
         format!(
             concat!(

--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -1926,6 +1926,184 @@ mod tests {
         )
     }
 
+    fn bot_configuration_xml(include_bot: bool) -> String {
+        let children = if include_bot {
+            concat!(
+                "\t\t\t<Language>Русский</Language>\n",
+                "\t\t\t<CommonModule>Core</CommonModule>\n",
+                "\t\t\t<Bot>Assistant</Bot>\n",
+                "\t\t\t<CommonAttribute>Shared</CommonAttribute>"
+            )
+        } else {
+            concat!(
+                "\t\t\t<Language>Русский</Language>\n",
+                "\t\t\t<CommonModule>Core</CommonModule>\n",
+                "\t\t\t<CommonAttribute>Shared</CommonAttribute>"
+            )
+        };
+        include_str!(
+            "../../../../tests/fixtures/unica_mcp_script_parity/cf-validate/Configuration.xml"
+        )
+        .replace("\t\t\t<Language>Русский</Language>", children)
+    }
+
+    fn bot_cf_workspace(prefix: &str, include_bot: bool) -> (PathBuf, PathBuf, PathBuf) {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("{prefix}-{nanos}"));
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        for directory in ["Languages", "CommonModules", "Bots", "CommonAttributes"] {
+            std::fs::create_dir_all(src.join(directory)).unwrap();
+        }
+        std::fs::write(
+            workspace.join("v8project.yaml"),
+            "format: DESIGNER\nsource-set:\n  - name: main\n    type: CONFIGURATION\n    path: src\n",
+        )
+        .unwrap();
+        let config_path = src.join("Configuration.xml");
+        std::fs::write(
+            &config_path,
+            format!("\u{feff}{}", bot_configuration_xml(include_bot)),
+        )
+        .unwrap();
+        std::fs::write(
+            src.join("Languages/Русский.xml"),
+            include_str!("../../../../tests/fixtures/unica_mcp_script_parity/cf-validate/Languages/Русский.xml"),
+        )
+        .unwrap();
+        if include_bot {
+            std::fs::write(src.join("Bots/Assistant.xml"), "<MetaDataObject/>").unwrap();
+        }
+        (root, workspace, config_path)
+    }
+
+    #[test]
+    fn cf_info_and_validate_recognize_bot_in_canonical_order() {
+        let (root, workspace, _config_path) = bot_cf_workspace("unica-cf-bot-read", true);
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("ConfigPath".to_string(), Value::String("src".to_string()));
+
+        let overview = UnicaApplication::new()
+            .call_tool("unica.cf.info", &args)
+            .unwrap();
+        assert!(overview.ok, "{overview:?}");
+        let overview_stdout = overview.stdout.unwrap();
+        assert!(
+            overview_stdout
+                .lines()
+                .any(|line| line.starts_with("  Боты") && line.ends_with('1')),
+            "{overview_stdout}"
+        );
+
+        args.insert("Mode".to_string(), Value::String("full".to_string()));
+        let full = UnicaApplication::new()
+            .call_tool("unica.cf.info", &args)
+            .unwrap();
+        assert!(full.ok, "{full:?}");
+        let full_stdout = full.stdout.unwrap();
+        assert!(full_stdout.contains("Боты (Bot): 1"), "{full_stdout}");
+        assert!(full_stdout.contains("    Assistant"), "{full_stdout}");
+
+        args.remove("Mode");
+        let validation = UnicaApplication::new()
+            .call_tool("unica.cf.validate", &args)
+            .unwrap();
+        assert!(validation.ok, "{validation:?}");
+        let validation_stdout = validation.stdout.unwrap_or_default();
+        assert!(!validation_stdout.contains("Unknown type 'Bot'"));
+        assert!(!validation_stdout.contains("out of canonical order"));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn cf_edit_adds_removes_and_noops_bot_through_registry() {
+        let (root, workspace, config_path) = bot_cf_workspace("unica-cf-bot-edit", false);
+        let src = workspace.join("src");
+        std::fs::write(src.join("Bots/Assistant.xml"), "<MetaDataObject/>").unwrap();
+        let before = std::fs::read_to_string(&config_path).unwrap();
+
+        let add = UnicaApplication::new()
+            .call_tool(
+                "unica.cf.edit",
+                &cf_edit_args(&workspace, "add-childObject", "Bot.Assistant"),
+            )
+            .unwrap();
+        assert!(add.ok, "{add:?}");
+        let after_add = std::fs::read_to_string(&config_path).unwrap();
+        assert!(
+            after_add.find("<CommonModule>Core</CommonModule>").unwrap()
+                < after_add.find("<Bot>Assistant</Bot>").unwrap()
+        );
+        assert!(
+            after_add.find("<Bot>Assistant</Bot>").unwrap()
+                < after_add
+                    .find("<CommonAttribute>Shared</CommonAttribute>")
+                    .unwrap()
+        );
+
+        let duplicate = UnicaApplication::new()
+            .call_tool(
+                "unica.cf.edit",
+                &cf_edit_args(&workspace, "add-childObject", "Bot.Assistant"),
+            )
+            .unwrap();
+        assert!(duplicate.ok, "{duplicate:?}");
+        assert!(duplicate.changes.is_empty(), "{duplicate:?}");
+        assert!(duplicate.cache.events.is_empty(), "{duplicate:?}");
+        assert_eq!(std::fs::read_to_string(&config_path).unwrap(), after_add);
+
+        let remove = UnicaApplication::new()
+            .call_tool(
+                "unica.cf.edit",
+                &cf_edit_args(&workspace, "remove-childObject", "Bot.Assistant"),
+            )
+            .unwrap();
+        assert!(remove.ok, "{remove:?}");
+        assert_eq!(std::fs::read_to_string(&config_path).unwrap(), before);
+
+        let missing = UnicaApplication::new()
+            .call_tool(
+                "unica.cf.edit",
+                &cf_edit_args(&workspace, "add-childObject", "Bot.Missing"),
+            )
+            .unwrap();
+        assert!(!missing.ok, "{missing:?}");
+        let missing_errors = missing.errors.join("\n");
+        assert!(missing_errors.contains("Bots/Missing.xml"), "{missing:?}");
+        assert!(!missing_errors.contains("use meta-compile"), "{missing:?}");
+        assert_eq!(std::fs::read_to_string(&config_path).unwrap(), before);
+
+        let unknown = UnicaApplication::new()
+            .call_tool(
+                "unica.cf.edit",
+                &cf_edit_args(
+                    &workspace,
+                    "remove-childObject",
+                    "SyntheticMetadata.Unknown",
+                ),
+            )
+            .unwrap();
+        assert!(!unknown.ok, "{unknown:?}");
+        assert!(
+            unknown
+                .errors
+                .join("\n")
+                .contains("Unknown type 'SyntheticMetadata'"),
+            "{unknown:?}"
+        );
+        assert_eq!(std::fs::read_to_string(&config_path).unwrap(), before);
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
     #[test]
     fn cf_edit_add_child_object_does_not_escape_structural_crlf() {
         let root = std::env::temp_dir().join(format!("unica-cf-child-crlf-{}", std::process::id()));
@@ -2717,6 +2895,32 @@ mod tests {
         assert!(config_text.contains("<Report>MetaCompileBomReport</Report>"));
         roxmltree::Document::parse(config_text.trim_start_matches('\u{feff}')).unwrap();
 
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn meta_compile_keeps_bot_outside_its_narrow_capability_gate() {
+        let root = temp_meta_compile_workspace("unica-meta-compile-bot-unsupported");
+        let workspace = root.join("workspace");
+        let json_path = workspace.join("bot.json");
+        std::fs::write(
+            &json_path,
+            r#"{
+  "type": "Bot",
+  "name": "Assistant",
+  "synonym": "Assistant"
+}"#,
+        )
+        .unwrap();
+
+        let result = call_meta_compile(&workspace, &json_path);
+
+        assert!(!result.ok, "{result:?}");
+        assert!(
+            result.errors.join("\n").contains("Unsupported type: Bot"),
+            "{result:?}"
+        );
+        assert!(!workspace.join("src/Bots").exists());
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -1458,19 +1458,18 @@ fn split_profile_name(raw: &str) -> (Option<String>, String) {
     let Some((prefix, name)) = trimmed.split_once('.') else {
         return (None, trimmed.to_string());
     };
-    let category = match prefix {
-        "Document" | "Документ" => "Document",
-        "Catalog" | "Справочник" => "Catalog",
-        "CommonModule" | "CommonModules" | "ОбщийМодуль" | "ОбщиеМодули" => {
-            "CommonModule"
-        }
-        "InformationRegister" | "РегистрСведений" => "InformationRegister",
-        "AccumulationRegister" | "РегистрНакопления" => "AccumulationRegister",
-        "Enum" | "Перечисление" => "Enum",
-        other => metadata_kind(other)
-            .or_else(|| metadata_kind_by_directory(other))
-            .map_or(other, |kind| kind.tag),
-    };
+    let category = metadata_kind(prefix)
+        .or_else(|| metadata_kind_by_directory(prefix))
+        .map(|kind| kind.tag)
+        .unwrap_or_else(|| match prefix {
+            "Документ" => "Document",
+            "Справочник" => "Catalog",
+            "ОбщийМодуль" | "ОбщиеМодули" => "CommonModule",
+            "РегистрСведений" => "InformationRegister",
+            "РегистрНакопления" => "AccumulationRegister",
+            "Перечисление" => "Enum",
+            other => other,
+        });
     (Some(category.to_string()), name.trim().to_string())
 }
 
@@ -2978,6 +2977,7 @@ fn _path_list(paths: &[PathBuf]) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::infrastructure::metadata_kinds::METADATA_KINDS;
     use crate::infrastructure::workspace_index::{IndexBackgroundJob, IndexCommand, IndexOutput};
     use rusqlite::Connection;
     use serde_json::json;
@@ -2988,27 +2988,71 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
-    fn metadata_profile_selector_normalizes_bot_tag_and_directory_alias() {
-        assert_eq!(
-            split_profile_name("Bot.Assistant"),
-            (Some("Bot".to_string()), "Assistant".to_string())
-        );
-        assert_eq!(
-            split_profile_name("Bots.Assistant"),
-            (Some("Bot".to_string()), "Assistant".to_string())
-        );
-        assert_eq!(
-            split_profile_name("CommonModules.Core"),
-            (Some("CommonModule".to_string()), "Core".to_string())
-        );
-        assert_eq!(
-            split_profile_name("ОбщийМодуль.Core"),
-            (Some("CommonModule".to_string()), "Core".to_string())
-        );
+    fn metadata_profile_selector_normalizes_every_registry_tag_and_directory() {
+        for kind in METADATA_KINDS {
+            let tag_selector = format!("{}.ObjectName", kind.tag);
+            assert_eq!(
+                split_profile_name(&tag_selector),
+                (Some(kind.tag.to_string()), "ObjectName".to_string()),
+                "canonical tag selector must use the registry: {tag_selector}"
+            );
+
+            let directory_selector = format!("{}.ObjectName", kind.directory);
+            assert_eq!(
+                split_profile_name(&directory_selector),
+                (Some(kind.tag.to_string()), "ObjectName".to_string()),
+                "plural directory selector must use the registry: {directory_selector}"
+            );
+        }
+
+        for (alias, expected) in [
+            ("Документ", "Document"),
+            ("Справочник", "Catalog"),
+            ("ОбщийМодуль", "CommonModule"),
+            ("ОбщиеМодули", "CommonModule"),
+            ("РегистрСведений", "InformationRegister"),
+            ("РегистрНакопления", "AccumulationRegister"),
+            ("Перечисление", "Enum"),
+        ] {
+            let selector = format!("{alias}.ObjectName");
+            assert_eq!(
+                split_profile_name(&selector),
+                (Some(expected.to_string()), "ObjectName".to_string()),
+                "Russian alias must remain supported: {selector}"
+            );
+        }
         assert_eq!(
             split_profile_name("SyntheticMetadata.Unknown"),
             (Some("SyntheticMetadata".to_string()), "Unknown".to_string())
         );
+    }
+
+    #[test]
+    fn metadata_profile_selector_has_no_local_english_kind_table() {
+        let source = include_str!("internal_adapters.rs");
+        let selector_body = source
+            .split_once("fn split_profile_name")
+            .and_then(|(_, tail)| tail.split_once("fn format_profile_section"))
+            .map(|(body, _)| body)
+            .expect("split_profile_name source must be present");
+        let local_match_patterns = selector_body
+            .lines()
+            .filter_map(|line| line.split_once("=>").map(|(pattern, _)| pattern))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        for kind in METADATA_KINDS {
+            assert!(
+                !local_match_patterns.contains(&format!("\"{}\"", kind.tag)),
+                "{} must be resolved through the shared registry",
+                kind.tag
+            );
+            assert!(
+                !local_match_patterns.contains(&format!("\"{}\"", kind.directory)),
+                "{} must be resolved through the shared registry",
+                kind.directory
+            );
+        }
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -1,5 +1,6 @@
 use crate::domain::workspace::WorkspaceContext;
 use crate::infrastructure::bundled_tools::resolve_bundled_tool;
+use crate::infrastructure::metadata_kinds::{metadata_kind, metadata_kind_by_directory};
 use crate::infrastructure::plugin_runtime::{find_plugin_root, value_to_cli_string};
 use crate::infrastructure::workspace_index::{
     IndexReadiness, IndexRunner, WorkspaceIndexService, SYSTEM_INDEX_RUNNER,
@@ -1466,7 +1467,9 @@ fn split_profile_name(raw: &str) -> (Option<String>, String) {
         "InformationRegister" | "РегистрСведений" => "InformationRegister",
         "AccumulationRegister" | "РегистрНакопления" => "AccumulationRegister",
         "Enum" | "Перечисление" => "Enum",
-        other => other,
+        other => metadata_kind(other)
+            .or_else(|| metadata_kind_by_directory(other))
+            .map_or(other, |kind| kind.tag),
     };
     (Some(category.to_string()), name.trim().to_string())
 }
@@ -2983,6 +2986,30 @@ mod tests {
     use std::path::Path;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn metadata_profile_selector_normalizes_bot_tag_and_directory_alias() {
+        assert_eq!(
+            split_profile_name("Bot.Assistant"),
+            (Some("Bot".to_string()), "Assistant".to_string())
+        );
+        assert_eq!(
+            split_profile_name("Bots.Assistant"),
+            (Some("Bot".to_string()), "Assistant".to_string())
+        );
+        assert_eq!(
+            split_profile_name("CommonModules.Core"),
+            (Some("CommonModule".to_string()), "Core".to_string())
+        );
+        assert_eq!(
+            split_profile_name("ОбщийМодуль.Core"),
+            (Some("CommonModule".to_string()), "Core".to_string())
+        );
+        assert_eq!(
+            split_profile_name("SyntheticMetadata.Unknown"),
+            (Some("SyntheticMetadata".to_string()), "Unknown".to_string())
+        );
+    }
 
     #[test]
     fn standards_search_maps_to_v8std_search_request() {

--- a/crates/unica-coder/src/infrastructure/metadata_kinds.rs
+++ b/crates/unica-coder/src/infrastructure/metadata_kinds.rs
@@ -1,0 +1,194 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MetadataKind {
+    pub(crate) tag: &'static str,
+    pub(crate) directory: &'static str,
+    pub(crate) display_name_ru: &'static str,
+    // ConfigDumpInfo is not mutated today; optional fields record only established facts.
+    #[allow(dead_code)]
+    pub(crate) config_dump_prefix: Option<&'static str>,
+    #[allow(dead_code)]
+    pub(crate) config_dump_module_suffix: Option<&'static str>,
+}
+
+macro_rules! metadata_kind_registry {
+    ($(
+        $tag:literal => {
+            directory: $directory:literal,
+            display_name_ru: $display_name_ru:literal,
+            config_dump_prefix: $config_dump_prefix:expr,
+            config_dump_module_suffix: $config_dump_module_suffix:expr $(,)?
+        }
+    ),+ $(,)?) => {
+        pub(crate) const METADATA_KINDS: &[MetadataKind] = &[
+            $(MetadataKind {
+                tag: $tag,
+                directory: $directory,
+                display_name_ru: $display_name_ru,
+                config_dump_prefix: $config_dump_prefix,
+                config_dump_module_suffix: $config_dump_module_suffix,
+            }),+
+        ];
+
+        pub(crate) const METADATA_KIND_TAGS: &[&str] = &[$($tag),+];
+    };
+}
+
+metadata_kind_registry! {
+    "Language" => { directory: "Languages", display_name_ru: "Языки", config_dump_prefix: None, config_dump_module_suffix: None },
+    "Subsystem" => { directory: "Subsystems", display_name_ru: "Подсистемы", config_dump_prefix: None, config_dump_module_suffix: None },
+    "StyleItem" => { directory: "StyleItems", display_name_ru: "Элементы стиля", config_dump_prefix: None, config_dump_module_suffix: None },
+    "Style" => { directory: "Styles", display_name_ru: "Стили", config_dump_prefix: None, config_dump_module_suffix: None },
+    "CommonPicture" => { directory: "CommonPictures", display_name_ru: "Общие картинки", config_dump_prefix: None, config_dump_module_suffix: None },
+    "SessionParameter" => { directory: "SessionParameters", display_name_ru: "Параметры сеанса", config_dump_prefix: None, config_dump_module_suffix: None },
+    "Role" => { directory: "Roles", display_name_ru: "Роли", config_dump_prefix: None, config_dump_module_suffix: None },
+    "CommonTemplate" => { directory: "CommonTemplates", display_name_ru: "Общие макеты", config_dump_prefix: None, config_dump_module_suffix: None },
+    "FilterCriterion" => { directory: "FilterCriteria", display_name_ru: "Критерии отбора", config_dump_prefix: None, config_dump_module_suffix: None },
+    "CommonModule" => { directory: "CommonModules", display_name_ru: "Общие модули", config_dump_prefix: None, config_dump_module_suffix: None },
+    "Bot" => { directory: "Bots", display_name_ru: "Боты", config_dump_prefix: Some("Bot"), config_dump_module_suffix: Some(".Module") },
+    "CommonAttribute" => { directory: "CommonAttributes", display_name_ru: "Общие реквизиты", config_dump_prefix: None, config_dump_module_suffix: None },
+    "ExchangePlan" => { directory: "ExchangePlans", display_name_ru: "Планы обмена", config_dump_prefix: None, config_dump_module_suffix: None },
+    "XDTOPackage" => { directory: "XDTOPackages", display_name_ru: "XDTO-пакеты", config_dump_prefix: None, config_dump_module_suffix: None },
+    "WebService" => { directory: "WebServices", display_name_ru: "Веб-сервисы", config_dump_prefix: None, config_dump_module_suffix: None },
+    "HTTPService" => { directory: "HTTPServices", display_name_ru: "HTTP-сервисы", config_dump_prefix: None, config_dump_module_suffix: None },
+    "WSReference" => { directory: "WSReferences", display_name_ru: "WS-ссылки", config_dump_prefix: None, config_dump_module_suffix: None },
+    "EventSubscription" => { directory: "EventSubscriptions", display_name_ru: "Подписки на события", config_dump_prefix: None, config_dump_module_suffix: None },
+    "ScheduledJob" => { directory: "ScheduledJobs", display_name_ru: "Регламентные задания", config_dump_prefix: None, config_dump_module_suffix: None },
+    "SettingsStorage" => { directory: "SettingsStorages", display_name_ru: "Хранилища настроек", config_dump_prefix: None, config_dump_module_suffix: None },
+    "FunctionalOption" => { directory: "FunctionalOptions", display_name_ru: "Функциональные опции", config_dump_prefix: None, config_dump_module_suffix: None },
+    "FunctionalOptionsParameter" => { directory: "FunctionalOptionsParameters", display_name_ru: "Параметры ФО", config_dump_prefix: None, config_dump_module_suffix: None },
+    "DefinedType" => { directory: "DefinedTypes", display_name_ru: "Определяемые типы", config_dump_prefix: None, config_dump_module_suffix: None },
+    "CommonCommand" => { directory: "CommonCommands", display_name_ru: "Общие команды", config_dump_prefix: None, config_dump_module_suffix: None },
+    "CommandGroup" => { directory: "CommandGroups", display_name_ru: "Группы команд", config_dump_prefix: None, config_dump_module_suffix: None },
+    "Constant" => { directory: "Constants", display_name_ru: "Константы", config_dump_prefix: None, config_dump_module_suffix: None },
+    "CommonForm" => { directory: "CommonForms", display_name_ru: "Общие формы", config_dump_prefix: None, config_dump_module_suffix: None },
+    "Catalog" => { directory: "Catalogs", display_name_ru: "Справочники", config_dump_prefix: None, config_dump_module_suffix: None },
+    "Document" => { directory: "Documents", display_name_ru: "Документы", config_dump_prefix: None, config_dump_module_suffix: None },
+    "DocumentNumerator" => { directory: "DocumentNumerators", display_name_ru: "Нумераторы", config_dump_prefix: None, config_dump_module_suffix: None },
+    "Sequence" => { directory: "Sequences", display_name_ru: "Последовательности", config_dump_prefix: None, config_dump_module_suffix: None },
+    "DocumentJournal" => { directory: "DocumentJournals", display_name_ru: "Журналы документов", config_dump_prefix: None, config_dump_module_suffix: None },
+    "Enum" => { directory: "Enums", display_name_ru: "Перечисления", config_dump_prefix: None, config_dump_module_suffix: None },
+    "Report" => { directory: "Reports", display_name_ru: "Отчёты", config_dump_prefix: None, config_dump_module_suffix: None },
+    "DataProcessor" => { directory: "DataProcessors", display_name_ru: "Обработки", config_dump_prefix: None, config_dump_module_suffix: None },
+    "InformationRegister" => { directory: "InformationRegisters", display_name_ru: "Регистры сведений", config_dump_prefix: None, config_dump_module_suffix: None },
+    "AccumulationRegister" => { directory: "AccumulationRegisters", display_name_ru: "Регистры накопления", config_dump_prefix: None, config_dump_module_suffix: None },
+    "ChartOfCharacteristicTypes" => { directory: "ChartsOfCharacteristicTypes", display_name_ru: "ПВХ", config_dump_prefix: None, config_dump_module_suffix: None },
+    "ChartOfAccounts" => { directory: "ChartsOfAccounts", display_name_ru: "Планы счетов", config_dump_prefix: None, config_dump_module_suffix: None },
+    "AccountingRegister" => { directory: "AccountingRegisters", display_name_ru: "Регистры бухгалтерии", config_dump_prefix: None, config_dump_module_suffix: None },
+    "ChartOfCalculationTypes" => { directory: "ChartsOfCalculationTypes", display_name_ru: "ПВР", config_dump_prefix: None, config_dump_module_suffix: None },
+    "CalculationRegister" => { directory: "CalculationRegisters", display_name_ru: "Регистры расчёта", config_dump_prefix: None, config_dump_module_suffix: None },
+    "BusinessProcess" => { directory: "BusinessProcesses", display_name_ru: "Бизнес-процессы", config_dump_prefix: None, config_dump_module_suffix: None },
+    "Task" => { directory: "Tasks", display_name_ru: "Задачи", config_dump_prefix: None, config_dump_module_suffix: None },
+    "IntegrationService" => { directory: "IntegrationServices", display_name_ru: "Сервисы интеграции", config_dump_prefix: None, config_dump_module_suffix: None },
+}
+
+pub(crate) fn metadata_kind(tag: &str) -> Option<&'static MetadataKind> {
+    METADATA_KINDS.iter().find(|kind| kind.tag == tag)
+}
+
+pub(crate) fn metadata_kind_by_directory(directory: &str) -> Option<&'static MetadataKind> {
+    METADATA_KINDS
+        .iter()
+        .find(|kind| kind.directory.eq_ignore_ascii_case(directory))
+}
+
+pub(crate) fn metadata_kind_index(tag: &str) -> Option<usize> {
+    METADATA_KINDS.iter().position(|kind| kind.tag == tag)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn registry_has_unique_canonical_tags_and_directories() {
+        const EXPECTED_TAGS: &[&str] = &[
+            "Language",
+            "Subsystem",
+            "StyleItem",
+            "Style",
+            "CommonPicture",
+            "SessionParameter",
+            "Role",
+            "CommonTemplate",
+            "FilterCriterion",
+            "CommonModule",
+            "Bot",
+            "CommonAttribute",
+            "ExchangePlan",
+            "XDTOPackage",
+            "WebService",
+            "HTTPService",
+            "WSReference",
+            "EventSubscription",
+            "ScheduledJob",
+            "SettingsStorage",
+            "FunctionalOption",
+            "FunctionalOptionsParameter",
+            "DefinedType",
+            "CommonCommand",
+            "CommandGroup",
+            "Constant",
+            "CommonForm",
+            "Catalog",
+            "Document",
+            "DocumentNumerator",
+            "Sequence",
+            "DocumentJournal",
+            "Enum",
+            "Report",
+            "DataProcessor",
+            "InformationRegister",
+            "AccumulationRegister",
+            "ChartOfCharacteristicTypes",
+            "ChartOfAccounts",
+            "AccountingRegister",
+            "ChartOfCalculationTypes",
+            "CalculationRegister",
+            "BusinessProcess",
+            "Task",
+            "IntegrationService",
+        ];
+
+        assert_eq!(METADATA_KINDS.len(), 45);
+        assert_eq!(METADATA_KIND_TAGS, EXPECTED_TAGS);
+        assert_eq!(METADATA_KIND_TAGS.len(), METADATA_KINDS.len());
+        assert_eq!(
+            METADATA_KIND_TAGS,
+            METADATA_KINDS
+                .iter()
+                .map(|kind| kind.tag)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            METADATA_KINDS
+                .iter()
+                .map(|kind| kind.tag)
+                .collect::<HashSet<_>>()
+                .len(),
+            METADATA_KINDS.len()
+        );
+        assert_eq!(
+            METADATA_KINDS
+                .iter()
+                .map(|kind| kind.directory.to_ascii_lowercase())
+                .collect::<HashSet<_>>()
+                .len(),
+            METADATA_KINDS.len()
+        );
+    }
+
+    #[test]
+    fn bot_registry_entry_models_known_platform_facts() {
+        let bot = metadata_kind("Bot").expect("Bot must be registered");
+        assert_eq!(bot.directory, "Bots");
+        assert_eq!(bot.display_name_ru, "Боты");
+        assert_eq!(bot.config_dump_prefix, Some("Bot"));
+        assert_eq!(bot.config_dump_module_suffix, Some(".Module"));
+        assert_eq!(
+            metadata_kind_index("Bot"),
+            metadata_kind_index("CommonModule").map(|index| index + 1)
+        );
+        assert_eq!(metadata_kind("SyntheticMetadata"), None);
+    }
+}

--- a/crates/unica-coder/src/infrastructure/mod.rs
+++ b/crates/unica-coder/src/infrastructure/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod bundled_tools;
 pub mod internal_adapters;
+pub(crate) mod metadata_kinds;
 pub mod native_operations;
 pub mod path_policy;
 pub mod plugin_runtime;

--- a/crates/unica-coder/src/infrastructure/native_operations/cf.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/cf.rs
@@ -1806,6 +1806,7 @@ pub(crate) fn edit_cf(args: &Map<String, Value>, context: &WorkspaceContext) -> 
         let obj_name = cf_edit_config_name(&text)?;
 
         let operations = cf_edit_operations(args, &context.cwd, operation, definition_file)?;
+        cf_edit_validate_child_object_kinds(&operations)?;
         let mut add_count = 0usize;
         let mut remove_count = 0usize;
         let mut modify_count = 0usize;
@@ -1842,15 +1843,8 @@ pub(crate) fn edit_cf(args: &Map<String, Value>, context: &WorkspaceContext) -> 
                 }
                 "remove-childObject" => {
                     for item in cf_edit_batch_value(&op_value) {
-                        let Some(dot_idx) = item.find('.') else {
-                            return Err(format!("Invalid format '{item}', expected 'Type.Name'"));
-                        };
-                        if dot_idx < 1 {
-                            return Err(format!("Invalid format '{item}', expected 'Type.Name'"));
-                        }
-                        let type_name = item[..dot_idx].to_string();
-                        let obj_name_val = item[dot_idx + 1..].to_string();
-                        if cf_edit_remove_child_object_text(&mut text, &type_name, &obj_name_val)? {
+                        let (type_name, obj_name_val) = cf_edit_parse_child_object(&item)?;
+                        if cf_edit_remove_child_object_text(&mut text, type_name, obj_name_val)? {
                             remove_count += 1;
                             config_changed = true;
                             stdout
@@ -1864,18 +1858,11 @@ pub(crate) fn edit_cf(args: &Map<String, Value>, context: &WorkspaceContext) -> 
                 }
                 "add-childObject" => {
                     for item in cf_edit_batch_value(&op_value) {
-                        let Some(dot_idx) = item.find('.') else {
-                            return Err(format!("Invalid format '{item}', expected 'Type.Name'"));
-                        };
-                        if dot_idx < 1 {
-                            return Err(format!("Invalid format '{item}', expected 'Type.Name'"));
-                        }
-                        let type_name = item[..dot_idx].to_string();
-                        let obj_name_val = item[dot_idx + 1..].to_string();
-                        if cf_validate_child_object_type_index(&type_name).is_none() {
+                        let (type_name, obj_name_val) = cf_edit_parse_child_object(&item)?;
+                        if cf_validate_child_object_type_index(type_name).is_none() {
                             return Err(format!("Unknown type '{type_name}'"));
                         }
-                        let type_dir = cf_validate_child_type_dir(&type_name)
+                        let type_dir = cf_validate_child_type_dir(type_name)
                             .ok_or_else(|| format!("Unknown type '{type_name}'"))?;
                         let object_file = config_dir
                             .join(type_dir)
@@ -1888,7 +1875,7 @@ pub(crate) fn edit_cf(args: &Map<String, Value>, context: &WorkspaceContext) -> 
                                      meta-compile does not support Bot; create the Bot metadata with platform tooling, then retry."
                                 ));
                             }
-                            let hint_skill = match type_name.as_str() {
+                            let hint_skill = match type_name {
                                 "Subsystem" => "subsystem-compile",
                                 "Role" => "role-compile",
                                 _ => "meta-compile",
@@ -1900,7 +1887,7 @@ pub(crate) fn edit_cf(args: &Map<String, Value>, context: &WorkspaceContext) -> 
                                    /{hint_skill} with {{\"type\":\"{type_name}\",\"name\":\"{obj_name_val}\"}}"
                             ));
                         }
-                        if cf_edit_add_child_object_text(&mut text, &type_name, &obj_name_val)? {
+                        if cf_edit_add_child_object_text(&mut text, type_name, obj_name_val)? {
                             add_count += 1;
                             config_changed = true;
                             stdout.push_str(&format!("[INFO] Added: {type_name}.{obj_name_val}\n"));
@@ -2089,6 +2076,33 @@ pub(crate) fn cf_edit_operations(
             ),
         )])
     }
+}
+
+pub(crate) fn cf_edit_validate_child_object_kinds(
+    operations: &[(String, Value)],
+) -> Result<(), String> {
+    for (op_name, op_value) in operations {
+        if !matches!(op_name.as_str(), "add-childObject" | "remove-childObject") {
+            continue;
+        }
+        for item in cf_edit_batch_value(op_value) {
+            let (type_name, _) = cf_edit_parse_child_object(&item)?;
+            if cf_validate_child_object_type_index(type_name).is_none() {
+                return Err(format!("Unknown type '{type_name}'"));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn cf_edit_parse_child_object(item: &str) -> Result<(&str, &str), String> {
+    let Some((type_name, object_name)) = item.split_once('.') else {
+        return Err(format!("Invalid format '{item}', expected 'Type.Name'"));
+    };
+    if type_name.is_empty() || object_name.is_empty() {
+        return Err(format!("Invalid format '{item}', expected 'Type.Name'"));
+    }
+    Ok((type_name, object_name))
 }
 
 pub(crate) fn cf_edit_batch_value(value: &Value) -> Vec<String> {

--- a/crates/unica-coder/src/infrastructure/native_operations/cf.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/cf.rs
@@ -1,6 +1,9 @@
 #![allow(dead_code, unused_imports)]
 
 use crate::domain::workspace::WorkspaceContext;
+use crate::infrastructure::metadata_kinds::{
+    metadata_kind, metadata_kind_by_directory, metadata_kind_index, METADATA_KIND_TAGS,
+};
 use crate::infrastructure::AdapterOutcome;
 use roxmltree::Document;
 use serde_json::{json, Map, Value};
@@ -800,108 +803,15 @@ pub(crate) fn cf_validate_enum_allowed(property: &str) -> &'static [&'static str
 }
 
 pub(crate) fn cf_validate_child_object_type_index(type_name: &str) -> Option<usize> {
-    cf_validate_child_object_types()
-        .iter()
-        .position(|known| *known == type_name)
+    metadata_kind_index(type_name)
 }
 
 pub(crate) fn cf_validate_child_object_types() -> &'static [&'static str] {
-    &[
-        "Language",
-        "Subsystem",
-        "StyleItem",
-        "Style",
-        "CommonPicture",
-        "SessionParameter",
-        "Role",
-        "CommonTemplate",
-        "FilterCriterion",
-        "CommonModule",
-        "CommonAttribute",
-        "ExchangePlan",
-        "XDTOPackage",
-        "WebService",
-        "HTTPService",
-        "WSReference",
-        "EventSubscription",
-        "ScheduledJob",
-        "SettingsStorage",
-        "FunctionalOption",
-        "FunctionalOptionsParameter",
-        "DefinedType",
-        "CommonCommand",
-        "CommandGroup",
-        "Constant",
-        "CommonForm",
-        "Catalog",
-        "Document",
-        "DocumentNumerator",
-        "Sequence",
-        "DocumentJournal",
-        "Enum",
-        "Report",
-        "DataProcessor",
-        "InformationRegister",
-        "AccumulationRegister",
-        "ChartOfCharacteristicTypes",
-        "ChartOfAccounts",
-        "AccountingRegister",
-        "ChartOfCalculationTypes",
-        "CalculationRegister",
-        "BusinessProcess",
-        "Task",
-        "IntegrationService",
-    ]
+    METADATA_KIND_TAGS
 }
 
 pub(crate) fn cf_validate_child_type_dir(type_name: &str) -> Option<&'static str> {
-    match type_name {
-        "Language" => Some("Languages"),
-        "Subsystem" => Some("Subsystems"),
-        "StyleItem" => Some("StyleItems"),
-        "Style" => Some("Styles"),
-        "CommonPicture" => Some("CommonPictures"),
-        "SessionParameter" => Some("SessionParameters"),
-        "Role" => Some("Roles"),
-        "CommonTemplate" => Some("CommonTemplates"),
-        "FilterCriterion" => Some("FilterCriteria"),
-        "CommonModule" => Some("CommonModules"),
-        "CommonAttribute" => Some("CommonAttributes"),
-        "ExchangePlan" => Some("ExchangePlans"),
-        "XDTOPackage" => Some("XDTOPackages"),
-        "WebService" => Some("WebServices"),
-        "HTTPService" => Some("HTTPServices"),
-        "WSReference" => Some("WSReferences"),
-        "EventSubscription" => Some("EventSubscriptions"),
-        "ScheduledJob" => Some("ScheduledJobs"),
-        "SettingsStorage" => Some("SettingsStorages"),
-        "FunctionalOption" => Some("FunctionalOptions"),
-        "FunctionalOptionsParameter" => Some("FunctionalOptionsParameters"),
-        "DefinedType" => Some("DefinedTypes"),
-        "CommonCommand" => Some("CommonCommands"),
-        "CommandGroup" => Some("CommandGroups"),
-        "Constant" => Some("Constants"),
-        "CommonForm" => Some("CommonForms"),
-        "Catalog" => Some("Catalogs"),
-        "Document" => Some("Documents"),
-        "DocumentNumerator" => Some("DocumentNumerators"),
-        "Sequence" => Some("Sequences"),
-        "DocumentJournal" => Some("DocumentJournals"),
-        "Enum" => Some("Enums"),
-        "Report" => Some("Reports"),
-        "DataProcessor" => Some("DataProcessors"),
-        "InformationRegister" => Some("InformationRegisters"),
-        "AccumulationRegister" => Some("AccumulationRegisters"),
-        "ChartOfCharacteristicTypes" => Some("ChartsOfCharacteristicTypes"),
-        "ChartOfAccounts" => Some("ChartsOfAccounts"),
-        "AccountingRegister" => Some("AccountingRegisters"),
-        "ChartOfCalculationTypes" => Some("ChartsOfCalculationTypes"),
-        "CalculationRegister" => Some("CalculationRegisters"),
-        "BusinessProcess" => Some("BusinessProcesses"),
-        "Task" => Some("Tasks"),
-        "IntegrationService" => Some("IntegrationServices"),
-        _ => None,
-    }
+    metadata_kind(type_name).map(|kind| kind.directory)
 }
 
 pub(crate) fn cf_validate_form_properties() -> &'static [&'static str] {
@@ -1799,101 +1709,76 @@ pub(crate) fn cf_paginate(lines: Vec<String>, args: &Map<String, Value>) -> Stri
 }
 
 pub(crate) fn cf_type_order() -> &'static [&'static str] {
-    &[
-        "Language",
-        "Subsystem",
-        "StyleItem",
-        "Style",
-        "CommonPicture",
-        "SessionParameter",
-        "Role",
-        "CommonTemplate",
-        "FilterCriterion",
-        "CommonModule",
-        "CommonAttribute",
-        "ExchangePlan",
-        "XDTOPackage",
-        "WebService",
-        "HTTPService",
-        "WSReference",
-        "EventSubscription",
-        "ScheduledJob",
-        "SettingsStorage",
-        "FunctionalOption",
-        "FunctionalOptionsParameter",
-        "DefinedType",
-        "CommonCommand",
-        "CommandGroup",
-        "Constant",
-        "CommonForm",
-        "Catalog",
-        "Document",
-        "DocumentNumerator",
-        "Sequence",
-        "DocumentJournal",
-        "Enum",
-        "Report",
-        "DataProcessor",
-        "InformationRegister",
-        "AccumulationRegister",
-        "ChartOfCharacteristicTypes",
-        "ChartOfAccounts",
-        "AccountingRegister",
-        "ChartOfCalculationTypes",
-        "CalculationRegister",
-        "BusinessProcess",
-        "Task",
-        "IntegrationService",
-    ]
+    METADATA_KIND_TAGS
 }
 
 pub(crate) fn cf_type_ru_name(type_name: &str) -> &'static str {
-    match type_name {
-        "Language" => "Языки",
-        "Subsystem" => "Подсистемы",
-        "StyleItem" => "Элементы стиля",
-        "Style" => "Стили",
-        "CommonPicture" => "Общие картинки",
-        "SessionParameter" => "Параметры сеанса",
-        "Role" => "Роли",
-        "CommonTemplate" => "Общие макеты",
-        "FilterCriterion" => "Критерии отбора",
-        "CommonModule" => "Общие модули",
-        "CommonAttribute" => "Общие реквизиты",
-        "ExchangePlan" => "Планы обмена",
-        "XDTOPackage" => "XDTO-пакеты",
-        "WebService" => "Веб-сервисы",
-        "HTTPService" => "HTTP-сервисы",
-        "WSReference" => "WS-ссылки",
-        "EventSubscription" => "Подписки на события",
-        "ScheduledJob" => "Регламентные задания",
-        "SettingsStorage" => "Хранилища настроек",
-        "FunctionalOption" => "Функциональные опции",
-        "FunctionalOptionsParameter" => "Параметры ФО",
-        "DefinedType" => "Определяемые типы",
-        "CommonCommand" => "Общие команды",
-        "CommandGroup" => "Группы команд",
-        "Constant" => "Константы",
-        "CommonForm" => "Общие формы",
-        "Catalog" => "Справочники",
-        "Document" => "Документы",
-        "DocumentNumerator" => "Нумераторы",
-        "Sequence" => "Последовательности",
-        "DocumentJournal" => "Журналы документов",
-        "Enum" => "Перечисления",
-        "Report" => "Отчёты",
-        "DataProcessor" => "Обработки",
-        "InformationRegister" => "Регистры сведений",
-        "AccumulationRegister" => "Регистры накопления",
-        "ChartOfCharacteristicTypes" => "ПВХ",
-        "ChartOfAccounts" => "Планы счетов",
-        "AccountingRegister" => "Регистры бухгалтерии",
-        "ChartOfCalculationTypes" => "ПВР",
-        "CalculationRegister" => "Регистры расчёта",
-        "BusinessProcess" => "Бизнес-процессы",
-        "Task" => "Задачи",
-        "IntegrationService" => "Сервисы интеграции",
-        _ => "Unknown",
+    metadata_kind(type_name).map_or("Unknown", |kind| kind.display_name_ru)
+}
+
+#[cfg(test)]
+mod metadata_kind_consumer_tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn cf_consumers_share_the_canonical_metadata_kind_order() {
+        let validate_kinds = cf_validate_child_object_types();
+
+        assert_eq!(validate_kinds.len(), 45);
+        assert_eq!(validate_kinds, cf_type_order());
+        let bot_index = validate_kinds
+            .iter()
+            .position(|kind| *kind == "Bot")
+            .expect("Bot must be a modeled metadata kind");
+        assert_eq!(validate_kinds[bot_index - 1], "CommonModule");
+        assert_eq!(validate_kinds[bot_index + 1], "CommonAttribute");
+        assert_eq!(cf_validate_child_type_dir("Bot"), Some("Bots"));
+        assert_eq!(cf_type_ru_name("Bot"), "Боты");
+        assert_eq!(cf_validate_child_type_dir("SyntheticMetadata"), None);
+
+        let directories = validate_kinds
+            .iter()
+            .map(|kind| cf_validate_child_type_dir(kind).expect("known kind has a directory"))
+            .collect::<HashSet<_>>();
+        assert_eq!(directories.len(), validate_kinds.len());
+        for kind in validate_kinds {
+            let directory = cf_validate_child_type_dir(kind).unwrap();
+            assert_eq!(cf_edit_dir_to_type(directory), Some(*kind));
+        }
+    }
+
+    #[test]
+    fn child_object_insertion_orders_bot_and_rejects_unknown_kinds() {
+        let mut xml = concat!(
+            "<MetaDataObject><Configuration><ChildObjects>\n",
+            "\t<CommonModule>Core</CommonModule>\n",
+            "\t<CommonAttribute>Shared</CommonAttribute>\n",
+            "</ChildObjects></Configuration></MetaDataObject>"
+        )
+        .to_string();
+
+        assert!(cf_edit_add_child_object_text(&mut xml, "Bot", "Assistant").unwrap());
+        assert!(
+            xml.find("<CommonModule>Core</CommonModule>").unwrap()
+                < xml.find("<Bot>Assistant</Bot>").unwrap()
+        );
+        assert!(
+            xml.find("<Bot>Assistant</Bot>").unwrap()
+                < xml
+                    .find("<CommonAttribute>Shared</CommonAttribute>")
+                    .unwrap()
+        );
+        assert!(!cf_edit_add_child_object_text(&mut xml, "Bot", "Assistant").unwrap());
+
+        let before_unknown = xml.clone();
+        let error = cf_edit_add_child_object_text(&mut xml, "SyntheticMetadata", "Unknown")
+            .expect_err("unknown metadata kinds must be rejected");
+        assert!(
+            error.contains("Unknown type 'SyntheticMetadata'"),
+            "{error}"
+        );
+        assert_eq!(xml, before_unknown);
     }
 }
 
@@ -1996,6 +1881,13 @@ pub(crate) fn edit_cf(args: &Map<String, Value>, context: &WorkspaceContext) -> 
                             .join(type_dir)
                             .join(format!("{obj_name_val}.xml"));
                         if !object_file.exists() {
+                            if type_name == "Bot" {
+                                return Err(format!(
+                                    "Object file not found: {type_dir}/{obj_name_val}.xml\n\
+                                     cf-edit add-childObject only references objects that already exist on disk.\n\
+                                     meta-compile does not support Bot; create the Bot metadata with platform tooling, then retry."
+                                ));
+                            }
                             let hint_skill = match type_name.as_str() {
                                 "Subsystem" => "subsystem-compile",
                                 "Role" => "role-compile",
@@ -2423,7 +2315,9 @@ pub(crate) fn cf_edit_child_object_entries(
         } else {
             range.start
         };
-        let end = if text[range.end..].starts_with('\n') {
+        let end = if text[range.end..].starts_with("\r\n") {
+            range.end + 2
+        } else if text[range.end..].starts_with('\n') {
             range.end + 1
         } else {
             range.end
@@ -2474,6 +2368,9 @@ pub(crate) fn cf_edit_remove_child_object_text(
     type_name: &str,
     object_name: &str,
 ) -> Result<bool, String> {
+    if metadata_kind(type_name).is_none() {
+        return Err(format!("Unknown type '{type_name}'"));
+    }
     let entries = cf_edit_child_object_entries(text)?;
     let Some(entry) = entries
         .into_iter()
@@ -2490,6 +2387,8 @@ pub(crate) fn cf_edit_add_child_object_text(
     type_name: &str,
     object_name: &str,
 ) -> Result<bool, String> {
+    let new_type_index =
+        metadata_kind_index(type_name).ok_or_else(|| format!("Unknown type '{type_name}'"))?;
     let Some((child_start, child_end, body_range)) = cf_edit_element_range(text, "ChildObjects")
     else {
         return Err("No <ChildObjects> element found".to_string());
@@ -2502,7 +2401,6 @@ pub(crate) fn cf_edit_add_child_object_text(
         return Ok(false);
     }
 
-    let new_type_index = cf_validate_child_object_type_index(type_name).unwrap_or(usize::MAX);
     let target = entries.iter().find(|entry| {
         let entry_type_index =
             cf_validate_child_object_type_index(&entry.type_name).unwrap_or(usize::MAX);
@@ -2966,27 +2864,7 @@ pub(crate) fn cf_edit_ru_type(value: &str) -> Option<&'static str> {
 }
 
 pub(crate) fn cf_edit_dir_to_type(value: &str) -> Option<&'static str> {
-    match value.to_lowercase().as_str() {
-        "catalogs" => Some("Catalog"),
-        "documents" => Some("Document"),
-        "enums" => Some("Enum"),
-        "reports" => Some("Report"),
-        "dataprocessors" => Some("DataProcessor"),
-        "commonforms" => Some("CommonForm"),
-        "documentjournals" => Some("DocumentJournal"),
-        "informationregisters" => Some("InformationRegister"),
-        "accumulationregisters" => Some("AccumulationRegister"),
-        "chartsofcharacteristictypes" => Some("ChartOfCharacteristicTypes"),
-        "chartsofaccounts" => Some("ChartOfAccounts"),
-        "accountingregisters" => Some("AccountingRegister"),
-        "chartsofcalculationtypes" => Some("ChartOfCalculationTypes"),
-        "calculationregisters" => Some("CalculationRegister"),
-        "businessprocesses" => Some("BusinessProcess"),
-        "tasks" => Some("Task"),
-        "exchangeplans" => Some("ExchangePlan"),
-        "settingsstorages" => Some("SettingsStorage"),
-        _ => None,
-    }
+    metadata_kind_by_directory(value).map(|kind| kind.tag)
 }
 
 pub(crate) fn cf_edit_json_object(

--- a/crates/unica-coder/src/infrastructure/native_operations/meta.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code, unused_imports)]
 
 use crate::domain::workspace::WorkspaceContext;
+use crate::infrastructure::metadata_kinds::metadata_kind;
 use crate::infrastructure::AdapterOutcome;
 use roxmltree::Document;
 use serde_json::{json, Map, Value};
@@ -33,6 +34,123 @@ mod uuid_tests {
             matches!(value.as_bytes()[19], b'8' | b'9' | b'a' | b'b'),
             "{value}"
         );
+    }
+}
+
+#[cfg(test)]
+mod registration_tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_output_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let output_dir = std::env::temp_dir().join(format!("unica-register-{name}-{nanos}"));
+        fs::create_dir_all(&output_dir).unwrap();
+        output_dir
+    }
+
+    #[test]
+    fn root_registration_uses_canonical_order_and_is_idempotent() {
+        let output_dir = temp_output_dir("canonical");
+        let config_path = output_dir.join("Configuration.xml");
+        fs::write(
+            &config_path,
+            concat!(
+                "<MetaDataObject><Configuration><ChildObjects>\n",
+                "\t<CommonModule>Core</CommonModule>\n",
+                "\t<CommonAttribute>Shared</CommonAttribute>\n",
+                "</ChildObjects></Configuration></MetaDataObject>"
+            ),
+        )
+        .unwrap();
+
+        let status = register_compiled_meta_in_configuration(&output_dir, "Bot", "Assistant")
+            .expect("Bot registration must succeed");
+        assert_eq!(status.as_deref(), Some("added"));
+        let after_add = fs::read_to_string(&config_path).unwrap();
+        assert!(
+            after_add.find("<CommonModule>Core</CommonModule>").unwrap()
+                < after_add.find("<Bot>Assistant</Bot>").unwrap()
+        );
+        assert!(
+            after_add.find("<Bot>Assistant</Bot>").unwrap()
+                < after_add
+                    .find("<CommonAttribute>Shared</CommonAttribute>")
+                    .unwrap()
+        );
+
+        let duplicate = register_compiled_meta_in_configuration(&output_dir, "Bot", "Assistant")
+            .expect("duplicate registration must be a no-op");
+        assert_eq!(duplicate.as_deref(), Some("already"));
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), after_add);
+
+        fs::remove_dir_all(output_dir).unwrap();
+    }
+
+    #[test]
+    fn root_registration_expands_self_closing_child_objects() {
+        let output_dir = temp_output_dir("self-closing");
+        let config_path = output_dir.join("Configuration.xml");
+        fs::write(
+            &config_path,
+            "<MetaDataObject><Configuration><ChildObjects/></Configuration></MetaDataObject>",
+        )
+        .unwrap();
+
+        let status = register_compiled_meta_in_configuration(&output_dir, "Bot", "Assistant")
+            .expect("Bot registration must succeed");
+
+        assert_eq!(status.as_deref(), Some("added"));
+        assert!(fs::read_to_string(&config_path)
+            .unwrap()
+            .contains("<ChildObjects>\n\t<Bot>Assistant</Bot>\n</ChildObjects>"));
+        fs::remove_dir_all(output_dir).unwrap();
+    }
+
+    #[test]
+    fn root_registration_rejects_unknown_metadata_kind_without_mutation() {
+        let output_dir = temp_output_dir("unknown");
+        let config_path = output_dir.join("Configuration.xml");
+        let before =
+            "<MetaDataObject><Configuration><ChildObjects/></Configuration></MetaDataObject>";
+        fs::write(&config_path, before).unwrap();
+
+        let error =
+            register_compiled_meta_in_configuration(&output_dir, "SyntheticMetadata", "Unknown")
+                .expect_err("unknown metadata kinds must be rejected");
+
+        assert!(
+            error.contains("Unknown type 'SyntheticMetadata'"),
+            "{error}"
+        );
+        assert_eq!(fs::read_to_string(&config_path).unwrap(), before);
+        fs::remove_dir_all(output_dir).unwrap();
+    }
+
+    #[test]
+    fn narrower_metadata_capability_sets_use_registry_directories_without_expansion() {
+        assert_eq!(meta_remove_supported_types().len(), 39);
+        assert!(!meta_remove_supported_types().contains(&"Bot"));
+        for object_type in meta_remove_supported_types() {
+            assert_eq!(
+                meta_remove_type_plural(object_type),
+                metadata_kind(object_type).map(|kind| kind.directory)
+            );
+        }
+
+        assert_eq!(META_COMPILE_SUPPORTED_TYPES.len(), 23);
+        assert!(!META_COMPILE_SUPPORTED_TYPES.contains(&"Bot"));
+        for object_type in META_COMPILE_SUPPORTED_TYPES {
+            assert_eq!(
+                meta_compile_type_plural(object_type),
+                metadata_kind(object_type).map(|kind| kind.directory)
+            );
+        }
+        assert_eq!(meta_compile_type_plural("Bot"), None);
+        assert_eq!(meta_remove_type_plural("Bot"), None);
     }
 }
 
@@ -5510,48 +5628,10 @@ pub(crate) fn meta_remove_supported_types() -> &'static [&'static str] {
 }
 
 pub(crate) fn meta_remove_type_plural(obj_type: &str) -> Option<&'static str> {
-    match obj_type {
-        "Catalog" => Some("Catalogs"),
-        "Document" => Some("Documents"),
-        "Enum" => Some("Enums"),
-        "Constant" => Some("Constants"),
-        "InformationRegister" => Some("InformationRegisters"),
-        "AccumulationRegister" => Some("AccumulationRegisters"),
-        "AccountingRegister" => Some("AccountingRegisters"),
-        "CalculationRegister" => Some("CalculationRegisters"),
-        "ChartOfAccounts" => Some("ChartsOfAccounts"),
-        "ChartOfCharacteristicTypes" => Some("ChartsOfCharacteristicTypes"),
-        "ChartOfCalculationTypes" => Some("ChartsOfCalculationTypes"),
-        "BusinessProcess" => Some("BusinessProcesses"),
-        "Task" => Some("Tasks"),
-        "ExchangePlan" => Some("ExchangePlans"),
-        "DocumentJournal" => Some("DocumentJournals"),
-        "Report" => Some("Reports"),
-        "DataProcessor" => Some("DataProcessors"),
-        "CommonModule" => Some("CommonModules"),
-        "ScheduledJob" => Some("ScheduledJobs"),
-        "EventSubscription" => Some("EventSubscriptions"),
-        "HTTPService" => Some("HTTPServices"),
-        "WebService" => Some("WebServices"),
-        "DefinedType" => Some("DefinedTypes"),
-        "Role" => Some("Roles"),
-        "Subsystem" => Some("Subsystems"),
-        "CommonForm" => Some("CommonForms"),
-        "CommonTemplate" => Some("CommonTemplates"),
-        "CommonPicture" => Some("CommonPictures"),
-        "CommonAttribute" => Some("CommonAttributes"),
-        "SessionParameter" => Some("SessionParameters"),
-        "FunctionalOption" => Some("FunctionalOptions"),
-        "FunctionalOptionsParameter" => Some("FunctionalOptionsParameters"),
-        "Sequence" => Some("Sequences"),
-        "FilterCriterion" => Some("FilterCriteria"),
-        "SettingsStorage" => Some("SettingsStorages"),
-        "XDTOPackage" => Some("XDTOPackages"),
-        "WSReference" => Some("WSReferences"),
-        "StyleItem" => Some("StyleItems"),
-        "Language" => Some("Languages"),
-        _ => None,
+    if !meta_remove_supported_types().contains(&obj_type) {
+        return None;
     }
+    metadata_kind(obj_type).map(|kind| kind.directory)
 }
 
 pub(crate) fn meta_remove_type_ref_names(obj_type: &str) -> Option<&'static [&'static str]> {
@@ -5627,32 +5707,10 @@ pub(crate) const META_COMPILE_SUPPORTED_TYPES: &[&str] = &[
 pub(crate) const META_COMPILE_PENDING_TYPES: &[&str] = &[];
 
 pub(crate) fn meta_compile_type_plural(obj_type: &str) -> Option<&'static str> {
-    match obj_type {
-        "Catalog" => Some("Catalogs"),
-        "Document" => Some("Documents"),
-        "Enum" => Some("Enums"),
-        "Constant" => Some("Constants"),
-        "InformationRegister" => Some("InformationRegisters"),
-        "AccumulationRegister" => Some("AccumulationRegisters"),
-        "AccountingRegister" => Some("AccountingRegisters"),
-        "CalculationRegister" => Some("CalculationRegisters"),
-        "ChartOfAccounts" => Some("ChartsOfAccounts"),
-        "ChartOfCharacteristicTypes" => Some("ChartsOfCharacteristicTypes"),
-        "ChartOfCalculationTypes" => Some("ChartsOfCalculationTypes"),
-        "BusinessProcess" => Some("BusinessProcesses"),
-        "Task" => Some("Tasks"),
-        "ExchangePlan" => Some("ExchangePlans"),
-        "DocumentJournal" => Some("DocumentJournals"),
-        "Report" => Some("Reports"),
-        "DataProcessor" => Some("DataProcessors"),
-        "CommonModule" => Some("CommonModules"),
-        "ScheduledJob" => Some("ScheduledJobs"),
-        "EventSubscription" => Some("EventSubscriptions"),
-        "HTTPService" => Some("HTTPServices"),
-        "WebService" => Some("WebServices"),
-        "DefinedType" => Some("DefinedTypes"),
-        _ => None,
+    if !META_COMPILE_SUPPORTED_TYPES.contains(&obj_type) {
+        return None;
     }
+    metadata_kind(obj_type).map(|kind| kind.directory)
 }
 
 pub(crate) fn meta_compile_uses_object_subdir(obj_type: &str) -> bool {
@@ -9312,65 +9370,21 @@ pub(crate) fn register_compiled_meta_in_configuration(
     child_tag: &str,
     obj_name: &str,
 ) -> Result<Option<String>, String> {
+    metadata_kind(child_tag).ok_or_else(|| format!("Unknown type '{child_tag}'"))?;
     let config_xml_path = output_dir.join("Configuration.xml");
     if !config_xml_path.is_file() {
         return Ok(Some("no-config".to_string()));
     }
     let mut raw_text = read_utf8_sig(&config_xml_path)?;
-    if raw_text.contains(&format!("<{child_tag}>{obj_name}</{child_tag}>")) {
-        return Ok(Some("already".to_string()));
+    if !raw_text.contains("<ChildObjects") {
+        return Ok(Some("no-childobj".to_string()));
     }
-    if raw_text.contains("</ChildObjects>") {
-        raw_text =
-            register_compiled_meta_child_text(&raw_text, child_tag, obj_name).unwrap_or(raw_text);
+    if cf_edit_add_child_object_text(&mut raw_text, child_tag, obj_name)? {
         write_utf8_bom(&config_xml_path, &raw_text)?;
         Ok(Some("added".to_string()))
     } else {
-        Ok(Some("no-childobj".to_string()))
+        Ok(Some("already".to_string()))
     }
-}
-
-fn register_compiled_meta_child_text(
-    xml_text: &str,
-    child_tag: &str,
-    obj_name: &str,
-) -> Option<String> {
-    let close = "</ChildObjects>";
-    let index = xml_text.find(close)?;
-    let line_start = xml_text[..index].rfind('\n').map_or(0, |pos| pos + 1);
-    let before_close_on_line = &xml_text[line_start..index];
-    let closing_indent = if before_close_on_line
-        .chars()
-        .all(|ch| ch == '\t' || ch == ' ')
-    {
-        before_close_on_line
-    } else {
-        let open_index = xml_text[..index].rfind("<ChildObjects")?;
-        let open_line_start = xml_text[..open_index].rfind('\n').map_or(0, |pos| pos + 1);
-        let open_indent = &xml_text[open_line_start..open_index];
-        if open_indent.chars().all(|ch| ch == '\t' || ch == ' ') {
-            open_indent
-        } else {
-            ""
-        }
-    };
-    let insertion = format!("<{child_tag}>{obj_name}</{child_tag}>");
-    let mut result =
-        String::with_capacity(xml_text.len() + 1 + insertion.len() + 1 + closing_indent.len());
-    result.push_str(&xml_text[..index]);
-    if !before_close_on_line
-        .chars()
-        .all(|ch| ch == '\t' || ch == ' ')
-    {
-        result.push('\n');
-        result.push_str(closing_indent);
-    }
-    result.push('\t');
-    result.push_str(&insertion);
-    result.push('\n');
-    result.push_str(closing_indent);
-    result.push_str(&xml_text[index..]);
-    Some(result)
 }
 
 #[derive(Default)]


### PR DESCRIPTION
Closes #78.

## Изменения

- добавлен единый упорядоченный registry из 45 metadata kinds;
- `Bot → Bots` (`Боты`) расположен после `CommonModule`; сохранены установленные факты `ConfigDumpInfo`: prefix `Bot`, suffix `.Module`;
- `cf.info`, `cf.validate`, `cf.edit`, registration writer и runtime selector normalization используют registry;
- узкие capability sets `meta.compile` (23) и `meta.remove` (39) не расширены: `Bot` в них не добавлен;
- batch `cf.edit` теперь предварительно проверяет все `add-childObject`/`remove-childObject` до любой записи; unknown kind и malformed `Type.Name` не могут изменить `Configuration.xml` или sidecar XML;
- разбор `Type.Name` общий для preflight и execution paths, поэтому validation и запись не расходятся.

## Проверки

- TDD RED/GREEN: 4 сценария unknown kind (`set-panels`/`set-home-page` × add/remove) и malformed `Catalog.`; после failed batch сравниваются исходные байты `Configuration.xml`, definition file и sidecar;
- `cargo fmt --all -- --check`;
- `cargo clippy --locked -p unica-coder --all-targets -- -D warnings`;
- `cargo test --workspace --locked` — 254 passed;
- `uv run --with lxml --with pyyaml python -m unittest discover -s tests/ci` — завершился успешно;
- `git diff --check`.

## Ревью и границы

- независимые spec-review и Rust quality review выполнили два полных цикла после исправлений; Critical/Important замечаний не осталось;
- `ConfigDumpInfo.xml` не изменяется;
- platform round-trip не запускался: в репозитории нет изолированного 1С workspace, а установленный MCP-плагин не собран из HEAD этого PR.