### PR TITLE
feat: scaffold EPF и ERF через MCP (#49)

### DIFF
--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -885,6 +885,34 @@ fn configuration_tools() -> Vec<ToolSpec> {
             },
         },
         ToolSpec {
+            name: "unica.epf.init",
+            description:
+                "Create a make-ready external data processor scaffold in a Designer/platform-XML external source-set, optionally with a managed form.",
+            mutating: true,
+            cache_access: cache_access_for(
+                "epf-init",
+                Some(DomainEventKind::SourceSetChanged),
+            ),
+            handler: ToolHandler::NativeOperation {
+                operation: "epf-init",
+                event: Some(DomainEventKind::SourceSetChanged),
+            },
+        },
+        ToolSpec {
+            name: "unica.erf.init",
+            description:
+                "Create a make-ready external report scaffold in a Designer/platform-XML external source-set, optionally with a managed form.",
+            mutating: true,
+            cache_access: cache_access_for(
+                "erf-init",
+                Some(DomainEventKind::SourceSetChanged),
+            ),
+            handler: ToolHandler::NativeOperation {
+                operation: "erf-init",
+                event: Some(DomainEventKind::SourceSetChanged),
+            },
+        },
+        ToolSpec {
             name: "unica.cfe.patch_method",
             description: "Generate a CFE method interceptor.",
             mutating: true,
@@ -1305,6 +1333,8 @@ mod tests {
         assert!(names.contains(&"unica.mxl.compile"));
         assert!(names.contains(&"unica.role.validate"));
         assert!(names.contains(&"unica.support.edit"));
+        assert!(names.contains(&"unica.epf.init"));
+        assert!(names.contains(&"unica.erf.init"));
         assert!(names.contains(&"unica.build.load"));
         assert!(names.contains(&"unica.runtime.execute"));
         assert!(names.contains(&"unica.code.definition"));
@@ -4617,6 +4647,211 @@ mod tests {
 
         assert!(error.contains("outside workspace root"));
         assert!(!root.join("outside").exists());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn external_init_preview_is_path_guarded_and_source_set_typed() {
+        let root = std::env::temp_dir().join(format!(
+            "unica-external-init-contract-{}",
+            std::process::id()
+        ));
+        let workspace = root.join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::write(
+            workspace.join("v8project.yaml"),
+            concat!(
+                "format: DESIGNER\n",
+                "source-set:\n",
+                "  - name: processors\n",
+                "    type: EXTERNAL_DATA_PROCESSORS\n",
+                "    path: epf\n",
+                "  - name: reports\n",
+                "    type: EXTERNAL_REPORTS\n",
+                "    path: erf\n",
+                "  - name: russian-processors\n",
+                "    type: EXTERNAL_DATA_PROCESSORS\n",
+                "    path: епф\n",
+            ),
+        )
+        .unwrap();
+
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(true));
+        args.insert("Name".to_string(), Value::String("Preview".to_string()));
+        args.insert("OutputDir".to_string(), Value::String("epf".to_string()));
+
+        let preview = UnicaApplication::new()
+            .call_tool("unica.epf.init", &args)
+            .unwrap();
+        assert!(preview.ok, "{:?}", preview.errors);
+        assert_eq!(preview.artifacts.len(), 2);
+        assert!(!workspace.join("epf").exists());
+
+        args.insert("OutputDir".to_string(), Value::String("EPF".to_string()));
+        let error = UnicaApplication::new()
+            .call_tool("unica.epf.init", &args)
+            .unwrap_err();
+        assert!(error.contains("exact source-set root"), "{error}");
+        assert!(!workspace.join("EPF").exists());
+
+        args.insert("OutputDir".to_string(), Value::String("ЕПФ".to_string()));
+        let error = UnicaApplication::new()
+            .call_tool("unica.epf.init", &args)
+            .unwrap_err();
+        assert!(error.contains("exact source-set root"), "{error}");
+        assert!(!workspace.join("ЕПФ").exists());
+
+        args.insert(
+            "OutputDir".to_string(),
+            Value::String("epf/nested".to_string()),
+        );
+        let error = UnicaApplication::new()
+            .call_tool("unica.epf.init", &args)
+            .unwrap_err();
+        assert!(error.contains("source-set root"), "{error}");
+        assert!(!workspace.join("epf").exists());
+
+        args.insert("OutputDir".to_string(), Value::String("erf".to_string()));
+        let error = UnicaApplication::new()
+            .call_tool("unica.epf.init", &args)
+            .unwrap_err();
+        assert!(error.contains("source-set `reports`"), "{error}");
+        assert!(error.contains("ExternalReport"), "{error}");
+        assert!(!workspace.join("erf").exists());
+
+        args.insert(
+            "OutputDir".to_string(),
+            Value::String("../outside".to_string()),
+        );
+        let error = UnicaApplication::new()
+            .call_tool("unica.epf.init", &args)
+            .unwrap_err();
+        assert!(error.contains("outside workspace root"), "{error}");
+        assert!(!root.join("outside").exists());
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(workspace.join("erf"), workspace.join("epf-link")).unwrap();
+            args.insert(
+                "OutputDir".to_string(),
+                Value::String("epf-link".to_string()),
+            );
+            let error = UnicaApplication::new()
+                .call_tool("unica.epf.init", &args)
+                .unwrap_err();
+            assert!(error.contains("must not traverse symlink"), "{error}");
+        }
+
+        std::fs::write(
+            workspace.join("v8project.yaml"),
+            concat!(
+                "format: DESIGNER\n",
+                "source-set:\n",
+                "  - name: configuration\n",
+                "    type: CONFIGURATION\n",
+                "    path: .\n",
+            ),
+        )
+        .unwrap();
+        args.insert(
+            "OutputDir".to_string(),
+            Value::String("external/epf".to_string()),
+        );
+        let preview = UnicaApplication::new()
+            .call_tool("unica.epf.init", &args)
+            .unwrap();
+        assert!(preview.ok, "{:?}", preview.errors);
+        assert_eq!(preview.artifacts.len(), 2);
+        assert!(!workspace.join("external").exists());
+
+        args.insert("OutputDir".to_string(), Value::String(".".to_string()));
+        let error = UnicaApplication::new()
+            .call_tool("unica.epf.init", &args)
+            .unwrap_err();
+        assert!(error.contains("source-set `configuration`"), "{error}");
+        assert!(error.contains("Configuration"), "{error}");
+
+        std::fs::write(
+            workspace.join("v8project.yaml"),
+            concat!(
+                "format: DESIGNER\n",
+                "source-set:\n",
+                "  - name: configuration\n",
+                "    type: CONFIGURATION\n",
+                "    path: src\n",
+            ),
+        )
+        .unwrap();
+        args.insert("OutputDir".to_string(), Value::String("SRC".to_string()));
+        let error = UnicaApplication::new()
+            .call_tool("unica.epf.init", &args)
+            .unwrap_err();
+        assert!(error.contains("exact source-set root"), "{error}");
+        assert!(!workspace.join("SRC").exists());
+
+        std::fs::write(
+            workspace.join("v8project.yaml"),
+            concat!(
+                "format: EDT\n",
+                "source-set:\n",
+                "  - name: processors\n",
+                "    type: EXTERNAL_DATA_PROCESSORS\n",
+                "    path: epf\n",
+            ),
+        )
+        .unwrap();
+        std::fs::create_dir_all(workspace.join("epf")).unwrap();
+        std::fs::write(
+            workspace.join("epf/Existing.xml"),
+            "<MetaDataObject><ExternalDataProcessor/></MetaDataObject>",
+        )
+        .unwrap();
+        args.insert("OutputDir".to_string(), Value::String("epf".to_string()));
+        let error = UnicaApplication::new()
+            .call_tool("unica.epf.init", &args)
+            .unwrap_err();
+        assert!(error.contains("format=DESIGNER"), "{error}");
+        assert!(!workspace.join("epf/Preview.xml").exists());
+
+        std::fs::write(
+            workspace.join("v8project.yaml"),
+            concat!(
+                "format: designer\n",
+                "source-set:\n",
+                "  - name: processors\n",
+                "    type: EXTERNAL_DATA_PROCESSORS\n",
+                "    path: epf\n",
+            ),
+        )
+        .unwrap();
+        let error = UnicaApplication::new()
+            .call_tool("unica.epf.init", &args)
+            .unwrap_err();
+        assert!(error.contains("exact `DESIGNER`"), "{error}");
+        assert!(!workspace.join("epf/Preview.xml").exists());
+
+        std::fs::write(
+            workspace.join("v8project.yaml"),
+            concat!(
+                "format: true\n",
+                "source-set:\n",
+                "  - name: processors\n",
+                "    type: EXTERNAL_DATA_PROCESSORS\n",
+                "    path: epf\n",
+            ),
+        )
+        .unwrap();
+        let error = UnicaApplication::new()
+            .call_tool("unica.epf.init", &args)
+            .unwrap_err();
+        assert!(error.contains("field `format` must be a string"), "{error}");
+        assert!(!workspace.join("epf/Preview.xml").exists());
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/crates/unica-coder/src/application/operation_descriptors.rs
+++ b/crates/unica-coder/src/application/operation_descriptors.rs
@@ -64,6 +64,7 @@ const FORM_EDIT_REQUIRED: &[&str] = &["FormPath", "JsonPath"];
 const SUBSYSTEM_COMPILE_REQUIRED: &[&str] = &["OutputDir"];
 const MXL_COMPILE_REQUIRED: &[&str] = &["JsonPath", "OutputPath"];
 const ROLE_COMPILE_REQUIRED: &[&str] = &["JsonPath", "OutputDir"];
+const EXTERNAL_INIT_REQUIRED: &[&str] = &["Name", "OutputDir"];
 
 pub(super) fn native_operation_descriptor(operation: &str) -> Option<&'static OperationDescriptor> {
     NATIVE_OPERATION_DESCRIPTORS
@@ -98,6 +99,20 @@ pub(super) const NATIVE_OPERATION_DESCRIPTORS: &[OperationDescriptor] = &[
         None,
     ),
     descriptor("cfe-init", EMPTY, OUTPUT_DIR, OUTPUT_DIR, None),
+    descriptor(
+        "epf-init",
+        EXTERNAL_INIT_REQUIRED,
+        OUTPUT_DIR,
+        OUTPUT_DIR,
+        None,
+    ),
+    descriptor(
+        "erf-init",
+        EXTERNAL_INIT_REQUIRED,
+        OUTPUT_DIR,
+        OUTPUT_DIR,
+        None,
+    ),
     descriptor(
         "cfe-patch-method",
         CFE_PATCH_METHOD_REQUIRED,

--- a/crates/unica-coder/src/application/tool_contracts.rs
+++ b/crates/unica-coder/src/application/tool_contracts.rs
@@ -1,6 +1,6 @@
 use super::operation_descriptors::native_operation_descriptor;
 use super::{ToolHandler, ToolSpec};
-use crate::domain::project_sources::{discover_project_source_map, SourceFormat};
+use crate::domain::project_sources::{discover_project_source_map, SourceFormat, SourceSetKind};
 use crate::domain::workspace::WorkspaceContext;
 use crate::infrastructure::path_policy::WorkspacePathPolicy;
 use serde_json::{json, Map, Value};
@@ -218,6 +218,8 @@ const NATIVE_XML_DSL_ARGS: &[&str] = &[
     "version",
     "withText",
 ];
+
+const EXTERNAL_INIT_ARGS: &[&str] = &["FormName", "Name", "OutputDir", "Synonym"];
 
 const BUILD_ARGS: &[&str] = &[
     "config",
@@ -588,8 +590,9 @@ pub fn validate_tool_arguments(
     validate_form_add_arguments(tool, args)?;
     validate_template_add_arguments(tool, args)?;
     validate_support_arguments(tool, args, dry_run)?;
+    validate_external_init_arguments(tool, args)?;
 
-    if !dry_run {
+    if !dry_run || is_external_init_tool(tool) {
         for required in required_args(&tool) {
             if !args.contains_key(required) {
                 return Err(format!("{} requires `{required}` argument", tool.name));
@@ -597,6 +600,30 @@ pub fn validate_tool_arguments(
         }
     }
 
+    Ok(())
+}
+
+fn validate_external_init_arguments(
+    tool: ToolSpec,
+    args: &Map<String, Value>,
+) -> Result<(), String> {
+    if !is_external_init_tool(tool) {
+        return Ok(());
+    }
+    for key in ["Name", "Synonym", "OutputDir", "FormName"] {
+        let Some(value) = args.get(key) else {
+            continue;
+        };
+        let Some(value) = value.as_str() else {
+            return Err(format!("{} argument `{key}` must be string", tool.name));
+        };
+        if value.trim().is_empty() {
+            return Err(format!(
+                "{} argument `{key}` must be a non-empty string",
+                tool.name
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -1078,7 +1105,7 @@ pub fn validate_workspace_paths(
     dry_run: bool,
     context: &WorkspaceContext,
 ) -> Result<(), String> {
-    if dry_run {
+    if dry_run && !is_external_init_tool(tool) {
         return Ok(());
     }
     if !is_native_xml_tool(tool) && !matches!(tool.handler, ToolHandler::RuntimeAdapter) {
@@ -1105,13 +1132,17 @@ pub fn validate_native_source_set_format(
     dry_run: bool,
     context: &WorkspaceContext,
 ) -> Result<(), String> {
-    if dry_run || !is_native_xml_tool(tool) {
+    if (dry_run && !is_external_init_tool(tool)) || !is_native_xml_tool(tool) {
         return Ok(());
     }
 
     let source_map = discover_project_source_map(&context.workspace_root)?;
-    if source_map.source_sets.is_empty() {
+    if source_map.source_sets.is_empty() && !is_external_init_tool(tool) {
         return Ok(());
+    }
+
+    if is_external_init_tool(tool) {
+        validate_external_project_format(tool, &source_map)?;
     }
 
     for key in native_source_path_args(tool) {
@@ -1119,6 +1150,10 @@ pub fn validate_native_source_set_format(
             continue;
         };
         let target = resolve_read_path(&context.cwd, raw_path);
+        if is_external_init_tool(tool) {
+            validate_external_init_destination(tool, &target, context, &source_map)?;
+            continue;
+        }
         let Some(source_set) = source_map
             .source_sets
             .iter()
@@ -1149,6 +1184,140 @@ pub fn validate_native_source_set_format(
     }
 
     Ok(())
+}
+
+fn validate_external_project_format(
+    tool: ToolSpec,
+    source_map: &crate::domain::project_sources::ProjectSourceMap,
+) -> Result<(), String> {
+    match source_map.configured_format_raw.as_deref() {
+        None | Some("DESIGNER") => Ok(()),
+        Some("EDT") => Err(format!(
+            "{} requires v8project.yaml format=DESIGNER; format=EDT uses a different external-project layout",
+            tool.name
+        )),
+        Some(other) => Err(format!(
+            "{} requires v8project.yaml format to be exact `DESIGNER` (or omitted for the Designer default); got {other:?}",
+            tool.name
+        )),
+    }
+}
+
+fn validate_external_init_destination(
+    tool: ToolSpec,
+    target: &Path,
+    context: &WorkspaceContext,
+    source_map: &crate::domain::project_sources::ProjectSourceMap,
+) -> Result<(), String> {
+    reject_symlink_components(target, &context.workspace_root)?;
+    let Some(expected_kind) = external_init_source_set_kind(tool) else {
+        return Ok(());
+    };
+
+    let matching_source_set = source_map
+        .source_sets
+        .iter()
+        .filter_map(|source_set| {
+            let source_root = normalize_lexical(&context.workspace_root.join(&source_set.path));
+            path_starts_with_case_insensitive(target, &source_root)
+                .then_some((source_set, source_root))
+        })
+        .max_by_key(|(_, source_root)| source_root.components().count());
+    let Some((source_set, source_root)) = matching_source_set else {
+        return Ok(());
+    };
+
+    if target != source_root {
+        let aliases_source_root = target.components().count() == source_root.components().count();
+        if aliases_source_root
+            || matches!(
+                source_set.kind,
+                SourceSetKind::ExternalProcessor | SourceSetKind::ExternalReport
+            )
+        {
+            return Err(format!(
+                "{} must target the exact source-set root {} so v8-runner can discover top-level external descriptors; got {}",
+                tool.name,
+                source_root.display(),
+                target.display()
+            ));
+        }
+        return Ok(());
+    }
+    if source_set.kind != expected_kind {
+        return Err(format!(
+            "{} targets source-set `{}` of kind {:?}; expected {:?}",
+            tool.name, source_set.name, source_set.kind, expected_kind
+        ));
+    }
+    match source_set.source_format {
+        SourceFormat::PlatformXml | SourceFormat::Unknown => Ok(()),
+        SourceFormat::Edt => Err(format!(
+            "{} targets source-set `{}` with sourceFormat=edt; native platform XML tools require sourceFormat=platform_xml",
+            tool.name, source_set.name
+        )),
+        SourceFormat::Invalid => Err(format!(
+            "{} targets source-set `{}` with invalid/ambiguous format; native platform XML tools require sourceFormat=platform_xml",
+            tool.name, source_set.name
+        )),
+    }
+}
+
+fn reject_symlink_components(target: &Path, workspace_root: &Path) -> Result<(), String> {
+    let workspace_root = normalize_lexical(workspace_root);
+    let relative = target.strip_prefix(&workspace_root).map_err(|_| {
+        format!(
+            "external scaffold target is outside workspace root: {}",
+            target.display()
+        )
+    })?;
+    let mut current = workspace_root;
+    for component in relative.components() {
+        current.push(component.as_os_str());
+        match std::fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata_is_link_or_reparse_point(&metadata) => {
+                return Err(format!(
+                    "external scaffold OutputDir must not traverse symlink: {}",
+                    current.display()
+                ));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => break,
+            Err(error) => {
+                return Err(format!("failed to inspect {}: {error}", current.display()));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn metadata_is_link_or_reparse_point(metadata: &std::fs::Metadata) -> bool {
+    if metadata.file_type().is_symlink() {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+        return metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0;
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
+fn path_starts_with_case_insensitive(path: &Path, base: &Path) -> bool {
+    let path_components = path.components().collect::<Vec<_>>();
+    let base_components = base.components().collect::<Vec<_>>();
+    path_components.len() >= base_components.len()
+        && path_components
+            .iter()
+            .zip(base_components.iter())
+            .all(|(left, right)| {
+                left.as_os_str().to_string_lossy().to_lowercase()
+                    == right.as_os_str().to_string_lossy().to_lowercase()
+            })
 }
 
 fn write_path_args(tool: ToolSpec) -> &'static [&'static str] {
@@ -1214,8 +1383,23 @@ fn allowed_args(tool: &ToolSpec) -> Vec<&'static str> {
     names
 }
 
-fn native_args_for(_operation: &str) -> &'static [&'static str] {
-    NATIVE_XML_DSL_ARGS
+fn native_args_for(operation: &str) -> &'static [&'static str] {
+    match operation {
+        "epf-init" | "erf-init" => EXTERNAL_INIT_ARGS,
+        _ => NATIVE_XML_DSL_ARGS,
+    }
+}
+
+fn is_external_init_tool(tool: ToolSpec) -> bool {
+    matches!(tool.name, "unica.epf.init" | "unica.erf.init")
+}
+
+fn external_init_source_set_kind(tool: ToolSpec) -> Option<SourceSetKind> {
+    match tool.name {
+        "unica.epf.init" => Some(SourceSetKind::ExternalProcessor),
+        "unica.erf.init" => Some(SourceSetKind::ExternalReport),
+        _ => None,
+    }
 }
 
 fn required_args(tool: &ToolSpec) -> Vec<&'static str> {
@@ -1741,6 +1925,65 @@ mod tests {
         args.insert("operation".to_string(), json!("shell"));
         let error = validate_tool_arguments(tool, &args, false).unwrap_err();
         assert!(error.contains("must be one of"));
+    }
+
+    #[test]
+    fn external_artifact_init_contracts_are_typed_and_require_destination() {
+        for tool_name in ["unica.epf.init", "unica.erf.init"] {
+            let tool = tools()
+                .into_iter()
+                .find(|tool| tool.name == tool_name)
+                .unwrap_or_else(|| panic!("missing tool {tool_name}"));
+            let schema = input_schema_for_tool(&tool);
+
+            assert_eq!(schema["additionalProperties"], false);
+            assert!(schema["required"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("Name")));
+            assert!(schema["required"]
+                .as_array()
+                .unwrap()
+                .contains(&json!("OutputDir")));
+            for argument in ["Name", "Synonym", "OutputDir", "FormName", "dryRun"] {
+                assert!(
+                    schema["properties"].get(argument).is_some(),
+                    "{tool_name} must expose {argument}"
+                );
+            }
+            assert!(schema["properties"].get("script").is_none());
+            assert!(schema["properties"].get("args").is_none());
+            let actual = schema["properties"]
+                .as_object()
+                .unwrap()
+                .keys()
+                .map(String::as_str)
+                .collect::<BTreeSet<_>>();
+            assert_eq!(
+                actual,
+                BTreeSet::from([
+                    "FormName",
+                    "Name",
+                    "OutputDir",
+                    "Synonym",
+                    "confirm",
+                    "cwd",
+                    "dryRun",
+                ])
+            );
+
+            let invalid = json!({"Name": "Sample", "OutputDir": 42})
+                .as_object()
+                .unwrap()
+                .clone();
+            let error = validate_tool_arguments(tool, &invalid, false).unwrap_err();
+            assert!(error.contains("OutputDir"), "{error}");
+            assert!(error.contains("must be string"), "{error}");
+
+            let missing_output = json!({"Name": "Sample"}).as_object().unwrap().clone();
+            let error = validate_tool_arguments(tool, &missing_output, true).unwrap_err();
+            assert!(error.contains("requires `OutputDir`"), "{error}");
+        }
     }
 
     #[test]

--- a/crates/unica-coder/src/domain/project_sources.rs
+++ b/crates/unica-coder/src/domain/project_sources.rs
@@ -8,6 +8,8 @@ pub struct ProjectSourceMap {
     pub workspace_root: String,
     pub config_path: Option<String>,
     pub source_sets: Vec<ProjectSourceSet>,
+    #[serde(skip_serializing)]
+    pub(crate) configured_format_raw: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -48,10 +50,10 @@ struct ConfigSourceSet {
 
 pub fn discover_project_source_map(workspace_root: &Path) -> Result<ProjectSourceMap, String> {
     let config_path = find_project_config(workspace_root);
-    let mut source_sets = if let Some(path) = &config_path {
+    let (mut source_sets, configured_format_raw) = if let Some(path) = &config_path {
         read_config_source_sets(workspace_root, path)?
     } else {
-        autodetect_source_sets(workspace_root)
+        (autodetect_source_sets(workspace_root), None)
     };
 
     if source_sets.is_empty() {
@@ -67,6 +69,7 @@ pub fn discover_project_source_map(workspace_root: &Path) -> Result<ProjectSourc
         workspace_root: workspace_root.display().to_string(),
         config_path: config_path.map(|path| path.display().to_string()),
         source_sets: project_source_sets,
+        configured_format_raw,
     })
 }
 
@@ -78,12 +81,24 @@ fn find_project_config(workspace_root: &Path) -> Option<PathBuf> {
 fn read_config_source_sets(
     workspace_root: &Path,
     config_path: &Path,
-) -> Result<Vec<ConfigSourceSet>, String> {
+) -> Result<(Vec<ConfigSourceSet>, Option<String>), String> {
     let text = std::fs::read_to_string(config_path)
         .map_err(|err| format!("failed to read {}: {err}", config_path.display()))?;
     let yaml = serde_yaml::from_str::<YamlValue>(&text)
         .map_err(|err| format!("failed to parse {}: {err}", config_path.display()))?;
-    let default_format = yaml_string(&yaml, "format").and_then(source_format_from_config);
+    let configured_format_raw = match yaml_mapping_get(&yaml, "format") {
+        None => None,
+        Some(YamlValue::String(value)) => Some(value.clone()),
+        Some(_) => {
+            return Err(format!(
+                "{} field `format` must be a string",
+                config_path.display()
+            ));
+        }
+    };
+    let default_format = configured_format_raw
+        .clone()
+        .and_then(source_format_from_config);
     let base_path = yaml_string(&yaml, "basePath").unwrap_or_else(|| ".".to_string());
     let source_set_value = yaml_mapping_get(&yaml, "source-set");
     let mut source_sets = Vec::new();
@@ -117,7 +132,7 @@ fn read_config_source_sets(
         source_set.path = normalize_configured_path(workspace_root, &base_path, &source_set.path);
     }
 
-    Ok(source_sets)
+    Ok((source_sets, configured_format_raw))
 }
 
 fn config_source_set_from_yaml(

--- a/crates/unica-coder/src/infrastructure/native_operations.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations.rs
@@ -6,6 +6,7 @@
 pub(crate) mod cf;
 pub(crate) mod cfe;
 pub(crate) mod common;
+pub(crate) mod external;
 pub(crate) mod form;
 pub(crate) mod help;
 pub(crate) mod interface;
@@ -35,6 +36,9 @@ impl NativeOperationAdapter {
         mutating: bool,
     ) -> Result<AdapterOutcome, String> {
         if dry_run {
+            if let Some(outcome) = external::preview(operation, tool_name, args, context) {
+                return Ok(outcome);
+            }
             return Ok(AdapterOutcome {
                 ok: true,
                 summary: format!("dry run: {tool_name} would execute native XML/DSL operation"),

--- a/crates/unica-coder/src/infrastructure/native_operations/external.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/external.rs
@@ -1,0 +1,906 @@
+use super::cf::cf_validate_identifier;
+use super::common::{escape_xml, path_arg, string_arg, write_utf8_bom};
+use super::form::{form_add_content_xml, form_add_metadata_xml, form_add_module_bsl};
+use crate::domain::workspace::WorkspaceContext;
+use crate::infrastructure::AdapterOutcome;
+use serde_json::{Map, Value};
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use uuid::Uuid;
+
+const FORMAT_VERSION: &str = "2.17";
+const OBJECT_MODULE_STUB: &str = "#Область ПрограммныйИнтерфейс\n\n#КонецОбласти\n";
+
+#[derive(Debug, Clone, Copy)]
+enum ExternalArtifactKind {
+    Processor,
+    Report,
+}
+
+impl ExternalArtifactKind {
+    fn from_operation(operation: &str) -> Option<Self> {
+        match operation {
+            "epf-init" => Some(Self::Processor),
+            "erf-init" => Some(Self::Report),
+            _ => None,
+        }
+    }
+
+    fn root_tag(self) -> &'static str {
+        match self {
+            Self::Processor => "ExternalDataProcessor",
+            Self::Report => "ExternalReport",
+        }
+    }
+
+    fn class_id(self) -> &'static str {
+        match self {
+            Self::Processor => "c3831ec8-d8d5-4f93-8a22-f9bfae07327f",
+            Self::Report => "e41aff26-25cf-4bb6-b6c1-3f478a75f374",
+        }
+    }
+
+    fn object_type(self) -> &'static str {
+        match self {
+            Self::Processor => "ExternalDataProcessorObject",
+            Self::Report => "ExternalReportObject",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Processor => "EPF",
+            Self::Report => "ERF",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ScaffoldPlan {
+    kind: ExternalArtifactKind,
+    name: String,
+    synonym: String,
+    form_name: Option<String>,
+    output_dir: PathBuf,
+    descriptor: PathBuf,
+    object_dir: PathBuf,
+    artifacts: Vec<PathBuf>,
+}
+
+struct ScaffoldContent {
+    descriptor: String,
+    form_metadata: Option<String>,
+    form_content: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ScaffoldMode {
+    Preview,
+    Apply,
+}
+
+pub(crate) fn preview(
+    operation: &str,
+    tool_name: &str,
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> Option<AdapterOutcome> {
+    invoke(operation, tool_name, args, context, ScaffoldMode::Preview)
+}
+
+pub(crate) fn apply(
+    operation: &str,
+    tool_name: &str,
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> Option<AdapterOutcome> {
+    invoke(operation, tool_name, args, context, ScaffoldMode::Apply)
+}
+
+fn invoke(
+    operation: &str,
+    tool_name: &str,
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+    mode: ScaffoldMode,
+) -> Option<AdapterOutcome> {
+    let kind = ExternalArtifactKind::from_operation(operation)?;
+    Some(match (prepare_plan(kind, args, context), mode) {
+        (Ok(plan), ScaffoldMode::Preview) => {
+            success_outcome(tool_name, &plan, ScaffoldMode::Preview, Vec::new())
+        }
+        (Ok(plan), ScaffoldMode::Apply) => match create_scaffold(&plan) {
+            Ok(warnings) => success_outcome(tool_name, &plan, ScaffoldMode::Apply, warnings),
+            Err(error) => failure_outcome(tool_name, error),
+        },
+        (Err(error), ScaffoldMode::Preview | ScaffoldMode::Apply) => {
+            failure_outcome(tool_name, error)
+        }
+    })
+}
+
+fn prepare_plan(
+    kind: ExternalArtifactKind,
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> Result<ScaffoldPlan, String> {
+    let name =
+        string_arg(args, &["Name"]).ok_or_else(|| "missing required Name argument".to_string())?;
+    validate_identifier("Name", name)?;
+    let synonym = string_arg(args, &["Synonym"]).unwrap_or(name);
+    let form_name = string_arg(args, &["FormName"])
+        .map(str::to_string)
+        .filter(|value| !value.is_empty());
+    if let Some(form_name) = form_name.as_deref() {
+        validate_identifier("FormName", form_name)?;
+    } else if args.get("FormName").is_some() {
+        return Err("FormName must be a non-empty 1C identifier".to_string());
+    }
+
+    let output_dir = path_arg(args, &["OutputDir"])
+        .ok_or_else(|| "missing required OutputDir argument".to_string())?;
+    let output_dir = if output_dir.is_absolute() {
+        output_dir
+    } else {
+        context.cwd.join(output_dir)
+    };
+    let output_dir = normalize_lexical_path(&output_dir);
+    if output_dir.exists() && !output_dir.is_dir() {
+        return Err(format!(
+            "OutputDir is not a directory: {}",
+            output_dir.display()
+        ));
+    }
+    let descriptor = output_dir.join(format!("{name}.xml"));
+    let object_dir = output_dir.join(name);
+    for target in [&descriptor, &object_dir] {
+        if target.exists() {
+            return Err(format!("target already exists: {}", target.display()));
+        }
+    }
+
+    let mut artifacts = vec![descriptor.clone(), object_dir.join("Ext/ObjectModule.bsl")];
+    if let Some(form_name) = form_name.as_deref() {
+        artifacts.extend([
+            object_dir.join("Forms").join(format!("{form_name}.xml")),
+            object_dir
+                .join("Forms")
+                .join(form_name)
+                .join("Ext/Form.xml"),
+            object_dir
+                .join("Forms")
+                .join(form_name)
+                .join("Ext/Form/Module.bsl"),
+        ]);
+    }
+
+    Ok(ScaffoldPlan {
+        kind,
+        name: name.to_string(),
+        synonym: synonym.to_string(),
+        form_name,
+        output_dir,
+        descriptor,
+        object_dir,
+        artifacts,
+    })
+}
+
+fn validate_identifier(argument: &str, value: &str) -> Result<(), String> {
+    if cf_validate_identifier(value) {
+        Ok(())
+    } else {
+        Err(format!(
+            "{argument} must be a valid 1C identifier: {value:?}"
+        ))
+    }
+}
+
+fn normalize_lexical_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn create_scaffold(plan: &ScaffoldPlan) -> Result<Vec<String>, String> {
+    let content = build_content(plan)?;
+    validate_xml("external descriptor", &content.descriptor)?;
+    if let Some(form_metadata) = content.form_metadata.as_deref() {
+        validate_xml("form metadata", form_metadata)?;
+    }
+    if let Some(form_content) = content.form_content.as_deref() {
+        validate_xml("managed form", form_content)?;
+    }
+
+    let output_existed = plan.output_dir.exists();
+    fs::create_dir_all(&plan.output_dir)
+        .map_err(|error| format!("failed to create {}: {error}", plan.output_dir.display()))?;
+    let staging = plan
+        .output_dir
+        .join(format!(".unica-external-init-{}.tmp", Uuid::new_v4()));
+    if let Err(error) = fs::create_dir(&staging) {
+        let mut cleanup_errors = Vec::new();
+        if !output_existed {
+            remove_empty_dir(&plan.output_dir, &mut cleanup_errors);
+        }
+        return Err(with_cleanup_errors(
+            format!("failed to create staging directory: {error}"),
+            cleanup_errors,
+        ));
+    }
+
+    let result = write_and_commit_staging(plan, &content, &staging);
+    match result {
+        Ok(warnings) => Ok(warnings),
+        Err(error) => {
+            let mut cleanup_errors = Vec::new();
+            if let Err(cleanup_error) = fs::remove_dir_all(&staging) {
+                cleanup_errors.push(format!(
+                    "failed to remove staging directory {}: {cleanup_error}",
+                    staging.display()
+                ));
+            }
+            if !output_existed {
+                remove_empty_dir(&plan.output_dir, &mut cleanup_errors);
+            }
+            Err(with_cleanup_errors(error, cleanup_errors))
+        }
+    }
+}
+
+fn build_content(plan: &ScaffoldPlan) -> Result<ScaffoldContent, String> {
+    let descriptor = descriptor_xml(plan);
+    let (form_metadata, form_content) = match plan.form_name.as_deref() {
+        Some(form_name) => (
+            Some(form_add_metadata_xml(
+                form_name,
+                form_name,
+                plan.kind.root_tag(),
+                FORMAT_VERSION,
+                &Uuid::new_v4().to_string(),
+            )),
+            Some(form_add_content_xml(
+                plan.kind.root_tag(),
+                &plan.name,
+                "Object",
+                FORMAT_VERSION,
+            )?),
+        ),
+        None => (None, None),
+    };
+    Ok(ScaffoldContent {
+        descriptor,
+        form_metadata,
+        form_content,
+    })
+}
+
+fn write_and_commit_staging(
+    plan: &ScaffoldPlan,
+    content: &ScaffoldContent,
+    staging: &Path,
+) -> Result<Vec<String>, String> {
+    let staged_descriptor = staging.join(format!("{}.xml", plan.name));
+    let staged_object_dir = staging.join(&plan.name);
+    let staged_object_ext = staged_object_dir.join("Ext");
+    fs::create_dir_all(&staged_object_ext)
+        .map_err(|error| format!("failed to create object module directory: {error}"))?;
+    write_utf8_bom(&staged_descriptor, &content.descriptor)?;
+    write_utf8_bom(
+        &staged_object_ext.join("ObjectModule.bsl"),
+        OBJECT_MODULE_STUB,
+    )?;
+
+    if let (Some(form_name), Some(form_metadata), Some(form_content)) = (
+        plan.form_name.as_deref(),
+        content.form_metadata.as_deref(),
+        content.form_content.as_deref(),
+    ) {
+        let forms_dir = staged_object_dir.join("Forms");
+        let form_ext = forms_dir.join(form_name).join("Ext");
+        let form_module_dir = form_ext.join("Form");
+        fs::create_dir_all(&form_module_dir)
+            .map_err(|error| format!("failed to create managed form directories: {error}"))?;
+        write_utf8_bom(&forms_dir.join(format!("{form_name}.xml")), form_metadata)?;
+        write_utf8_bom(&form_ext.join("Form.xml"), form_content)?;
+        write_utf8_bom(&form_module_dir.join("Module.bsl"), form_add_module_bsl())?;
+    }
+
+    for target in [&plan.descriptor, &plan.object_dir] {
+        if target.exists() {
+            return Err(format!("target already exists: {}", target.display()));
+        }
+    }
+    fs::create_dir(&plan.object_dir).map_err(|error| {
+        format!(
+            "failed to reserve object directory {} without overwrite: {error}",
+            plan.object_dir.display()
+        )
+    })?;
+    let mut published_subtrees = Vec::new();
+    let publish_object = (|| -> Result<(), String> {
+        let final_ext = plan.object_dir.join("Ext");
+        fs::rename(staged_object_dir.join("Ext"), &final_ext)
+            .map_err(|error| format!("failed to publish object module directory: {error}"))?;
+        published_subtrees.push(final_ext);
+        let staged_forms = staged_object_dir.join("Forms");
+        if staged_forms.exists() {
+            let final_forms = plan.object_dir.join("Forms");
+            fs::rename(&staged_forms, &final_forms)
+                .map_err(|error| format!("failed to publish managed form directory: {error}"))?;
+            published_subtrees.push(final_forms);
+        }
+        Ok(())
+    })();
+    if let Err(error) = publish_object {
+        return Err(with_cleanup_errors(
+            error,
+            rollback_published_object(plan, &published_subtrees),
+        ));
+    }
+    if let Err(error) = fs::hard_link(&staged_descriptor, &plan.descriptor) {
+        return Err(with_cleanup_errors(
+            format!(
+                "failed to publish descriptor {} without overwrite: {error}",
+                plan.descriptor.display()
+            ),
+            rollback_published_object(plan, &published_subtrees),
+        ));
+    }
+
+    let mut warnings = Vec::new();
+    if let Err(error) = fs::remove_dir_all(staging) {
+        warnings.push(format!(
+            "scaffold committed but staging cleanup failed for {}: {error}",
+            staging.display()
+        ));
+    }
+    Ok(warnings)
+}
+
+fn rollback_published_object(plan: &ScaffoldPlan, published_subtrees: &[PathBuf]) -> Vec<String> {
+    let mut cleanup_errors = Vec::new();
+    let published_files = plan.artifacts.iter().skip(1).filter(|path| {
+        published_subtrees
+            .iter()
+            .any(|subtree| path.starts_with(subtree))
+    });
+    for path in published_files.rev() {
+        match fs::remove_file(path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => cleanup_errors.push(format!(
+                "failed to remove published file {}: {error}",
+                path.display()
+            )),
+        }
+    }
+
+    let mut directories = Vec::new();
+    for path in plan.artifacts.iter().skip(1).filter(|path| {
+        published_subtrees
+            .iter()
+            .any(|subtree| path.starts_with(subtree))
+    }) {
+        let mut parent = path.parent();
+        while let Some(directory) = parent {
+            if !directory.starts_with(&plan.object_dir) {
+                break;
+            }
+            directories.push(directory.to_path_buf());
+            if directory == plan.object_dir {
+                break;
+            }
+            parent = directory.parent();
+        }
+    }
+    directories.sort_by_key(|path| std::cmp::Reverse(path.components().count()));
+    directories.dedup();
+    for directory in directories {
+        remove_empty_dir(&directory, &mut cleanup_errors);
+    }
+    if plan.object_dir.exists() {
+        remove_empty_dir(&plan.object_dir, &mut cleanup_errors);
+    }
+    cleanup_errors
+}
+
+fn remove_empty_dir(path: &Path, cleanup_errors: &mut Vec<String>) {
+    match fs::remove_dir(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => cleanup_errors.push(format!(
+            "failed to remove empty directory {}: {error}",
+            path.display()
+        )),
+    }
+}
+
+fn with_cleanup_errors(error: String, cleanup_errors: Vec<String>) -> String {
+    if cleanup_errors.is_empty() {
+        error
+    } else {
+        format!("{error}; cleanup incomplete: {}", cleanup_errors.join("; "))
+    }
+}
+
+fn descriptor_xml(plan: &ScaffoldPlan) -> String {
+    let root_tag = plan.kind.root_tag();
+    let default_form = plan.form_name.as_deref().map_or_else(
+        || "\t\t\t<DefaultForm/>".to_string(),
+        |form_name| {
+            format!(
+                "\t\t\t<DefaultForm>{}.{}.Form.{}</DefaultForm>",
+                root_tag,
+                escape_xml(&plan.name),
+                escape_xml(form_name)
+            )
+        },
+    );
+    let child_objects = plan.form_name.as_deref().map_or_else(
+        || "\t\t<ChildObjects/>".to_string(),
+        |form_name| {
+            format!(
+                "\t\t<ChildObjects>\n\t\t\t<Form>{}</Form>\n\t\t</ChildObjects>",
+                escape_xml(form_name)
+            )
+        },
+    );
+    let report_properties = match plan.kind {
+        ExternalArtifactKind::Processor => String::new(),
+        ExternalArtifactKind::Report => concat!(
+            "\n\t\t\t<MainDataCompositionSchema/>",
+            "\n\t\t\t<DefaultSettingsForm/>",
+            "\n\t\t\t<AuxiliarySettingsForm/>",
+            "\n\t\t\t<DefaultVariantForm/>",
+            "\n\t\t\t<VariantsStorage/>",
+            "\n\t\t\t<SettingsStorage/>"
+        )
+        .to_string(),
+    };
+    let root_uuid = Uuid::new_v4();
+    let object_id = Uuid::new_v4();
+    let type_id = Uuid::new_v4();
+    let value_id = Uuid::new_v4();
+
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:app="http://v8.1c.ru/8.2/managed-application/core" xmlns:cfg="http://v8.1c.ru/8.1/data/enterprise/current-config" xmlns:cmi="http://v8.1c.ru/8.2/managed-application/cmi" xmlns:ent="http://v8.1c.ru/8.1/data/enterprise" xmlns:lf="http://v8.1c.ru/8.2/managed-application/logform" xmlns:style="http://v8.1c.ru/8.1/data/ui/style" xmlns:sys="http://v8.1c.ru/8.1/data/ui/fonts/system" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:v8ui="http://v8.1c.ru/8.1/data/ui" xmlns:web="http://v8.1c.ru/8.1/data/ui/colors/web" xmlns:win="http://v8.1c.ru/8.1/data/ui/colors/windows" xmlns:xen="http://v8.1c.ru/8.3/xcf/enums" xmlns:xpr="http://v8.1c.ru/8.3/xcf/predef" xmlns:xr="http://v8.1c.ru/8.3/xcf/readable" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="{FORMAT_VERSION}">
+	<{root_tag} uuid="{root_uuid}">
+		<InternalInfo>
+			<xr:ContainedObject>
+				<xr:ClassId>{class_id}</xr:ClassId>
+				<xr:ObjectId>{object_id}</xr:ObjectId>
+			</xr:ContainedObject>
+			<xr:GeneratedType name="{object_type}.{name}" category="Object">
+				<xr:TypeId>{type_id}</xr:TypeId>
+				<xr:ValueId>{value_id}</xr:ValueId>
+			</xr:GeneratedType>
+		</InternalInfo>
+		<Properties>
+			<Name>{name}</Name>
+			<Synonym>
+				<v8:item>
+					<v8:lang>ru</v8:lang>
+					<v8:content>{synonym}</v8:content>
+				</v8:item>
+			</Synonym>
+			<Comment/>
+{default_form}
+			<AuxiliaryForm/>{report_properties}
+		</Properties>
+{child_objects}
+	</{root_tag}>
+</MetaDataObject>"#,
+        class_id = plan.kind.class_id(),
+        object_type = plan.kind.object_type(),
+        name = escape_xml(&plan.name),
+        synonym = escape_xml(&plan.synonym),
+    )
+}
+
+fn validate_xml(label: &str, text: &str) -> Result<(), String> {
+    roxmltree::Document::parse(text)
+        .map(|_| ())
+        .map_err(|error| format!("generated {label} is invalid XML: {error}"))
+}
+
+fn success_outcome(
+    tool_name: &str,
+    plan: &ScaffoldPlan,
+    mode: ScaffoldMode,
+    warnings: Vec<String>,
+) -> AdapterOutcome {
+    let (verb, summary) = match mode {
+        ScaffoldMode::Preview => (
+            "would create",
+            format!(
+                "dry run: {tool_name} would create {} scaffold",
+                plan.kind.label()
+            ),
+        ),
+        ScaffoldMode::Apply => (
+            "created",
+            format!("{tool_name} created {} scaffold", plan.kind.label()),
+        ),
+    };
+    let artifacts = plan
+        .artifacts
+        .iter()
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>();
+    AdapterOutcome {
+        ok: true,
+        summary,
+        changes: artifacts
+            .iter()
+            .map(|path| format!("{verb} {path}"))
+            .collect(),
+        warnings,
+        errors: Vec::new(),
+        artifacts,
+        stdout: Some(format!(
+            "{} scaffold: {}\nSource-set root: {}\nGenerated XML structure validated before publication.\nNext: ensure this root is declared in v8project.yaml and run unica.runtime.execute operation=make.\n",
+            plan.kind.label(),
+            plan.name,
+            plan.output_dir.display()
+        )),
+        stderr: None,
+        command: None,
+    }
+}
+
+fn failure_outcome(tool_name: &str, error: String) -> AdapterOutcome {
+    AdapterOutcome {
+        ok: false,
+        summary: format!("{tool_name} failed to create external artifact scaffold"),
+        changes: Vec::new(),
+        warnings: Vec::new(),
+        errors: vec![error.clone()],
+        artifacts: Vec::new(),
+        stdout: None,
+        stderr: Some(format!("{error}\n")),
+        command: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infrastructure::native_operations::NativeOperationAdapter;
+    use serde_json::{json, Map, Value};
+    use std::collections::BTreeSet;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn epf_init_creates_make_ready_layout_with_optional_managed_form() {
+        let root = temp_root("epf-init-layout");
+        let context = WorkspaceContext::discover(root.clone()).unwrap();
+        let args = map(json!({
+            "Name": "ИмпортТоваров",
+            "Synonym": "Импорт товаров & цен",
+            "OutputDir": "external/epf",
+            "FormName": "ОсновнаяФорма"
+        }));
+
+        let outcome = apply("epf-init", "unica.epf.init", &args, &context).unwrap();
+        assert!(outcome.ok, "{:?}", outcome.errors);
+        let descriptor = root.join("external/epf/ИмпортТоваров.xml");
+        let object_dir = root.join("external/epf/ИмпортТоваров");
+        for path in [
+            descriptor.clone(),
+            object_dir.join("Ext/ObjectModule.bsl"),
+            object_dir.join("Forms/ОсновнаяФорма.xml"),
+            object_dir.join("Forms/ОсновнаяФорма/Ext/Form.xml"),
+            object_dir.join("Forms/ОсновнаяФорма/Ext/Form/Module.bsl"),
+        ] {
+            assert!(path.is_file(), "missing {}", path.display());
+        }
+
+        let bytes = fs::read(&descriptor).unwrap();
+        assert!(bytes.starts_with(&[0xef, 0xbb, 0xbf]));
+        let xml = String::from_utf8(bytes[3..].to_vec()).unwrap();
+        assert!(xml.contains("<ExternalDataProcessor uuid=\""));
+        assert!(xml.contains("<xr:ClassId>c3831ec8-d8d5-4f93-8a22-f9bfae07327f</xr:ClassId>"));
+        assert!(xml.contains("name=\"ExternalDataProcessorObject.ИмпортТоваров\""));
+        assert!(xml.contains("<v8:content>Импорт товаров &amp; цен</v8:content>"));
+        assert!(xml.contains(
+            "<DefaultForm>ExternalDataProcessor.ИмпортТоваров.Form.ОсновнаяФорма</DefaultForm>"
+        ));
+        assert_eq!(xml.matches("<Form>ОсновнаяФорма</Form>").count(), 1);
+        assert_metadata_uuids_v4(&xml, "ExternalDataProcessor", 4);
+
+        let form_metadata_bytes = fs::read(object_dir.join("Forms/ОсновнаяФорма.xml")).unwrap();
+        assert!(form_metadata_bytes.starts_with(&[0xef, 0xbb, 0xbf]));
+        let form_metadata = String::from_utf8(form_metadata_bytes[3..].to_vec()).unwrap();
+        assert_metadata_uuids_v4(&form_metadata, "Form", 1);
+
+        let form_path = object_dir.join("Forms/ОсновнаяФорма/Ext/Form.xml");
+        let form_bytes = fs::read(&form_path).unwrap();
+        assert!(form_bytes.starts_with(&[0xef, 0xbb, 0xbf]));
+        let form_xml = String::from_utf8(form_bytes[3..].to_vec()).unwrap();
+        assert!(
+            form_xml.contains("<v8:Type>cfg:ExternalDataProcessorObject.ИмпортТоваров</v8:Type>")
+        );
+        assert!(form_xml.contains("<MainAttribute>true</MainAttribute>"));
+        assert!(!form_xml.contains("<SavedData>"));
+        assert!(roxmltree::Document::parse(&form_xml).is_ok());
+        for path in [
+            object_dir.join("Ext/ObjectModule.bsl"),
+            object_dir.join("Forms/ОсновнаяФорма/Ext/Form/Module.bsl"),
+        ] {
+            assert!(fs::read(path).unwrap().starts_with(&[0xef, 0xbb, 0xbf]));
+        }
+
+        let validate_args = map(json!({"FormPath": form_path}));
+        let validation = NativeOperationAdapter::invoke(
+            "form-validate",
+            "unica.form.validate",
+            &validate_args,
+            &context,
+            false,
+            false,
+        )
+        .unwrap();
+        assert!(validation.ok, "{:?}", validation.errors);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn erf_init_creates_minimal_report_layout_without_a_form() {
+        let root = temp_root("erf-init-layout");
+        let context = WorkspaceContext::discover(root.clone()).unwrap();
+        let args = map(json!({"Name": "Остатки", "OutputDir": "external/erf"}));
+        let outcome = apply("erf-init", "unica.erf.init", &args, &context).unwrap();
+        assert!(outcome.ok, "{:?}", outcome.errors);
+
+        let descriptor = root.join("external/erf/Остатки.xml");
+        let object_dir = root.join("external/erf/Остатки");
+        assert!(object_dir.join("Ext/ObjectModule.bsl").is_file());
+        assert!(!object_dir.join("Forms").exists());
+        let bytes = fs::read(&descriptor).unwrap();
+        assert!(bytes.starts_with(&[0xef, 0xbb, 0xbf]));
+        let xml = String::from_utf8(bytes[3..].to_vec()).unwrap();
+        assert!(xml.contains("<ExternalReport uuid=\""));
+        assert!(xml.contains("<xr:ClassId>e41aff26-25cf-4bb6-b6c1-3f478a75f374</xr:ClassId>"));
+        assert!(xml.contains("name=\"ExternalReportObject.Остатки\""));
+        assert_metadata_uuids_v4(&xml, "ExternalReport", 4);
+        let document = roxmltree::Document::parse(&xml).unwrap();
+        let properties = document
+            .descendants()
+            .find(|node| node.tag_name().name() == "Properties")
+            .unwrap();
+        assert_eq!(
+            properties
+                .children()
+                .filter(|node| node.is_element())
+                .map(|node| node.tag_name().name())
+                .collect::<Vec<_>>(),
+            vec![
+                "Name",
+                "Synonym",
+                "Comment",
+                "DefaultForm",
+                "AuxiliaryForm",
+                "MainDataCompositionSchema",
+                "DefaultSettingsForm",
+                "AuxiliarySettingsForm",
+                "DefaultVariantForm",
+                "VariantsStorage",
+                "SettingsStorage",
+            ]
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn erf_init_optional_form_uses_external_report_object_type() {
+        let root = temp_root("erf-init-form");
+        let context = WorkspaceContext::discover(root.clone()).unwrap();
+        let args = map(json!({
+            "Name": "Продажи",
+            "OutputDir": "external/erf",
+            "FormName": "ФормаОтчета"
+        }));
+        let outcome = apply("erf-init", "unica.erf.init", &args, &context).unwrap();
+        assert!(outcome.ok, "{:?}", outcome.errors);
+
+        let object_dir = root.join("external/erf/Продажи");
+        let descriptor = fs::read_to_string(root.join("external/erf/Продажи.xml")).unwrap();
+        assert!(descriptor
+            .contains("<DefaultForm>ExternalReport.Продажи.Form.ФормаОтчета</DefaultForm>"));
+        let form_path = object_dir.join("Forms/ФормаОтчета/Ext/Form.xml");
+        let form_bytes = fs::read(&form_path).unwrap();
+        let form_xml = String::from_utf8(form_bytes[3..].to_vec()).unwrap();
+        assert!(form_xml.contains("<v8:Type>cfg:ExternalReportObject.Продажи</v8:Type>"));
+        assert!(!form_xml.contains("ExternalDataProcessorObject"));
+
+        let validate_args = map(json!({"FormPath": form_path}));
+        let validation = NativeOperationAdapter::invoke(
+            "form-validate",
+            "unica.form.validate",
+            &validate_args,
+            &context,
+            false,
+            false,
+        )
+        .unwrap();
+        assert!(validation.ok, "{:?}", validation.errors);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn external_init_dry_run_lists_files_without_writing() {
+        let root = temp_root("external-init-dry-run");
+        let context = WorkspaceContext::discover(root.clone()).unwrap();
+        let args = map(json!({
+            "Name": "Preview",
+            "OutputDir": "external",
+            "FormName": "Form"
+        }));
+        let outcome = NativeOperationAdapter::invoke(
+            "epf-init",
+            "unica.epf.init",
+            &args,
+            &context,
+            true,
+            true,
+        )
+        .unwrap();
+        assert!(outcome.ok, "{:?}", outcome.errors);
+        assert!(outcome.summary.contains("dry run"));
+        assert_eq!(outcome.artifacts.len(), 5);
+        assert!(outcome
+            .changes
+            .iter()
+            .any(|change| change.contains("Preview.xml")));
+        assert!(!root.join("external").exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn external_init_rejects_invalid_name_and_existing_targets_without_mutation() {
+        let root = temp_root("external-init-collision");
+        let output = root.join("external");
+        fs::create_dir_all(&output).unwrap();
+        let existing = output.join("Existing.xml");
+        fs::write(&existing, "sentinel").unwrap();
+        let context = WorkspaceContext::discover(root.clone()).unwrap();
+
+        for (name, expected) in [("Existing", "already exists"), ("1Invalid", "identifier")] {
+            let args = map(json!({"Name": name, "OutputDir": "external"}));
+            let outcome = apply("epf-init", "unica.epf.init", &args, &context).unwrap();
+            assert!(!outcome.ok, "{name} unexpectedly succeeded");
+            assert!(outcome.errors.iter().any(|error| error.contains(expected)));
+        }
+        assert_eq!(fs::read_to_string(&existing).unwrap(), "sentinel");
+        assert!(!output.join("Existing").exists());
+        assert!(!output.join("1Invalid.xml").exists());
+
+        let directory_target = output.join("DirectoryOnly");
+        fs::create_dir(&directory_target).unwrap();
+        fs::write(directory_target.join("sentinel"), "keep").unwrap();
+        let args = map(json!({"Name": "DirectoryOnly", "OutputDir": "external"}));
+        let outcome = apply("erf-init", "unica.erf.init", &args, &context).unwrap();
+        assert!(!outcome.ok);
+        assert_eq!(
+            fs::read_to_string(directory_target.join("sentinel")).unwrap(),
+            "keep"
+        );
+        assert!(!output.join("DirectoryOnly.xml").exists());
+
+        let args = map(json!({
+            "Name": "Valid",
+            "OutputDir": "external",
+            "FormName": "../Escape"
+        }));
+        let outcome = apply("epf-init", "unica.epf.init", &args, &context).unwrap();
+        assert!(!outcome.ok);
+        assert!(outcome
+            .errors
+            .iter()
+            .any(|error| error.contains("FormName")));
+        assert!(!output.join("Valid.xml").exists());
+        assert!(!output.join("Valid").exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn rollback_removes_only_known_files_and_preserves_unexpected_entries() {
+        let root = temp_root("rollback-preserves-concurrent");
+        let context = WorkspaceContext::discover(root.clone()).unwrap();
+        let args = map(json!({"Name": "Rollback", "OutputDir": "external"}));
+        let plan = prepare_plan(ExternalArtifactKind::Processor, &args, &context).unwrap();
+        fs::create_dir_all(plan.object_dir.join("Ext")).unwrap();
+        fs::write(
+            plan.object_dir.join("Ext/ObjectModule.bsl"),
+            "published by this operation",
+        )
+        .unwrap();
+        let unexpected = plan.object_dir.join("concurrent-sentinel.txt");
+        fs::write(&unexpected, "must survive rollback").unwrap();
+
+        let cleanup_errors = rollback_published_object(&plan, &[plan.object_dir.join("Ext")]);
+
+        assert!(!plan.object_dir.join("Ext/ObjectModule.bsl").exists());
+        assert_eq!(
+            fs::read_to_string(&unexpected).unwrap(),
+            "must survive rollback"
+        );
+        assert!(plan.object_dir.is_dir());
+        assert!(cleanup_errors
+            .iter()
+            .any(|error| error.contains("failed to remove empty directory")));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn normalized_output_path_never_traverses_symlink_before_parent_component() {
+        let root = temp_root("normalized-output");
+        let workspace = root.join("workspace");
+        let outside = root.join("outside");
+        fs::create_dir_all(&workspace).unwrap();
+        fs::create_dir_all(outside.join("target")).unwrap();
+        std::os::unix::fs::symlink(outside.join("target"), workspace.join("link")).unwrap();
+        let context = WorkspaceContext::discover(workspace.clone()).unwrap();
+        let args = map(json!({
+            "Name": "Safe",
+            "OutputDir": "link/../external"
+        }));
+
+        let outcome = apply("epf-init", "unica.epf.init", &args, &context).unwrap();
+
+        assert!(outcome.ok, "{:?}", outcome.errors);
+        assert!(workspace.join("external/Safe.xml").is_file());
+        assert!(!outside.join("external/Safe.xml").exists());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    fn map(value: Value) -> Map<String, Value> {
+        value.as_object().unwrap().clone()
+    }
+
+    fn assert_metadata_uuids_v4(xml: &str, root_tag: &str, expected_count: usize) {
+        let document = roxmltree::Document::parse(xml).unwrap();
+        let root = document
+            .descendants()
+            .find(|node| node.tag_name().name() == root_tag)
+            .unwrap();
+        let mut values = vec![root.attribute("uuid").unwrap().to_string()];
+        for tag in ["ObjectId", "TypeId", "ValueId"] {
+            if let Some(value) = document
+                .descendants()
+                .find(|node| node.tag_name().name() == tag)
+                .and_then(|node| node.text())
+            {
+                values.push(value.to_string());
+            }
+        }
+        assert_eq!(values.len(), expected_count);
+        assert_eq!(values.iter().collect::<BTreeSet<_>>().len(), expected_count);
+        for value in values {
+            let uuid = Uuid::parse_str(&value).unwrap();
+            assert!(!uuid.is_nil());
+            assert_eq!(uuid.get_version(), Some(uuid::Version::Random));
+        }
+    }
+
+    fn temp_root(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("unica-external-{name}-{nanos}"));
+        fs::create_dir_all(&root).unwrap();
+        root
+    }
+}

--- a/crates/unica-coder/src/infrastructure/native_operations/registry.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/registry.rs
@@ -2,7 +2,9 @@ use crate::domain::workspace::WorkspaceContext;
 use crate::infrastructure::AdapterOutcome;
 use serde_json::{Map, Value};
 
-use super::{cf, cfe, form, help, interface, meta, mxl, role, skd, subsystem, support, template};
+use super::{
+    cf, cfe, external, form, help, interface, meta, mxl, role, skd, subsystem, support, template,
+};
 
 pub(crate) fn invoke_read(
     operation: &str,
@@ -30,6 +32,7 @@ pub(crate) fn invoke_mutation(
 ) -> Option<AdapterOutcome> {
     cf::invoke_mutation(operation, tool_name, args, context)
         .or_else(|| cfe::invoke_mutation(operation, tool_name, args, context))
+        .or_else(|| external::apply(operation, tool_name, args, context))
         .or_else(|| meta::invoke_mutation(operation, tool_name, args, context))
         .or_else(|| match operation {
             "help-add" => Some(help::add_help(args, context)),

--- a/plugins/unica/README.md
+++ b/plugins/unica/README.md
@@ -5,7 +5,7 @@ Unica is a Codex plugin for day-to-day 1C:Enterprise development work.
 The public skills model developer operations, not infrastructure tools:
 
 - create, inspect, edit, validate, compile, dump, and load 1C metadata;
-- build, dump, and publish external processing/report source sets (`EPF`/`ERF`) through v8-runner MCP workflows;
+- create make-ready external processing/report scaffolds (`EPF`/`ERF`) inside Designer/platform-XML external source sets and build, dump, or publish them through v8-runner MCP workflows;
 - run v8-runner database/build/runtime workflows through MCP `unica`;
 - work with forms, roles, SKD, MXL, subsystems, command interfaces, help, templates, and autonomous web-client debug;
 - search, review, diagnose, test, and analyze BSL code inside those workflows.
@@ -20,6 +20,7 @@ The `skills/` directory contains operation skills and scenario references for 1C
 - `cf-edit`, `cf-info`, `cf-init`, `cf-validate`
 - `cfe-init`, `cfe-borrow`, `cfe-diff`, `cfe-patch-method`, `cfe-validate`
 - `v8-runner`, `db-auth-check`
+- `epf-init`, `erf-init` for make-ready EPF/ERF scaffolds inside Designer/platform-XML external source sets
 - `epf-bsp-init`, `epf-bsp-add-command` for BSP registration helpers; EPF/ERF build and dump workflows live in `v8-runner`
 - `form-add`, `form-edit`, `form-info`, `form-compile`, `form-validate`, `form-remove`
 - `meta-compile`, `meta-edit`, `meta-info`, `meta-remove`, `meta-validate`

--- a/plugins/unica/provenance/skill-upstreams.json
+++ b/plugins/unica/provenance/skill-upstreams.json
@@ -261,6 +261,49 @@
           "decisionReason": "Reviewed cbde49 drift as EOL normalization, raw PowerShell wrapper/guidance churn, shared donor docs, or donor-only capabilities outside the current Unica packaged surface; no prompt-visible Unica skill or typed MCP behavior change is required."
         },
         {
+          "skill": "epf-init",
+          "status": "ported-to-unica",
+          "notes": "Ported the current donor EPF scaffold contract into native typed Unica MCP. Unica adds workspace path policy, source-set kind validation, dry-run artifact preview, no-clobber publication, and an optional canonical managed form while preserving the make-ready ExternalDataProcessor descriptor and ObjectModule layout.",
+          "upstreamPaths": [
+            ".claude/skills/epf-init/**",
+            "docs/epf-guide.md",
+            "docs/1c-epf-spec.md"
+          ],
+          "localPaths": [
+            "plugins/unica/skills/epf-init"
+          ],
+          "contractPaths": [
+            "crates/unica-coder/src/application/mod.rs",
+            "crates/unica-coder/src/application/tool_contracts.rs",
+            "crates/unica-coder/src/infrastructure/native_operations/external.rs",
+            "tests/ci/test_unica_mcp_smoke.py",
+            "tests/ci/test_unica_skills.py"
+          ],
+          "baselineCommit": "9e1341b80bbd9eab65f8d9f6e7caa72add930ea9",
+          "decision": "ported"
+        },
+        {
+          "skill": "erf-init",
+          "status": "ported-to-unica",
+          "notes": "Ported the current donor ERF scaffold contract into native typed Unica MCP. Unica adds workspace path policy, source-set kind validation, dry-run artifact preview, no-clobber publication, and an optional canonical managed form while preserving the make-ready ExternalReport descriptor and ObjectModule layout; optional SKD remains a follow-up through existing SKD/template tools.",
+          "upstreamPaths": [
+            ".claude/skills/erf-init/**",
+            "docs/1c-erf-spec.md"
+          ],
+          "localPaths": [
+            "plugins/unica/skills/erf-init"
+          ],
+          "contractPaths": [
+            "crates/unica-coder/src/application/mod.rs",
+            "crates/unica-coder/src/application/tool_contracts.rs",
+            "crates/unica-coder/src/infrastructure/native_operations/external.rs",
+            "tests/ci/test_unica_mcp_smoke.py",
+            "tests/ci/test_unica_skills.py"
+          ],
+          "baselineCommit": "9e1341b80bbd9eab65f8d9f6e7caa72add930ea9",
+          "decision": "ported"
+        },
+        {
           "skill": "form-add",
           "status": "ported-to-unica",
           "notes": "Runtime backend is native Rust (crates/unica-coder/src/infrastructure/native_operations/form.rs) behind unica.form.*; donor script behavior is kept only as fixture parity under tests/fixtures/unica_mcp_script_parity/reference_skills. Packaged legacy operation directories are intentionally absent.",

--- a/plugins/unica/references/tooling/v8project.md
+++ b/plugins/unica/references/tooling/v8project.md
@@ -72,6 +72,12 @@ Within one source-set the format cannot be mixed: conflicting platform XML and
 EDT markers mean the source-set is invalid/ambiguous and must be fixed or
 converted before XML metadata tools are used.
 
+Format discovery remains per source-set, but `unica.epf.init` and
+`unica.erf.init` specifically require the global `format` value to be exact
+`DESIGNER` or omitted. v8-runner selects the external-project layout from that
+global value; use a separate Designer workspace/config when the active config
+has global `format: EDT`.
+
 ## Command Mapping
 
 Use the `v8-runner` skill and MCP `unica.runtime.execute` for runtime operations.

--- a/plugins/unica/references/use-cases/reports-printing.md
+++ b/plugins/unica/references/use-cases/reports-printing.md
@@ -14,8 +14,34 @@ reports are handled through external source-sets with `build`, `dump`, and
 - `unica.skd.*` for SKD/DCS schema info, compile, edit, and validation.
 - `unica.mxl.*` for MXL info, compile, decompile, and validation.
 - `unica.template.*` for adding/removing templates on metadata objects.
+- `epf-init` and `erf-init` for make-ready artifact scaffolds inside external
+  source-sets, with an optional managed form. These skills call
+  `unica.epf.init` or `unica.erf.init`
+  and do not synthesize `Configuration.xml` or `ConfigDumpInfo.xml`.
 - `epf-bsp-init` and `epf-bsp-add-command` for BSP registration code.
 - `v8-runner` with `unica.runtime.execute` for EPF/ERF external source-set build/dump/make.
+
+Declare the generated directory in `v8project.yaml` as
+`EXTERNAL_DATA_PROCESSORS` or `EXTERNAL_REPORTS` under `format: DESIGNER` and
+place descriptors directly in that source-set root, then use `operation=make`.
+These scaffolds are platform XML and are rejected for EDT external-project
+layouts. Do not use `operation=load` for `.epf` or `.erf`.
+
+This is a fragment to merge into an existing valid `v8project.yaml`; it does
+not replace required `workPath`, `builder`, or `infobase.connection`. Preserve
+the existing connection and local overrides, and never initialize an existing
+project database merely to create a scaffold:
+
+```yaml
+format: DESIGNER
+source-set:
+  - name: external-processors
+    type: EXTERNAL_DATA_PROCESSORS
+    path: src/external-processors
+  - name: external-reports
+    type: EXTERNAL_REPORTS
+    path: src/external-reports
+```
 
 ## Related references
 

--- a/plugins/unica/skills/epf-init/SKILL.md
+++ b/plugins/unica/skills/epf-init/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: epf-init
+description: Создать пустой make-ready scaffold внешней обработки 1С (EPF) в корне Designer/platform-XML external source-set, с модулем объекта и опциональной управляемой формой. Используй при запросе создать новую внешнюю обработку с нуля; не используй для обычного DataProcessor внутри конфигурации.
+---
+
+# Создание внешней обработки EPF
+
+## MCP routing
+
+- Использовать MCP `unica` tool `unica.epf.init` для scaffold XML/BSL.
+- Не вызывать внутренние adapters и не добавлять skill-local scripts.
+- Для сборки результата использовать `v8-runner` через `unica.runtime.execute` с `operation=make`.
+
+## Порядок работы
+
+1. Убедиться, что `v8project.yaml` использует Designer mode: явно `format: DESIGNER` либо поле `format` отсутствует и действует Designer default v8-runner. Skill создаёт platform XML, а EDT external-project layout не поддерживается.
+2. Сохранить существующие `workPath`, `infobase`, credentials и local overrides. Не заменять connection string и не инициализировать существующую ИБ ради scaffold.
+3. Найти source-set с `type: EXTERNAL_DATA_PROCESSORS` и передать его `path` как `OutputDir` без вложенного подкаталога. v8-runner ищет descriptors непосредственно в корне source-set.
+4. Если source-set ещё не объявлен, создать scaffold в выбранном новом каталоге, затем явно добавить этот каталог как корень Designer source-set. Проверить регистрацию через `unica.project.map`: `kind=external_processor`, `sourceFormat=platform_xml`.
+5. Передать `FormName`, только если нужна пустая управляемая форма. Без него создаются descriptor и `ObjectModule.bsl`.
+6. Сначала проверить точный список файлов через `dryRun: true`; при явном запросе пользователя повторить с `dryRun: false`.
+7. Собрать `.epf` через `unica.runtime.execute operation=make`. Для make в `v8project.yaml` должна быть доступная `infobase.connection`.
+
+`Name` и `FormName` должны быть идентификаторами 1С. Существующие descriptor или одноимённый каталог не перезаписываются. При `format: EDT` остановиться и объяснить несовместимость, не создавать Designer XML внутри EDT source-set.
+
+В существующем валидном `v8project.yaml` добавить только этот фрагмент, используя ключ `source-set` в единственном числе и не затирая остальные поля:
+
+```yaml
+source-set:
+  - name: external-processors
+    type: EXTERNAL_DATA_PROCESSORS
+    path: src/external-processors
+```
+
+Для нового изолированного workspace полный минимальный пример имеет также обязательный runtime-контекст:
+
+```yaml
+workPath: build/runtime
+execution_timeout: 300000
+format: DESIGNER
+builder: DESIGNER
+infobase:
+  connection: 'File=build/ib'
+source-set:
+  - name: external-processors
+    type: EXTERNAL_DATA_PROCESSORS
+    path: src/external-processors
+```
+
+`operation=init` допустима только по явному запросу или разрешению пользователя и только для новой изолированной пустой ИБ. Не выполнять `init` ради самого scaffold или для существующей проектной базы. Для существующей connection использовать её без переинициализации; при проблемах доступа следовать skill `v8-runner`/`db-auth-check`.
+
+## Параметры
+
+| Параметр | Назначение |
+| --- | --- |
+| `Name` | Имя внешней обработки, обязательно |
+| `Synonym` | Русский синоним; по умолчанию равен `Name` |
+| `OutputDir` | Корень external source-set, обязательно |
+| `FormName` | Опциональная пустая управляемая форма |
+
+## Примеры
+
+Preview обработки с формой:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "unica.epf.init",
+    "arguments": {
+      "cwd": "<workspace>",
+      "Name": "ИмпортТоваров",
+      "Synonym": "Импорт товаров",
+      "OutputDir": "src/external-processors",
+      "FormName": "ОсновнаяФорма",
+      "dryRun": true
+    }
+  }
+}
+```
+
+Создание после проверки preview:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "unica.epf.init",
+    "arguments": {
+      "cwd": "<workspace>",
+      "Name": "ИмпортТоваров",
+      "Synonym": "Импорт товаров",
+      "OutputDir": "src/external-processors",
+      "FormName": "ОсновнаяФорма",
+      "dryRun": false
+    }
+  }
+}
+```
+
+## Верификация
+
+`unica.epf.init` разбирает весь сгенерированный XML до публикации. Проверить, что созданы `<Name>.xml`, `<Name>/Ext/ObjectModule.bsl` и, если запрошена форма, три файла под `<Name>/Forms/`. Форму дополнительно проверить через `unica.form.validate` с путём к её `Ext/Form.xml`. `unica.meta.validate` не использовать: он не принимает root `ExternalDataProcessor`. Не создавать `Configuration.xml` или `ConfigDumpInfo.xml`.
+
+Перед реальной сборкой проверить ту же команду с `dryRun: true`. Повторить с `dryRun: false` только если пользователь явно запросил сборку EPF:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "unica.runtime.execute",
+    "arguments": {
+      "cwd": "<workspace>",
+      "operation": "make",
+      "sourceSet": "external-processors",
+      "output": "build/external",
+      "dryRun": true
+    }
+  }
+}
+```
+
+После проверки заменить только `dryRun` на `false`.
+
+Не использовать `operation=load` для `.epf`.

--- a/plugins/unica/skills/epf-init/agents/openai.yaml
+++ b/plugins/unica/skills/epf-init/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Создать внешнюю обработку (EPF)"
+  short_description: "Создаёт make-ready EPF scaffold в source-set"
+  default_prompt: "Используй $epf-init, чтобы создать пустую внешнюю обработку с опциональной управляемой формой."

--- a/plugins/unica/skills/erf-init/SKILL.md
+++ b/plugins/unica/skills/erf-init/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: erf-init
+description: Создать пустой make-ready scaffold внешнего отчёта 1С (ERF) в корне Designer/platform-XML external source-set, с модулем объекта и опциональной управляемой формой. Используй при запросе создать новый внешний отчёт с нуля; не используй для обычного Report внутри конфигурации.
+---
+
+# Создание внешнего отчёта ERF
+
+## MCP routing
+
+- Использовать MCP `unica` tool `unica.erf.init` для scaffold XML/BSL.
+- Не вызывать внутренние adapters и не добавлять skill-local scripts.
+- Для сборки результата использовать `v8-runner` через `unica.runtime.execute` с `operation=make`.
+
+## Порядок работы
+
+1. Убедиться, что `v8project.yaml` использует Designer mode: явно `format: DESIGNER` либо поле `format` отсутствует и действует Designer default v8-runner. Skill создаёт platform XML, а EDT external-project layout не поддерживается.
+2. Сохранить существующие `workPath`, `infobase`, credentials и local overrides. Не заменять connection string и не инициализировать существующую ИБ ради scaffold.
+3. Найти source-set с `type: EXTERNAL_REPORTS` и передать его `path` как `OutputDir` без вложенного подкаталога. v8-runner ищет descriptors непосредственно в корне source-set.
+4. Если source-set ещё не объявлен, создать scaffold в выбранном новом каталоге, затем явно добавить этот каталог как корень Designer source-set. Проверить регистрацию через `unica.project.map`: `kind=external_report`, `sourceFormat=platform_xml`.
+5. Передать `FormName`, только если нужна пустая управляемая форма. Без него создаются descriptor и `ObjectModule.bsl`; пустая СКД автоматически не добавляется.
+6. Сначала проверить точный список файлов через `dryRun: true`; при явном запросе пользователя повторить с `dryRun: false`.
+7. Добавлять СКД позже через `skd-*`/`template-*`, затем собрать `.erf` через `unica.runtime.execute operation=make`. Для make в `v8project.yaml` должна быть доступная `infobase.connection`.
+
+`Name` и `FormName` должны быть идентификаторами 1С. Существующие descriptor или одноимённый каталог не перезаписываются. При `format: EDT` остановиться и объяснить несовместимость, не создавать Designer XML внутри EDT source-set.
+
+В существующем валидном `v8project.yaml` добавить только этот фрагмент, используя ключ `source-set` в единственном числе и не затирая остальные поля:
+
+```yaml
+source-set:
+  - name: external-reports
+    type: EXTERNAL_REPORTS
+    path: src/external-reports
+```
+
+Для нового изолированного workspace полный минимальный пример имеет также обязательный runtime-контекст:
+
+```yaml
+workPath: build/runtime
+execution_timeout: 300000
+format: DESIGNER
+builder: DESIGNER
+infobase:
+  connection: 'File=build/ib'
+source-set:
+  - name: external-reports
+    type: EXTERNAL_REPORTS
+    path: src/external-reports
+```
+
+`operation=init` допустима только по явному запросу или разрешению пользователя и только для новой изолированной пустой ИБ. Не выполнять `init` ради самого scaffold или для существующей проектной базы. Для существующей connection использовать её без переинициализации; при проблемах доступа следовать skill `v8-runner`/`db-auth-check`.
+
+## Параметры
+
+| Параметр | Назначение |
+| --- | --- |
+| `Name` | Имя внешнего отчёта, обязательно |
+| `Synonym` | Русский синоним; по умолчанию равен `Name` |
+| `OutputDir` | Корень external source-set, обязательно |
+| `FormName` | Опциональная пустая управляемая форма |
+
+## Примеры
+
+Preview отчёта с пустой управляемой формой:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "unica.erf.init",
+    "arguments": {
+      "cwd": "<workspace>",
+      "Name": "Остатки",
+      "Synonym": "Остатки товаров",
+      "OutputDir": "src/external-reports",
+      "FormName": "ФормаОтчета",
+      "dryRun": true
+    }
+  }
+}
+```
+
+Создание отчёта с пустой управляемой формой:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "unica.erf.init",
+    "arguments": {
+      "cwd": "<workspace>",
+      "Name": "Остатки",
+      "Synonym": "Остатки товаров",
+      "OutputDir": "src/external-reports",
+      "FormName": "ФормаОтчета",
+      "dryRun": false
+    }
+  }
+}
+```
+
+## Верификация
+
+`unica.erf.init` разбирает весь сгенерированный XML до публикации. Проверить, что созданы `<Name>.xml`, `<Name>/Ext/ObjectModule.bsl` и, если запрошена форма, три файла под `<Name>/Forms/`. Форму дополнительно проверить через `unica.form.validate` с путём к её `Ext/Form.xml`. `unica.meta.validate` не использовать: он не принимает root `ExternalReport`. Не создавать `Configuration.xml`, `ConfigDumpInfo.xml` или СКД без запроса.
+
+Перед реальной сборкой проверить ту же команду с `dryRun: true`. Повторить с `dryRun: false` только если пользователь явно запросил сборку ERF:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "unica.runtime.execute",
+    "arguments": {
+      "cwd": "<workspace>",
+      "operation": "make",
+      "sourceSet": "external-reports",
+      "output": "build/external",
+      "dryRun": true
+    }
+  }
+}
+```
+
+После проверки заменить только `dryRun` на `false`.
+
+Не использовать `operation=load` для `.erf`.

--- a/plugins/unica/skills/erf-init/agents/openai.yaml
+++ b/plugins/unica/skills/erf-init/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Создать внешний отчёт (ERF)"
+  short_description: "Создаёт make-ready ERF scaffold в source-set"
+  default_prompt: "Используй $erf-init, чтобы создать пустой внешний отчёт с опциональной управляемой формой."

--- a/tests/ci/test_unica_mcp_smoke.py
+++ b/tests/ci/test_unica_mcp_smoke.py
@@ -42,6 +42,8 @@ class UnicaMcpSmokeTests(unittest.TestCase):
         self.assertIn("unica.project.status", tools)
         self.assertIn("unica.project.map", tools)
         self.assertIn("unica.form.edit", tools)
+        self.assertIn("unica.epf.init", tools)
+        self.assertIn("unica.erf.init", tools)
         self.assertIn("unica.build.load", tools)
         self.assertIn("unica.runtime.execute", tools)
         self.assertIn("unica.standards.explain", tools)
@@ -102,3 +104,90 @@ class UnicaMcpSmokeTests(unittest.TestCase):
         self.assertIn("bin/", command)
         self.assertIn("v8-runner", command)
         self.assertNotIn("run-v8-runner.sh", command)
+
+    def test_external_init_creates_epf_and_erf_fixture_scenarios(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            (tmp_path / "v8project.yaml").write_text(
+                "format: DESIGNER\n"
+                "source-set:\n"
+                "  - name: external-processors\n"
+                "    type: EXTERNAL_DATA_PROCESSORS\n"
+                "    path: epf\n"
+                "  - name: external-reports\n"
+                "    type: EXTERNAL_REPORTS\n"
+                "    path: erf\n",
+                encoding="utf-8",
+            )
+            responses = self.call_mcp(
+                [
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "tools/call",
+                        "params": {
+                            "name": "unica.epf.init",
+                            "arguments": {
+                                "cwd": str(tmp_path),
+                                "Name": "Import",
+                                "Synonym": "Import & prices",
+                                "OutputDir": "epf",
+                                "FormName": "MainForm",
+                                "dryRun": False,
+                            },
+                        },
+                    },
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "method": "tools/call",
+                        "params": {
+                            "name": "unica.erf.init",
+                            "arguments": {
+                                "cwd": str(tmp_path),
+                                "Name": "Balances",
+                                "OutputDir": "erf",
+                                "dryRun": False,
+                            },
+                        },
+                    },
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 3,
+                        "method": "tools/call",
+                        "params": {
+                            "name": "unica.project.map",
+                            "arguments": {"cwd": str(tmp_path)},
+                        },
+                    },
+                ],
+                cache_dir=tmp_path / "cache",
+            )
+
+            payloads = [
+                json.loads(response["result"]["content"][0]["text"])
+                for response in responses
+            ]
+            self.assertTrue(payloads[0]["ok"], payloads[0])
+            self.assertTrue(payloads[1]["ok"], payloads[1])
+            self.assertEqual(len(payloads[0]["artifacts"]), 5)
+            self.assertEqual(len(payloads[1]["artifacts"]), 2)
+
+            epf_descriptor = (tmp_path / "epf/Import.xml").read_text(encoding="utf-8-sig")
+            erf_descriptor = (tmp_path / "erf/Balances.xml").read_text(encoding="utf-8-sig")
+            self.assertIn("<ExternalDataProcessor", epf_descriptor)
+            self.assertIn("Import &amp; prices", epf_descriptor)
+            self.assertIn("<Form>MainForm</Form>", epf_descriptor)
+            self.assertIn("<ExternalReport", erf_descriptor)
+            self.assertIn("<MainDataCompositionSchema/>", erf_descriptor)
+            self.assertTrue((tmp_path / "epf/Import/Ext/ObjectModule.bsl").is_file())
+            self.assertTrue((tmp_path / "epf/Import/Forms/MainForm/Ext/Form.xml").is_file())
+            self.assertTrue((tmp_path / "erf/Balances/Ext/ObjectModule.bsl").is_file())
+            source_sets = {
+                source_set["name"]: source_set
+                for source_set in json.loads(payloads[2]["stdout"])["sourceSets"]
+            }
+            self.assertEqual(source_sets["external-processors"]["kind"], "external_processor")
+            self.assertEqual(source_sets["external-processors"]["sourceFormat"], "platform_xml")
+            self.assertEqual(source_sets["external-reports"]["kind"], "external_report")
+            self.assertEqual(source_sets["external-reports"]["sourceFormat"], "platform_xml")

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -16,6 +16,8 @@ IN_SCOPE_TOOLS = {
     "cfe-init": "unica.cfe.init",
     "cfe-patch-method": "unica.cfe.patch_method",
     "cfe-validate": "unica.cfe.validate",
+    "epf-init": "unica.epf.init",
+    "erf-init": "unica.erf.init",
     "meta-compile": "unica.meta.compile",
     "meta-edit": "unica.meta.edit",
     "meta-info": "unica.meta.info",
@@ -258,11 +260,9 @@ REPLACED_RUNTIME_SKILLS = {
     "db-update",
     "db-run",
     "workspace-init",
-    "epf-init",
     "epf-build",
     "epf-dump",
     "epf-validate",
-    "erf-init",
     "erf-build",
     "erf-dump",
     "erf-validate",
@@ -278,6 +278,8 @@ TASK_EXAMPLE_ARGUMENT_KEYS = {
     "cfe-init": ["Name", "OutputDir"],
     "cfe-patch-method": ["ExtensionPath", "ModulePath", "MethodName"],
     "cfe-validate": ["ExtensionPath"],
+    "epf-init": ["Name", "OutputDir", "FormName"],
+    "erf-init": ["Name", "OutputDir", "FormName"],
     "meta-compile": ["JsonPath", "OutputDir"],
     "meta-edit": ["ObjectPath", "Operation", "Value"],
     "meta-info": ["ObjectPath"],
@@ -349,6 +351,8 @@ ALLOWED_ADDITIONAL_MCP_TOOL_NAMES = {
     "cf-init": {"unica.cf.info", "unica.cf.validate"},
     "cfe-borrow": {"unica.cfe.validate"},
     "cfe-init": {"unica.cfe.validate"},
+    "epf-init": {"unica.runtime.execute"},
+    "erf-init": {"unica.runtime.execute"},
     "form-compile": {"unica.form.info", "unica.form.validate"},
     "interface-edit": {"unica.interface.validate"},
     "meta-edit": {"unica.meta.info", "unica.meta.validate"},
@@ -1182,7 +1186,10 @@ class UnicaSkillRoutingTests(unittest.TestCase):
         referenced_skills = {
             path.parent.parent.name for path in reference_root.glob("*/scripts/*.py")
         }
-        self.assertEqual(referenced_skills, set(IN_SCOPE_TOOLS))
+        self.assertEqual(
+            referenced_skills,
+            set(IN_SCOPE_TOOLS) - {"epf-init", "erf-init"},
+        )
         allowed_suffixes = {".json", ".md", ".ps1", ".py"}
         for path in reference_root.rglob("*"):
             if path.is_file():


### PR DESCRIPTION
Закрывает #49.

## Что сделано

- Добавлены typed MCP-инструменты `unica.epf.init` и `unica.erf.init`.
- Они создают canonical Designer/platform-XML descriptor внешней обработки или отчёта, ObjectModule и опциональную управляемую форму с DefaultForm.
- Поддержаны preview через `dryRun`, no-clobber, безопасная публикация с ownership-aware rollback и проверки workspace/source-set/format/path/symlink/case aliases.
- Добавлены prompt-visible skills `epf-init` и `erf-init`, provenance и документация make workflow в README и use-cases.
- Добавлены Rust и Python/parity-сценарии для обоих типов артефактов.

## Проверки

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — 248 passed
- `uv run --with lxml --with pyyaml python -m unittest discover -s tests/ci` — 136 passed, 1 skipped
- `git diff --check main...7e03a26`

## Изолированная platform-проверка

В новой временной File ИБ через public MCP созданы EPF и ERF с формами. Оба `dryRun` выдали точный план без записи, обе формы прошли `unica.form.validate`, после чего `unica.runtime.execute operation=make` успешно собрал:

- `Issue49Processor.epf` — 6045 байт;
- `Issue49Report.erf` — 6045 байт.

Для артефактов использованы разные output-каталоги, пользовательская ИБ не открывалась. Два независимых review-gate, включая обязательное Rust best-practices review, замечаний не нашли. Merge в upstream не выполнялся.
