### PR TITLE
fix: атомарная каноническая регистрация compile-операций

### DIFF
--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -312,7 +312,7 @@ fn call_tool(
     tool_contracts::validate_workspace_paths(spec, args, dry_run, &context)?;
     tool_contracts::validate_native_source_set_format(spec, args, dry_run, &context)?;
     let index_report = crate::infrastructure::workspace_index::IndexStartReport::default();
-    let support_guard_warning = if spec.mutating && !dry_run {
+    let mut support_guard_warning = if spec.mutating && !dry_run {
         match support_guard_check(spec, args, &context)? {
             SupportGuardCheck::Allow => None,
             SupportGuardCheck::Warn(warning) => Some(warning),
@@ -339,6 +339,29 @@ fn call_tool(
     };
 
     let mut outcome = ports.invoke_handler(spec, args, &context, dry_run)?;
+    if is_successful_detailed_compile_preview(spec, dry_run, &outcome) {
+        match support_guard_check(spec, args, &context)? {
+            SupportGuardCheck::Allow => {}
+            SupportGuardCheck::Warn(warning) => support_guard_warning = Some(warning),
+            SupportGuardCheck::Block(mut blocked) => {
+                blocked.warnings.extend(index_report.warnings);
+                let cache = ports.cache_report(&context, &[], dry_run, spec.cache_access)?;
+                return Ok(OperationResult {
+                    ok: blocked.ok,
+                    summary: blocked.summary,
+                    changes: blocked.changes,
+                    warnings: blocked.warnings,
+                    errors: blocked.errors,
+                    artifacts: blocked.artifacts,
+                    cache,
+                    stdout: blocked.stdout,
+                    stderr: blocked.stderr,
+                    command: blocked.command,
+                    diagnostics: None,
+                });
+            }
+        }
+    }
     if let Some(warning) = support_guard_warning {
         outcome.warnings.insert(0, warning);
     }
@@ -370,8 +393,25 @@ fn call_tool(
     })
 }
 
+fn is_successful_detailed_compile_preview(
+    spec: ToolSpec,
+    dry_run: bool,
+    outcome: &AdapterOutcome,
+) -> bool {
+    dry_run
+        && outcome.ok
+        && outcome.summary.contains("planned native")
+        && matches!(
+            spec.handler,
+            ToolHandler::NativeOperation {
+                operation: "meta-compile" | "role-compile" | "subsystem-compile",
+                ..
+            }
+        )
+}
+
 fn should_emit_events(spec: ToolSpec, dry_run: bool, outcome: &AdapterOutcome) -> bool {
-    spec.mutating && (dry_run || (outcome.ok && !outcome.changes.is_empty()))
+    spec.mutating && outcome.ok && (dry_run || !outcome.changes.is_empty())
 }
 
 fn runtime_result_diagnostics(
@@ -2862,6 +2902,158 @@ mod tests {
     }
 
     #[test]
+    fn meta_compile_dry_run_reports_exact_registration_diff_without_writes() {
+        let root = temp_meta_compile_workspace("unica-meta-compile-dry-run-plan");
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        let config_path = src.join("Configuration.xml");
+        let config_before = concat!(
+            "\u{feff}<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n",
+            "<MetaDataObject xmlns=\"http://v8.1c.ru/8.3/MDClasses\" version=\"2.17\">\r\n",
+            "\t<Configuration uuid=\"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa\">\r\n",
+            "\t\t<Properties><Name>Demo</Name></Properties>\r\n",
+            "\t\t<ChildObjects><Catalog>Items</Catalog></ChildObjects>\r\n",
+            "\t</Configuration>\r\n",
+            "</MetaDataObject><!-- registrar-tail -->\r\n\r\n"
+        )
+        .as_bytes()
+        .to_vec();
+        std::fs::write(&config_path, &config_before).unwrap();
+        let json_path = workspace.join("common-module.json");
+        std::fs::write(
+            &json_path,
+            r#"{
+  "type": "CommonModule",
+  "name": "SampleService",
+  "synonym": "Sample service"
+}"#,
+        )
+        .unwrap();
+
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(true));
+        args.insert(
+            "JsonPath".to_string(),
+            Value::String(json_path.display().to_string()),
+        );
+        args.insert("OutputDir".to_string(), Value::String("src".to_string()));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.meta.compile", &args)
+            .unwrap();
+
+        assert!(result.ok, "{:?}", result.errors);
+        assert!(result.summary.contains("dry run"), "{}", result.summary);
+        assert!(result
+            .changes
+            .iter()
+            .any(|change| change.contains("would create") && change.contains("SampleService.xml")));
+        assert!(result
+            .changes
+            .iter()
+            .any(|change| change.contains("would update") && change.contains("Configuration.xml")));
+        let preview = result.stdout.unwrap_or_default();
+        assert!(preview.contains("@@ bytes"), "{preview}");
+        assert!(
+            preview.contains("<CommonModule>SampleService</CommonModule>\\r\\n"),
+            "{preview}"
+        );
+        assert!(result.artifacts.is_empty());
+        assert_eq!(result.cache.mode, "dry-run");
+        assert!(result.cache.events.contains(&"MetadataChanged".to_string()));
+        assert_eq!(std::fs::read(&config_path).unwrap(), config_before);
+        assert!(!src.join("CommonModules/SampleService.xml").exists());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn repeated_meta_compile_is_a_byte_for_byte_noop() {
+        let root = temp_meta_compile_workspace("unica-meta-compile-repeat-noop");
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        let json_path = workspace.join("common-module.json");
+        std::fs::write(
+            &json_path,
+            r#"{
+  "type": "CommonModule",
+  "name": "SampleService",
+  "synonym": "Sample service"
+}"#,
+        )
+        .unwrap();
+        let first = call_meta_compile(&workspace, &json_path);
+        assert!(first.ok, "{:?}", first.errors);
+        let metadata_path = src.join("CommonModules/SampleService.xml");
+        let module_path = src.join("CommonModules/SampleService/Ext/Module.bsl");
+        let config_path = src.join("Configuration.xml");
+        let metadata_before = std::fs::read(&metadata_path).unwrap();
+        let module_before = std::fs::read(&module_path).unwrap();
+        let config_before = std::fs::read(&config_path).unwrap();
+        std::fs::write(
+            &json_path,
+            r#"{
+  "type": "CommonModule",
+  "name": "SampleService",
+  "synonym": "A changed definition must not overwrite the object"
+}"#,
+        )
+        .unwrap();
+
+        let repeated = call_meta_compile(&workspace, &json_path);
+
+        assert!(repeated.ok, "{:?}", repeated.errors);
+        assert!(repeated.changes.is_empty(), "{:?}", repeated.changes);
+        assert!(repeated.artifacts.is_empty(), "{:?}", repeated.artifacts);
+        assert_eq!(std::fs::read(&metadata_path).unwrap(), metadata_before);
+        assert_eq!(std::fs::read(&module_path).unwrap(), module_before);
+        assert_eq!(std::fs::read(&config_path).unwrap(), config_before);
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn meta_compile_batch_rolls_back_after_object_files_failure() {
+        use crate::infrastructure::native_operations::compile_transaction::{
+            with_commit_failpoint, CommitFailpoint,
+        };
+
+        let root = temp_meta_compile_workspace("unica-meta-compile-batch-rollback");
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        let config_path = src.join("Configuration.xml");
+        let config_before = std::fs::read(&config_path).unwrap();
+        let json_path = workspace.join("batch.json");
+        std::fs::write(
+            &json_path,
+            r#"[
+  {"type":"CommonModule","name":"RollbackService"},
+  {"type":"Catalog","name":"RollbackCatalog"}
+]"#,
+        )
+        .unwrap();
+
+        let result = with_commit_failpoint(CommitFailpoint::AfterObjectFiles, || {
+            call_meta_compile(&workspace, &json_path)
+        });
+
+        assert!(!result.ok, "{result:?}");
+        assert!(
+            result.errors.join("\n").contains("after object files"),
+            "{result:?}"
+        );
+        assert_eq!(std::fs::read(&config_path).unwrap(), config_before);
+        assert!(!src.join("CommonModules").exists());
+        assert!(!src.join("Catalogs").exists());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn meta_compile_preserves_single_configuration_bom() {
         let root = temp_meta_compile_workspace("unica-meta-compile-single-bom");
         let workspace = root.join("workspace");
@@ -2965,12 +3157,13 @@ mod tests {
             String::from_utf8_lossy(&std::fs::read(&config_path).unwrap()).to_string();
         assert!(config_text.contains(concat!(
             "\r\n\t\t\t<Catalog>Items</Catalog>\r\n",
-            "\t\t\t<Report>MetaCompileFormatReport</Report>\n",
+            "\t\t\t<Report>MetaCompileFormatReport</Report>\r\n",
             "\t\t</ChildObjects>"
         )));
         assert!(!config_text.contains("\t\t\t\t\t<Report>MetaCompileFormatReport</Report>"));
-        assert!(!config_text
-            .contains("<Report>MetaCompileFormatReport</Report>\r\n\t\t</ChildObjects>"));
+        assert!(
+            !config_text.contains("<Report>MetaCompileFormatReport</Report>\n\t\t</ChildObjects>")
+        );
 
         let _ = std::fs::remove_dir_all(root);
     }
@@ -3169,6 +3362,134 @@ mod tests {
     }
 
     #[test]
+    fn role_compile_registers_in_canonical_position_and_preserves_crlf() {
+        let root = temp_meta_compile_workspace("unica-role-compile-canonical-registration");
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        let config_path = src.join("Configuration.xml");
+        std::fs::write(
+            &config_path,
+            concat!(
+                "\u{feff}<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n",
+                "<MetaDataObject xmlns=\"http://v8.1c.ru/8.3/MDClasses\">\r\n",
+                "\t<Configuration>\r\n",
+                "\t\t<ChildObjects>\r\n",
+                "\t\t\t<SessionParameter>CurrentUser</SessionParameter>\r\n",
+                "\t\t\t<CommonTemplate>Shared</CommonTemplate>\r\n",
+                "\t\t</ChildObjects>\r\n",
+                "\t</Configuration>\r\n",
+                "</MetaDataObject><!-- registrar-tail -->\r\n\r\n"
+            ),
+        )
+        .unwrap();
+        let config_before = std::fs::read(&config_path).unwrap();
+        let role_json = workspace.join("sample-user.json");
+        std::fs::write(
+            &role_json,
+            r#"{
+  "name": "SampleUser",
+  "synonym": "Sample user",
+  "objects": ["Catalog.Items: @view"]
+}"#,
+        )
+        .unwrap();
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(true));
+        args.insert(
+            "JsonPath".to_string(),
+            Value::String(role_json.display().to_string()),
+        );
+        args.insert("OutputDir".to_string(), Value::String("src".to_string()));
+
+        let preview = UnicaApplication::new()
+            .call_tool("unica.role.compile", &args)
+            .unwrap();
+
+        assert!(preview.ok, "{:?}", preview.errors);
+        assert!(preview.summary.contains("dry run"));
+        assert!(preview
+            .changes
+            .iter()
+            .any(|change| change.contains("would create") && change.contains("SampleUser.xml")));
+        assert!(preview
+            .changes
+            .iter()
+            .any(|change| change.contains("would update") && change.contains("Configuration.xml")));
+        assert!(preview.stdout.unwrap_or_default().contains("@@ bytes"));
+        assert!(preview.artifacts.is_empty());
+        assert_eq!(std::fs::read(&config_path).unwrap(), config_before);
+        assert!(!src.join("Roles/SampleUser.xml").exists());
+
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        let result = UnicaApplication::new()
+            .call_tool("unica.role.compile", &args)
+            .unwrap();
+
+        assert!(result.ok, "{:?}", result.errors);
+        let config = String::from_utf8(std::fs::read(&config_path).unwrap()).unwrap();
+        assert!(config.contains(concat!(
+            "\t\t\t<SessionParameter>CurrentUser</SessionParameter>\r\n",
+            "\t\t\t<Role>SampleUser</Role>\r\n",
+            "\t\t\t<CommonTemplate>Shared</CommonTemplate>\r\n"
+        )));
+        assert!(config.ends_with("<!-- registrar-tail -->\r\n\r\n"));
+        assert!(!config.replace("\r\n", "").contains('\n'));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn role_compile_rolls_back_after_object_files_failure() {
+        use crate::infrastructure::native_operations::compile_transaction::{
+            with_commit_failpoint, CommitFailpoint,
+        };
+
+        let root = temp_meta_compile_workspace("unica-role-compile-rollback");
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        let config_path = src.join("Configuration.xml");
+        let config_before = std::fs::read(&config_path).unwrap();
+        let role_json = workspace.join("rollback-user.json");
+        std::fs::write(
+            &role_json,
+            r#"{
+  "name": "RollbackUser",
+  "synonym": "Rollback user",
+  "objects": ["Catalog.Items: @view"]
+}"#,
+        )
+        .unwrap();
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(false));
+        args.insert(
+            "JsonPath".to_string(),
+            Value::String(role_json.display().to_string()),
+        );
+        args.insert("OutputDir".to_string(), Value::String("src".to_string()));
+
+        let result = with_commit_failpoint(CommitFailpoint::AfterObjectFiles, || {
+            UnicaApplication::new()
+                .call_tool("unica.role.compile", &args)
+                .unwrap()
+        });
+
+        assert!(!result.ok, "{result:?}");
+        assert!(result.errors.join("\n").contains("after object files"));
+        assert_eq!(std::fs::read(&config_path).unwrap(), config_before);
+        assert!(!src.join("Roles").exists());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn role_compile_generates_distinct_non_placeholder_uuid_v4() {
         let root = temp_meta_compile_workspace("unica-role-compile-uuid-v4");
         let workspace = root.join("workspace");
@@ -3280,6 +3601,22 @@ mod tests {
         let first_xml =
             std::fs::read_to_string(workspace.join("src/Roles/SampleReader.xml")).unwrap();
         let first_uuid = metadata_root_uuid(&first_xml, "Role");
+        let metadata_path = workspace.join("src/Roles/SampleReader.xml");
+        let rights_path = workspace.join("src/Roles/SampleReader/Ext/Rights.xml");
+        let config_path = workspace.join("src/Configuration.xml");
+        let metadata_before = std::fs::read(&metadata_path).unwrap();
+        let rights_before = std::fs::read(&rights_path).unwrap();
+        let config_before = std::fs::read(&config_path).unwrap();
+        std::fs::write(
+            &role_json,
+            r#"{
+  "name": "SampleReader",
+  "synonym": "Changed definition must not overwrite",
+  "comment": "Synthetic repro",
+  "objects": ["Catalog.Items: @view @edit"]
+}"#,
+        )
+        .unwrap();
 
         let mut args = Map::new();
         args.insert(
@@ -3297,11 +3634,16 @@ mod tests {
             .unwrap();
 
         assert!(result.ok, "{:?}", result.errors);
+        assert!(result.changes.is_empty(), "{:?}", result.changes);
+        assert!(result.artifacts.is_empty(), "{:?}", result.artifacts);
 
         let regenerated_xml =
             std::fs::read_to_string(workspace.join("src/Roles/SampleReader.xml")).unwrap();
         let regenerated_uuid = metadata_root_uuid(&regenerated_xml, "Role");
         assert_eq!(first_uuid, regenerated_uuid);
+        assert_eq!(std::fs::read(&metadata_path).unwrap(), metadata_before);
+        assert_eq!(std::fs::read(&rights_path).unwrap(), rights_before);
+        assert_eq!(std::fs::read(&config_path).unwrap(), config_before);
 
         let _ = std::fs::remove_dir_all(root);
     }
@@ -4822,6 +5164,174 @@ mod tests {
         assert!(error.contains("outside workspace root"));
         assert!(!root.join("outside").exists());
 
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn detailed_compile_dry_run_rejects_output_escape_like_apply() {
+        let root = temp_meta_compile_workspace("unica-compile-preview-path-policy");
+        let workspace = root.join("workspace");
+        let json_path = workspace.join("module.json");
+        std::fs::write(
+            &json_path,
+            r#"{"type":"CommonModule","name":"PreviewPathPolicy"}"#,
+        )
+        .unwrap();
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(true));
+        args.insert(
+            "JsonPath".to_string(),
+            Value::String(json_path.display().to_string()),
+        );
+        args.insert(
+            "OutputDir".to_string(),
+            Value::String("../outside".to_string()),
+        );
+
+        let error = UnicaApplication::new()
+            .call_tool("unica.meta.compile", &args)
+            .expect_err("preview must enforce the same output path policy as apply");
+
+        assert!(error.contains("outside workspace root"), "{error}");
+        assert!(!root.join("outside").exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn detailed_compile_dry_run_rejects_edt_source_set_like_apply() {
+        let root = test_workspace_root("unica-compile-preview-edt-guard");
+        let workspace = root.join("workspace");
+        std::fs::create_dir_all(workspace.join("src/Configuration")).unwrap();
+        std::fs::write(
+            workspace.join("v8project.yaml"),
+            "format: EDT\nsource-set:\n  - name: main\n    type: CONFIGURATION\n    path: src\n",
+        )
+        .unwrap();
+        std::fs::write(workspace.join("src/.project"), "<projectDescription/>").unwrap();
+        std::fs::write(
+            workspace.join("src/Configuration/Configuration.mdo"),
+            "<mdclass:Configuration/>",
+        )
+        .unwrap();
+        let json_path = workspace.join("module.json");
+        std::fs::write(
+            &json_path,
+            r#"{"type":"CommonModule","name":"PreviewEdtGuard"}"#,
+        )
+        .unwrap();
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(true));
+        args.insert(
+            "JsonPath".to_string(),
+            Value::String(json_path.display().to_string()),
+        );
+        args.insert("OutputDir".to_string(), Value::String("src".to_string()));
+
+        let error = UnicaApplication::new()
+            .call_tool("unica.meta.compile", &args)
+            .expect_err("preview must enforce the same source-format guard as apply");
+
+        assert!(error.contains("sourceFormat=edt"), "{error}");
+        assert!(error.contains("platform_xml"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn detailed_compile_dry_run_reports_planner_errors_instead_of_masking_them() {
+        let root = temp_meta_compile_workspace("unica-compile-preview-error-parity");
+        let workspace = root.join("workspace");
+        let config_path = workspace.join("src/Configuration.xml");
+        let config_before = std::fs::read(&config_path).unwrap();
+        let json_path = workspace.join("invalid.json");
+        std::fs::write(
+            &json_path,
+            r#"{"type":"UnknownMetadata","name":"InvalidPreview"}"#,
+        )
+        .unwrap();
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(true));
+        args.insert(
+            "JsonPath".to_string(),
+            Value::String(json_path.display().to_string()),
+        );
+        args.insert("OutputDir".to_string(), Value::String("src".to_string()));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.meta.compile", &args)
+            .unwrap();
+
+        assert!(!result.ok, "{result:?}");
+        assert!(result.summary.contains("dry run"), "{}", result.summary);
+        assert!(
+            result.errors.join("\n").contains("UnknownMetadata"),
+            "{:?}",
+            result.errors
+        );
+        assert!(result.changes.is_empty());
+        assert!(result.artifacts.is_empty());
+        assert!(result.cache.events.is_empty());
+        assert_eq!(std::fs::read(&config_path).unwrap(), config_before);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn detailed_compile_dry_run_applies_the_same_support_guard_as_apply() {
+        let root = temp_meta_compile_workspace("unica-compile-preview-support-guard");
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        let ext = src.join("Ext");
+        std::fs::create_dir_all(&ext).unwrap();
+        std::fs::write(
+            ext.join("ParentConfigurations.bin"),
+            support_test_parent_configurations_bin(
+                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            )
+            .replace("{6,0,", "{6,1,"),
+        )
+        .unwrap();
+        let config_path = src.join("Configuration.xml");
+        let config_before = std::fs::read(&config_path).unwrap();
+        let json_path = workspace.join("module.json");
+        std::fs::write(
+            &json_path,
+            r#"{"type":"CommonModule","name":"PreviewSupportGuard"}"#,
+        )
+        .unwrap();
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(true));
+        args.insert(
+            "JsonPath".to_string(),
+            Value::String(json_path.display().to_string()),
+        );
+        args.insert("OutputDir".to_string(), Value::String("src".to_string()));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.meta.compile", &args)
+            .unwrap();
+
+        assert!(!result.ok, "{result:?}");
+        assert!(result.summary.contains("support guard"), "{result:?}");
+        assert!(result.cache.events.is_empty(), "{result:?}");
+        assert_eq!(std::fs::read(&config_path).unwrap(), config_before);
+        assert!(!src.join("CommonModules/PreviewSupportGuard.xml").exists());
         let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/crates/unica-coder/src/application/tool_contracts.rs
+++ b/crates/unica-coder/src/application/tool_contracts.rs
@@ -1078,7 +1078,7 @@ pub fn validate_workspace_paths(
     dry_run: bool,
     context: &WorkspaceContext,
 ) -> Result<(), String> {
-    if dry_run {
+    if dry_run && !validates_compile_preview_like_apply(tool) {
         return Ok(());
     }
     if !is_native_xml_tool(tool) && !matches!(tool.handler, ToolHandler::RuntimeAdapter) {
@@ -1105,7 +1105,7 @@ pub fn validate_native_source_set_format(
     dry_run: bool,
     context: &WorkspaceContext,
 ) -> Result<(), String> {
-    if dry_run || !is_native_xml_tool(tool) {
+    if (dry_run && !validates_compile_preview_like_apply(tool)) || !is_native_xml_tool(tool) {
         return Ok(());
     }
 
@@ -1149,6 +1149,16 @@ pub fn validate_native_source_set_format(
     }
 
     Ok(())
+}
+
+fn validates_compile_preview_like_apply(tool: ToolSpec) -> bool {
+    matches!(
+        tool.handler,
+        ToolHandler::NativeOperation {
+            operation: "meta-compile" | "role-compile" | "subsystem-compile",
+            ..
+        }
+    )
 }
 
 fn write_path_args(tool: ToolSpec) -> &'static [&'static str] {

--- a/crates/unica-coder/src/infrastructure/native_operations.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations.rs
@@ -6,6 +6,7 @@
 pub(crate) mod cf;
 pub(crate) mod cfe;
 pub(crate) mod common;
+pub(crate) mod compile_transaction;
 pub(crate) mod form;
 pub(crate) mod help;
 pub(crate) mod interface;
@@ -35,7 +36,7 @@ impl NativeOperationAdapter {
         mutating: bool,
     ) -> Result<AdapterOutcome, String> {
         if dry_run {
-            return Ok(AdapterOutcome {
+            let mut fallback = AdapterOutcome {
                 ok: true,
                 summary: format!("dry run: {tool_name} would execute native XML/DSL operation"),
                 changes: if mutating {
@@ -49,7 +50,30 @@ impl NativeOperationAdapter {
                 stdout: None,
                 stderr: None,
                 command: None,
-            });
+            };
+            if let Some(preview) = registry::invoke_preview(operation, args, context) {
+                return match preview {
+                    registry::PreviewInvocation::Unavailable(error) => {
+                        fallback.warnings.push(format!(
+                            "detailed compile preview is unavailable; using safe placeholder: {error}"
+                        ));
+                        Ok(fallback)
+                    }
+                    registry::PreviewInvocation::Planned(Ok(outcome)) => Ok(outcome),
+                    registry::PreviewInvocation::Planned(Err(error)) => Ok(AdapterOutcome {
+                        ok: false,
+                        summary: format!("dry run: {tool_name} compile planning failed"),
+                        changes: Vec::new(),
+                        warnings: Vec::new(),
+                        errors: vec![error.clone()],
+                        artifacts: Vec::new(),
+                        stdout: None,
+                        stderr: Some(format!("{error}\n")),
+                        command: None,
+                    }),
+                };
+            }
+            return Ok(fallback);
         }
 
         if mutating {
@@ -99,6 +123,64 @@ mod tests {
         assert!(result
             .unwrap_err()
             .contains("native mutation handler is not registered"));
+    }
+
+    #[test]
+    fn compile_preview_without_payload_uses_the_safe_dry_run_placeholder() {
+        let root = temp_root("compile-preview-fallback");
+        let context = WorkspaceContext::discover(root.clone()).unwrap();
+
+        let result = NativeOperationAdapter::invoke(
+            "meta-compile",
+            "unica.meta.compile",
+            &Map::new(),
+            &context,
+            true,
+            true,
+        )
+        .expect("a missing preview payload must preserve the legacy dry-run contract");
+
+        assert!(result.ok);
+        assert!(result.summary.contains("dry run"));
+        assert_eq!(
+            result.changes,
+            vec!["no files changed because dryRun is true".to_string()]
+        );
+        assert!(result.artifacts.is_empty());
+        assert!(result
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("detailed compile preview is unavailable")));
+        assert!(fs::read_dir(&root).unwrap().next().is_none());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn subsystem_preview_with_unavailable_parent_uses_the_legacy_placeholder() {
+        let root = temp_root("subsystem-preview-parent-fallback");
+        let context = WorkspaceContext::discover(root.clone()).unwrap();
+        let args = serde_json::from_value(serde_json::json!({
+            "OutputDir": root.display().to_string(),
+            "Value": r#"{"name":"Child"}"#,
+            "Parent": "Subsystems/Missing.xml"
+        }))
+        .unwrap();
+
+        let result = NativeOperationAdapter::invoke(
+            "subsystem-compile",
+            "unica.subsystem.compile",
+            &args,
+            &context,
+            true,
+            true,
+        )
+        .unwrap();
+
+        assert!(result.ok);
+        assert!(result.summary.contains("dry run"));
+        assert!(result.warnings[0].contains("parent subsystem is unavailable"));
+        fs::remove_dir_all(root).unwrap();
     }
 
     fn temp_root(name: &str) -> PathBuf {

--- a/crates/unica-coder/src/infrastructure/native_operations/cf.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/cf.rs
@@ -1780,6 +1780,76 @@ mod metadata_kind_consumer_tests {
         );
         assert_eq!(xml, before_unknown);
     }
+
+    #[test]
+    fn child_object_insertion_preserves_crlf_for_existing_and_self_closing_lists() {
+        let mut populated = concat!(
+            "<MetaDataObject>\r\n",
+            "\t<Configuration>\r\n",
+            "\t\t<ChildObjects>\r\n",
+            "\t\t\t<Catalog>Items</Catalog>\r\n",
+            "\t\t</ChildObjects>\r\n",
+            "\t</Configuration>\r\n",
+            "</MetaDataObject>"
+        )
+        .to_string();
+
+        assert!(cf_edit_add_child_object_text(&mut populated, "Report", "Sales").unwrap());
+        assert!(populated.contains(concat!(
+            "\t\t\t<Catalog>Items</Catalog>\r\n",
+            "\t\t\t<Report>Sales</Report>\r\n",
+            "\t\t</ChildObjects>"
+        )));
+        assert!(!populated.replace("\r\n", "").contains('\n'));
+
+        let mut empty = concat!(
+            "<MetaDataObject>\r\n",
+            "\t<Configuration>\r\n",
+            "\t\t<ChildObjects/>\r\n",
+            "\t</Configuration>\r\n",
+            "</MetaDataObject>"
+        )
+        .to_string();
+        assert!(cf_edit_add_child_object_text(&mut empty, "Role", "User").unwrap());
+        assert!(empty.contains(concat!(
+            "\t\t<ChildObjects>\r\n",
+            "\t\t\t<Role>User</Role>\r\n",
+            "\t\t</ChildObjects>"
+        )));
+        assert!(!empty.replace("\r\n", "").contains('\n'));
+    }
+
+    #[test]
+    fn child_object_insertion_targets_only_the_root_metadata_child_objects() {
+        let mut xml = concat!(
+            "\u{feff}<MetaDataObject>\r\n",
+            "\t<Configuration>\r\n",
+            "\t\t<Properties>\r\n",
+            "\t\t\t<!-- <ChildObjects><Role>CommentTrap</Role></ChildObjects> -->\r\n",
+            "\t\t\t<Nested><ChildObjects><Role>NestedTrap</Role></ChildObjects></Nested>\r\n",
+            "\t\t</Properties>\r\n",
+            "\t\t<ChildObjects>\r\n",
+            "\t\t\t<Catalog>Items</Catalog>\r\n",
+            "\t\t</ChildObjects>\r\n",
+            "\t</Configuration>\r\n",
+            "</MetaDataObject>"
+        )
+        .to_string();
+
+        assert!(cf_edit_add_child_object_text(&mut xml, "Role", "Reader").unwrap());
+
+        assert!(
+            xml.contains("<Nested><ChildObjects><Role>NestedTrap</Role></ChildObjects></Nested>")
+        );
+        assert!(xml.contains(concat!(
+            "\t\t<ChildObjects>\r\n",
+            "\t\t\t<Role>Reader</Role>\r\n",
+            "\t\t\t<Catalog>Items</Catalog>\r\n",
+            "\t\t</ChildObjects>"
+        )));
+        assert_eq!(xml.matches("<Role>Reader</Role>").count(), 1);
+        assert!(!xml.replace("\r\n", "").contains('\n'));
+    }
 }
 
 pub(crate) fn edit_cf(args: &Map<String, Value>, context: &WorkspaceContext) -> AdapterOutcome {
@@ -2297,15 +2367,55 @@ pub(crate) struct CfEditChildObjectEntry {
 pub(crate) fn cf_edit_child_object_entries(
     text: &str,
 ) -> Result<Vec<CfEditChildObjectEntry>, String> {
-    let doc = Document::parse(text.trim_start_matches('\u{feff}'))
-        .map_err(|err| format!("XML parse error: {err}"))?;
-    let child_objects = doc
-        .descendants()
-        .find(|node| node.is_element() && node.tag_name().name() == "ChildObjects")
-        .ok_or_else(|| "No <ChildObjects> element found".to_string())?;
+    cf_edit_root_child_objects(text).map(|(_, entries)| entries)
+}
+
+fn cf_edit_root_child_objects(
+    text: &str,
+) -> Result<(CfEditElementRange, Vec<CfEditChildObjectEntry>), String> {
+    let source = text.trim_start_matches('\u{feff}');
+    let source_offset = text.len() - source.len();
+    let doc = Document::parse(source).map_err(|err| format!("XML parse error: {err}"))?;
+    let root = doc.root_element();
+    if root.tag_name().name() != "MetaDataObject" {
+        return Err("Root element must be <MetaDataObject>".to_string());
+    }
+
+    let mut direct_lists = root
+        .children()
+        .filter(|node| node.is_element())
+        .filter_map(|owner| {
+            owner
+                .children()
+                .find(|node| node.is_element() && node.tag_name().name() == "ChildObjects")
+        });
+    let child_objects = direct_lists.next().ok_or_else(|| {
+        "No <ChildObjects> element found directly under the root metadata object".to_string()
+    })?;
+    if direct_lists.next().is_some() {
+        return Err("Multiple root metadata <ChildObjects> elements found".to_string());
+    }
+
+    let node_range = child_objects.range();
+    let child_start = source_offset + node_range.start;
+    let child_end = source_offset + node_range.end;
+    let child_text = &text[child_start..child_end];
+    let open_end = child_text
+        .find('>')
+        .ok_or_else(|| "Malformed root metadata <ChildObjects> element".to_string())?;
+    let body_range = if child_text[..=open_end].trim_end().ends_with("/>") {
+        None
+    } else {
+        let close_start = child_text
+            .rfind("</ChildObjects>")
+            .ok_or_else(|| "Malformed root metadata </ChildObjects> element".to_string())?;
+        Some((child_start + open_end + 1, child_start + close_start))
+    };
+
     let mut entries = Vec::new();
     for child in child_objects.children().filter(|node| node.is_element()) {
-        let range = child.range();
+        let raw_range = child.range();
+        let range = (source_offset + raw_range.start)..(source_offset + raw_range.end);
         let line_start = text[..range.start].rfind('\n').map_or(0, |pos| pos + 1);
         let prefix_is_indent = text[line_start..range.start]
             .chars()
@@ -2329,7 +2439,7 @@ pub(crate) fn cf_edit_child_object_entries(
             line_range: start..end,
         });
     }
-    Ok(entries)
+    Ok(((child_start, child_end, body_range), entries))
 }
 
 pub(crate) fn cf_edit_line_indent(text: &str, index: usize) -> Option<String> {
@@ -2352,14 +2462,29 @@ pub(crate) fn cf_edit_child_name_cmp(left: &str, right: &str) -> std::cmp::Order
         .then_with(|| left.cmp(right))
 }
 
+pub(crate) fn cf_edit_line_ending(text: &str) -> &'static str {
+    let bytes = text.as_bytes();
+    let Some(index) = bytes.iter().position(|byte| matches!(byte, b'\r' | b'\n')) else {
+        return "\n";
+    };
+    if bytes[index] == b'\r' && bytes.get(index + 1) == Some(&b'\n') {
+        "\r\n"
+    } else if bytes[index] == b'\r' {
+        "\r"
+    } else {
+        "\n"
+    }
+}
+
 pub(crate) fn cf_edit_child_object_line(
     type_name: &str,
     object_name: &str,
     indent: &str,
+    line_ending: &str,
 ) -> String {
     format!(
-        "{indent}<{type_name}>{}</{type_name}>\n",
-        escape_xml(object_name)
+        "{indent}<{type_name}>{}</{type_name}>{line_ending}",
+        escape_xml(object_name),
     )
 }
 
@@ -2389,11 +2514,8 @@ pub(crate) fn cf_edit_add_child_object_text(
 ) -> Result<bool, String> {
     let new_type_index =
         metadata_kind_index(type_name).ok_or_else(|| format!("Unknown type '{type_name}'"))?;
-    let Some((child_start, child_end, body_range)) = cf_edit_element_range(text, "ChildObjects")
-    else {
-        return Err("No <ChildObjects> element found".to_string());
-    };
-    let entries = cf_edit_child_object_entries(text)?;
+    let ((child_start, child_end, body_range), entries) = cf_edit_root_child_objects(text)?;
+    let line_ending = cf_edit_line_ending(text);
     if entries
         .iter()
         .any(|entry| entry.type_name == type_name && entry.object_name == object_name)
@@ -2412,7 +2534,7 @@ pub(crate) fn cf_edit_add_child_object_text(
     if let Some(target) = target {
         let indent =
             cf_edit_line_indent(text, target.range.start).unwrap_or_else(|| "\t\t\t".to_string());
-        let line = cf_edit_child_object_line(type_name, object_name, &indent);
+        let line = cf_edit_child_object_line(type_name, object_name, &indent, line_ending);
         text.insert_str(target.line_range.start, &line);
         return Ok(true);
     }
@@ -2420,7 +2542,7 @@ pub(crate) fn cf_edit_add_child_object_text(
     if let Some(last) = entries.last() {
         let indent =
             cf_edit_line_indent(text, last.range.start).unwrap_or_else(|| "\t\t\t".to_string());
-        let line = cf_edit_child_object_line(type_name, object_name, &indent);
+        let line = cf_edit_child_object_line(type_name, object_name, &indent, line_ending);
         text.insert_str(last.line_range.end, &line);
         return Ok(true);
     }
@@ -2430,8 +2552,8 @@ pub(crate) fn cf_edit_add_child_object_text(
         let child_indent = format!("{open_indent}\t");
         let close_indent = open_indent;
         let replacement = format!(
-            "<ChildObjects>\n{}{}</ChildObjects>",
-            cf_edit_child_object_line(type_name, object_name, &child_indent),
+            "<ChildObjects>{line_ending}{}{}</ChildObjects>",
+            cf_edit_child_object_line(type_name, object_name, &child_indent, line_ending),
             close_indent
         );
         text.replace_range(child_start..child_end, &replacement);
@@ -2448,9 +2570,9 @@ pub(crate) fn cf_edit_add_child_object_text(
         cf_edit_line_indent(text, child_start).unwrap_or_default()
     };
     let child_indent = format!("{close_indent}\t");
-    let line = cf_edit_child_object_line(type_name, object_name, &child_indent);
+    let line = cf_edit_child_object_line(type_name, object_name, &child_indent, line_ending);
     if body_start == body_end {
-        text.insert_str(body_start, &format!("\n{line}{close_indent}"));
+        text.insert_str(body_start, &format!("{line_ending}{line}{close_indent}"));
     } else {
         text.insert_str(close_line_start, &line);
     }

--- a/crates/unica-coder/src/infrastructure/native_operations/cf.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/cf.rs
@@ -1820,6 +1820,32 @@ mod metadata_kind_consumer_tests {
     }
 
     #[test]
+    fn child_object_insertion_preserves_cr_only_line_boundaries() {
+        let mut xml = concat!(
+            "<MetaDataObject>\r",
+            "\t<Configuration>\r",
+            "\t\t<ChildObjects>\r",
+            "\t\t\t<Catalog>Items</Catalog>\r",
+            "\t\t</ChildObjects>\r",
+            "\t</Configuration>\r",
+            "</MetaDataObject>"
+        )
+        .to_string();
+
+        assert!(cf_edit_add_child_object_text(&mut xml, "Role", "Reader").unwrap());
+
+        assert!(
+            xml.contains(concat!(
+                "\t\t\t<Role>Reader</Role>\r",
+                "\t\t\t<Catalog>Items</Catalog>\r",
+                "\t\t</ChildObjects>"
+            )),
+            "{xml:?}"
+        );
+        assert!(!xml.contains('\n'));
+    }
+
+    #[test]
     fn child_object_insertion_targets_only_the_root_metadata_child_objects() {
         let mut xml = concat!(
             "\u{feff}<MetaDataObject>\r\n",
@@ -2416,7 +2442,7 @@ fn cf_edit_root_child_objects(
     for child in child_objects.children().filter(|node| node.is_element()) {
         let raw_range = child.range();
         let range = (source_offset + raw_range.start)..(source_offset + raw_range.end);
-        let line_start = text[..range.start].rfind('\n').map_or(0, |pos| pos + 1);
+        let line_start = cf_edit_line_start(text, range.start);
         let prefix_is_indent = text[line_start..range.start]
             .chars()
             .all(|ch| ch == '\t' || ch == ' ');
@@ -2427,7 +2453,7 @@ fn cf_edit_root_child_objects(
         };
         let end = if text[range.end..].starts_with("\r\n") {
             range.end + 2
-        } else if text[range.end..].starts_with('\n') {
+        } else if matches!(text[range.end..].chars().next(), Some('\n' | '\r')) {
             range.end + 1
         } else {
             range.end
@@ -2443,13 +2469,19 @@ fn cf_edit_root_child_objects(
 }
 
 pub(crate) fn cf_edit_line_indent(text: &str, index: usize) -> Option<String> {
-    let line_start = text[..index].rfind('\n').map_or(0, |pos| pos + 1);
+    let line_start = cf_edit_line_start(text, index);
     let indent = &text[line_start..index];
     if indent.chars().all(|ch| ch == '\t' || ch == ' ') {
         Some(indent.to_string())
     } else {
         None
     }
+}
+
+fn cf_edit_line_start(text: &str, index: usize) -> usize {
+    text[..index]
+        .rfind(['\r', '\n'])
+        .map_or(0, |position| position + 1)
 }
 
 pub(crate) fn cf_edit_child_name_key(value: &str) -> String {
@@ -2560,7 +2592,7 @@ pub(crate) fn cf_edit_add_child_object_text(
         return Ok(true);
     };
 
-    let close_line_start = text[..body_end].rfind('\n').map_or(body_end, |pos| pos + 1);
+    let close_line_start = cf_edit_line_start(text, body_end);
     let close_indent = if text[close_line_start..body_end]
         .chars()
         .all(|ch| ch == '\t' || ch == ' ')

--- a/crates/unica-coder/src/infrastructure/native_operations/compile_transaction.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/compile_transaction.rs
@@ -1,0 +1,1767 @@
+//! Failure-atomic publication for the metadata compile writers.
+//!
+//! The compile families build their files in memory, add them to a single
+//! [`CompileTransaction`], and publish the transaction once.  Object files are
+//! create-only.  Existing XML registration targets are edited textually through
+//! the canonical `cf.edit` registrar and are never re-serialized.
+//!
+//! "Failure-atomic" here covers reported I/O and validation errors. It does not
+//! claim process-crash or power-loss atomicity; those require a persistent journal
+//! and directory-entry synchronization that this transaction does not provide.
+
+use fs2::FileExt;
+use roxmltree::Document;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::ffi::OsString;
+use std::fs::{self, File, OpenOptions};
+use std::io::{ErrorKind, Write};
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock, TryLockError, Weak};
+
+#[cfg(test)]
+use std::cell::{Cell, RefCell};
+
+#[cfg(test)]
+use std::sync::{mpsc::Sender, Barrier};
+
+use super::cf::cf_edit_add_child_object_text;
+
+const UTF8_BOM: &[u8] = b"\xef\xbb\xbf";
+static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+static REGISTRATION_PROCESS_LOCKS: OnceLock<Mutex<HashMap<PathBuf, Weak<Mutex<()>>>>> =
+    OnceLock::new();
+
+/// Result of asking the canonical registrar to add one child object.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RegistrationStatus {
+    Added,
+    AlreadyPresent,
+    MissingTarget,
+}
+
+/// Exact replacement required to turn the original bytes into planned bytes.
+///
+/// Applying `after` to `byte_range` of the original file reproduces the planned
+/// registration file byte-for-byte.  `before` is included so callers can render
+/// or verify a dry-run preview without reading the target again.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RegistrationDiff {
+    pub(crate) path: PathBuf,
+    pub(crate) byte_range: Range<usize>,
+    pub(crate) before: Vec<u8>,
+    pub(crate) after: Vec<u8>,
+}
+
+/// Files actually published by a successful transaction.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct CommitReport {
+    pub(crate) created: Vec<PathBuf>,
+    pub(crate) updated: Vec<PathBuf>,
+    /// Cleanup failures do not invalidate already-validated published bytes.
+    /// They are surfaced so a caller can report an orphaned backup explicitly.
+    pub(crate) cleanup_warnings: Vec<String>,
+}
+
+#[derive(Debug)]
+struct PlannedCreate {
+    path: PathBuf,
+    bytes: Vec<u8>,
+}
+
+#[derive(Debug)]
+struct PlannedRegistration {
+    path: PathBuf,
+    lock_path: PathBuf,
+    original: Vec<u8>,
+    updated: Vec<u8>,
+    original_permissions: fs::Permissions,
+}
+
+impl PlannedRegistration {
+    fn changed(&self) -> bool {
+        self.original != self.updated
+    }
+
+    fn diff(&self) -> Option<RegistrationDiff> {
+        self.changed()
+            .then(|| byte_diff(&self.path, &self.original, &self.updated))
+    }
+}
+
+/// In-memory plan for one compile invocation, including a `meta.compile` batch.
+#[derive(Debug, Default)]
+pub(crate) struct CompileTransaction {
+    creates: Vec<PlannedCreate>,
+    create_paths: HashSet<PathBuf>,
+    registrations: BTreeMap<PathBuf, PlannedRegistration>,
+}
+
+impl CompileTransaction {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Plan a create-only file with exact bytes.
+    pub(crate) fn create_bytes(
+        &mut self,
+        path: impl Into<PathBuf>,
+        bytes: impl Into<Vec<u8>>,
+    ) -> Result<(), String> {
+        let path = path.into();
+        self.reject_duplicate_plan_path(&path)?;
+        reject_existing_or_symlink_create_target(&path)?;
+        self.create_paths.insert(path.clone());
+        self.creates.push(PlannedCreate {
+            path,
+            bytes: bytes.into(),
+        });
+        Ok(())
+    }
+
+    /// Plan a create-only UTF-8 file without adding a BOM.
+    #[allow(dead_code)]
+    pub(crate) fn create_text(
+        &mut self,
+        path: impl Into<PathBuf>,
+        text: impl AsRef<str>,
+    ) -> Result<(), String> {
+        self.create_bytes(path, text.as_ref().as_bytes().to_vec())
+    }
+
+    /// Plan a create-only UTF-8 file with exactly one leading BOM.
+    pub(crate) fn create_utf8_bom_text(
+        &mut self,
+        path: impl Into<PathBuf>,
+        text: impl AsRef<str>,
+    ) -> Result<(), String> {
+        let text = text.as_ref().trim_start_matches('\u{feff}');
+        let mut bytes = Vec::with_capacity(UTF8_BOM.len() + text.len());
+        bytes.extend_from_slice(UTF8_BOM);
+        bytes.extend_from_slice(text.as_bytes());
+        self.create_bytes(path, bytes)
+    }
+
+    /// Add one child object to an existing XML target using the canonical
+    /// registrar. Multiple calls for the same target accumulate in memory and
+    /// result in one replacement during commit.
+    pub(crate) fn register_canonical_child(
+        &mut self,
+        target: impl Into<PathBuf>,
+        type_name: &str,
+        object_name: &str,
+    ) -> Result<RegistrationStatus, String> {
+        let target = target.into();
+        if self.create_paths.contains(&target) {
+            return Err(format!(
+                "compile transaction path is both create-only and a registration target: {}",
+                target.display()
+            ));
+        }
+
+        if !self.registrations.contains_key(&target) {
+            let metadata = match fs::symlink_metadata(&target) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == ErrorKind::NotFound => {
+                    return Ok(RegistrationStatus::MissingTarget);
+                }
+                Err(error) => {
+                    return Err(format!(
+                        "failed to inspect registration target {}: {error}",
+                        target.display()
+                    ));
+                }
+            };
+            if metadata.file_type().is_symlink() {
+                return Err(format!(
+                    "registration target must not be a symbolic link: {}",
+                    target.display()
+                ));
+            }
+            if !metadata.is_file() {
+                return Err(format!(
+                    "registration target is not a regular file: {}",
+                    target.display()
+                ));
+            }
+            let original = fs::read(&target).map_err(|error| {
+                format!(
+                    "failed to read registration target {}: {error}",
+                    target.display()
+                )
+            })?;
+            validate_xml_bytes(&target, &original)?;
+            let lock_path = registration_lock_path(&target)?;
+            self.registrations.insert(
+                target.clone(),
+                PlannedRegistration {
+                    path: target.clone(),
+                    lock_path,
+                    updated: original.clone(),
+                    original,
+                    original_permissions: metadata.permissions(),
+                },
+            );
+        }
+
+        let registration = self
+            .registrations
+            .get_mut(&target)
+            .ok_or_else(|| format!("registration target was not cached: {}", target.display()))?;
+        let (bom, payload) = split_utf8_bom_prefix(&registration.updated);
+        let source = std::str::from_utf8(payload).map_err(|error| {
+            format!(
+                "registration target is not valid UTF-8 {}: {error}",
+                target.display()
+            )
+        })?;
+        let source = source.to_string();
+        let mut updated = source.clone();
+        let changed = cf_edit_add_child_object_text(&mut updated, type_name, object_name).map_err(
+            |error| {
+                format!(
+                    "failed to plan registration in {}: {error}",
+                    target.display()
+                )
+            },
+        )?;
+        if !changed {
+            return Ok(RegistrationStatus::AlreadyPresent);
+        }
+
+        updated = preserve_inserted_line_endings(&source, &updated);
+        let mut updated_bytes = Vec::with_capacity(bom.len() + updated.len());
+        updated_bytes.extend_from_slice(bom);
+        updated_bytes.extend_from_slice(updated.as_bytes());
+        validate_xml_bytes(&target, &updated_bytes)?;
+        registration.updated = updated_bytes;
+        Ok(RegistrationStatus::Added)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.creates.is_empty()
+            && self
+                .registrations
+                .values()
+                .all(|registration| !registration.changed())
+    }
+
+    pub(crate) fn planned_created_paths(&self) -> Vec<PathBuf> {
+        self.creates.iter().map(|file| file.path.clone()).collect()
+    }
+
+    pub(crate) fn planned_updated_paths(&self) -> Vec<PathBuf> {
+        self.registrations
+            .values()
+            .filter(|registration| registration.changed())
+            .map(|registration| registration.path.clone())
+            .collect()
+    }
+
+    pub(crate) fn registration_diffs(&self) -> Vec<RegistrationDiff> {
+        self.registrations
+            .values()
+            .filter_map(PlannedRegistration::diff)
+            .collect()
+    }
+
+    /// Stable, compact `changes` entries suitable for a dry-run result.
+    pub(crate) fn dry_run_changes(&self) -> Vec<String> {
+        let mut changes = self
+            .creates
+            .iter()
+            .map(|file| {
+                format!(
+                    "would create {} ({} bytes)",
+                    file.path.display(),
+                    file.bytes.len()
+                )
+            })
+            .collect::<Vec<_>>();
+        changes.extend(self.registration_diffs().into_iter().map(|diff| {
+            format!(
+                "would update {} bytes {}..{} ({} replacement bytes)",
+                diff.path.display(),
+                diff.byte_range.start,
+                diff.byte_range.end,
+                diff.after.len()
+            )
+        }));
+        changes
+    }
+
+    /// Human-readable preview with hexadecimal before/after fragments. Hex is
+    /// used deliberately so CR/LF, BOM, and non-ASCII bytes remain exact.
+    pub(crate) fn dry_run_stdout(&self) -> String {
+        let mut lines = self
+            .creates
+            .iter()
+            .map(|file| {
+                format!(
+                    "[DRY-RUN] would create {} ({} bytes)",
+                    file.path.display(),
+                    file.bytes.len()
+                )
+            })
+            .collect::<Vec<_>>();
+        for diff in self.registration_diffs() {
+            lines.push(format!("[DRY-RUN] would update {}", diff.path.display()));
+            lines.push(format!(
+                "@@ bytes {}..{} @@",
+                diff.byte_range.start, diff.byte_range.end
+            ));
+            lines.push(format!(
+                "  before-utf8: {:?}",
+                String::from_utf8_lossy(&diff.before)
+            ));
+            lines.push(format!(
+                "  after-utf8:  {:?}",
+                String::from_utf8_lossy(&diff.after)
+            ));
+            lines.push(format!("  before-hex: {}", bytes_hex(&diff.before)));
+            lines.push(format!("  after-hex:  {}", bytes_hex(&diff.after)));
+        }
+        if lines.is_empty() {
+            "[DRY-RUN] no file changes\n".to_string()
+        } else {
+            format!("{}\n", lines.join("\n"))
+        }
+    }
+
+    /// Stage, publish, validate, and finalize every planned change as one
+    /// failure-atomic transaction for reported errors. This is not a
+    /// process-crash or power-loss atomicity guarantee.
+    pub(crate) fn commit(self) -> Result<CommitReport, String> {
+        let lock_paths = self.registration_lock_paths();
+        let process_locks = registration_process_locks(&lock_paths);
+        let process_guards = process_locks
+            .iter()
+            .map(|lock| lock_registration_process_mutex(lock))
+            .collect::<Vec<_>>();
+        let file_locks = acquire_registration_file_locks(&lock_paths)?;
+        pause_after_registration_locks();
+
+        let mut state = PublishState::default();
+        let result = match self.commit_inner(&mut state) {
+            Ok(mut report) => {
+                report.cleanup_warnings = finalize_success(&mut state);
+                Ok(report)
+            }
+            Err(error) => {
+                let rollback_errors = rollback(&mut state);
+                if rollback_errors.is_empty() {
+                    Err(error)
+                } else {
+                    Err(format!(
+                        "{error}; rollback encountered: {}",
+                        rollback_errors.join("; ")
+                    ))
+                }
+            }
+        };
+
+        // Keep both lock layers alive through success cleanup or rollback. File
+        // closure releases the advisory locks; persistent lock files must not be
+        // removed because a waiter may already hold their inode open.
+        drop(file_locks);
+        drop(process_guards);
+        result
+    }
+
+    fn commit_inner(&self, state: &mut PublishState) -> Result<CommitReport, String> {
+        self.preflight()?;
+
+        for create in &self.creates {
+            ensure_parent_directories(&create.path, &mut state.created_dirs)?;
+        }
+        for registration in self.registrations.values().filter(|item| item.changed()) {
+            ensure_parent_directories(&registration.path, &mut state.created_dirs)?;
+        }
+
+        for create in &self.creates {
+            let staged = stage_bytes(&create.path, &create.bytes, None)?;
+            state.staged_paths.push(staged.clone());
+            state.create_stages.push(StagedCreate {
+                target: create.path.clone(),
+                staged,
+            });
+        }
+        for registration in self.registrations.values().filter(|item| item.changed()) {
+            let staged = stage_bytes(
+                &registration.path,
+                &registration.updated,
+                Some(registration.original_permissions.clone()),
+            )?;
+            state.staged_paths.push(staged.clone());
+            state.registration_stages.push(StagedRegistration {
+                target: registration.path.clone(),
+                staged,
+                original: registration.original.clone(),
+            });
+        }
+
+        for staged in &state.create_stages {
+            reject_existing_or_symlink_create_target(&staged.target)?;
+            fs::hard_link(&staged.staged, &staged.target).map_err(|error| {
+                format!(
+                    "failed to publish create-only file {}: {error}",
+                    staged.target.display()
+                )
+            })?;
+            state.created_paths.push(staged.target.clone());
+            remove_if_exists(&staged.staged).map_err(|error| {
+                format!(
+                    "failed to remove staged link {}: {error}",
+                    staged.staged.display()
+                )
+            })?;
+        }
+
+        failpoint_after_object_files()?;
+
+        for staged in &state.registration_stages {
+            reject_registration_target_change(&staged.target, &staged.original)?;
+            let backup = reserve_backup(&staged.target)?;
+            if let Err(error) = fs::rename(&staged.target, &backup.path) {
+                let cleanup_error = fs::remove_dir(&backup.directory).err();
+                let cleanup_note = cleanup_error.map_or_else(String::new, |cleanup_error| {
+                    format!(
+                        "; failed to remove empty backup reservation {}: {cleanup_error}",
+                        backup.directory.display()
+                    )
+                });
+                return Err(format!(
+                    "failed to move registration target {} to backup {}: {error}{cleanup_note}",
+                    staged.target.display(),
+                    backup.path.display()
+                ));
+            }
+            state.published_registrations.push(PublishedRegistration {
+                target: staged.target.clone(),
+                backup: backup.path,
+                backup_directory: backup.directory,
+                original: staged.original.clone(),
+            });
+            failpoint_after_registration_backup()?;
+            fs::rename(&staged.staged, &staged.target).map_err(|error| {
+                format!(
+                    "failed to publish registration target {}: {error}",
+                    staged.target.display()
+                )
+            })?;
+        }
+
+        self.post_validate()?;
+        failpoint_post_write_validation()?;
+
+        Ok(CommitReport {
+            created: self.planned_created_paths(),
+            updated: self.planned_updated_paths(),
+            cleanup_warnings: Vec::new(),
+        })
+    }
+
+    fn reject_duplicate_plan_path(&self, path: &Path) -> Result<(), String> {
+        if self.create_paths.contains(path) || self.registrations.contains_key(path) {
+            Err(format!(
+                "compile transaction contains duplicate path: {}",
+                path.display()
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn registration_lock_paths(&self) -> Vec<PathBuf> {
+        let mut paths = self
+            .registrations
+            .values()
+            .filter(|registration| registration.changed())
+            .map(|registration| registration.lock_path.clone())
+            .collect::<Vec<_>>();
+        paths.sort();
+        paths.dedup();
+        paths
+    }
+
+    fn preflight(&self) -> Result<(), String> {
+        for create in &self.creates {
+            reject_existing_or_symlink_create_target(&create.path)?;
+            validate_xml_when_applicable(&create.path, &create.bytes)?;
+        }
+        for registration in self.registrations.values().filter(|item| item.changed()) {
+            reject_registration_target_change(&registration.path, &registration.original)?;
+            validate_xml_bytes(&registration.path, &registration.updated)?;
+        }
+        Ok(())
+    }
+
+    fn post_validate(&self) -> Result<(), String> {
+        for create in &self.creates {
+            validate_published_file(&create.path, &create.bytes)?;
+        }
+        for registration in self.registrations.values().filter(|item| item.changed()) {
+            validate_published_file(&registration.path, &registration.updated)?;
+            validate_xml_bytes(&registration.path, &registration.updated)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct StagedCreate {
+    target: PathBuf,
+    staged: PathBuf,
+}
+
+#[derive(Debug)]
+struct StagedRegistration {
+    target: PathBuf,
+    staged: PathBuf,
+    original: Vec<u8>,
+}
+
+#[derive(Debug)]
+struct PublishedRegistration {
+    target: PathBuf,
+    backup: PathBuf,
+    backup_directory: PathBuf,
+    original: Vec<u8>,
+}
+
+#[derive(Debug)]
+struct BackupReservation {
+    directory: PathBuf,
+    path: PathBuf,
+}
+
+#[derive(Debug, Default)]
+struct PublishState {
+    create_stages: Vec<StagedCreate>,
+    registration_stages: Vec<StagedRegistration>,
+    staged_paths: Vec<PathBuf>,
+    created_paths: Vec<PathBuf>,
+    published_registrations: Vec<PublishedRegistration>,
+    created_dirs: Vec<PathBuf>,
+}
+
+fn registration_lock_path(target: &Path) -> Result<PathBuf, String> {
+    let canonical_target = fs::canonicalize(target).map_err(|error| {
+        format!(
+            "failed to canonicalize registration target {} for locking: {error}",
+            target.display()
+        )
+    })?;
+    let canonical_text = canonical_target.to_string_lossy();
+    let mut hasher = Sha256::new();
+    hasher.update(b"unica-compile-registration-lock-v1\0");
+    #[cfg(any(windows, target_os = "macos"))]
+    hasher.update(canonical_text.to_lowercase().as_bytes());
+    #[cfg(not(any(windows, target_os = "macos")))]
+    hasher.update(canonical_text.as_bytes());
+    let lock_name = format!("{:x}.lock", hasher.finalize());
+    Ok(std::env::temp_dir()
+        .join("unica-compile-registration-locks-v1")
+        .join(lock_name))
+}
+
+fn registration_process_locks(lock_paths: &[PathBuf]) -> Vec<Arc<Mutex<()>>> {
+    let registry = REGISTRATION_PROCESS_LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut registry = registry
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    registry.retain(|_, lock| lock.strong_count() > 0);
+
+    lock_paths
+        .iter()
+        .map(|path| {
+            if let Some(lock) = registry.get(path).and_then(Weak::upgrade) {
+                return lock;
+            }
+            let lock = Arc::new(Mutex::new(()));
+            registry.insert(path.clone(), Arc::downgrade(&lock));
+            lock
+        })
+        .collect()
+}
+
+fn lock_registration_process_mutex(lock: &Mutex<()>) -> MutexGuard<'_, ()> {
+    match lock.try_lock() {
+        Ok(guard) => guard,
+        Err(TryLockError::WouldBlock) => {
+            signal_registration_lock_contention();
+            lock.lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+        }
+        Err(TryLockError::Poisoned(error)) => error.into_inner(),
+    }
+}
+
+fn acquire_registration_file_locks(lock_paths: &[PathBuf]) -> Result<Vec<File>, String> {
+    lock_paths
+        .iter()
+        .map(|path| {
+            let file = open_registration_lock_file(path)?;
+            FileExt::lock_exclusive(&file).map_err(|error| {
+                format!(
+                    "failed to lock registration target via {}: {error}",
+                    path.display()
+                )
+            })?;
+            Ok(file)
+        })
+        .collect()
+}
+
+fn open_registration_lock_file(path: &Path) -> Result<File, String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "failed to create registration lock directory {}: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    match OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(path)
+    {
+        Ok(file) => Ok(file),
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+            let metadata = fs::symlink_metadata(path).map_err(|inspect_error| {
+                format!(
+                    "failed to inspect existing registration lock {} after {error}: {inspect_error}",
+                    path.display()
+                )
+            })?;
+            if metadata.file_type().is_symlink() {
+                return Err(format!(
+                    "registration lock must not be a symbolic link: {}",
+                    path.display()
+                ));
+            }
+            if !metadata.is_file() {
+                return Err(format!(
+                    "registration lock is not a regular file: {}",
+                    path.display()
+                ));
+            }
+            OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(path)
+                .map_err(|open_error| {
+                    format!(
+                        "failed to open existing registration lock {}: {open_error}",
+                        path.display()
+                    )
+                })
+        }
+        Err(error) => Err(format!(
+            "failed to create registration lock {}: {error}",
+            path.display()
+        )),
+    }
+}
+
+fn reject_existing_or_symlink_create_target(path: &Path) -> Result<(), String> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            let kind = if metadata.file_type().is_symlink() {
+                "symbolic link"
+            } else if metadata.is_dir() {
+                "directory"
+            } else {
+                "existing file"
+            };
+            Err(format!(
+                "create-only compile target is already a {kind}: {}",
+                path.display()
+            ))
+        }
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!(
+            "failed to inspect create-only target {}: {error}",
+            path.display()
+        )),
+    }
+}
+
+fn reject_registration_target_change(path: &Path, original: &[u8]) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        format!(
+            "registration target disappeared before commit {}: {error}",
+            path.display()
+        )
+    })?;
+    if metadata.file_type().is_symlink() {
+        return Err(format!(
+            "registration target became a symbolic link before commit: {}",
+            path.display()
+        ));
+    }
+    if !metadata.is_file() {
+        return Err(format!(
+            "registration target is no longer a regular file: {}",
+            path.display()
+        ));
+    }
+    let current =
+        fs::read(path).map_err(|error| format!("failed to re-read {}: {error}", path.display()))?;
+    if current != original {
+        return Err(format!(
+            "registration target changed after planning: {}",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+fn validate_published_file(path: &Path, expected: &[u8]) -> Result<(), String> {
+    let actual = fs::read(path)
+        .map_err(|error| format!("failed to validate published {}: {error}", path.display()))?;
+    if actual != expected {
+        return Err(format!(
+            "post-write byte validation failed for {}",
+            path.display()
+        ));
+    }
+    validate_xml_when_applicable(path, &actual)
+}
+
+fn validate_xml_when_applicable(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let is_xml = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("xml"));
+    if is_xml {
+        validate_xml_bytes(path, bytes)
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_xml_bytes(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let (_, payload) = split_utf8_bom_prefix(bytes);
+    let text = std::str::from_utf8(payload)
+        .map_err(|error| format!("{} is not valid UTF-8: {error}", path.display()))?;
+    Document::parse(text.trim_start_matches('\u{feff}'))
+        .map(|_| ())
+        .map_err(|error| format!("XML parse error in {}: {error}", path.display()))
+}
+
+fn stage_bytes(
+    target: &Path,
+    bytes: &[u8],
+    permissions: Option<fs::Permissions>,
+) -> Result<PathBuf, String> {
+    let mut attempts = 0usize;
+    loop {
+        attempts += 1;
+        let staged = unique_sibling_path(target, "stage");
+        let open = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&staged);
+        let mut file = match open {
+            Ok(file) => file,
+            Err(error) if error.kind() == ErrorKind::AlreadyExists && attempts < 16 => continue,
+            Err(error) => {
+                return Err(format!(
+                    "failed to create staged file {}: {error}",
+                    staged.display()
+                ));
+            }
+        };
+        let write_result = write_and_sync(&mut file, bytes);
+        drop(file);
+        if let Err(error) = write_result {
+            let _ = fs::remove_file(&staged);
+            return Err(format!(
+                "failed to write staged file {}: {error}",
+                staged.display()
+            ));
+        }
+        if let Some(permissions) = permissions {
+            if let Err(error) = fs::set_permissions(&staged, permissions) {
+                let _ = fs::remove_file(&staged);
+                return Err(format!(
+                    "failed to preserve permissions on staged file {}: {error}",
+                    staged.display()
+                ));
+            }
+        }
+        return Ok(staged);
+    }
+}
+
+fn reserve_backup(target: &Path) -> Result<BackupReservation, String> {
+    reserve_backup_with(target, || unique_sibling_path(target, "backup"))
+}
+
+fn reserve_backup_with(
+    target: &Path,
+    mut next_directory: impl FnMut() -> PathBuf,
+) -> Result<BackupReservation, String> {
+    for attempt in 1..=16 {
+        let directory = next_directory();
+        match fs::create_dir(&directory) {
+            Ok(()) => {
+                return Ok(BackupReservation {
+                    path: directory.join("original"),
+                    directory,
+                });
+            }
+            Err(error) if error.kind() == ErrorKind::AlreadyExists && attempt < 16 => continue,
+            Err(error) => {
+                return Err(format!(
+                    "failed to reserve no-clobber backup for {} at {}: {error}",
+                    target.display(),
+                    directory.display()
+                ));
+            }
+        }
+    }
+    Err(format!(
+        "failed to reserve no-clobber backup for {}",
+        target.display()
+    ))
+}
+
+fn write_and_sync(file: &mut File, bytes: &[u8]) -> std::io::Result<()> {
+    file.write_all(bytes)?;
+    file.flush()?;
+    file.sync_all()
+}
+
+fn unique_sibling_path(target: &Path, label: &str) -> PathBuf {
+    let parent = usable_parent(target);
+    let mut name = OsString::from(".");
+    name.push(
+        target
+            .file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new("compile")),
+    );
+    name.push(format!(
+        ".unica-{label}-{}-{}",
+        std::process::id(),
+        TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    ));
+    parent.join(name)
+}
+
+fn usable_parent(path: &Path) -> &Path {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
+fn ensure_parent_directories(path: &Path, created_dirs: &mut Vec<PathBuf>) -> Result<(), String> {
+    let mut current = usable_parent(path).to_path_buf();
+    let mut missing = Vec::new();
+    loop {
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) => {
+                if !metadata.is_dir() {
+                    return Err(format!(
+                        "compile target parent is not a directory: {}",
+                        current.display()
+                    ));
+                }
+                break;
+            }
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                missing.push(current.clone());
+                let Some(parent) = current.parent() else {
+                    return Err(format!(
+                        "cannot find an existing ancestor for {}",
+                        path.display()
+                    ));
+                };
+                current = if parent.as_os_str().is_empty() {
+                    PathBuf::from(".")
+                } else {
+                    parent.to_path_buf()
+                };
+            }
+            Err(error) => {
+                return Err(format!(
+                    "failed to inspect parent {}: {error}",
+                    current.display()
+                ));
+            }
+        }
+    }
+
+    for directory in missing.into_iter().rev() {
+        match fs::create_dir(&directory) {
+            Ok(()) => created_dirs.push(directory),
+            Err(error) if error.kind() == ErrorKind::AlreadyExists && directory.is_dir() => {}
+            Err(error) => {
+                return Err(format!(
+                    "failed to create directory {}: {error}",
+                    directory.display()
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn remove_if_exists(path: &Path) -> std::io::Result<()> {
+    prepare_file_for_removal(path)?;
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(not(windows))]
+fn prepare_file_for_removal(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(windows)]
+fn prepare_file_for_removal(path: &Path) -> std::io::Result<()> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    let mut permissions = metadata.permissions();
+    if permissions.readonly() {
+        permissions.set_readonly(false);
+        fs::set_permissions(path, permissions)?;
+    }
+    Ok(())
+}
+
+fn rollback(state: &mut PublishState) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    for published in state.published_registrations.iter().rev() {
+        match fs::symlink_metadata(&published.target) {
+            Ok(_) => {
+                if let Err(error) = remove_if_exists(&published.target) {
+                    errors.push(format!(
+                        "failed to remove published registration {}: {error}; original remains at {}",
+                        published.target.display(),
+                        published.backup.display()
+                    ));
+                    continue;
+                }
+            }
+            Err(error) if error.kind() == ErrorKind::NotFound => {}
+            Err(error) => {
+                errors.push(format!(
+                    "failed to inspect published registration {}: {error}; original remains at {}",
+                    published.target.display(),
+                    published.backup.display()
+                ));
+                continue;
+            }
+        }
+        if let Err(error) = fs::rename(&published.backup, &published.target) {
+            errors.push(format!(
+                "failed to restore registration {} from {}: {error}",
+                published.target.display(),
+                published.backup.display()
+            ));
+            continue;
+        }
+        match fs::read(&published.target) {
+            Ok(bytes) if bytes == published.original => {}
+            Ok(_) => errors.push(format!(
+                "restored registration bytes differ from original: {}",
+                published.target.display()
+            )),
+            Err(error) => errors.push(format!(
+                "failed to verify restored registration {}: {error}",
+                published.target.display()
+            )),
+        }
+        if let Err(error) = fs::remove_dir(&published.backup_directory) {
+            errors.push(format!(
+                "failed to remove restored registration backup directory {}: {error}",
+                published.backup_directory.display()
+            ));
+        }
+    }
+
+    for path in state.created_paths.iter().rev() {
+        if let Err(error) = remove_if_exists(path) {
+            errors.push(format!(
+                "failed to remove published create-only file {}: {error}",
+                path.display()
+            ));
+        }
+    }
+    for path in &state.staged_paths {
+        if let Err(error) = remove_if_exists(path) {
+            errors.push(format!(
+                "failed to remove staged file {}: {error}",
+                path.display()
+            ));
+        }
+    }
+    for directory in state.created_dirs.iter().rev() {
+        match fs::remove_dir(directory) {
+            Ok(()) => {}
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    ErrorKind::NotFound | ErrorKind::DirectoryNotEmpty
+                ) => {}
+            Err(error) => errors.push(format!(
+                "failed to remove transaction-created directory {}: {error}",
+                directory.display()
+            )),
+        }
+    }
+    errors
+}
+
+fn finalize_success(state: &mut PublishState) -> Vec<String> {
+    let mut warnings = Vec::new();
+    for path in &state.staged_paths {
+        if let Err(error) = remove_if_exists(path) {
+            warnings.push(format!(
+                "failed to remove staged file {}: {error}",
+                path.display()
+            ));
+        }
+    }
+    for published in &state.published_registrations {
+        if let Err(error) = remove_if_exists(&published.backup) {
+            warnings.push(format!(
+                "failed to remove registration backup {}: {error}",
+                published.backup.display()
+            ));
+            continue;
+        }
+        if let Err(error) = fs::remove_dir(&published.backup_directory) {
+            warnings.push(format!(
+                "failed to remove registration backup directory {}: {error}",
+                published.backup_directory.display()
+            ));
+        }
+    }
+    warnings
+}
+
+fn split_utf8_bom_prefix(bytes: &[u8]) -> (&[u8], &[u8]) {
+    let mut offset = 0usize;
+    while bytes[offset..].starts_with(UTF8_BOM) {
+        offset += UTF8_BOM.len();
+    }
+    bytes.split_at(offset)
+}
+
+fn preserve_inserted_line_endings(source: &str, updated: &str) -> String {
+    let line_ending = source_line_ending(source);
+    if line_ending == "\n" {
+        return updated.to_string();
+    }
+
+    let (prefix, _source_end, updated_end) = string_diff_bounds(source, updated);
+    let changed = &updated[prefix..updated_end];
+    let changed = replace_bare_lf(changed, line_ending);
+    format!(
+        "{}{}{}",
+        &updated[..prefix],
+        changed,
+        &updated[updated_end..]
+    )
+}
+
+fn source_line_ending(text: &str) -> &'static str {
+    let bytes = text.as_bytes();
+    if let Some(index) = bytes.iter().position(|byte| *byte == b'\n') {
+        if index > 0 && bytes[index - 1] == b'\r' {
+            "\r\n"
+        } else {
+            "\n"
+        }
+    } else if bytes.contains(&b'\r') {
+        "\r"
+    } else {
+        "\n"
+    }
+}
+
+fn replace_bare_lf(text: &str, line_ending: &str) -> String {
+    let mut output = String::with_capacity(text.len());
+    let mut previous_was_cr = false;
+    for character in text.chars() {
+        if character == '\n' && !previous_was_cr {
+            output.push_str(line_ending);
+        } else {
+            output.push(character);
+        }
+        previous_was_cr = character == '\r';
+    }
+    output
+}
+
+fn string_diff_bounds(before: &str, after: &str) -> (usize, usize, usize) {
+    let mut prefix = common_prefix_len(before.as_bytes(), after.as_bytes());
+    while prefix > 0 && (!before.is_char_boundary(prefix) || !after.is_char_boundary(prefix)) {
+        prefix -= 1;
+    }
+    let max_suffix = before.len().min(after.len()).saturating_sub(prefix);
+    let mut suffix = common_suffix_len(&before.as_bytes()[prefix..], &after.as_bytes()[prefix..])
+        .min(max_suffix);
+    while suffix > 0
+        && (!before.is_char_boundary(before.len() - suffix)
+            || !after.is_char_boundary(after.len() - suffix))
+    {
+        suffix -= 1;
+    }
+    (prefix, before.len() - suffix, after.len() - suffix)
+}
+
+fn byte_diff(path: &Path, before: &[u8], after: &[u8]) -> RegistrationDiff {
+    let prefix = common_prefix_len(before, after);
+    let suffix = common_suffix_len(&before[prefix..], &after[prefix..]);
+    let before_end = before.len() - suffix;
+    let after_end = after.len() - suffix;
+    RegistrationDiff {
+        path: path.to_path_buf(),
+        byte_range: prefix..before_end,
+        before: before[prefix..before_end].to_vec(),
+        after: after[prefix..after_end].to_vec(),
+    }
+}
+
+fn common_prefix_len(left: &[u8], right: &[u8]) -> usize {
+    left.iter()
+        .zip(right)
+        .take_while(|(left, right)| left == right)
+        .count()
+}
+
+fn common_suffix_len(left: &[u8], right: &[u8]) -> usize {
+    left.iter()
+        .rev()
+        .zip(right.iter().rev())
+        .take_while(|(left, right)| left == right)
+        .count()
+}
+
+fn bytes_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CommitFailpoint {
+    AfterObjectFiles,
+    AfterRegistrationBackup,
+    PostWriteValidation,
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct RegistrationLockPause {
+    acquired: Arc<Barrier>,
+    release: Arc<Barrier>,
+}
+
+#[cfg(test)]
+thread_local! {
+    static TEST_FAILPOINT: Cell<Option<CommitFailpoint>> = const { Cell::new(None) };
+    static TEST_REGISTRATION_LOCK_PAUSE: RefCell<Option<RegistrationLockPause>> = const { RefCell::new(None) };
+    static TEST_REGISTRATION_LOCK_CONTENDED: RefCell<Option<Sender<()>>> = const { RefCell::new(None) };
+}
+
+#[cfg(test)]
+pub(crate) fn with_commit_failpoint<T>(
+    failpoint: CommitFailpoint,
+    action: impl FnOnce() -> T,
+) -> T {
+    struct Reset(Option<CommitFailpoint>);
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            TEST_FAILPOINT.with(|slot| slot.set(self.0));
+        }
+    }
+
+    let previous = TEST_FAILPOINT.with(|slot| slot.replace(Some(failpoint)));
+    let _reset = Reset(previous);
+    action()
+}
+
+#[cfg(test)]
+fn with_registration_lock_pause<T>(
+    acquired: Arc<Barrier>,
+    release: Arc<Barrier>,
+    action: impl FnOnce() -> T,
+) -> T {
+    struct Reset(Option<RegistrationLockPause>);
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            TEST_REGISTRATION_LOCK_PAUSE.with(|slot| slot.replace(self.0.take()));
+        }
+    }
+
+    let pause = RegistrationLockPause { acquired, release };
+    let previous = TEST_REGISTRATION_LOCK_PAUSE.with(|slot| slot.replace(Some(pause)));
+    let _reset = Reset(previous);
+    action()
+}
+
+#[cfg(test)]
+fn with_registration_lock_contention_signal<T>(
+    sender: Sender<()>,
+    action: impl FnOnce() -> T,
+) -> T {
+    struct Reset(Option<Sender<()>>);
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            TEST_REGISTRATION_LOCK_CONTENDED.with(|slot| slot.replace(self.0.take()));
+        }
+    }
+
+    let previous = TEST_REGISTRATION_LOCK_CONTENDED.with(|slot| slot.replace(Some(sender)));
+    let _reset = Reset(previous);
+    action()
+}
+
+fn pause_after_registration_locks() {
+    #[cfg(test)]
+    TEST_REGISTRATION_LOCK_PAUSE.with(|slot| {
+        if let Some(pause) = slot.borrow().clone() {
+            pause.acquired.wait();
+            pause.release.wait();
+        }
+    });
+}
+
+fn signal_registration_lock_contention() {
+    #[cfg(test)]
+    TEST_REGISTRATION_LOCK_CONTENDED.with(|slot| {
+        if let Some(sender) = slot.borrow().as_ref() {
+            let _ = sender.send(());
+        }
+    });
+}
+
+fn failpoint_after_object_files() -> Result<(), String> {
+    #[cfg(test)]
+    if TEST_FAILPOINT.with(|slot| slot.get()) == Some(CommitFailpoint::AfterObjectFiles) {
+        return Err("injected compile transaction failure after object files".to_string());
+    }
+    Ok(())
+}
+
+fn failpoint_after_registration_backup() -> Result<(), String> {
+    #[cfg(test)]
+    if TEST_FAILPOINT.with(|slot| slot.get()) == Some(CommitFailpoint::AfterRegistrationBackup) {
+        return Err("injected compile transaction failure after registration backup".to_string());
+    }
+    Ok(())
+}
+
+fn failpoint_post_write_validation() -> Result<(), String> {
+    #[cfg(test)]
+    if TEST_FAILPOINT.with(|slot| slot.get()) == Some(CommitFailpoint::PostWriteValidation) {
+        return Err("injected compile transaction post-write validation failure".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    fn temp_root(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock must follow epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "unica-compile-transaction-{name}-{}-{nanos}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&root).expect("temporary root must be created");
+        root
+    }
+
+    fn configuration_bytes() -> Vec<u8> {
+        let text = concat!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n",
+            "<MetaDataObject xmlns=\"http://v8.1c.ru/8.3/MDClasses\" ",
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" ",
+            "xmlns:cfg=\"urn:kept-only-as-qname\" xsi:type=\"cfg:MetaDataObject\">\r\n",
+            "\t<Configuration>\r\n",
+            "\t\t<ChildObjects>\r\n",
+            "\t\t\t<Catalog>Items</Catalog>\r\n",
+            "\t\t</ChildObjects>\r\n",
+            "\t</Configuration>\r\n",
+            "</MetaDataObject><!--tail stays exact-->"
+        );
+        let mut bytes = UTF8_BOM.to_vec();
+        bytes.extend_from_slice(text.as_bytes());
+        bytes
+    }
+
+    fn assert_no_bare_lf(bytes: &[u8]) {
+        for (index, byte) in bytes.iter().enumerate() {
+            if *byte == b'\n' {
+                assert!(index > 0 && bytes[index - 1] == b'\r', "bare LF at {index}");
+            }
+        }
+    }
+
+    fn transaction_debris(root: &Path) -> Vec<PathBuf> {
+        fn visit(path: &Path, result: &mut Vec<PathBuf>) {
+            let Ok(entries) = fs::read_dir(path) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| {
+                        name.contains(".unica-stage-") || name.contains(".unica-backup-")
+                    })
+                {
+                    result.push(path.clone());
+                }
+                if path.is_dir() {
+                    visit(&path, result);
+                }
+            }
+        }
+
+        let mut result = Vec::new();
+        visit(root, &mut result);
+        result
+    }
+
+    #[test]
+    fn canonical_registrations_accumulate_and_preserve_source_bytes() {
+        let root = temp_root("canonical");
+        let config = root.join("Configuration.xml");
+        let original = configuration_bytes();
+        fs::write(&config, &original).expect("fixture must be written");
+        let mut transaction = CompileTransaction::new();
+
+        assert_eq!(
+            transaction
+                .register_canonical_child(&config, "Role", "Reader")
+                .expect("role registration must plan"),
+            RegistrationStatus::Added
+        );
+        assert_eq!(
+            transaction
+                .register_canonical_child(&config, "Subsystem", "Core")
+                .expect("subsystem registration must plan"),
+            RegistrationStatus::Added
+        );
+        assert_eq!(
+            transaction
+                .register_canonical_child(&config, "Role", "Reader")
+                .expect("duplicate must be detected"),
+            RegistrationStatus::AlreadyPresent
+        );
+
+        let diffs = transaction.registration_diffs();
+        assert_eq!(diffs.len(), 1);
+        let diff = &diffs[0];
+        let mut reconstructed = original.clone();
+        reconstructed.splice(diff.byte_range.clone(), diff.after.clone());
+        assert_eq!(transaction.planned_updated_paths(), vec![config.clone()]);
+        assert!(transaction.dry_run_changes()[0].starts_with("would update "));
+        let preview = transaction.dry_run_stdout();
+        assert!(preview.contains("@@ bytes"), "{preview}");
+        assert!(preview.contains("<Role>Reader</Role>\\r\\n"), "{preview}");
+        assert!(preview.contains("after-hex"), "{preview}");
+
+        let report = transaction.commit().expect("transaction must commit");
+        assert!(report.created.is_empty());
+        assert_eq!(report.updated, vec![config.clone()]);
+        assert!(report.cleanup_warnings.is_empty());
+        let actual = fs::read(&config).expect("configuration must remain readable");
+        assert_eq!(actual, reconstructed);
+        assert!(actual.starts_with(UTF8_BOM));
+        assert_no_bare_lf(&actual);
+        let text = String::from_utf8(actual).expect("configuration must be UTF-8");
+        assert!(text.contains("xmlns:cfg=\"urn:kept-only-as-qname\""));
+        assert!(text.contains("xsi:type=\"cfg:MetaDataObject\""));
+        assert!(text.ends_with("</MetaDataObject><!--tail stays exact-->"));
+        let subsystem = text.find("<Subsystem>Core</Subsystem>").unwrap();
+        let role = text.find("<Role>Reader</Role>").unwrap();
+        let catalog = text.find("<Catalog>Items</Catalog>").unwrap();
+        assert!(subsystem < role && role < catalog);
+        assert!(transaction_debris(&root).is_empty());
+        fs::remove_dir_all(root).expect("temporary root must be removed");
+    }
+
+    #[test]
+    fn missing_registration_target_is_explicit_and_does_not_add_an_update() {
+        let root = temp_root("missing-target");
+        let mut transaction = CompileTransaction::new();
+        assert_eq!(
+            transaction
+                .register_canonical_child(root.join("Configuration.xml"), "Role", "Reader")
+                .expect("missing target is an allowed status"),
+            RegistrationStatus::MissingTarget
+        );
+        assert!(transaction.is_empty());
+        assert!(transaction.registration_diffs().is_empty());
+        fs::remove_dir_all(root).expect("temporary root must be removed");
+    }
+
+    #[test]
+    fn self_closing_registration_keeps_a_bom_free_lf_source_bom_free() {
+        let root = temp_root("bom-free-self-closing");
+        let config = root.join("Configuration.xml");
+        let original = concat!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
+            "<MetaDataObject><Configuration><ChildObjects/></Configuration></MetaDataObject>"
+        );
+        fs::write(&config, original).expect("fixture must be written");
+        let mut transaction = CompileTransaction::new();
+
+        assert_eq!(
+            transaction
+                .register_canonical_child(&config, "Role", "Reader")
+                .expect("registration must plan"),
+            RegistrationStatus::Added
+        );
+        transaction.commit().expect("transaction must commit");
+
+        let actual = fs::read(&config).expect("configuration must remain readable");
+        assert!(!actual.starts_with(UTF8_BOM));
+        assert!(String::from_utf8(actual)
+            .unwrap()
+            .contains("<ChildObjects>\n\t<Role>Reader</Role>\n</ChildObjects>"));
+        assert!(transaction_debris(&root).is_empty());
+        fs::remove_dir_all(root).expect("temporary root must be removed");
+    }
+
+    #[test]
+    fn already_present_registration_commits_as_a_byte_for_byte_noop() {
+        let root = temp_root("registration-noop");
+        let config = root.join("Configuration.xml");
+        let original = concat!(
+            "<?xml version=\"1.0\"?>\r\n",
+            "<MetaDataObject><Configuration><ChildObjects>\r\n",
+            "\t<Role>Reader</Role>\r\n",
+            "</ChildObjects></Configuration></MetaDataObject>"
+        )
+        .as_bytes()
+        .to_vec();
+        fs::write(&config, &original).expect("fixture must be written");
+        let mut transaction = CompileTransaction::new();
+
+        assert_eq!(
+            transaction
+                .register_canonical_child(&config, "Role", "Reader")
+                .expect("duplicate registration must plan"),
+            RegistrationStatus::AlreadyPresent
+        );
+        assert!(transaction.is_empty());
+        let report = transaction.commit().expect("no-op transaction must commit");
+
+        assert!(report.created.is_empty());
+        assert!(report.updated.is_empty());
+        assert_eq!(fs::read(&config).unwrap(), original);
+        assert!(transaction_debris(&root).is_empty());
+        fs::remove_dir_all(root).expect("temporary root must be removed");
+    }
+
+    #[test]
+    fn existing_target_without_child_objects_is_rejected_without_mutation() {
+        let root = temp_root("missing-child-objects");
+        let config = root.join("Configuration.xml");
+        let original = b"<?xml version=\"1.0\"?><MetaDataObject><Configuration/></MetaDataObject>";
+        fs::write(&config, original).expect("fixture must be written");
+        let mut transaction = CompileTransaction::new();
+
+        let error = transaction
+            .register_canonical_child(&config, "Role", "Reader")
+            .expect_err("missing ChildObjects must fail");
+
+        assert!(error.contains("No <ChildObjects>"), "{error}");
+        assert_eq!(fs::read(&config).unwrap(), original);
+        fs::remove_dir_all(root).expect("temporary root must be removed");
+    }
+
+    #[test]
+    fn commit_creates_bom_text_and_updates_registration_once() {
+        let root = temp_root("success");
+        let config = root.join("Configuration.xml");
+        fs::write(&config, configuration_bytes()).expect("fixture must be written");
+        let object = root.join("Roles/Reader.xml");
+        let rights = root.join("Roles/Reader/Ext/Rights.xml");
+        let mut transaction = CompileTransaction::new();
+        transaction
+            .create_utf8_bom_text(
+                &object,
+                "<?xml version=\"1.0\"?><MetaDataObject><Role/></MetaDataObject>",
+            )
+            .unwrap();
+        transaction
+            .create_utf8_bom_text(
+                &rights,
+                "<?xml version=\"1.0\"?><Rights xmlns=\"http://v8.1c.ru/8.2/roles\"/>",
+            )
+            .unwrap();
+        transaction
+            .register_canonical_child(&config, "Role", "Reader")
+            .unwrap();
+
+        let report = transaction.commit().expect("transaction must commit");
+
+        assert_eq!(report.created, vec![object.clone(), rights.clone()]);
+        assert_eq!(report.updated, vec![config.clone()]);
+        assert!(fs::read(&object).unwrap().starts_with(UTF8_BOM));
+        assert!(fs::read(&rights).unwrap().starts_with(UTF8_BOM));
+        assert!(fs::read_to_string(&config)
+            .unwrap()
+            .contains("<Role>Reader</Role>"));
+        assert!(transaction_debris(&root).is_empty());
+        fs::remove_dir_all(root).expect("temporary root must be removed");
+    }
+
+    #[test]
+    fn after_object_files_failure_removes_files_and_created_directories() {
+        let root = temp_root("rollback-objects");
+        let config = root.join("Configuration.xml");
+        let original = configuration_bytes();
+        fs::write(&config, &original).expect("fixture must be written");
+        let object = root.join("Deep/Roles/Reader.xml");
+        let mut transaction = CompileTransaction::new();
+        transaction
+            .create_utf8_bom_text(
+                &object,
+                "<?xml version=\"1.0\"?><MetaDataObject><Role/></MetaDataObject>",
+            )
+            .unwrap();
+        transaction
+            .register_canonical_child(&config, "Role", "Reader")
+            .unwrap();
+
+        let error =
+            with_commit_failpoint(CommitFailpoint::AfterObjectFiles, || transaction.commit())
+                .expect_err("failpoint must abort commit");
+
+        assert!(error.contains("after object files"), "{error}");
+        assert!(!object.exists());
+        assert!(!root.join("Deep").exists());
+        assert_eq!(fs::read(&config).unwrap(), original);
+        assert!(transaction_debris(&root).is_empty());
+        fs::remove_dir_all(root).expect("temporary root must be removed");
+    }
+
+    #[test]
+    fn post_write_validation_failure_restores_exact_registration_bytes() {
+        let root = temp_root("rollback-validation");
+        let config = root.join("Configuration.xml");
+        let original = configuration_bytes();
+        fs::write(&config, &original).expect("fixture must be written");
+        let object = root.join("Roles/Reader.xml");
+        let mut transaction = CompileTransaction::new();
+        transaction
+            .create_utf8_bom_text(
+                &object,
+                "<?xml version=\"1.0\"?><MetaDataObject><Role/></MetaDataObject>",
+            )
+            .unwrap();
+        transaction
+            .register_canonical_child(&config, "Role", "Reader")
+            .unwrap();
+
+        let error = with_commit_failpoint(CommitFailpoint::PostWriteValidation, || {
+            transaction.commit()
+        })
+        .expect_err("failpoint must abort commit");
+
+        assert!(error.contains("post-write validation"), "{error}");
+        assert!(!object.exists());
+        assert_eq!(fs::read(&config).unwrap(), original);
+        assert!(transaction_debris(&root).is_empty());
+        fs::remove_dir_all(root).expect("temporary root must be removed");
+    }
+
+    #[test]
+    fn after_registration_backup_failure_restores_exact_bytes_and_removes_debris() {
+        let root = temp_root("rollback-registration-backup");
+        let config = root.join("Configuration.xml");
+        let original = configuration_bytes();
+        fs::write(&config, &original).expect("fixture must be written");
+        let object = root.join("Roles/Reader.xml");
+        let mut transaction = CompileTransaction::new();
+        transaction
+            .create_utf8_bom_text(
+                &object,
+                "<?xml version=\"1.0\"?><MetaDataObject><Role/></MetaDataObject>",
+            )
+            .unwrap();
+        transaction
+            .register_canonical_child(&config, "Role", "Reader")
+            .unwrap();
+
+        let error = with_commit_failpoint(CommitFailpoint::AfterRegistrationBackup, || {
+            transaction.commit()
+        })
+        .expect_err("failpoint must abort between registration renames");
+
+        assert!(error.contains("after registration backup"), "{error}");
+        assert!(!object.exists());
+        assert_eq!(fs::read(&config).unwrap(), original);
+        assert!(transaction_debris(&root).is_empty());
+        assert!(fs::read_dir(&root).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .contains("unica-compile.lock")
+        }));
+        fs::remove_dir_all(root).expect("temporary root must be removed");
+    }
+
+    #[test]
+    fn backup_reservation_retries_without_clobbering_an_occupied_candidate() {
+        let root = temp_root("backup-reservation-collision");
+        let target = root.join("Configuration.xml");
+        let occupied = root.join("occupied-backup");
+        let available = root.join("available-backup");
+        fs::write(&occupied, b"must remain exact").expect("collision fixture must be written");
+        let mut candidates = vec![occupied.clone(), available.clone()].into_iter();
+
+        let reservation = reserve_backup_with(&target, || {
+            candidates
+                .next()
+                .expect("reservation should need only one retry")
+        })
+        .expect("second candidate must reserve successfully");
+
+        assert_eq!(fs::read(&occupied).unwrap(), b"must remain exact");
+        assert_eq!(reservation.directory, available);
+        assert!(reservation.directory.is_dir());
+        assert!(!reservation.path.exists());
+        fs::remove_dir(&reservation.directory).expect("reservation must be removable");
+        fs::remove_dir_all(root).expect("temporary root must be removed");
+    }
+
+    #[test]
+    fn concurrent_registration_commits_serialize_before_preflight() {
+        let root = temp_root("concurrent-registration");
+        let config = root.join("Configuration.xml");
+        fs::write(&config, configuration_bytes()).expect("fixture must be written");
+        let object_a = root.join("Roles/ReaderA.xml");
+        let object_b = root.join("Roles/ReaderB.xml");
+
+        let mut transaction_a = CompileTransaction::new();
+        transaction_a
+            .create_utf8_bom_text(
+                &object_a,
+                "<?xml version=\"1.0\"?><MetaDataObject><Role/></MetaDataObject>",
+            )
+            .unwrap();
+        transaction_a
+            .register_canonical_child(&config, "Role", "ReaderA")
+            .unwrap();
+
+        let mut transaction_b = CompileTransaction::new();
+        transaction_b
+            .create_utf8_bom_text(
+                &object_b,
+                "<?xml version=\"1.0\"?><MetaDataObject><Role/></MetaDataObject>",
+            )
+            .unwrap();
+        transaction_b
+            .register_canonical_child(&config, "Role", "ReaderB")
+            .unwrap();
+
+        let acquired = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let acquired_by_a = acquired.clone();
+        let release_a = release.clone();
+        let thread_a = thread::spawn(move || {
+            with_registration_lock_pause(acquired_by_a, release_a, || transaction_a.commit())
+        });
+        acquired.wait();
+
+        let (contended_sender, contended_receiver) = mpsc::channel();
+        let thread_b = thread::spawn(move || {
+            with_registration_lock_contention_signal(contended_sender, || transaction_b.commit())
+        });
+        let contention = contended_receiver.recv_timeout(Duration::from_secs(2));
+        release.wait();
+
+        let result_a = thread_a.join().expect("first commit thread must not panic");
+        let result_b = thread_b
+            .join()
+            .expect("second commit thread must not panic");
+        contention.expect("second thread must contend on the in-process registration lock");
+        let report_a = result_a.expect("first transaction must commit");
+        let error_b = result_b.expect_err("stale second plan must fail after acquiring the lock");
+
+        assert_eq!(report_a.created, vec![object_a.clone()]);
+        assert!(error_b.contains("changed after planning"), "{error_b}");
+        assert!(object_a.is_file());
+        assert!(!object_b.exists());
+        let actual = fs::read_to_string(&config).unwrap();
+        assert!(actual.contains("<Role>ReaderA</Role>"));
+        assert!(!actual.contains("<Role>ReaderB</Role>"));
+        assert!(transaction_debris(&root).is_empty());
+        fs::remove_dir_all(root).expect("temporary root must be removed");
+    }
+
+    #[test]
+    fn create_only_collision_is_rejected_before_publication() {
+        let root = temp_root("collision");
+        let target = root.join("existing.txt");
+        fs::write(&target, b"original").expect("fixture must be written");
+        let mut transaction = CompileTransaction::new();
+
+        let error = transaction
+            .create_text(&target, "replacement")
+            .expect_err("existing target must be rejected");
+
+        assert!(error.contains("create-only"), "{error}");
+        assert_eq!(fs::read(&target).unwrap(), b"original");
+        fs::remove_dir_all(root).expect("temporary root must be removed");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_targets_are_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let root = temp_root("symlink");
+        let real = root.join("real.xml");
+        let link = root.join("Configuration.xml");
+        fs::write(&real, configuration_bytes()).expect("fixture must be written");
+        symlink(&real, &link).expect("symlink must be created");
+        let mut transaction = CompileTransaction::new();
+
+        let error = transaction
+            .register_canonical_child(&link, "Role", "Reader")
+            .expect_err("symlink registration target must be rejected");
+
+        assert!(error.contains("symbolic link"), "{error}");
+        assert_eq!(fs::read(&real).unwrap(), configuration_bytes());
+        fs::remove_dir_all(root).expect("temporary root must be removed");
+    }
+}

--- a/crates/unica-coder/src/infrastructure/native_operations/compile_transaction.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/compile_transaction.rs
@@ -1458,6 +1458,50 @@ mod tests {
     }
 
     #[test]
+    fn appended_registration_preserves_cr_only_line_boundaries() {
+        let root = temp_root("cr-only-append");
+        let config = root.join("Configuration.xml");
+        fs::write(
+            &config,
+            concat!(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r",
+                "<MetaDataObject>\r",
+                "\t<Configuration>\r",
+                "\t\t<ChildObjects>\r",
+                "\t\t\t<Catalog>Items</Catalog>\r",
+                "\t\t</ChildObjects>\r",
+                "\t</Configuration>\r",
+                "</MetaDataObject>"
+            ),
+        )
+        .expect("fixture must be written");
+        let mut transaction = CompileTransaction::new();
+
+        assert_eq!(
+            transaction
+                .register_canonical_child(&config, "Document", "Orders")
+                .expect("registration must plan"),
+            RegistrationStatus::Added
+        );
+        transaction.commit().expect("transaction must commit");
+
+        let actual = String::from_utf8(fs::read(&config).expect("configuration must be readable"))
+            .expect("configuration must remain UTF-8");
+        assert!(
+            actual.contains(concat!(
+                "\t\t\t<Catalog>Items</Catalog>\r",
+                "\t\t\t<Document>Orders</Document>\r",
+                "\t\t</ChildObjects>"
+            )),
+            "{actual:?}"
+        );
+        assert!(!actual.contains("\r\r\t\t</ChildObjects>"), "{actual:?}");
+        assert!(!actual.contains('\n'));
+        assert!(transaction_debris(&root).is_empty());
+        fs::remove_dir_all(root).expect("temporary root must be removed");
+    }
+
+    #[test]
     fn already_present_registration_commits_as_a_byte_for_byte_noop() {
         let root = temp_root("registration-noop");
         let config = root.join("Configuration.xml");

--- a/crates/unica-coder/src/infrastructure/native_operations/meta.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta.rs
@@ -11,6 +11,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use super::common::*;
+use super::compile_transaction::{CompileTransaction, RegistrationStatus};
 use super::{
     cf::*, cfe::*, form::*, interface::*, mxl::*, role::*, skd::*, subsystem::*, template::*,
 };
@@ -5767,33 +5768,28 @@ pub(crate) fn compile_meta(
     args: &Map<String, Value>,
     context: &WorkspaceContext,
 ) -> AdapterOutcome {
-    let write_result = (|| -> Result<(String, Vec<PathBuf>), String> {
-        let json_path_raw = required_path(args, &["jsonPath", "JsonPath"], "JsonPath")?;
-        let output_dir_label = string_arg(args, &["outputDir", "OutputDir"])
-            .ok_or_else(|| "missing required OutputDir argument".to_string())?
-            .to_string();
-        let output_dir = absolutize(PathBuf::from(&output_dir_label), &context.cwd);
-        let json_path = absolutize(json_path_raw.clone(), &context.cwd);
-        if !json_path.is_file() {
-            return Err(format!("File not found: {}", json_path_raw.display()));
-        }
-
-        let json_text = fs::read_to_string(&json_path)
-            .map_err(|err| format!("failed to read {}: {err}", json_path.display()))?;
-        let defn: Value = serde_json::from_str(json_text.trim_start_matches('\u{feff}'))
-            .map_err(|err| format!("failed to parse metadata JSON: {err}"))?;
-        compile_meta_value(defn, &output_dir_label, &output_dir)
-    })();
+    let write_result = plan_meta_compile(args, context).and_then(|(stdout, transaction)| {
+        let report = transaction.commit()?;
+        let mut changes = report
+            .created
+            .iter()
+            .map(|path| format!("created {}", path.display()))
+            .collect::<Vec<_>>();
+        changes.extend(
+            report
+                .updated
+                .iter()
+                .map(|path| format!("updated {}", path.display())),
+        );
+        Ok((stdout, report.created, changes, report.cleanup_warnings))
+    });
 
     match write_result {
-        Ok((stdout, artifacts)) => AdapterOutcome {
+        Ok((stdout, artifacts, changes, warnings)) => AdapterOutcome {
             ok: true,
             summary: "unica.meta.compile completed with native metadata compiler".to_string(),
-            changes: artifacts
-                .iter()
-                .map(|path| format!("updated {}", path.display()))
-                .collect(),
-            warnings: Vec::new(),
+            changes,
+            warnings,
             errors: Vec::new(),
             artifacts: artifacts
                 .iter()
@@ -5817,14 +5813,57 @@ pub(crate) fn compile_meta(
     }
 }
 
+pub(crate) fn preview_meta_compile(
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> Result<AdapterOutcome, String> {
+    let (_stdout, transaction) = plan_meta_compile(args, context)?;
+    Ok(AdapterOutcome {
+        ok: true,
+        summary: "dry run: unica.meta.compile planned native metadata compilation".to_string(),
+        changes: transaction.dry_run_changes(),
+        warnings: Vec::new(),
+        errors: Vec::new(),
+        artifacts: Vec::new(),
+        stdout: Some(transaction.dry_run_stdout()),
+        stderr: None,
+        command: None,
+    })
+}
+
+fn plan_meta_compile(
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> Result<(String, CompileTransaction), String> {
+    let json_path_raw = required_path(args, &["jsonPath", "JsonPath"], "JsonPath")?;
+    let output_dir_label = string_arg(args, &["outputDir", "OutputDir"])
+        .ok_or_else(|| "missing required OutputDir argument".to_string())?
+        .to_string();
+    let output_dir = absolutize(PathBuf::from(&output_dir_label), &context.cwd);
+    let json_path = absolutize(json_path_raw.clone(), &context.cwd);
+    if !json_path.is_file() {
+        return Err(format!("File not found: {}", json_path_raw.display()));
+    }
+
+    let json_text = fs::read_to_string(&json_path)
+        .map_err(|err| format!("failed to read {}: {err}", json_path.display()))?;
+    let defn: Value = serde_json::from_str(json_text.trim_start_matches('\u{feff}'))
+        .map_err(|err| format!("failed to parse metadata JSON: {err}"))?;
+    let mut transaction = CompileTransaction::new();
+    let (stdout, _planned_artifacts) =
+        compile_meta_value(defn, &output_dir_label, &output_dir, &mut transaction)?;
+    Ok((stdout, transaction))
+}
+
 fn compile_meta_value(
     defn: Value,
     output_dir_label: &str,
     output_dir: &Path,
+    transaction: &mut CompileTransaction,
 ) -> Result<(String, Vec<PathBuf>), String> {
     match defn {
-        Value::Array(items) => compile_meta_batch(items, output_dir_label, output_dir),
-        single => compile_meta_object(single, output_dir_label, output_dir),
+        Value::Array(items) => compile_meta_batch(items, output_dir_label, output_dir, transaction),
+        single => compile_meta_object(single, output_dir_label, output_dir, transaction),
     }
 }
 
@@ -5832,6 +5871,7 @@ fn compile_meta_batch(
     items: Vec<Value>,
     output_dir_label: &str,
     output_dir: &Path,
+    transaction: &mut CompileTransaction,
 ) -> Result<(String, Vec<PathBuf>), String> {
     let total = items.len();
     let mut stdout = String::new();
@@ -5839,7 +5879,7 @@ fn compile_meta_batch(
     let mut failed = Vec::<String>::new();
 
     for (index, item) in items.into_iter().enumerate() {
-        match compile_meta_object(item, output_dir_label, output_dir) {
+        match compile_meta_object(item, output_dir_label, output_dir, transaction) {
             Ok((item_stdout, mut item_artifacts)) => {
                 stdout.push_str(&item_stdout);
                 artifacts.append(&mut item_artifacts);
@@ -5868,6 +5908,7 @@ fn compile_meta_object(
     mut defn: Value,
     output_dir_label: &str,
     output_dir: &Path,
+    transaction: &mut CompileTransaction,
 ) -> Result<(String, Vec<PathBuf>), String> {
     if defn.get("type").is_none() {
         if let Some(object_type) = defn.get("objectType").cloned() {
@@ -5901,25 +5942,41 @@ fn compile_meta_object(
     let obj_sub_dir = type_dir.join(obj_name);
     let ext_dir = obj_sub_dir.join("Ext");
 
-    fs::create_dir_all(&type_dir)
-        .map_err(|err| format!("failed to create {}: {err}", type_dir.display()))?;
-    if meta_compile_uses_object_subdir(&obj_type) {
-        fs::create_dir_all(&obj_sub_dir)
-            .map_err(|err| format!("failed to create {}: {err}", obj_sub_dir.display()))?;
+    match fs::symlink_metadata(&main_xml_path) {
+        Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink() => {
+            return Ok((
+                format!(
+                    "[SKIP] {obj_type} '{obj_name}' already exists at {}; no files changed\n",
+                    main_xml_path.display()
+                ),
+                Vec::new(),
+            ));
+        }
+        Ok(_) => {
+            return Err(format!(
+                "existing metadata target is not a regular file: {}",
+                main_xml_path.display()
+            ));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(format!(
+                "failed to inspect metadata target {}: {error}",
+                main_xml_path.display()
+            ));
+        }
     }
     let format_version = detect_format_version(output_dir);
     let (metadata_xml, uid) =
         meta_compile_object_xml(object, &obj_type, obj_name, &format_version)?;
-    write_utf8_bom(&main_xml_path, &metadata_xml)?;
+    transaction.create_utf8_bom_text(&main_xml_path, &metadata_xml)?;
 
     let mut artifacts = vec![main_xml_path.clone()];
     let mut modules_created = Vec::<PathBuf>::new();
     for module_name in meta_compile_module_files(&obj_type) {
         let module_path = ext_dir.join(module_name);
         if !module_path.is_file() {
-            fs::create_dir_all(&ext_dir)
-                .map_err(|err| format!("failed to create {}: {err}", ext_dir.display()))?;
-            write_utf8_bom(&module_path, "")?;
+            transaction.create_utf8_bom_text(&module_path, "")?;
             modules_created.push(module_path.clone());
             artifacts.push(module_path.clone());
         }
@@ -5927,15 +5984,17 @@ fn compile_meta_object(
     for (file_name, content) in meta_compile_extra_ext_files(&obj_type, &format_version) {
         let file_path = ext_dir.join(file_name);
         if !file_path.is_file() {
-            fs::create_dir_all(&ext_dir)
-                .map_err(|err| format!("failed to create {}: {err}", ext_dir.display()))?;
-            write_utf8_bom(&file_path, &content)?;
+            transaction.create_utf8_bom_text(&file_path, &content)?;
             modules_created.push(file_path.clone());
             artifacts.push(file_path.clone());
         }
     }
 
-    let reg_result = register_compiled_meta_in_configuration(output_dir, &obj_type, obj_name)?;
+    let reg_result = transaction.register_canonical_child(
+        output_dir.join("Configuration.xml"),
+        &obj_type,
+        obj_name,
+    )?;
 
     let attr_count = object
         .get("attributes")
@@ -5997,15 +6056,14 @@ fn compile_meta_object(
                 .unwrap_or("ObjectModule.bsl")
         ));
     }
-    match reg_result.as_deref() {
-        Some("added") => stdout.push_str(&format!(
+    match reg_result {
+        RegistrationStatus::Added => stdout.push_str(&format!(
             "     Configuration.xml: <{obj_type}>{obj_name}</{obj_type}> added to ChildObjects\n"
         )),
-        Some("already") => stdout.push_str(&format!(
+        RegistrationStatus::AlreadyPresent => stdout.push_str(&format!(
             "     Configuration.xml: <{obj_type}>{obj_name}</{obj_type}> already registered\n"
         )),
-        Some("no-childobj") => {}
-        _ => stdout.push_str(&format!(
+        RegistrationStatus::MissingTarget => stdout.push_str(&format!(
             "     Configuration.xml: not found at {}/Configuration.xml (register manually)\n",
             output_dir_label.trim_end_matches(['/', '\\'])
         )),
@@ -9372,19 +9430,19 @@ pub(crate) fn register_compiled_meta_in_configuration(
 ) -> Result<Option<String>, String> {
     metadata_kind(child_tag).ok_or_else(|| format!("Unknown type '{child_tag}'"))?;
     let config_xml_path = output_dir.join("Configuration.xml");
-    if !config_xml_path.is_file() {
-        return Ok(Some("no-config".to_string()));
+    let mut transaction = CompileTransaction::new();
+    let status = transaction.register_canonical_child(&config_xml_path, child_tag, obj_name)?;
+    if status == RegistrationStatus::Added {
+        transaction.commit()?;
     }
-    let mut raw_text = read_utf8_sig(&config_xml_path)?;
-    if !raw_text.contains("<ChildObjects") {
-        return Ok(Some("no-childobj".to_string()));
-    }
-    if cf_edit_add_child_object_text(&mut raw_text, child_tag, obj_name)? {
-        write_utf8_bom(&config_xml_path, &raw_text)?;
-        Ok(Some("added".to_string()))
-    } else {
-        Ok(Some("already".to_string()))
-    }
+    Ok(Some(
+        match status {
+            RegistrationStatus::Added => "added",
+            RegistrationStatus::AlreadyPresent => "already",
+            RegistrationStatus::MissingTarget => "no-config",
+        }
+        .to_string(),
+    ))
 }
 
 #[derive(Default)]

--- a/crates/unica-coder/src/infrastructure/native_operations/registry.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/registry.rs
@@ -1,6 +1,7 @@
 use crate::domain::workspace::WorkspaceContext;
 use crate::infrastructure::AdapterOutcome;
 use serde_json::{Map, Value};
+use std::path::PathBuf;
 
 use super::{cf, cfe, form, help, interface, meta, mxl, role, skd, subsystem, support, template};
 
@@ -20,6 +21,96 @@ pub(crate) fn invoke_read(
         .or_else(|| skd::invoke_read(operation, tool_name, args, context))
         .or_else(|| mxl::invoke_read(operation, tool_name, args, context))
         .or_else(|| role::invoke_read(operation, tool_name, args, context))
+}
+
+pub(crate) enum PreviewInvocation {
+    Unavailable(String),
+    Planned(Result<AdapterOutcome, String>),
+}
+
+pub(crate) fn invoke_preview(
+    operation: &str,
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> Option<PreviewInvocation> {
+    if !matches!(
+        operation,
+        "meta-compile" | "role-compile" | "subsystem-compile"
+    ) {
+        return None;
+    }
+    if let Some(reason) = compile_preview_unavailable(operation, args, context) {
+        return Some(PreviewInvocation::Unavailable(reason));
+    }
+    let planned = match operation {
+        "meta-compile" => meta::preview_meta_compile(args, context),
+        "role-compile" => role::preview_role_compile(args, context),
+        "subsystem-compile" => subsystem::preview_subsystem_compile(args, context),
+        _ => unreachable!("compile preview operations were checked above"),
+    };
+    Some(PreviewInvocation::Planned(planned))
+}
+
+fn compile_preview_unavailable(
+    operation: &str,
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> Option<String> {
+    if string_arg(args, &["OutputDir", "outputDir"]).is_none() {
+        return Some("missing required OutputDir argument".to_string());
+    }
+
+    match operation {
+        "meta-compile" | "role-compile" => {
+            let Some(json_path) = string_arg(args, &["JsonPath", "jsonPath"]) else {
+                return Some("missing required JsonPath argument".to_string());
+            };
+            let json_path = PathBuf::from(json_path);
+            let json_path = if json_path.is_absolute() {
+                json_path
+            } else {
+                context.cwd.join(json_path)
+            };
+            (!json_path.is_file())
+                .then(|| format!("definition file is unavailable: {}", json_path.display()))
+        }
+        "subsystem-compile" => {
+            if let Some(parent) = string_arg(args, &["Parent", "parent"]) {
+                let parent = PathBuf::from(parent);
+                let parent = if parent.is_absolute() {
+                    parent
+                } else {
+                    context.cwd.join(parent)
+                };
+                if !parent.exists() {
+                    return Some(format!(
+                        "parent subsystem is unavailable: {}",
+                        parent.display()
+                    ));
+                }
+            }
+            if string_arg(args, &["Value", "value"]).is_some() {
+                return None;
+            }
+            let Some(definition) = string_arg(args, &["DefinitionFile", "definitionFile"]) else {
+                return Some("missing Value or DefinitionFile argument".to_string());
+            };
+            let definition = PathBuf::from(definition);
+            let definition = if definition.is_absolute() {
+                definition
+            } else {
+                context.cwd.join(definition)
+            };
+            (!definition.is_file())
+                .then(|| format!("definition file is unavailable: {}", definition.display()))
+        }
+        _ => None,
+    }
+}
+
+fn string_arg<'a>(args: &'a Map<String, Value>, keys: &[&str]) -> Option<&'a str> {
+    keys.iter()
+        .find_map(|key| args.get(*key).and_then(Value::as_str))
 }
 
 pub(crate) fn invoke_mutation(

--- a/crates/unica-coder/src/infrastructure/native_operations/role.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/role.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::common::*;
+use super::compile_transaction::{CompileTransaction, RegistrationStatus};
 use super::{
     cf::*, cfe::*, form::*, interface::*, meta::*, mxl::*, skd::*, subsystem::*, template::*,
 };
@@ -1139,11 +1140,40 @@ pub(crate) fn role_validate_known_rights(object_type: &str) -> &'static [&'stati
     }
 }
 
+struct RoleCompileResult {
+    stdout: String,
+    stderr: String,
+    artifacts: Vec<PathBuf>,
+    changes: Vec<String>,
+    warnings: Vec<String>,
+}
+
 pub(crate) fn compile_role(
     args: &Map<String, Value>,
     context: &WorkspaceContext,
 ) -> AdapterOutcome {
-    let write_result = (|| -> Result<(String, String, Vec<PathBuf>), String> {
+    compile_role_internal(args, context, false)
+}
+
+pub(crate) fn preview_role_compile(
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> Result<AdapterOutcome, String> {
+    let outcome = compile_role_internal(args, context, true);
+    if outcome.ok {
+        Ok(outcome)
+    } else {
+        Err(outcome.errors.join("; "))
+    }
+}
+
+fn compile_role_internal(
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+    dry_run: bool,
+) -> AdapterOutcome {
+    let write_result = (|| -> Result<RoleCompileResult, String> {
+        let mut transaction = CompileTransaction::new();
         let json_path_raw = required_path(args, &["jsonPath", "JsonPath"], "JsonPath")?;
         let output_dir_raw = required_path(args, &["outputDir", "OutputDir"], "OutputDir")?;
         let json_path = absolutize(json_path_raw, &context.cwd);
@@ -1269,42 +1299,42 @@ pub(crate) fn compile_role(
 
         let metadata_path = roles_dir.join(format!("{role_name}.xml"));
         let rights_path = roles_dir.join(&role_name).join("Ext").join("Rights.xml");
-        let uid =
-            reusable_existing_role_uuid(&metadata_path).unwrap_or_else(fresh_meta_compile_uuid);
-        let metadata_xml = role_metadata_xml(&role_name, &synonym, &comment, &format_version, &uid);
-        fs::create_dir_all(&roles_dir)
-            .map_err(|err| format!("failed to create {}: {err}", roles_dir.display()))?;
-        if let Some(ext_dir) = rights_path.parent() {
-            fs::create_dir_all(ext_dir)
-                .map_err(|err| format!("failed to create {}: {err}", ext_dir.display()))?;
+        match fs::symlink_metadata(&metadata_path) {
+            Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink() => {
+                let message = format!(
+                    "[SKIP] Role '{role_name}' already exists at {}; no files changed\n",
+                    metadata_path.display()
+                );
+                return Ok(RoleCompileResult {
+                    stdout: message,
+                    stderr,
+                    artifacts: Vec::new(),
+                    changes: Vec::new(),
+                    warnings: Vec::new(),
+                });
+            }
+            Ok(_) => {
+                return Err(format!(
+                    "existing role target is not a regular file: {}",
+                    metadata_path.display()
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!(
+                    "failed to inspect role target {}: {error}",
+                    metadata_path.display()
+                ));
+            }
         }
-        write_utf8_bom(&metadata_path, &metadata_xml)?;
-        write_utf8_bom(&rights_path, &rights_xml)?;
+        let uid = fresh_meta_compile_uuid();
+        let metadata_xml = role_metadata_xml(&role_name, &synonym, &comment, &format_version, &uid);
+        transaction.create_utf8_bom_text(&metadata_path, &metadata_xml)?;
+        transaction.create_utf8_bom_text(&rights_path, &rights_xml)?;
 
         let config_xml_path = config_dir.join("Configuration.xml");
-        let reg_result = if config_xml_path.exists() {
-            let mut raw_text = fs::read_to_string(&config_xml_path)
-                .map_err(|err| format!("failed to read {}: {err}", config_xml_path.display()))?
-                .trim_start_matches('\u{feff}')
-                .to_string();
-            let role_tag = format!("<Role>{role_name}</Role>");
-            if raw_text.contains(&role_tag) {
-                "already"
-            } else {
-                if let Some(insert_at) = last_xml_role_end(&raw_text) {
-                    raw_text.insert_str(insert_at, &format!("\n\t\t\t{role_tag}"));
-                } else {
-                    raw_text = raw_text.replace(
-                        "</ChildObjects>",
-                        &format!("\t\t\t{role_tag}\n\t\t</ChildObjects>"),
-                    );
-                }
-                write_utf8_bom(&config_xml_path, &raw_text)?;
-                "added"
-            }
-        } else {
-            "no-config"
-        };
+        let reg_result =
+            transaction.register_canonical_child(&config_xml_path, "Role", &role_name)?;
 
         let mut stdout = format!(
             "[OK] Role '{role_name}' compiled\n     UUID: {uid}\n     Metadata: {}\n     Rights:   {}\n     Objects: {}, Rights: {total_rights}, Templates: {template_count}\n",
@@ -1313,38 +1343,68 @@ pub(crate) fn compile_role(
             parsed_objects.len()
         );
         match reg_result {
-            "added" => stdout.push_str(&format!(
+            RegistrationStatus::Added => stdout.push_str(&format!(
                 "     Configuration.xml: <Role>{role_name}</Role> added to ChildObjects\n"
             )),
-            "already" => stdout.push_str(&format!(
+            RegistrationStatus::AlreadyPresent => stdout.push_str(&format!(
                 "     Configuration.xml: <Role>{role_name}</Role> already registered\n"
             )),
-            "no-config" => stderr.push_str(&format!(
+            RegistrationStatus::MissingTarget => stderr.push_str(&format!(
                 "WARNING: Configuration.xml not found at {} -- register manually\n",
                 config_xml_path.display()
             )),
-            _ => {}
         }
 
-        Ok((stdout, stderr, vec![metadata_path, rights_path]))
+        let (artifacts, changes, warnings, output) = if dry_run {
+            (
+                Vec::new(),
+                transaction.dry_run_changes(),
+                Vec::new(),
+                transaction.dry_run_stdout(),
+            )
+        } else {
+            let report = transaction.commit()?;
+            let mut changes = report
+                .created
+                .iter()
+                .map(|path| format!("created {}", path.display()))
+                .collect::<Vec<_>>();
+            changes.extend(
+                report
+                    .updated
+                    .iter()
+                    .map(|path| format!("updated {}", path.display())),
+            );
+            (report.created, changes, report.cleanup_warnings, stdout)
+        };
+
+        Ok(RoleCompileResult {
+            stdout: output,
+            stderr,
+            artifacts,
+            changes,
+            warnings,
+        })
     })();
 
     match write_result {
-        Ok((stdout, stderr, artifacts)) => AdapterOutcome {
+        Ok(result) => AdapterOutcome {
             ok: true,
-            summary: "unica.role.compile completed with native role writer".to_string(),
-            changes: artifacts
-                .iter()
-                .map(|path| format!("updated {}", path.display()))
-                .collect(),
-            warnings: Vec::new(),
+            summary: if dry_run {
+                "dry run: unica.role.compile planned native role compilation".to_string()
+            } else {
+                "unica.role.compile completed with native role writer".to_string()
+            },
+            changes: result.changes,
+            warnings: result.warnings,
             errors: Vec::new(),
-            artifacts: artifacts
+            artifacts: result
+                .artifacts
                 .iter()
                 .map(|path| path.display().to_string())
                 .collect(),
-            stdout: Some(stdout),
-            stderr: (!stderr.is_empty()).then_some(stderr),
+            stdout: Some(result.stdout),
+            stderr: (!result.stderr.is_empty()).then_some(result.stderr),
             command: None,
         },
         Err(error) => AdapterOutcome {
@@ -1359,20 +1419,6 @@ pub(crate) fn compile_role(
             command: None,
         },
     }
-}
-
-fn reusable_existing_role_uuid(metadata_path: &Path) -> Option<String> {
-    let text = fs::read_to_string(metadata_path).ok()?;
-    let doc = Document::parse(text.trim_start_matches('\u{feff}')).ok()?;
-    let role_node = doc
-        .descendants()
-        .find(|node| role_info_element(*node, "Role", None))?;
-    let uuid = role_node.attribute("uuid")?.to_string();
-    (is_valid_uuid(&uuid) && !is_placeholder_uuid(&uuid)).then_some(uuid)
-}
-
-fn is_placeholder_uuid(value: &str) -> bool {
-    value.starts_with("00000000-0000-0000-")
 }
 
 pub(crate) fn role_metadata_xml(
@@ -1705,20 +1751,6 @@ pub(crate) fn role_preset_rights(
     .into_iter()
     .map(ToOwned::to_owned)
     .collect()
-}
-
-pub(crate) fn last_xml_role_end(text: &str) -> Option<usize> {
-    let mut search_start = 0usize;
-    let mut last_end = None;
-    while let Some(rel_start) = text[search_start..].find("<Role>") {
-        let start = search_start + rel_start;
-        let Some(rel_end) = text[start..].find("</Role>") else {
-            break;
-        };
-        last_end = Some(start + rel_end + "</Role>".len());
-        search_start = start + rel_end + "</Role>".len();
-    }
-    last_end
 }
 
 pub(crate) fn invoke_read(

--- a/crates/unica-coder/src/infrastructure/native_operations/subsystem.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/subsystem.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::common::*;
+use super::compile_transaction::{CompileTransaction, RegistrationStatus};
 use super::{cf::*, cfe::*, form::*, interface::*, meta::*, mxl::*, role::*, skd::*, template::*};
 pub(crate) struct SubsystemInfoData {
     pub(crate) name: String,
@@ -1303,11 +1304,39 @@ pub(crate) fn subsystem_known_plural_types() -> &'static [&'static str] {
     ]
 }
 
+struct SubsystemCompileResult {
+    stdout: String,
+    artifacts: Vec<PathBuf>,
+    changes: Vec<String>,
+    warnings: Vec<String>,
+}
+
 pub(crate) fn compile_subsystem(
     args: &Map<String, Value>,
     context: &WorkspaceContext,
 ) -> AdapterOutcome {
-    let write_result = (|| -> Result<(String, Vec<PathBuf>), String> {
+    compile_subsystem_internal(args, context, false)
+}
+
+pub(crate) fn preview_subsystem_compile(
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> Result<AdapterOutcome, String> {
+    let outcome = compile_subsystem_internal(args, context, true);
+    if outcome.ok {
+        Ok(outcome)
+    } else {
+        Err(outcome.errors.join("; "))
+    }
+}
+
+fn compile_subsystem_internal(
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+    dry_run: bool,
+) -> AdapterOutcome {
+    let write_result = (|| -> Result<SubsystemCompileResult, String> {
+        let mut transaction = CompileTransaction::new();
         let definition_file = path_arg(args, &["definitionFile", "DefinitionFile"]);
         let value_arg = string_arg(args, &["value", "Value"]);
         if definition_file.is_some() && value_arg.is_some() {
@@ -1478,19 +1507,41 @@ pub(crate) fn compile_subsystem(
             output_dir.join("Subsystems")
         };
 
-        fs::create_dir_all(&subs_dir)
-            .map_err(|err| format!("failed to create {}: {err}", subs_dir.display()))?;
         let target_xml = subs_dir.join(format!("{obj_name}.xml"));
-        write_utf8_bom(&target_xml, &format!("{}\n", lines.join("\n")))?;
+        match fs::symlink_metadata(&target_xml) {
+            Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink() => {
+                let message = format!(
+                    "[SKIP] Subsystem '{obj_name}' already exists at {}; no files changed\n",
+                    target_xml.display()
+                );
+                return Ok(SubsystemCompileResult {
+                    stdout: message,
+                    artifacts: Vec::new(),
+                    changes: Vec::new(),
+                    warnings: Vec::new(),
+                });
+            }
+            Ok(_) => {
+                return Err(format!(
+                    "existing subsystem target is not a regular file: {}",
+                    target_xml.display()
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!(
+                    "failed to inspect subsystem target {}: {error}",
+                    target_xml.display()
+                ));
+            }
+        }
+        transaction.create_utf8_bom_text(&target_xml, format!("{}\n", lines.join("\n")))?;
         let mut artifacts = vec![target_xml.clone()];
         stdout.push_str(&format!("[OK] Created: {}\n", target_xml.display()));
 
         if !children.is_empty() {
             let child_subs_dir = subs_dir.join(&obj_name).join("Subsystems");
             if !child_subs_dir.exists() {
-                fs::create_dir_all(&child_subs_dir).map_err(|err| {
-                    format!("failed to create {}: {err}", child_subs_dir.display())
-                })?;
                 stdout.push_str(&format!(
                     "[OK] Created directory: {}\n",
                     child_subs_dir.display()
@@ -1504,7 +1555,10 @@ pub(crate) fn compile_subsystem(
                 seen.push(child.clone());
                 let child_xml = child_subs_dir.join(format!("{child}.xml"));
                 if !child_xml.exists() {
-                    write_child_subsystem_stub(&child_xml, child, &format_version)?;
+                    transaction.create_utf8_bom_text(
+                        &child_xml,
+                        child_subsystem_stub_xml(child, &format_version),
+                    )?;
                     stdout.push_str(&format!("[OK] Created stub: {}\n", child_xml.display()));
                     artifacts.push(child_xml);
                 }
@@ -1519,46 +1573,18 @@ pub(crate) fn compile_subsystem(
         };
 
         if let Some(parent_xml_path) = parent_xml_path {
-            if parent_xml_path.exists() {
-                let mut raw_text = fs::read_to_string(&parent_xml_path)
-                    .map_err(|err| format!("failed to read {}: {err}", parent_xml_path.display()))?
-                    .trim_start_matches('\u{feff}')
-                    .to_string();
-                let tag = format!("<Subsystem>{}</Subsystem>", escape_xml(&obj_name));
-                if raw_text.contains(&tag) {
-                    stdout.push_str(&format!(
-                        "[SKIP] Already registered in: {}\n",
-                        parent_xml_path.display()
-                    ));
-                } else if raw_text.contains("<ChildObjects/>") {
-                    let replacement = format!("<ChildObjects>\n\t\t\t{tag}\n\t\t</ChildObjects>");
-                    raw_text = raw_text.replacen("<ChildObjects/>", &replacement, 1);
-                    write_utf8_bom(&parent_xml_path, &raw_text)?;
-                    stdout.push_str(&format!(
-                        "[OK] Registered in: {}\n",
-                        parent_xml_path.display()
-                    ));
-                    artifacts.push(parent_xml_path);
-                } else if raw_text.contains("</ChildObjects>") {
-                    raw_text = raw_text.replacen(
-                        "</ChildObjects>",
-                        &format!("\t\t\t{tag}\n\t\t</ChildObjects>"),
-                        1,
-                    );
-                    write_utf8_bom(&parent_xml_path, &raw_text)?;
-                    stdout.push_str(&format!(
-                        "[OK] Registered in: {}\n",
-                        parent_xml_path.display()
-                    ));
-                    artifacts.push(parent_xml_path);
-                } else {
-                    stdout.push_str(&format!(
-                        "[WARN] ChildObjects not found in: {}\n",
-                        parent_xml_path.display()
-                    ));
+            match transaction.register_canonical_child(&parent_xml_path, "Subsystem", &obj_name)? {
+                RegistrationStatus::Added => stdout.push_str(&format!(
+                    "[OK] Registered in: {}\n",
+                    parent_xml_path.display()
+                )),
+                RegistrationStatus::AlreadyPresent => stdout.push_str(&format!(
+                    "[SKIP] Already registered in: {}\n",
+                    parent_xml_path.display()
+                )),
+                RegistrationStatus::MissingTarget => {
+                    stdout.push_str("[INFO] No parent XML to register in\n")
                 }
-            } else {
-                stdout.push_str("[INFO] No parent XML to register in\n");
             }
         } else {
             stdout.push_str("[INFO] No parent XML to register in\n");
@@ -1572,24 +1598,61 @@ pub(crate) fn compile_subsystem(
         stdout.push_str(&format!("  Children: {}\n", children.len()));
         stdout.push_str(&format!("  File:     {}\n", target_xml.display()));
 
-        Ok((stdout, artifacts))
+        let (artifacts, changes, warnings, output) = if dry_run {
+            (
+                Vec::new(),
+                transaction.dry_run_changes(),
+                Vec::new(),
+                transaction.dry_run_stdout(),
+            )
+        } else {
+            let report = transaction.commit()?;
+            let mut changes = report
+                .created
+                .iter()
+                .map(|path| format!("created {}", path.display()))
+                .collect::<Vec<_>>();
+            changes.extend(
+                report
+                    .updated
+                    .iter()
+                    .map(|path| format!("updated {}", path.display())),
+            );
+            let mut committed_artifacts = report.created;
+            committed_artifacts.extend(report.updated);
+            (
+                committed_artifacts,
+                changes,
+                report.cleanup_warnings,
+                stdout,
+            )
+        };
+
+        Ok(SubsystemCompileResult {
+            stdout: output,
+            artifacts,
+            changes,
+            warnings,
+        })
     })();
 
     match write_result {
-        Ok((stdout, artifacts)) => AdapterOutcome {
+        Ok(result) => AdapterOutcome {
             ok: true,
-            summary: "unica.subsystem.compile completed with native XML writer".to_string(),
-            changes: artifacts
-                .iter()
-                .map(|path| format!("updated {}", path.display()))
-                .collect(),
-            warnings: Vec::new(),
+            summary: if dry_run {
+                "dry run: unica.subsystem.compile planned native subsystem compilation".to_string()
+            } else {
+                "unica.subsystem.compile completed with native XML writer".to_string()
+            },
+            changes: result.changes,
+            warnings: result.warnings,
             errors: Vec::new(),
-            artifacts: artifacts
+            artifacts: result
+                .artifacts
                 .iter()
                 .map(|path| path.display().to_string())
                 .collect(),
-            stdout: Some(stdout),
+            stdout: Some(result.stdout),
             stderr: None,
             command: None,
         },
@@ -1612,6 +1675,13 @@ pub(crate) fn write_child_subsystem_stub(
     child_name: &str,
     format_version: &str,
 ) -> Result<(), String> {
+    write_utf8_bom(
+        child_path,
+        &child_subsystem_stub_xml(child_name, format_version),
+    )
+}
+
+pub(crate) fn child_subsystem_stub_xml(child_name: &str, format_version: &str) -> String {
     let subsystem_uuid = fresh_uuid();
     let mut lines = Vec::new();
     lines.push("<?xml version=\"1.0\" encoding=\"UTF-8\"?>".to_string());
@@ -1633,7 +1703,7 @@ pub(crate) fn write_child_subsystem_stub(
     lines.push("\t\t<ChildObjects/>".to_string());
     lines.push("\t</Subsystem>".to_string());
     lines.push("</MetaDataObject>".to_string());
-    write_utf8_bom(child_path, &format!("{}\n", lines.join("\n")))
+    format!("{}\n", lines.join("\n"))
 }
 
 pub(crate) fn normalize_subsystem_content_ref(raw: &str) -> String {
@@ -1899,6 +1969,183 @@ mod tests {
         let first_uuid = child_subsystem_uuid(&context.cwd, "GeneratedParentA", "GeneratedChildA");
         let second_uuid = child_subsystem_uuid(&context.cwd, "GeneratedParentB", "GeneratedChildB");
         assert_ne!(first_uuid, second_uuid);
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
+    fn compile_subsystem_registers_in_canonical_position_and_preserves_crlf() {
+        let context = temp_context("canonical-registration");
+        let config_path = context.cwd.join("Configuration.xml");
+        fs::write(
+            &config_path,
+            concat!(
+                "\u{feff}<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n",
+                "<MetaDataObject xmlns=\"http://v8.1c.ru/8.3/MDClasses\">\r\n",
+                "\t<Configuration>\r\n",
+                "\t\t<ChildObjects>\r\n",
+                "\t\t\t<Language>Russian</Language>\r\n",
+                "\t\t\t<StyleItem>Accent</StyleItem>\r\n",
+                "\t\t</ChildObjects>\r\n",
+                "\t</Configuration>\r\n",
+                "</MetaDataObject><!-- registrar-tail -->\r\n\r\n"
+            ),
+        )
+        .unwrap();
+        let config_before = fs::read(&config_path).unwrap();
+        let args = compile_args(
+            &context.cwd,
+            json!({
+                "name": "SampleArea",
+                "uuid": "11111111-2222-4333-8444-555555555555"
+            }),
+        );
+
+        let preview = preview_subsystem_compile(&args, &context).unwrap();
+        assert!(preview.ok, "{:?}", preview.errors);
+        assert!(preview.summary.contains("dry run"));
+        assert!(preview
+            .changes
+            .iter()
+            .any(|change| change.contains("would create") && change.contains("SampleArea.xml")));
+        assert!(preview
+            .changes
+            .iter()
+            .any(|change| change.contains("would update") && change.contains("Configuration.xml")));
+        assert!(preview.stdout.unwrap_or_default().contains("@@ bytes"));
+        assert!(preview.artifacts.is_empty());
+        assert_eq!(fs::read(&config_path).unwrap(), config_before);
+        assert!(!context.cwd.join("Subsystems/SampleArea.xml").exists());
+
+        let outcome = compile_subsystem(&args, &context);
+
+        assert!(outcome.ok, "{:?}", outcome.errors);
+        let bytes = fs::read(&config_path).unwrap();
+        let text = String::from_utf8(bytes).unwrap();
+        assert!(text.contains(concat!(
+            "\t\t\t<Language>Russian</Language>\r\n",
+            "\t\t\t<Subsystem>SampleArea</Subsystem>\r\n",
+            "\t\t\t<StyleItem>Accent</StyleItem>\r\n"
+        )));
+        assert!(text.ends_with("<!-- registrar-tail -->\r\n\r\n"));
+        assert!(!text.replace("\r\n", "").contains('\n'));
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
+    fn nested_subsystem_compile_sorts_names_case_insensitively_in_parent() {
+        let context = temp_context("nested-canonical-order");
+        let parent_path = context.cwd.join("Subsystems/Parent.xml");
+        fs::create_dir_all(parent_path.parent().unwrap()).unwrap();
+        fs::write(
+            &parent_path,
+            concat!(
+                "\u{feff}<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n",
+                "<MetaDataObject xmlns=\"http://v8.1c.ru/8.3/MDClasses\">\r\n",
+                "\t<Subsystem>\r\n",
+                "\t\t<ChildObjects>\r\n",
+                "\t\t\t<Subsystem>alpha</Subsystem>\r\n",
+                "\t\t\t<Subsystem>Zulu</Subsystem>\r\n",
+                "\t\t</ChildObjects>\r\n",
+                "\t</Subsystem>\r\n",
+                "</MetaDataObject><!-- parent-tail -->\r\n"
+            ),
+        )
+        .unwrap();
+        let mut args = compile_args(
+            &context.cwd,
+            json!({
+                "name": "Beta",
+                "uuid": "11111111-2222-4333-8444-555555555555"
+            }),
+        );
+        args.insert(
+            "Parent".to_string(),
+            Value::String(parent_path.display().to_string()),
+        );
+
+        let outcome = compile_subsystem(&args, &context);
+
+        assert!(outcome.ok, "{:?}", outcome.errors);
+        let parent = String::from_utf8(fs::read(&parent_path).unwrap()).unwrap();
+        assert!(parent.contains(concat!(
+            "\t\t\t<Subsystem>alpha</Subsystem>\r\n",
+            "\t\t\t<Subsystem>Beta</Subsystem>\r\n",
+            "\t\t\t<Subsystem>Zulu</Subsystem>\r\n"
+        )));
+        assert!(parent.ends_with("<!-- parent-tail -->\r\n"));
+        assert!(!parent.replace("\r\n", "").contains('\n'));
+        assert!(context
+            .cwd
+            .join("Subsystems/Parent/Subsystems/Beta.xml")
+            .is_file());
+
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
+    fn repeated_subsystem_compile_does_not_overwrite_or_report_changes() {
+        let context = temp_context("repeat-noop");
+        let args = compile_args(
+            &context.cwd,
+            json!({
+                "name": "StableArea",
+                "uuid": "11111111-2222-4333-8444-555555555555",
+                "children": ["StableChild"]
+            }),
+        );
+        let first = compile_subsystem(&args, &context);
+        assert!(first.ok, "{:?}", first.errors);
+        let object_path = context.cwd.join("Subsystems/StableArea.xml");
+        let child_path = context
+            .cwd
+            .join("Subsystems/StableArea/Subsystems/StableChild.xml");
+        let object_before = fs::read(&object_path).unwrap();
+        let child_before = fs::read(&child_path).unwrap();
+
+        let repeated = compile_subsystem(&args, &context);
+
+        assert!(repeated.ok, "{:?}", repeated.errors);
+        assert!(repeated.changes.is_empty(), "{:?}", repeated.changes);
+        assert!(repeated.artifacts.is_empty(), "{:?}", repeated.artifacts);
+        assert_eq!(fs::read(&object_path).unwrap(), object_before);
+        assert_eq!(fs::read(&child_path).unwrap(), child_before);
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
+    fn subsystem_compile_rolls_back_after_object_files_failure() {
+        use crate::infrastructure::native_operations::compile_transaction::{
+            with_commit_failpoint, CommitFailpoint,
+        };
+
+        let context = temp_context("rollback-after-files");
+        let config_path = context.cwd.join("Configuration.xml");
+        let config_before = concat!(
+            "\u{feff}<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n",
+            "<MetaDataObject xmlns=\"http://v8.1c.ru/8.3/MDClasses\">\r\n",
+            "\t<Configuration><ChildObjects/></Configuration>\r\n",
+            "</MetaDataObject>"
+        )
+        .as_bytes()
+        .to_vec();
+        fs::write(&config_path, &config_before).unwrap();
+        let args = compile_args(
+            &context.cwd,
+            json!({
+                "name": "RollbackArea",
+                "uuid": "11111111-2222-4333-8444-555555555555",
+                "children": ["RollbackChild"]
+            }),
+        );
+
+        let outcome = with_commit_failpoint(CommitFailpoint::AfterObjectFiles, || {
+            compile_subsystem(&args, &context)
+        });
+
+        assert!(!outcome.ok, "{outcome:?}");
+        assert!(outcome.errors.join("\n").contains("after object files"));
+        assert_eq!(fs::read(&config_path).unwrap(), config_before);
+        assert!(!context.cwd.join("Subsystems").exists());
         let _ = fs::remove_dir_all(&context.cwd);
     }
 }


### PR DESCRIPTION
Зависит от #81.

Связано с #75.

## Что изменено

- Единый root-aware канонический регистратор применяется в `meta.compile`, `role.compile` и root/nested `subsystem.compile`.
- Dry-run и apply используют один чистый план: точные byte-diff регистрации и подлинный byte-for-byte no-op.
- Create-only compile-операции публикуются failure-atomic транзакцией с блокировками, валидацией и точным rollback.
- Добавлены регрессии для CR-only EOL: вставка перед существующей строкой и добавление последней записи сохраняют строки и отступ без лишнего `CR`.

## Границы

Транзакция откатывает ошибки, сообщённые во время работы операции; атомарность при аварийном завершении процесса или отключении питания не заявляется. Матрица writer-core из #74 вне границ этой задачи.

## Проверки

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — 284 passed, 0 failed
- `git diff --check`
- `uv run --with lxml --with pyyaml python -m unittest discover -s tests/ci` — завершена, 1 штатно пропущен
- независимый spec-review — одобрен
- независимый Rust quality review по `rust-expert-best-practices-code-review` — одобрен

Изолированный 1С platform round-trip в текущем цикле не запускался: в worktree нет `v8project.yaml` и тестовой ИБ. Пользовательская ИБ не изменялась.

PR остаётся Draft до принятия зависимости #81. Merge в upstream не выполнялся.