### PR TITLE
feat: durable lifecycle для runtime jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,6 +705,7 @@ name = "unica-coder"
 version = "0.6.1"
 dependencies = [
  "fs2",
+ "libc",
  "roxmltree",
  "rusqlite",
  "serde",

--- a/crates/unica-coder/Cargo.toml
+++ b/crates/unica-coder/Cargo.toml
@@ -23,3 +23,6 @@ roxmltree.workspace = true
 rusqlite.workspace = true
 ureq.workspace = true
 uuid.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -1,7 +1,8 @@
 use crate::domain::cache::{CacheAccess, CacheReport};
-use crate::domain::events::{DomainEvent, DomainEventKind};
+use crate::domain::events::{runtime_event_kind, DomainEvent, DomainEventKind};
 use crate::domain::project_sources::discover_project_source_map;
 use crate::domain::workspace::WorkspaceContext;
+use crate::infrastructure::internal_adapters::RuntimeJobAction;
 use crate::infrastructure::native_operations::common::{
     absolutize, path_arg, required_string, support_guard_violation, SupportGuardRequirement,
     SupportGuardViolation,
@@ -42,6 +43,9 @@ pub enum ToolHandler {
         event: Option<DomainEventKind>,
     },
     RuntimeAdapter,
+    RuntimeJob {
+        action: RuntimeJobAction,
+    },
     CodeAdapter {
         command: &'static [&'static str],
     },
@@ -67,6 +71,8 @@ pub struct OperationResult {
     pub command: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diagnostics: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub job: Option<Value>,
 }
 
 pub struct UnicaApplication {
@@ -202,6 +208,61 @@ pub fn tools() -> Vec<ToolSpec> {
             handler: ToolHandler::RuntimeAdapter,
         },
         ToolSpec {
+            name: "unica.runtime.job.start",
+            description:
+                "Start a durable typed v8-runner runtime job without changing runtime.execute.",
+            mutating: true,
+            cache_access: CacheAccess::default(),
+            handler: ToolHandler::RuntimeJob {
+                action: RuntimeJobAction::Start,
+            },
+        },
+        ToolSpec {
+            name: "unica.runtime.job.status",
+            description: "Read a durable runtime job snapshot by jobId.",
+            mutating: false,
+            cache_access: CacheAccess::default(),
+            handler: ToolHandler::RuntimeJob {
+                action: RuntimeJobAction::Status,
+            },
+        },
+        ToolSpec {
+            name: "unica.runtime.job.wait",
+            description: "Wait for a durable runtime job with a caller-side bounded timeout.",
+            mutating: false,
+            cache_access: CacheAccess::default(),
+            handler: ToolHandler::RuntimeJob {
+                action: RuntimeJobAction::Wait,
+            },
+        },
+        ToolSpec {
+            name: "unica.runtime.job.logs",
+            description: "Read bounded redacted stdout and stderr tails for a durable runtime job.",
+            mutating: false,
+            cache_access: CacheAccess::default(),
+            handler: ToolHandler::RuntimeJob {
+                action: RuntimeJobAction::Logs,
+            },
+        },
+        ToolSpec {
+            name: "unica.runtime.job.cancel",
+            description: "Request safe cancellation for a durable runtime job.",
+            mutating: true,
+            cache_access: CacheAccess::default(),
+            handler: ToolHandler::RuntimeJob {
+                action: RuntimeJobAction::Cancel,
+            },
+        },
+        ToolSpec {
+            name: "unica.runtime.job.list",
+            description: "List durable runtime job snapshots in the current workspace.",
+            mutating: false,
+            cache_access: CacheAccess::default(),
+            handler: ToolHandler::RuntimeJob {
+                action: RuntimeJobAction::List,
+            },
+        },
+        ToolSpec {
             name: "unica.code.search",
             description: "Search BSL code through the internal RLM index.",
             mutating: false,
@@ -331,6 +392,7 @@ fn call_tool(
                     stderr: outcome.stderr,
                     command: outcome.command,
                     diagnostics: None,
+                    job: None,
                 });
             }
         }
@@ -338,7 +400,8 @@ fn call_tool(
         None
     };
 
-    let mut outcome = ports.invoke_handler(spec, args, &context, dry_run)?;
+    let handler_outcome = ports.invoke_handler(spec, args, &context, dry_run)?;
+    let mut outcome = handler_outcome.adapter;
     if let Some(warning) = support_guard_warning {
         outcome.warnings.insert(0, warning);
     }
@@ -367,6 +430,7 @@ fn call_tool(
         stderr: outcome.stderr,
         command: outcome.command,
         diagnostics,
+        job: handler_outcome.job,
     })
 }
 
@@ -720,17 +784,15 @@ fn domain_events(spec: ToolSpec, args: &Map<String, Value>) -> Vec<DomainEvent> 
         ToolHandler::RuntimeAdapter => runtime_event(args)
             .map(|event| vec![DomainEvent::new(event, spec.name)])
             .unwrap_or_default(),
+        ToolHandler::RuntimeJob { .. } => Vec::new(),
         _ => Vec::new(),
     }
 }
 
 fn runtime_event(args: &Map<String, Value>) -> Option<DomainEventKind> {
-    match args.get("operation").and_then(Value::as_str)? {
-        "config-init" | "init" | "convert" | "dump" => Some(DomainEventKind::SourceSetChanged),
-        "build" | "load" | "extensions" | "test" => Some(DomainEventKind::BuildCompleted),
-        "make" | "syntax" | "launch" => None,
-        _ => None,
-    }
+    args.get("operation")
+        .and_then(Value::as_str)
+        .and_then(runtime_event_kind)
 }
 
 fn project_status(context: &WorkspaceContext) -> AdapterOutcome {
@@ -1307,6 +1369,16 @@ mod tests {
         assert!(names.contains(&"unica.support.edit"));
         assert!(names.contains(&"unica.build.load"));
         assert!(names.contains(&"unica.runtime.execute"));
+        for name in [
+            "unica.runtime.job.start",
+            "unica.runtime.job.status",
+            "unica.runtime.job.wait",
+            "unica.runtime.job.logs",
+            "unica.runtime.job.cancel",
+            "unica.runtime.job.list",
+        ] {
+            assert!(names.contains(&name), "missing {name}");
+        }
         assert!(names.contains(&"unica.code.definition"));
         assert!(names.contains(&"unica.code.outline"));
         assert!(names.contains(&"unica.code.grep"));
@@ -1349,6 +1421,22 @@ mod tests {
             .events
             .contains(&"SourceSetChanged".to_string()));
         assert!(result.command.unwrap().join(" ").contains(" dump"));
+    }
+
+    #[test]
+    fn runtime_job_start_defaults_to_dry_run_without_runtime_cache_invalidation() {
+        let mut args = Map::new();
+        args.insert("operation".to_string(), Value::String("dump".to_string()));
+
+        let result = UnicaApplication::new()
+            .call_tool("unica.runtime.job.start", &args)
+            .expect("dry-run job start succeeds");
+
+        assert!(result.ok);
+        assert!(result.summary.contains("dry run"));
+        assert_eq!(result.job, None);
+        assert_eq!(result.cache.mode, "read");
+        assert!(result.cache.events.is_empty());
     }
 
     #[test]
@@ -2306,9 +2394,11 @@ mod tests {
                 _args: &Map<String, Value>,
                 _context: &WorkspaceContext,
                 _dry_run: bool,
-            ) -> Result<AdapterOutcome, String> {
+            ) -> Result<ports::HandlerOutcome, String> {
                 self.invoked.borrow_mut().push(spec.name);
-                Ok(AdapterOutcome::ok("fake port outcome"))
+                Ok(ports::HandlerOutcome::plain(AdapterOutcome::ok(
+                    "fake port outcome",
+                )))
             }
 
             fn cache_report(
@@ -3930,8 +4020,8 @@ mod tests {
             _args: &Map<String, Value>,
             _context: &WorkspaceContext,
             _dry_run: bool,
-        ) -> Result<AdapterOutcome, String> {
-            Ok(self.outcome.clone())
+        ) -> Result<ports::HandlerOutcome, String> {
+            Ok(ports::HandlerOutcome::plain(self.outcome.clone()))
         }
 
         fn cache_report(

--- a/crates/unica-coder/src/application/ports.rs
+++ b/crates/unica-coder/src/application/ports.rs
@@ -4,7 +4,7 @@ use crate::domain::events::DomainEvent;
 use crate::domain::workspace::WorkspaceContext;
 use crate::infrastructure::internal_adapters::{
     BslAnalyzerMcpAdapter, CliAdapter, CodeNavigationAdapter, CodeSearchAdapter, RuntimeAdapter,
-    StandardsAdapter,
+    RuntimeJobAdapter, StandardsAdapter,
 };
 use crate::infrastructure::native_operations::NativeOperationAdapter;
 use crate::infrastructure::workspace_services::WorkspaceServiceManager;
@@ -12,6 +12,17 @@ use crate::infrastructure::workspace_state::WorkspaceStateRepository;
 use crate::infrastructure::AdapterOutcome;
 use serde_json::{Map, Value};
 use std::path::PathBuf;
+
+pub(crate) struct HandlerOutcome {
+    pub(crate) adapter: AdapterOutcome,
+    pub(crate) job: Option<Value>,
+}
+
+impl HandlerOutcome {
+    pub(crate) fn plain(adapter: AdapterOutcome) -> Self {
+        Self { adapter, job: None }
+    }
+}
 
 pub(crate) trait ApplicationPorts {
     fn discover_workspace(&self, cwd: PathBuf) -> Result<WorkspaceContext, String>;
@@ -22,7 +33,7 @@ pub(crate) trait ApplicationPorts {
         args: &Map<String, Value>,
         context: &WorkspaceContext,
         dry_run: bool,
-    ) -> Result<AdapterOutcome, String>;
+    ) -> Result<HandlerOutcome, String>;
 
     fn cache_report(
         &self,
@@ -48,7 +59,7 @@ impl ApplicationPorts for DefaultApplicationPorts {
         args: &Map<String, Value>,
         context: &WorkspaceContext,
         dry_run: bool,
-    ) -> Result<AdapterOutcome, String> {
+    ) -> Result<HandlerOutcome, String> {
         match spec.handler {
             ToolHandler::NativeOperation { operation, .. } => NativeOperationAdapter::invoke(
                 operation,
@@ -57,36 +68,48 @@ impl ApplicationPorts for DefaultApplicationPorts {
                 context,
                 dry_run,
                 spec.mutating,
-            ),
-            ToolHandler::ProjectStatus => Ok(project_status(context)),
-            ToolHandler::ProjectMap => Ok(project_map(context)),
-            ToolHandler::BuildRuntime { command, .. } => CliAdapter::new(
-                "v8-runner",
-                command,
-                "build/runtime",
             )
-            .invoke(spec.name, args, context, dry_run, spec.mutating),
-            ToolHandler::RuntimeAdapter => {
-                RuntimeAdapter::new().invoke(spec.name, args, context, dry_run, spec.mutating)
+            .map(HandlerOutcome::plain),
+            ToolHandler::ProjectStatus => Ok(HandlerOutcome::plain(project_status(context))),
+            ToolHandler::ProjectMap => Ok(HandlerOutcome::plain(project_map(context))),
+            ToolHandler::BuildRuntime { command, .. } => {
+                CliAdapter::new("v8-runner", command, "build/runtime")
+                    .invoke(spec.name, args, context, dry_run, spec.mutating)
+                    .map(HandlerOutcome::plain)
             }
+            ToolHandler::RuntimeAdapter => RuntimeAdapter::new()
+                .invoke(spec.name, args, context, dry_run, spec.mutating)
+                .map(HandlerOutcome::plain),
+            ToolHandler::RuntimeJob { action } => RuntimeJobAdapter::invoke(
+                action, spec.name, args, context, dry_run,
+            )
+            .map(|outcome| HandlerOutcome {
+                adapter: outcome.outcome,
+                job: outcome.job,
+            }),
             ToolHandler::CodeAdapter { command } if command == ["search"] => {
-                CodeSearchAdapter::new().invoke(spec.name, args, context, dry_run)
+                CodeSearchAdapter::new()
+                    .invoke(spec.name, args, context, dry_run)
+                    .map(HandlerOutcome::plain)
             }
             ToolHandler::CodeAdapter {
                 command: ["definition"] | ["outline"] | ["grep"] | ["meta-profile"],
-            } => CodeNavigationAdapter::new().invoke(spec.name, args, context, dry_run),
+            } => CodeNavigationAdapter::new()
+                .invoke(spec.name, args, context, dry_run)
+                .map(HandlerOutcome::plain),
             ToolHandler::CodeAdapter {
                 command: ["graph"] | ["analyze"],
-            } => BslAnalyzerMcpAdapter::new().invoke(spec.name, args, context, dry_run),
-            ToolHandler::CodeAdapter { command } => CliAdapter::new(
-                "bsl-analyzer",
-                command,
-                "code analysis",
-            )
-            .invoke(spec.name, args, context, dry_run, spec.mutating),
-            ToolHandler::StandardsAdapter { operation } => {
-                Ok(StandardsAdapter::invoke(operation, args))
+            } => BslAnalyzerMcpAdapter::new()
+                .invoke(spec.name, args, context, dry_run)
+                .map(HandlerOutcome::plain),
+            ToolHandler::CodeAdapter { command } => {
+                CliAdapter::new("bsl-analyzer", command, "code analysis")
+                    .invoke(spec.name, args, context, dry_run, spec.mutating)
+                    .map(HandlerOutcome::plain)
             }
+            ToolHandler::StandardsAdapter { operation } => Ok(HandlerOutcome::plain(
+                StandardsAdapter::invoke(operation, args),
+            )),
         }
     }
 

--- a/crates/unica-coder/src/application/tool_contracts.rs
+++ b/crates/unica-coder/src/application/tool_contracts.rs
@@ -6,8 +6,12 @@ use crate::infrastructure::path_policy::WorkspacePathPolicy;
 use serde_json::{json, Map, Value};
 use std::collections::BTreeSet;
 use std::path::{Component, Path, PathBuf};
+use uuid::Uuid;
 
 const COMMON_ARGS: &[&str] = &["cwd", "dryRun", "confirm"];
+const RUNTIME_JOB_STATUS_ARGS: &[&str] = &["jobId"];
+const RUNTIME_JOB_WAIT_ARGS: &[&str] = &["jobId", "timeoutSeconds"];
+const RUNTIME_JOB_LOGS_ARGS: &[&str] = &["jobId", "tailChars"];
 
 const META_EDIT_OPERATIONS: &[&str] = &[
     "modify-property",
@@ -583,6 +587,9 @@ pub fn validate_tool_arguments(
     if matches!(tool.handler, ToolHandler::RuntimeAdapter) {
         validate_runtime_arguments(tool.name, args, dry_run)?;
     }
+    if let ToolHandler::RuntimeJob { action } = tool.handler {
+        validate_runtime_job_arguments(tool.name, action, args, dry_run)?;
+    }
     validate_code_arguments(tool, args, dry_run)?;
     validate_meta_edit_arguments(tool, args)?;
     validate_form_add_arguments(tool, args)?;
@@ -881,6 +888,58 @@ fn validate_runtime_arguments(
     Ok(())
 }
 
+fn validate_runtime_job_arguments(
+    tool_name: &str,
+    action: crate::infrastructure::internal_adapters::RuntimeJobAction,
+    args: &Map<String, Value>,
+    dry_run: bool,
+) -> Result<(), String> {
+    use crate::infrastructure::internal_adapters::RuntimeJobAction;
+
+    if action == RuntimeJobAction::Start {
+        return validate_runtime_arguments(tool_name, args, dry_run);
+    }
+    if action == RuntimeJobAction::List {
+        return Ok(());
+    }
+    let Some(job_id) = args.get("jobId") else {
+        return Err(format!("{tool_name} requires `jobId` argument"));
+    };
+    let Some(job_id) = job_id.as_str() else {
+        return Err(format!("{tool_name} argument `jobId` must be string"));
+    };
+    Uuid::parse_str(job_id).map_err(|_| format!("{tool_name} argument `jobId` must be a UUID"))?;
+
+    if action == RuntimeJobAction::Wait {
+        validate_runtime_job_bound(tool_name, args, "timeoutSeconds", 1, 60)?;
+    }
+    if action == RuntimeJobAction::Logs {
+        validate_runtime_job_bound(tool_name, args, "tailChars", 1, 32_768)?;
+    }
+    Ok(())
+}
+
+fn validate_runtime_job_bound(
+    tool_name: &str,
+    args: &Map<String, Value>,
+    key: &str,
+    minimum: u64,
+    maximum: u64,
+) -> Result<(), String> {
+    let Some(value) = args.get(key) else {
+        return Ok(());
+    };
+    let Some(value) = value.as_u64() else {
+        return Err(format!("{tool_name} argument `{key}` must be integer"));
+    };
+    if !(minimum..=maximum).contains(&value) {
+        return Err(format!(
+            "{tool_name} argument `{key}` must be between {minimum} and {maximum}"
+        ));
+    }
+    Ok(())
+}
+
 fn validate_string_array_argument(
     tool_name: &str,
     args: &Map<String, Value>,
@@ -1081,7 +1140,15 @@ pub fn validate_workspace_paths(
     if dry_run {
         return Ok(());
     }
-    if !is_native_xml_tool(tool) && !matches!(tool.handler, ToolHandler::RuntimeAdapter) {
+    if !is_native_xml_tool(tool)
+        && !matches!(
+            tool.handler,
+            ToolHandler::RuntimeAdapter
+                | ToolHandler::RuntimeJob {
+                    action: crate::infrastructure::internal_adapters::RuntimeJobAction::Start
+                }
+        )
+    {
         return Ok(());
     }
 
@@ -1157,6 +1224,9 @@ fn write_path_args(tool: ToolSpec) -> &'static [&'static str] {
             .map(|descriptor| descriptor.write_path_args)
             .unwrap_or(&[]),
         ToolHandler::RuntimeAdapter => &["config", "path", "output", "settings", "mcpConfig"],
+        ToolHandler::RuntimeJob {
+            action: crate::infrastructure::internal_adapters::RuntimeJobAction::Start,
+        } => &["config", "path", "output", "settings", "mcpConfig"],
         _ => &[],
     }
 }
@@ -1205,6 +1275,7 @@ fn allowed_args(tool: &ToolSpec) -> Vec<&'static str> {
         }
         ToolHandler::BuildRuntime { .. } => names.extend(BUILD_ARGS),
         ToolHandler::RuntimeAdapter => names.extend(RUNTIME_ARGS),
+        ToolHandler::RuntimeJob { action } => names.extend(runtime_job_args(action)),
         ToolHandler::CodeAdapter { .. } => names.extend(code_args_for(tool.name)),
         ToolHandler::StandardsAdapter { .. } => names.extend(STANDARDS_ARGS),
         ToolHandler::ProjectStatus | ToolHandler::ProjectMap => {}
@@ -1228,6 +1299,7 @@ fn required_args(tool: &ToolSpec) -> Vec<&'static str> {
             ..
         } => vec!["query"],
         ToolHandler::RuntimeAdapter => runtime_required_args(tool),
+        ToolHandler::RuntimeJob { action } => runtime_job_required_args(action),
         ToolHandler::CodeAdapter { .. } => match tool.name {
             "unica.code.definition" => vec!["name"],
             "unica.code.outline" => vec!["path"],
@@ -1255,6 +1327,35 @@ fn code_args_for(tool_name: &str) -> &'static [&'static str] {
 fn runtime_required_args(tool: &ToolSpec) -> Vec<&'static str> {
     debug_assert!(matches!(tool.handler, ToolHandler::RuntimeAdapter));
     vec!["operation"]
+}
+
+fn runtime_job_args(
+    action: crate::infrastructure::internal_adapters::RuntimeJobAction,
+) -> &'static [&'static str] {
+    use crate::infrastructure::internal_adapters::RuntimeJobAction;
+
+    match action {
+        RuntimeJobAction::Start => RUNTIME_ARGS,
+        RuntimeJobAction::Status | RuntimeJobAction::Cancel => RUNTIME_JOB_STATUS_ARGS,
+        RuntimeJobAction::Wait => RUNTIME_JOB_WAIT_ARGS,
+        RuntimeJobAction::Logs => RUNTIME_JOB_LOGS_ARGS,
+        RuntimeJobAction::List => &[],
+    }
+}
+
+fn runtime_job_required_args(
+    action: crate::infrastructure::internal_adapters::RuntimeJobAction,
+) -> Vec<&'static str> {
+    use crate::infrastructure::internal_adapters::RuntimeJobAction;
+
+    match action {
+        RuntimeJobAction::Start => vec!["operation"],
+        RuntimeJobAction::Status
+        | RuntimeJobAction::Wait
+        | RuntimeJobAction::Logs
+        | RuntimeJobAction::Cancel => vec!["jobId"],
+        RuntimeJobAction::List => Vec::new(),
+    }
 }
 
 fn property_schema(name: &str) -> Value {
@@ -1328,6 +1429,8 @@ fn property_schema(name: &str) -> Value {
             | "maxFiles"
             | "rangeStart"
             | "rangeEnd"
+            | "timeoutSeconds"
+            | "tailChars"
     ) {
         "integer"
     } else if matches!(
@@ -1367,7 +1470,13 @@ fn property_schema_for_tool(tool: &ToolSpec, name: &str) -> Value {
     if tool.name == "unica.meta.edit" && matches!(name, "Operation" | "operation") {
         return json!({ "type": "string", "enum": META_EDIT_OPERATIONS });
     }
-    if matches!(tool.handler, ToolHandler::RuntimeAdapter) {
+    if matches!(
+        tool.handler,
+        ToolHandler::RuntimeAdapter
+            | ToolHandler::RuntimeJob {
+                action: crate::infrastructure::internal_adapters::RuntimeJobAction::Start
+            }
+    ) {
         match name {
             "operation" => return json!({ "type": "string", "enum": RUNTIME_OPERATIONS }),
             "clientMode" => {
@@ -1504,6 +1613,8 @@ fn expected_scalar_type(key: &str) -> Option<&'static str> {
             | "maxFiles"
             | "rangeStart"
             | "rangeEnd"
+            | "timeoutSeconds"
+            | "tailChars"
     ) {
         Some("integer")
     } else if matches!(
@@ -1848,6 +1959,96 @@ mod tests {
         assert_eq!(schema["properties"]["ignoreTags"]["type"], "array");
         assert_eq!(schema["properties"]["scenarioFilters"]["type"], "array");
         assert_eq!(schema["properties"]["projects"]["type"], "array");
+    }
+
+    #[test]
+    fn runtime_job_schemas_keep_execution_typed_and_controls_narrow() {
+        let job_start = tools()
+            .into_iter()
+            .find(|tool| tool.name == "unica.runtime.job.start")
+            .expect("runtime job start is registered");
+        let job_wait = tools()
+            .into_iter()
+            .find(|tool| tool.name == "unica.runtime.job.wait")
+            .expect("runtime job wait is registered");
+        let job_logs = tools()
+            .into_iter()
+            .find(|tool| tool.name == "unica.runtime.job.logs")
+            .expect("runtime job logs is registered");
+
+        let start_schema = input_schema_for_tool(&job_start);
+        assert_eq!(start_schema["additionalProperties"], false);
+        assert!(start_schema["properties"].get("operation").is_some());
+        assert!(start_schema["properties"].get("args").is_none());
+
+        let wait_schema = input_schema_for_tool(&job_wait);
+        assert_eq!(wait_schema["required"], json!(["jobId"]));
+        assert_eq!(
+            wait_schema["properties"]["timeoutSeconds"]["type"],
+            "integer"
+        );
+        assert!(wait_schema["properties"].get("operation").is_none());
+
+        let logs_schema = input_schema_for_tool(&job_logs);
+        assert_eq!(logs_schema["required"], json!(["jobId"]));
+        assert_eq!(logs_schema["properties"]["tailChars"]["type"], "integer");
+    }
+
+    #[test]
+    fn runtime_job_controls_reject_invalid_ids_bounds_and_execution_arguments() {
+        let wait = tools()
+            .into_iter()
+            .find(|tool| tool.name == "unica.runtime.job.wait")
+            .expect("runtime job wait is registered");
+        let cancel = tools()
+            .into_iter()
+            .find(|tool| tool.name == "unica.runtime.job.cancel")
+            .expect("runtime job cancel is registered");
+        let logs = tools()
+            .into_iter()
+            .find(|tool| tool.name == "unica.runtime.job.logs")
+            .expect("runtime job logs is registered");
+        let valid_id = "00000000-0000-4000-8000-000000000001";
+
+        assert!(validate_tool_arguments(wait, &Map::new(), false).is_err());
+        assert!(validate_tool_arguments(
+            wait,
+            json!({"jobId":"not-a-uuid"}).as_object().unwrap(),
+            false
+        )
+        .is_err());
+        assert!(validate_tool_arguments(
+            wait,
+            json!({"jobId":valid_id,"timeoutSeconds":0})
+                .as_object()
+                .unwrap(),
+            false
+        )
+        .is_err());
+        assert!(validate_tool_arguments(
+            wait,
+            json!({"jobId":valid_id,"timeoutSeconds":61})
+                .as_object()
+                .unwrap(),
+            false
+        )
+        .is_err());
+        assert!(validate_tool_arguments(
+            logs,
+            json!({"jobId":valid_id,"tailChars":32769})
+                .as_object()
+                .unwrap(),
+            false
+        )
+        .is_err());
+        assert!(validate_tool_arguments(
+            cancel,
+            json!({"jobId":valid_id,"operation":"build"})
+                .as_object()
+                .unwrap(),
+            true
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/unica-coder/src/domain/events.rs
+++ b/crates/unica-coder/src/domain/events.rs
@@ -53,3 +53,30 @@ impl DomainEvent {
         self.kind.as_str()
     }
 }
+
+pub fn runtime_event_kind(operation: &str) -> Option<DomainEventKind> {
+    match operation {
+        "config-init" | "init" | "convert" | "dump" => Some(DomainEventKind::SourceSetChanged),
+        "build" | "load" | "extensions" | "test" => Some(DomainEventKind::BuildCompleted),
+        "make" | "syntax" | "launch" | "tools-download" => None,
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{runtime_event_kind, DomainEventKind};
+
+    #[test]
+    fn runtime_job_and_synchronous_runtime_share_event_mapping() {
+        assert_eq!(
+            runtime_event_kind("dump"),
+            Some(DomainEventKind::SourceSetChanged)
+        );
+        assert_eq!(
+            runtime_event_kind("build"),
+            Some(DomainEventKind::BuildCompleted)
+        );
+        assert_eq!(runtime_event_kind("make"), None);
+    }
+}

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -2,6 +2,9 @@ use crate::domain::workspace::WorkspaceContext;
 use crate::infrastructure::bundled_tools::resolve_bundled_tool;
 use crate::infrastructure::plugin_runtime::{find_plugin_root, value_to_cli_string};
 use crate::infrastructure::redaction::{is_secret_key, redactor};
+use crate::infrastructure::runtime_jobs::{
+    self, RuntimeJobOperation, RuntimeJobRequest, RuntimeJobService,
+};
 use crate::infrastructure::workspace_index::{
     IndexReadiness, IndexRunner, WorkspaceIndexService, SYSTEM_INDEX_RUNNER,
 };
@@ -74,6 +77,23 @@ pub struct CliAdapter<'a> {
 pub struct RuntimeAdapter<'a> {
     runner: &'a dyn ProcessRunner,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeJobAction {
+    Start,
+    Status,
+    Wait,
+    Logs,
+    Cancel,
+    List,
+}
+
+pub struct RuntimeJobAdapterOutcome {
+    pub outcome: AdapterOutcome,
+    pub job: Option<Value>,
+}
+
+pub struct RuntimeJobAdapter;
 
 pub struct CodeSearchAdapter<'a> {
     bsl_runner: &'a dyn ProcessRunner,
@@ -347,6 +367,301 @@ impl<'a> Default for RuntimeAdapter<'a> {
     fn default() -> Self {
         Self::new()
     }
+}
+
+impl RuntimeJobAdapter {
+    pub fn invoke(
+        action: RuntimeJobAction,
+        tool_name: &str,
+        args: &Map<String, Value>,
+        context: &WorkspaceContext,
+        dry_run: bool,
+    ) -> Result<RuntimeJobAdapterOutcome, String> {
+        match action {
+            RuntimeJobAction::Start => Self::start(tool_name, args, context, dry_run),
+            RuntimeJobAction::Status => Self::status(tool_name, args, context),
+            RuntimeJobAction::Wait => Self::wait(tool_name, args, context),
+            RuntimeJobAction::Logs => Self::logs(tool_name, args, context),
+            RuntimeJobAction::Cancel => Self::cancel(tool_name, args, context, dry_run),
+            RuntimeJobAction::List => Self::list(tool_name, context),
+        }
+    }
+
+    fn start(
+        tool_name: &str,
+        args: &Map<String, Value>,
+        context: &WorkspaceContext,
+        dry_run: bool,
+    ) -> Result<RuntimeJobAdapterOutcome, String> {
+        let plugin_root = find_plugin_root(&context.cwd).ok_or_else(|| {
+            "could not locate Unica plugin root for internal adapter lookup".to_string()
+        })?;
+        let reported_args = runtime_args(args, true)?;
+        let execution_args = runtime_args(args, false)?;
+        let bundled_tool = resolve_bundled_tool(&plugin_root, "v8-runner", !dry_run)?;
+        let mut command = vec![bundled_tool.program.display().to_string()];
+        command.extend(reported_args);
+
+        if dry_run {
+            return Ok(RuntimeJobAdapterOutcome {
+                outcome: AdapterOutcome {
+                    ok: true,
+                    summary: format!("dry run: {tool_name} would start a durable runtime job"),
+                    changes: vec!["no runtime job started because dryRun is true".to_string()],
+                    warnings: bundled_tool.warnings,
+                    errors: Vec::new(),
+                    artifacts: Vec::new(),
+                    stdout: None,
+                    stderr: None,
+                    command: Some(command),
+                },
+                job: None,
+            });
+        }
+
+        let operation_name = args
+            .get("operation")
+            .and_then(Value::as_str)
+            .ok_or_else(|| format!("{tool_name} requires string `operation` argument"))?;
+        let operation = RuntimeJobOperation::from_label(operation_name)?;
+        let request = RuntimeJobRequest::new(
+            operation,
+            execution_args,
+            runtime_job_safe_target(context),
+            args.get("output")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        );
+        match runtime_jobs::start_detached_worker(
+            context.cache_root.clone(),
+            bundled_tool.program,
+            context.cwd.clone(),
+            request,
+        ) {
+            Ok(snapshot) => Ok(RuntimeJobAdapterOutcome {
+                outcome: AdapterOutcome {
+                    ok: true,
+                    summary: format!("{tool_name} queued durable runtime job {}", snapshot.id),
+                    changes: Vec::new(),
+                    warnings: bundled_tool.warnings,
+                    errors: Vec::new(),
+                    artifacts: Vec::new(),
+                    stdout: None,
+                    stderr: None,
+                    command: Some(command),
+                },
+                job: Some(runtime_job_snapshot_value(&snapshot)),
+            }),
+            Err(error) => Ok(Self::failure(tool_name, error, Some(command))),
+        }
+    }
+
+    fn status(
+        tool_name: &str,
+        args: &Map<String, Value>,
+        context: &WorkspaceContext,
+    ) -> Result<RuntimeJobAdapterOutcome, String> {
+        let id = runtime_job_id(tool_name, args)?;
+        match RuntimeJobService::status_at(context.cache_root.clone(), id) {
+            Ok(snapshot) => Ok(Self::success(
+                format!("{tool_name} read durable runtime job {id}"),
+                runtime_job_snapshot_value(&snapshot),
+            )),
+            Err(error) => Ok(Self::failure(tool_name, error, None)),
+        }
+    }
+
+    fn wait(
+        tool_name: &str,
+        args: &Map<String, Value>,
+        context: &WorkspaceContext,
+    ) -> Result<RuntimeJobAdapterOutcome, String> {
+        let id = runtime_job_id(tool_name, args)?;
+        let timeout_seconds = args
+            .get("timeoutSeconds")
+            .and_then(Value::as_u64)
+            .unwrap_or(30);
+        match RuntimeJobService::wait_at(
+            context.cache_root.clone(),
+            id,
+            Duration::from_secs(timeout_seconds),
+        ) {
+            Ok(snapshot) => Ok(Self::success(
+                format!("{tool_name} observed durable runtime job {id}"),
+                runtime_job_snapshot_value(&snapshot),
+            )),
+            Err(error) => Ok(Self::failure(tool_name, error, None)),
+        }
+    }
+
+    fn logs(
+        tool_name: &str,
+        args: &Map<String, Value>,
+        context: &WorkspaceContext,
+    ) -> Result<RuntimeJobAdapterOutcome, String> {
+        let id = runtime_job_id(tool_name, args)?;
+        let tail_chars = args
+            .get("tailChars")
+            .and_then(Value::as_u64)
+            .map(|value| usize::try_from(value).unwrap_or(usize::MAX))
+            .unwrap_or(4096);
+        let snapshot = match RuntimeJobService::status_at(context.cache_root.clone(), id) {
+            Ok(snapshot) => snapshot,
+            Err(error) => return Ok(Self::failure(tool_name, error, None)),
+        };
+        match RuntimeJobService::logs_at(context.cache_root.clone(), id, tail_chars) {
+            Ok(logs) => {
+                let mut job = runtime_job_snapshot_value(&snapshot);
+                if let Value::Object(ref mut object) = job {
+                    object.insert("stdout".to_string(), Value::String(logs.stdout));
+                    object.insert("stderr".to_string(), Value::String(logs.stderr));
+                    object.insert("stdoutPath".to_string(), Value::String(logs.stdout_path));
+                    object.insert("stderrPath".to_string(), Value::String(logs.stderr_path));
+                }
+                Ok(Self::success(
+                    format!("{tool_name} read durable runtime job logs for {id}"),
+                    job,
+                ))
+            }
+            Err(error) => Ok(Self::failure(tool_name, error, None)),
+        }
+    }
+
+    fn cancel(
+        tool_name: &str,
+        args: &Map<String, Value>,
+        context: &WorkspaceContext,
+        dry_run: bool,
+    ) -> Result<RuntimeJobAdapterOutcome, String> {
+        let id = runtime_job_id(tool_name, args)?;
+        if dry_run {
+            return Ok(RuntimeJobAdapterOutcome {
+                outcome: AdapterOutcome {
+                    ok: true,
+                    summary: format!("dry run: {tool_name} would request cancellation for {id}"),
+                    changes: vec!["no cancellation requested because dryRun is true".to_string()],
+                    warnings: Vec::new(),
+                    errors: Vec::new(),
+                    artifacts: Vec::new(),
+                    stdout: None,
+                    stderr: None,
+                    command: None,
+                },
+                job: None,
+            });
+        }
+        match RuntimeJobService::request_cancel_at(context.cache_root.clone(), id) {
+            Ok(snapshot) => Ok(Self::success(
+                format!("{tool_name} requested cancellation for durable runtime job {id}"),
+                runtime_job_snapshot_value(&snapshot),
+            )),
+            Err(error) => Ok(Self::failure(tool_name, error, None)),
+        }
+    }
+
+    fn list(
+        tool_name: &str,
+        context: &WorkspaceContext,
+    ) -> Result<RuntimeJobAdapterOutcome, String> {
+        let list = RuntimeJobService::list_at(context.cache_root.clone());
+        let jobs = list
+            .jobs
+            .iter()
+            .map(runtime_job_snapshot_value)
+            .collect::<Vec<_>>();
+        Ok(RuntimeJobAdapterOutcome {
+            outcome: AdapterOutcome {
+                ok: true,
+                summary: format!("{tool_name} listed durable runtime jobs"),
+                changes: Vec::new(),
+                warnings: list.warnings,
+                errors: Vec::new(),
+                artifacts: Vec::new(),
+                stdout: None,
+                stderr: None,
+                command: None,
+            },
+            job: Some(json!({ "jobs": jobs })),
+        })
+    }
+
+    fn success(summary: String, job: Value) -> RuntimeJobAdapterOutcome {
+        RuntimeJobAdapterOutcome {
+            outcome: AdapterOutcome {
+                ok: true,
+                summary,
+                changes: Vec::new(),
+                warnings: Vec::new(),
+                errors: Vec::new(),
+                artifacts: Vec::new(),
+                stdout: None,
+                stderr: None,
+                command: None,
+            },
+            job: Some(job),
+        }
+    }
+
+    fn failure(
+        tool_name: &str,
+        error: String,
+        command: Option<Vec<String>>,
+    ) -> RuntimeJobAdapterOutcome {
+        RuntimeJobAdapterOutcome {
+            outcome: AdapterOutcome {
+                ok: false,
+                summary: format!("{tool_name} failed for durable runtime job lifecycle"),
+                changes: Vec::new(),
+                warnings: Vec::new(),
+                errors: vec![redactor(&error)],
+                artifacts: Vec::new(),
+                stdout: None,
+                stderr: Some(format!("{}\n", redactor(&error))),
+                command,
+            },
+            job: None,
+        }
+    }
+}
+
+fn runtime_job_id<'a>(tool_name: &str, args: &'a Map<String, Value>) -> Result<&'a str, String> {
+    args.get("jobId")
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("{tool_name} requires string `jobId` argument"))
+}
+
+fn runtime_job_safe_target(context: &WorkspaceContext) -> String {
+    let name = context
+        .workspace_root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("workspace");
+    format!("workspace:{name}")
+}
+
+fn runtime_job_snapshot_value(snapshot: &runtime_jobs::RuntimeJobSnapshot) -> Value {
+    json!({
+        "jobId": snapshot.id,
+        "phase": snapshot.phase,
+        "operation": snapshot.operation,
+        "safeTarget": snapshot.safe_target,
+        "createdAt": snapshot.created_at_ms,
+        "startedAt": snapshot.started_at_ms,
+        "heartbeatAt": snapshot.heartbeat_at_ms,
+        "finishedAt": snapshot.finished_at_ms,
+        "pid": snapshot.pid,
+        "pidIdentity": snapshot.pid_identity,
+        "exitCode": snapshot.exit_code,
+        "cancelled": snapshot.cancelled,
+        "cancelDeferred": snapshot.cancel_deferred,
+        "unsafePhase": snapshot.unsafe_phase,
+        "timeoutReason": snapshot.timeout_reason,
+        "artifactPath": snapshot.artifact_path,
+        "stdoutPath": snapshot.stdout_path,
+        "stderrPath": snapshot.stderr_path,
+        "warnings": snapshot.warnings,
+        "waitTimedOut": snapshot.wait_timed_out,
+    })
 }
 
 impl<'a> CodeSearchAdapter<'a> {

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -1,6 +1,7 @@
 use crate::domain::workspace::WorkspaceContext;
 use crate::infrastructure::bundled_tools::resolve_bundled_tool;
 use crate::infrastructure::plugin_runtime::{find_plugin_root, value_to_cli_string};
+use crate::infrastructure::redaction::{is_secret_key, redactor};
 use crate::infrastructure::workspace_index::{
     IndexReadiness, IndexRunner, WorkspaceIndexService, SYSTEM_INDEX_RUNNER,
 };
@@ -279,7 +280,7 @@ impl<'a> RuntimeAdapter<'a> {
         let output = match self.runner.run(&process_command) {
             Ok(output) => output,
             Err(error) => {
-                let error = redact_sensitive_text(&error);
+                let error = redactor(&error);
                 return Ok(AdapterOutcome {
                     ok: false,
                     summary: format!(
@@ -298,8 +299,8 @@ impl<'a> RuntimeAdapter<'a> {
             }
         };
         let ok = output.status_success;
-        let stdout = redact_sensitive_text(&output.stdout);
-        let stderr = redact_sensitive_text(&output.stderr);
+        let stdout = redactor(&output.stdout);
+        let stderr = redactor(&output.stderr);
         Ok(AdapterOutcome {
             ok,
             summary: if ok {
@@ -646,59 +647,6 @@ fn process_timeout_error(label: &str, timeout: Option<Duration>) -> String {
         ),
         None => format!("internal {label} adapter timed out"),
     }
-}
-
-fn redact_sensitive_text(text: &str) -> String {
-    let chars = text.chars().collect::<Vec<_>>();
-    let mut output = String::with_capacity(text.len());
-    let mut index = 0;
-    while index < chars.len() {
-        if secret_key_char(chars[index]) {
-            let key_start = index;
-            index += 1;
-            while index < chars.len() && secret_key_char(chars[index]) {
-                index += 1;
-            }
-            let key_end = index;
-            let mut separator = index;
-            while separator < chars.len() && chars[separator].is_whitespace() {
-                separator += 1;
-            }
-            if separator < chars.len() && matches!(chars[separator], '=' | ':') {
-                let mut value_start = separator + 1;
-                while value_start < chars.len() && chars[value_start].is_whitespace() {
-                    value_start += 1;
-                }
-                let key = chars[key_start..key_end].iter().collect::<String>();
-                if is_secret_key(&key) {
-                    for ch in &chars[key_start..value_start] {
-                        output.push(*ch);
-                    }
-                    output.push_str("<redacted>");
-                    index = value_start;
-                    while index < chars.len() && !secret_value_delimiter(chars[index]) {
-                        index += 1;
-                    }
-                    continue;
-                }
-            }
-            for ch in &chars[key_start..key_end] {
-                output.push(*ch);
-            }
-            continue;
-        }
-        output.push(chars[index]);
-        index += 1;
-    }
-    output
-}
-
-fn secret_key_char(ch: char) -> bool {
-    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-')
-}
-
-fn secret_value_delimiter(ch: char) -> bool {
-    matches!(ch, ';' | '&' | ',' | '\n' | '\r' | '}')
 }
 
 fn search_rlm_index(
@@ -2936,15 +2884,6 @@ fn string_arg(args: &Map<String, Value>, key: &str, redact: bool) -> Option<Stri
             Some(value_to_cli_string(value))
         }
     })
-}
-
-fn is_secret_key(key: &str) -> bool {
-    let key = key.to_ascii_lowercase();
-    key == "connection"
-        || key == "pwd"
-        || key.contains("password")
-        || key.contains("token")
-        || key.contains("secret")
 }
 
 fn kebab_case(key: &str) -> String {

--- a/crates/unica-coder/src/infrastructure/mod.rs
+++ b/crates/unica-coder/src/infrastructure/mod.rs
@@ -3,6 +3,7 @@ pub mod internal_adapters;
 pub mod native_operations;
 pub mod path_policy;
 pub mod plugin_runtime;
+pub(crate) mod redaction;
 pub mod workspace_index;
 pub mod workspace_services;
 pub mod workspace_state;

--- a/crates/unica-coder/src/infrastructure/mod.rs
+++ b/crates/unica-coder/src/infrastructure/mod.rs
@@ -4,6 +4,7 @@ pub mod native_operations;
 pub mod path_policy;
 pub mod plugin_runtime;
 pub(crate) mod redaction;
+pub(crate) mod runtime_jobs;
 pub mod workspace_index;
 pub mod workspace_services;
 pub mod workspace_state;

--- a/crates/unica-coder/src/infrastructure/redaction.rs
+++ b/crates/unica-coder/src/infrastructure/redaction.rs
@@ -118,7 +118,7 @@ impl StreamRedactorState {
                     Self::after_secret_key(ch, output)
                 }
             }
-            Self::AfterSecretKey => Self::after_secret_key(ch, output),
+            Self::AfterSecretKey => Self::after_secret_key_value(ch, output),
             Self::RedactingSecretValue { marker } => Self::redact_value(ch, marker, output),
         }
     }
@@ -156,6 +156,21 @@ impl StreamRedactorState {
         } else {
             output.push(ch);
             Self::Text
+        }
+    }
+
+    fn after_secret_key_value(ch: char, output: &mut String) -> Self {
+        if ch.is_whitespace() {
+            output.push(ch);
+            Self::AfterSecretKey
+        } else if secret_value_delimiter(ch) {
+            output.push(ch);
+            Self::Text
+        } else {
+            output.push_str("<redacted>");
+            Self::RedactingSecretValue {
+                marker: RedactionMarker::Written,
+            }
         }
     }
 
@@ -321,5 +336,17 @@ mod tests {
             redactor("starting build\nfinished successfully\n"),
             "starting build\nfinished successfully\n"
         );
+    }
+
+    #[test]
+    fn redactor_hides_whitespace_delimited_runtime_secrets() {
+        let output = redactor(
+            "v8-runner --password runtime-secret --connection Srvr=server;Pwd=connection-secret\n",
+        );
+
+        assert!(!output.contains("runtime-secret"), "{output}");
+        assert!(!output.contains("connection-secret"), "{output}");
+        assert!(output.contains("--password <redacted>"), "{output}");
+        assert!(output.contains("Pwd=<redacted>"), "{output}");
     }
 }

--- a/crates/unica-coder/src/infrastructure/redaction.rs
+++ b/crates/unica-coder/src/infrastructure/redaction.rs
@@ -1,0 +1,134 @@
+pub(crate) fn redactor(text: &str) -> String {
+    let mut stream = StreamRedactor::new();
+    let mut output = stream.push(text);
+    output.push_str(&stream.finish());
+    output
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct StreamRedactor {
+    pending: String,
+    redacting_secret_value: bool,
+}
+
+impl StreamRedactor {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn push(&mut self, chunk: &str) -> String {
+        self.pending.push_str(chunk);
+
+        let chars = self.pending.chars().collect::<Vec<_>>();
+        let mut output = String::with_capacity(chars.len());
+        let mut index = 0;
+
+        while index < chars.len() {
+            if self.redacting_secret_value {
+                if secret_value_delimiter(chars[index]) {
+                    output.push(chars[index]);
+                    self.redacting_secret_value = false;
+                }
+                index += 1;
+                continue;
+            }
+
+            if !secret_key_char(chars[index]) {
+                output.push(chars[index]);
+                index += 1;
+                continue;
+            }
+
+            let key_start = index;
+            index += 1;
+            while index < chars.len() && secret_key_char(chars[index]) {
+                index += 1;
+            }
+            let key_end = index;
+
+            if key_end == chars.len() {
+                self.pending = chars[key_start..].iter().collect();
+                return output;
+            }
+
+            let mut separator = index;
+            while separator < chars.len() && chars[separator].is_whitespace() {
+                separator += 1;
+            }
+            if separator == chars.len() {
+                if is_secret_key(&chars[key_start..key_end].iter().collect::<String>()) {
+                    self.pending = chars[key_start..].iter().collect();
+                    return output;
+                }
+                output.extend(chars[key_start..separator].iter());
+                index = separator;
+                continue;
+            }
+
+            if matches!(chars[separator], '=' | ':')
+                && is_secret_key(&chars[key_start..key_end].iter().collect::<String>())
+            {
+                let mut value_start = separator + 1;
+                while value_start < chars.len() && chars[value_start].is_whitespace() {
+                    value_start += 1;
+                }
+                output.extend(chars[key_start..value_start].iter());
+                output.push_str("<redacted>");
+                self.redacting_secret_value = true;
+                index = value_start;
+                continue;
+            }
+
+            output.extend(chars[key_start..key_end].iter());
+        }
+
+        self.pending.clear();
+        output
+    }
+
+    pub(crate) fn finish(&mut self) -> String {
+        self.redacting_secret_value = false;
+        std::mem::take(&mut self.pending)
+    }
+}
+
+pub(crate) fn is_secret_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key == "connection"
+        || key == "pwd"
+        || key.contains("password")
+        || key.contains("token")
+        || key.contains("secret")
+}
+
+fn secret_key_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-')
+}
+
+fn secret_value_delimiter(ch: char) -> bool {
+    matches!(ch, ';' | '&' | ',' | '\n' | '\r' | '}')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{redactor, StreamRedactor};
+
+    #[test]
+    fn stream_redactor_redacts_secret_key_split_across_chunks() {
+        let mut redactor = StreamRedactor::new();
+
+        assert_eq!(redactor.push("starting; P"), "starting; ");
+        assert_eq!(
+            redactor.push("wd=super-secret\nfinished\n"),
+            "Pwd=<redacted>\nfinished\n"
+        );
+    }
+
+    #[test]
+    fn redactor_preserves_normal_text() {
+        assert_eq!(
+            redactor("starting build\nfinished successfully\n"),
+            "starting build\nfinished successfully\n"
+        );
+    }
+}

--- a/crates/unica-coder/src/infrastructure/redaction.rs
+++ b/crates/unica-coder/src/infrastructure/redaction.rs
@@ -5,10 +5,47 @@ pub(crate) fn redactor(text: &str) -> String {
     output
 }
 
-#[derive(Debug, Default)]
+const EXACT_SECRET_KEYS: &[&str] = &["connection", "pwd"];
+const SUBSTRING_SECRET_KEYS: &[&str] = &["password", "token", "secret"];
+const MAX_RETAINED_KEY_BYTES: usize = "connection".len();
+
+#[derive(Debug)]
 pub(crate) struct StreamRedactor {
-    pending: String,
-    redacting_secret_value: bool,
+    state: StreamRedactorState,
+}
+
+#[derive(Debug)]
+enum StreamRedactorState {
+    Text,
+    Candidate {
+        pending: String,
+        exact_key: ExactKeyStatus,
+    },
+    ConfirmedSecretKey,
+    AfterSecretKey,
+    RedactingSecretValue {
+        marker: RedactionMarker,
+    },
+}
+
+#[derive(Debug)]
+enum ExactKeyStatus {
+    Possible,
+    Discarded,
+}
+
+#[derive(Debug)]
+enum RedactionMarker {
+    Pending,
+    Written,
+}
+
+impl Default for StreamRedactor {
+    fn default() -> Self {
+        Self {
+            state: StreamRedactorState::Text,
+        }
+    }
 }
 
 impl StreamRedactor {
@@ -17,88 +54,230 @@ impl StreamRedactor {
     }
 
     pub(crate) fn push(&mut self, chunk: &str) -> String {
-        self.pending.push_str(chunk);
+        let mut output = String::with_capacity(chunk.len());
 
-        let chars = self.pending.chars().collect::<Vec<_>>();
-        let mut output = String::with_capacity(chars.len());
-        let mut index = 0;
-
-        while index < chars.len() {
-            if self.redacting_secret_value {
-                if secret_value_delimiter(chars[index]) {
-                    output.push(chars[index]);
-                    self.redacting_secret_value = false;
-                }
-                index += 1;
-                continue;
-            }
-
-            if !secret_key_char(chars[index]) {
-                output.push(chars[index]);
-                index += 1;
-                continue;
-            }
-
-            let key_start = index;
-            index += 1;
-            while index < chars.len() && secret_key_char(chars[index]) {
-                index += 1;
-            }
-            let key_end = index;
-
-            if key_end == chars.len() {
-                self.pending = chars[key_start..].iter().collect();
-                return output;
-            }
-
-            let mut separator = index;
-            while separator < chars.len() && chars[separator].is_whitespace() {
-                separator += 1;
-            }
-            if separator == chars.len() {
-                if is_secret_key(&chars[key_start..key_end].iter().collect::<String>()) {
-                    self.pending = chars[key_start..].iter().collect();
-                    return output;
-                }
-                output.extend(chars[key_start..separator].iter());
-                index = separator;
-                continue;
-            }
-
-            if matches!(chars[separator], '=' | ':')
-                && is_secret_key(&chars[key_start..key_end].iter().collect::<String>())
-            {
-                let mut value_start = separator + 1;
-                while value_start < chars.len() && chars[value_start].is_whitespace() {
-                    value_start += 1;
-                }
-                output.extend(chars[key_start..value_start].iter());
-                output.push_str("<redacted>");
-                self.redacting_secret_value = true;
-                index = value_start;
-                continue;
-            }
-
-            output.extend(chars[key_start..key_end].iter());
+        for ch in chunk.chars() {
+            let state = std::mem::replace(&mut self.state, StreamRedactorState::Text);
+            self.state = state.push(ch, &mut output);
         }
-
-        self.pending.clear();
         output
     }
 
     pub(crate) fn finish(&mut self) -> String {
-        self.redacting_secret_value = false;
-        std::mem::take(&mut self.pending)
+        let state = std::mem::replace(&mut self.state, StreamRedactorState::Text);
+        state.finish()
+    }
+
+    #[cfg(test)]
+    fn retained_len(&self) -> usize {
+        match &self.state {
+            StreamRedactorState::Candidate { pending, .. } => pending.len(),
+            StreamRedactorState::Text
+            | StreamRedactorState::ConfirmedSecretKey
+            | StreamRedactorState::AfterSecretKey
+            | StreamRedactorState::RedactingSecretValue { .. } => 0,
+        }
+    }
+}
+
+impl StreamRedactorState {
+    fn push(self, ch: char, output: &mut String) -> Self {
+        match self {
+            Self::Text => {
+                if secret_key_char(ch) {
+                    Self::advance_candidate(ch.to_string(), ExactKeyStatus::Possible, output)
+                } else {
+                    output.push(ch);
+                    Self::Text
+                }
+            }
+            Self::Candidate {
+                mut pending,
+                exact_key,
+            } => {
+                if secret_key_char(ch) {
+                    pending.push(ch);
+                    Self::advance_candidate(pending, exact_key, output)
+                } else {
+                    let is_secret = matches!(exact_key, ExactKeyStatus::Possible)
+                        && is_exact_secret_key(&pending);
+                    output.push_str(&pending);
+                    if is_secret {
+                        Self::after_secret_key(ch, output)
+                    } else {
+                        output.push(ch);
+                        Self::Text
+                    }
+                }
+            }
+            Self::ConfirmedSecretKey => {
+                if secret_key_char(ch) {
+                    output.push(ch);
+                    Self::ConfirmedSecretKey
+                } else {
+                    Self::after_secret_key(ch, output)
+                }
+            }
+            Self::AfterSecretKey => Self::after_secret_key(ch, output),
+            Self::RedactingSecretValue { marker } => Self::redact_value(ch, marker, output),
+        }
+    }
+
+    fn advance_candidate(
+        mut pending: String,
+        exact_key: ExactKeyStatus,
+        output: &mut String,
+    ) -> Self {
+        if contains_substring_secret_key(&pending) {
+            output.push_str(&pending);
+            return Self::ConfirmedSecretKey;
+        }
+
+        let exact_key = exact_key.advance(&pending);
+        if matches!(exact_key, ExactKeyStatus::Possible) {
+            return Self::Candidate { pending, exact_key };
+        }
+
+        retain_secret_key_suffix(&mut pending, output);
+        Self::Candidate { pending, exact_key }
+    }
+
+    fn after_secret_key(ch: char, output: &mut String) -> Self {
+        if matches!(ch, '=' | ':') {
+            output.push(ch);
+            Self::RedactingSecretValue {
+                marker: RedactionMarker::Pending,
+            }
+        } else if ch.is_whitespace() {
+            output.push(ch);
+            Self::AfterSecretKey
+        } else if secret_key_char(ch) {
+            Self::advance_candidate(ch.to_string(), ExactKeyStatus::Possible, output)
+        } else {
+            output.push(ch);
+            Self::Text
+        }
+    }
+
+    fn redact_value(ch: char, marker: RedactionMarker, output: &mut String) -> Self {
+        match marker {
+            RedactionMarker::Pending if ch.is_whitespace() => {
+                output.push(ch);
+                Self::RedactingSecretValue {
+                    marker: RedactionMarker::Pending,
+                }
+            }
+            RedactionMarker::Pending => {
+                output.push_str("<redacted>");
+                if secret_value_delimiter(ch) {
+                    output.push(ch);
+                    Self::Text
+                } else {
+                    Self::RedactingSecretValue {
+                        marker: RedactionMarker::Written,
+                    }
+                }
+            }
+            RedactionMarker::Written if secret_value_delimiter(ch) => {
+                output.push(ch);
+                Self::Text
+            }
+            RedactionMarker::Written => Self::RedactingSecretValue {
+                marker: RedactionMarker::Written,
+            },
+        }
+    }
+
+    fn finish(self) -> String {
+        match self {
+            Self::Candidate { pending, .. } => pending,
+            Self::RedactingSecretValue {
+                marker: RedactionMarker::Pending,
+            } => "<redacted>".to_string(),
+            Self::Text
+            | Self::ConfirmedSecretKey
+            | Self::AfterSecretKey
+            | Self::RedactingSecretValue {
+                marker: RedactionMarker::Written,
+            } => String::new(),
+        }
+    }
+}
+
+impl ExactKeyStatus {
+    fn advance(self, key: &str) -> Self {
+        match self {
+            Self::Possible if is_possible_exact_secret_key(key) => Self::Possible,
+            Self::Possible | Self::Discarded => Self::Discarded,
+        }
     }
 }
 
 pub(crate) fn is_secret_key(key: &str) -> bool {
     let key = key.to_ascii_lowercase();
-    key == "connection"
-        || key == "pwd"
-        || key.contains("password")
-        || key.contains("token")
-        || key.contains("secret")
+    EXACT_SECRET_KEYS.contains(&key.as_str())
+        || SUBSTRING_SECRET_KEYS
+            .iter()
+            .any(|secret_key| key.contains(secret_key))
+}
+
+fn is_possible_exact_secret_key(key: &str) -> bool {
+    EXACT_SECRET_KEYS.iter().any(|secret_key| {
+        secret_key
+            .get(..key.len())
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case(key))
+    })
+}
+
+fn is_exact_secret_key(key: &str) -> bool {
+    EXACT_SECRET_KEYS
+        .iter()
+        .any(|secret_key| secret_key.eq_ignore_ascii_case(key))
+}
+
+fn contains_substring_secret_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    SUBSTRING_SECRET_KEYS
+        .iter()
+        .any(|secret_key| key.contains(secret_key))
+}
+
+fn retain_secret_key_suffix(pending: &mut String, output: &mut String) {
+    let mut retained_len = 0;
+    for length in (1..=MAX_RETAINED_KEY_BYTES).rev() {
+        let Some(suffix_start) = pending.len().checked_sub(length) else {
+            continue;
+        };
+        let Some(suffix) = pending.get(suffix_start..) else {
+            continue;
+        };
+        if SUBSTRING_SECRET_KEYS.iter().any(|secret_key| {
+            secret_key
+                .get(..length)
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case(suffix))
+        }) {
+            retained_len = length;
+            break;
+        }
+    }
+
+    if retained_len == 0 {
+        output.push_str(pending);
+        pending.clear();
+        return;
+    }
+
+    let Some(suffix_start) = pending.len().checked_sub(retained_len) else {
+        return;
+    };
+    let Some(prefix) = pending.get(..suffix_start) else {
+        return;
+    };
+    let Some(suffix) = pending.get(suffix_start..) else {
+        return;
+    };
+    output.push_str(prefix);
+    *pending = suffix.to_string();
 }
 
 fn secret_key_char(ch: char) -> bool {
@@ -122,6 +301,18 @@ mod tests {
             redactor.push("wd=super-secret\nfinished\n"),
             "Pwd=<redacted>\nfinished\n"
         );
+    }
+
+    #[test]
+    fn stream_redactor_bounds_state_for_delimiter_free_chunks() {
+        let mut redactor = StreamRedactor::new();
+
+        for _ in 0..1_024 {
+            assert_eq!(redactor.push("x"), "x");
+            assert!(redactor.retained_len() <= 10);
+        }
+
+        assert_eq!(redactor.push("token=super-secret\n"), "token=<redacted>\n");
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/runtime_jobs.rs
+++ b/crates/unica-coder/src/infrastructure/runtime_jobs.rs
@@ -1,13 +1,20 @@
-//! Durable, private runtime-job state used by future runtime tool adapters.
-#![allow(dead_code)] // Wired to the public transport in the follow-up runtime-tools task.
+//! Durable runtime-job state used by the runtime-job worker and transport adapter.
 
 use super::redaction;
+use crate::domain::cache::CacheAccess;
+use crate::domain::events::{runtime_event_kind, DomainEvent};
+use crate::domain::workspace::WorkspaceContext;
+use crate::infrastructure::workspace_services::WorkspaceServiceManager;
+use crate::infrastructure::workspace_state::WorkspaceStateRepository;
 use serde::{Deserialize, Serialize};
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 use std::{
     collections::HashMap,
     fs::{self, File, OpenOptions},
-    io::Write,
+    io::{self, Read, Write},
     path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
     sync::{Arc, Mutex},
     thread,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -29,7 +36,8 @@ pub(crate) enum CancelPolicy {
 }
 
 /// The operation classes deliberately accepted by the durable core.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub(crate) enum RuntimeJobOperation {
     Make,
     Syntax,
@@ -42,6 +50,7 @@ pub(crate) enum RuntimeJobOperation {
     Convert,
     Load,
     Launch,
+    Extensions,
 }
 
 impl RuntimeJobOperation {
@@ -54,11 +63,12 @@ impl RuntimeJobOperation {
             | Self::Dump
             | Self::Convert
             | Self::Load
-            | Self::Launch => CancelPolicy::Critical,
+            | Self::Launch
+            | Self::Extensions => CancelPolicy::Critical,
         }
     }
 
-    fn label(self) -> &'static str {
+    pub(crate) fn label(self) -> &'static str {
         match self {
             Self::Make => "make",
             Self::Syntax => "syntax",
@@ -71,6 +81,25 @@ impl RuntimeJobOperation {
             Self::Convert => "convert",
             Self::Load => "load",
             Self::Launch => "launch",
+            Self::Extensions => "extensions",
+        }
+    }
+
+    pub(crate) fn from_label(label: &str) -> JobResult<Self> {
+        match label {
+            "make" => Ok(Self::Make),
+            "syntax" => Ok(Self::Syntax),
+            "test" => Ok(Self::Test),
+            "tools-download" => Ok(Self::ToolsDownload),
+            "config-init" => Ok(Self::ConfigInit),
+            "init" => Ok(Self::Init),
+            "build" => Ok(Self::Build),
+            "dump" => Ok(Self::Dump),
+            "convert" => Ok(Self::Convert),
+            "load" => Ok(Self::Load),
+            "launch" => Ok(Self::Launch),
+            "extensions" => Ok(Self::Extensions),
+            _ => Err(redacted_error("unsupported runtime job operation")),
         }
     }
 }
@@ -134,8 +163,15 @@ impl RuntimeJobPhase {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum RuntimeJobProcessState {
     Running,
-    Exited { exit_code: i32 },
-    TimedOut { reason: String },
+    Exited {
+        exit_code: i32,
+    },
+    // SystemRuntimeJobRunner delegates execution timeouts to v8-runner, while
+    // the runner boundary still models timeout-capable implementations.
+    #[allow(dead_code)]
+    TimedOut {
+        reason: String,
+    },
 }
 
 #[derive(Debug, Clone, Default)]
@@ -159,14 +195,215 @@ pub(crate) trait RuntimeJobRunner: Send + Sync {
     fn attach(&self, process_id: u32) -> JobResult<Box<dyn RuntimeJobProcess>>;
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct WorkerStartRequest {
+    cache_root: PathBuf,
+    job_id: String,
+    program: PathBuf,
+    cwd: PathBuf,
+    operation: String,
+    argv: Vec<String>,
+    safe_target: String,
+    artifact_path: Option<String>,
+    timeout_reason: Option<String>,
+}
+
+impl WorkerStartRequest {
+    fn runtime_request(&self) -> JobResult<RuntimeJobRequest> {
+        let operation = RuntimeJobOperation::from_label(&self.operation)?;
+        let mut request = RuntimeJobRequest::new(
+            operation,
+            self.argv.clone(),
+            self.safe_target.clone(),
+            self.artifact_path.clone(),
+        );
+        request.timeout_reason = self.timeout_reason.clone();
+        Ok(request)
+    }
+}
+
+struct SystemRuntimeJobRunner {
+    program: PathBuf,
+    cwd: PathBuf,
+}
+
+impl RuntimeJobRunner for SystemRuntimeJobRunner {
+    fn spawn(&self, request: &RuntimeJobRequest) -> JobResult<Box<dyn RuntimeJobProcess>> {
+        let mut command = Command::new(&self.program);
+        command
+            .args(&request.raw_argv)
+            .current_dir(&self.cwd)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        // The group makes safe cancellation cover v8-runner descendants too.
+        #[cfg(unix)]
+        command.process_group(0);
+        let mut child = command
+            .spawn()
+            .map_err(|error| redacted_error(&format!("spawn runtime job process: {error}")))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| redacted_error("runtime job process has no stdout pipe"))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| redacted_error("runtime job process has no stderr pipe"))?;
+        Ok(Box::new(SystemRuntimeJobProcess {
+            id: child.id(),
+            child,
+            stdout: StreamTail::spawn(stdout),
+            stderr: StreamTail::spawn(stderr),
+            exited: false,
+        }))
+    }
+
+    fn attach(&self, _process_id: u32) -> JobResult<Box<dyn RuntimeJobProcess>> {
+        Err(redacted_error(
+            "runtime job worker cannot attach to an unowned process",
+        ))
+    }
+}
+
+struct SystemRuntimeJobProcess {
+    id: u32,
+    child: Child,
+    stdout: StreamTail,
+    stderr: StreamTail,
+    exited: bool,
+}
+
+impl RuntimeJobProcess for SystemRuntimeJobProcess {
+    fn id(&self) -> u32 {
+        self.id
+    }
+
+    fn try_wait(&mut self) -> JobResult<RuntimeJobProcessState> {
+        match self
+            .child
+            .try_wait()
+            .map_err(|error| redacted_error(&format!("poll runtime job process: {error}")))?
+        {
+            Some(status) => {
+                self.exited = true;
+                Ok(RuntimeJobProcessState::Exited {
+                    exit_code: status.code().unwrap_or(1),
+                })
+            }
+            None => Ok(RuntimeJobProcessState::Running),
+        }
+    }
+
+    fn cancel(&mut self) -> JobResult<()> {
+        #[cfg(unix)]
+        {
+            let group = i32::try_from(self.id)
+                .map_err(|_| redacted_error("runtime job process id is outside Unix pid range"))?;
+            // A negative pid targets the process group created in spawn().
+            let result = unsafe { libc::kill(-group, libc::SIGKILL) };
+            if result == 0 {
+                Ok(())
+            } else {
+                let error = io::Error::last_os_error();
+                if error.raw_os_error() == Some(libc::ESRCH) {
+                    Ok(())
+                } else {
+                    Err(io_error("cancel runtime job process group", &error))
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        #[cfg(windows)]
+        {
+            let status = Command::new("taskkill")
+                .args(["/PID", &self.id.to_string(), "/T", "/F"])
+                .status()
+                .map_err(|error| io_error("cancel runtime job process tree", &error))?;
+            if status.success() {
+                Ok(())
+            } else {
+                Err(redacted_error("cancel runtime job process tree failed"))
+            }
+        }
+        #[cfg(all(not(unix), not(windows)))]
+        Err(redacted_error(
+            "runtime job process-tree cancellation is unsupported on this platform",
+        ))
+    }
+
+    fn output_tails(&mut self, max_bytes: usize) -> JobResult<RuntimeJobOutput> {
+        if self.exited {
+            self.stdout.finish()?;
+            self.stderr.finish()?;
+        }
+        Ok(RuntimeJobOutput {
+            stdout: self.stdout.tail(max_bytes)?,
+            stderr: self.stderr.tail(max_bytes)?,
+        })
+    }
+}
+
+struct StreamTail {
+    text: Arc<Mutex<String>>,
+    reader: Option<thread::JoinHandle<io::Result<()>>>,
+}
+
+impl StreamTail {
+    fn spawn<R>(mut stream: R) -> Self
+    where
+        R: Read + Send + 'static,
+    {
+        let text = Arc::new(Mutex::new(String::new()));
+        let captured = Arc::clone(&text);
+        let reader = thread::spawn(move || {
+            let mut buffer = [0_u8; 4096];
+            let mut redactor = redaction::StreamRedactor::new();
+            loop {
+                let count = stream.read(&mut buffer)?;
+                if count == 0 {
+                    append_tail(&captured, &redactor.finish())?;
+                    return Ok(());
+                }
+                let chunk = String::from_utf8_lossy(&buffer[..count]);
+                append_tail(&captured, &redactor.push(&chunk))?;
+            }
+        });
+        Self {
+            text,
+            reader: Some(reader),
+        }
+    }
+
+    fn finish(&mut self) -> JobResult<()> {
+        let Some(reader) = self.reader.take() else {
+            return Ok(());
+        };
+        reader
+            .join()
+            .map_err(|_| redacted_error("join runtime job output reader"))?
+            .map_err(|error| io_error("read runtime job output", &error))
+    }
+
+    fn tail(&self, max_bytes: usize) -> JobResult<String> {
+        let text = self
+            .text
+            .lock()
+            .map_err(|error| redacted_error(&format!("lock runtime job output: {error}")))?;
+        Ok(bounded_tail(&text, max_bytes))
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct RuntimeJobSnapshot {
     pub(crate) id: String,
     pub(crate) phase: RuntimeJobPhase,
+    pub(crate) operation: String,
     pub(crate) safe_target: String,
     pub(crate) redacted_argv: Vec<String>,
     pub(crate) created_at_ms: u64,
+    pub(crate) started_at_ms: Option<u64>,
     pub(crate) heartbeat_at_ms: Option<u64>,
     pub(crate) finished_at_ms: Option<u64>,
     pub(crate) pid: Option<u32>,
@@ -187,6 +424,8 @@ pub(crate) struct RuntimeJobSnapshot {
 pub(crate) struct RuntimeJobLogs {
     pub(crate) stdout: String,
     pub(crate) stderr: String,
+    pub(crate) stdout_path: String,
+    pub(crate) stderr_path: String,
 }
 
 #[derive(Debug, Clone)]
@@ -202,6 +441,7 @@ struct RuntimeJobRecord {
     schema_version: u8,
     id: String,
     phase: RuntimeJobPhase,
+    operation: String,
     safe_target: String,
     redacted_argv: Vec<String>,
     created_at_ms: u64,
@@ -214,6 +454,7 @@ struct RuntimeJobRecord {
     cancel_policy: CancelPolicy,
     cancelled: bool,
     cancel_deferred: bool,
+    cancel_attempted: bool,
     unsafe_phase: Option<String>,
     timeout_reason: Option<String>,
     artifact_path: Option<String>,
@@ -229,10 +470,14 @@ impl RuntimeJobRecord {
             schema_version: RECORD_SCHEMA_VERSION,
             id: id.clone(),
             phase: RuntimeJobPhase::Queued,
+            operation: request.operation.label().to_string(),
             safe_target: redact_text(&request.safe_target),
             redacted_argv: redact_argv(&request.raw_argv),
             created_at_ms: now,
-            started_at_ms: None,
+            // The public start contract reports when the durable job lifecycle
+            // began. The worker replaces this with the child-start timestamp
+            // once it has successfully claimed the queued record.
+            started_at_ms: Some(now),
             heartbeat_at_ms: Some(now),
             finished_at_ms: None,
             pid: None,
@@ -241,7 +486,8 @@ impl RuntimeJobRecord {
             cancel_policy: request.operation.cancel_policy(),
             cancelled: false,
             cancel_deferred: false,
-            unsafe_phase: Some(request.operation.label().to_string()),
+            cancel_attempted: false,
+            unsafe_phase: None,
             timeout_reason: request.timeout_reason.as_deref().map(redact_text),
             artifact_path: request.artifact_path.as_deref().map(redact_text),
             stdout_path: format!("jobs/{id}/stdout.log"),
@@ -254,9 +500,11 @@ impl RuntimeJobRecord {
         RuntimeJobSnapshot {
             id: self.id.clone(),
             phase: self.phase,
+            operation: self.operation.clone(),
             safe_target: self.safe_target.clone(),
             redacted_argv: self.redacted_argv.clone(),
             created_at_ms: self.created_at_ms,
+            started_at_ms: self.started_at_ms,
             heartbeat_at_ms: self.heartbeat_at_ms,
             finished_at_ms: self.finished_at_ms,
             pid: self.pid,
@@ -279,6 +527,7 @@ impl RuntimeJobRecord {
             RuntimeJobPhase::Queued => matches!(
                 next,
                 RuntimeJobPhase::Running
+                    | RuntimeJobPhase::CancelRequested
                     | RuntimeJobPhase::Failed
                     | RuntimeJobPhase::Cancelled
                     | RuntimeJobPhase::Lost
@@ -345,6 +594,10 @@ impl RuntimeJobStore {
 
     fn active_lock_path(&self) -> PathBuf {
         self.jobs_root().join("active.lock")
+    }
+
+    fn recovery_lock_path(&self) -> PathBuf {
+        self.jobs_root().join("active.recovery.lock")
     }
 
     fn job_dir(&self, id: &str) -> JobResult<PathBuf> {
@@ -431,6 +684,70 @@ impl RuntimeJobStore {
         fs::write(directory.join("stderr.log"), "")
             .map_err(|error| io_error("create runtime job stderr log", &error))?;
         Ok(record)
+    }
+
+    fn enqueue(&self, id: &str, request: &RuntimeJobRequest) -> JobResult<RuntimeJobRecord> {
+        if let Err(error) = self.acquire_active_lock(id) {
+            if !self.recover_stale_active()? {
+                return Err(error);
+            }
+            self.acquire_active_lock(id)?;
+        }
+        match self.create_record(id, request) {
+            Ok(record) => Ok(record),
+            Err(error) => {
+                let _ = self.release_active_lock_for(id);
+                Err(error)
+            }
+        }
+    }
+
+    fn recover_stale_active(&self) -> JobResult<bool> {
+        fs::create_dir_all(self.jobs_root())
+            .map_err(|error| io_error("create runtime jobs directory", &error))?;
+        let recovery_lock = match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(self.recovery_lock_path())
+        {
+            Ok(lock) => lock,
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => return Ok(false),
+            Err(error) => return Err(io_error("create runtime job recovery lock", &error)),
+        };
+        let result = self.recover_stale_active_locked();
+        drop(recovery_lock);
+        match fs::remove_file(self.recovery_lock_path()) {
+            Ok(()) => result,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => result,
+            Err(error) => Err(io_error("remove runtime job recovery lock", &error)),
+        }
+    }
+
+    fn recover_stale_active_locked(&self) -> JobResult<bool> {
+        let id = match fs::read_to_string(self.active_lock_path()) {
+            Ok(id) => id.trim().to_string(),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => return Err(io_error("read active runtime job lock", &error)),
+        };
+        let mut record = self.read_record(&id)?;
+        if record.phase.is_terminal() {
+            // A terminal write can succeed while the final lock removal fails.
+            // Its own id makes this cleanup safe. Lost is deliberately excluded:
+            // its child may still be alive after a worker crash.
+            if record.phase != RuntimeJobPhase::Lost {
+                self.release_active_lock_for(&id)?;
+                return Ok(true);
+            }
+            return Ok(false);
+        }
+        if !self.stale(&record) {
+            return Ok(false);
+        }
+        record.transition(RuntimeJobPhase::Lost)?;
+        record.finished_at_ms = Some(now_millis());
+        record.warnings.push("stale worker heartbeat".to_string());
+        self.write_record(&record)?;
+        Ok(true)
     }
 
     fn read_record(&self, id: &str) -> JobResult<RuntimeJobRecord> {
@@ -590,17 +907,50 @@ impl RuntimeJobService {
         }
     }
 
-    pub(crate) fn start(&self, request: RuntimeJobRequest) -> JobResult<RuntimeJobSnapshot> {
+    #[cfg(test)]
+    fn start(&self, request: RuntimeJobRequest) -> JobResult<RuntimeJobSnapshot> {
         let id = Uuid::new_v4().to_string();
-        self.store.acquire_active_lock(&id)?;
-        let mut record = match self.store.create_record(&id, &request) {
-            Ok(record) => record,
-            Err(error) => {
-                let _ = self.store.release_active_lock_for(&id);
-                return Err(error);
-            }
-        };
-        let process = match self.runner.spawn(&request) {
+        self.store.enqueue(&id, &request)?;
+        self.activate_enqueued(&id, &request)
+    }
+
+    pub(crate) fn enqueue(
+        cache_root: impl Into<PathBuf>,
+        request: &RuntimeJobRequest,
+    ) -> JobResult<RuntimeJobSnapshot> {
+        let store = RuntimeJobStore::new(cache_root, DEFAULT_STALE_AFTER);
+        let id = Uuid::new_v4().to_string();
+        let record = store.enqueue(&id, request)?;
+        Ok(record.snapshot(false))
+    }
+
+    fn activate_enqueued(
+        &self,
+        id: &str,
+        request: &RuntimeJobRequest,
+    ) -> JobResult<RuntimeJobSnapshot> {
+        let mut record = self.store.read_record(id)?;
+        // A cancellation that arrived before the worker claimed the record is
+        // safe to complete without starting the child process. A cancellation
+        // that races after this read is observed by poll() through cancel.json.
+        if record.phase == RuntimeJobPhase::CancelRequested {
+            record.cancelled = true;
+            record.finished_at_ms = Some(now_millis());
+            record.heartbeat_at_ms = Some(now_millis());
+            record.transition(RuntimeJobPhase::Cancelled)?;
+            self.store.write_record(&record)?;
+            self.store.release_active_lock_for(id)?;
+            return Ok(record.snapshot(false));
+        }
+        if record.phase != RuntimeJobPhase::Queued {
+            return Err(redacted_error("runtime job worker expected a queued job"));
+        }
+        if record.operation != request.operation.label() {
+            return Err(redacted_error(
+                "runtime job worker operation does not match queued job",
+            ));
+        }
+        let mut process = match self.runner.spawn(request) {
             Ok(process) => process,
             Err(error) => {
                 let error = redacted_error(&error);
@@ -614,18 +964,32 @@ impl RuntimeJobService {
         record.heartbeat_at_ms = Some(now_millis());
         record.transition(RuntimeJobPhase::Running)?;
         if let Err(error) = self.store.write_record(&record) {
-            let _ = self.store.release_active_lock_for(&id);
+            self.cleanup_activation_failure(&mut record, &mut *process, &error);
             return Err(error);
         }
-        let mut processes = self.lock_processes()?;
-        processes.insert(id, process);
+        let mut processes = match self.lock_processes() {
+            Ok(processes) => processes,
+            Err(error) => {
+                self.cleanup_activation_failure(&mut record, &mut *process, &error);
+                return Err(error);
+            }
+        };
+        processes.insert(id.to_string(), process);
         Ok(record.snapshot(false))
     }
 
-    pub(crate) fn status(&self, id: &str) -> JobResult<RuntimeJobSnapshot> {
-        self.store
-            .read_record(id)
-            .map(|record| record.snapshot(false))
+    #[cfg(test)]
+    fn status(&self, id: &str) -> JobResult<RuntimeJobSnapshot> {
+        Self::status_at(&self.store.cache_root, id)
+    }
+
+    pub(crate) fn status_at(
+        cache_root: impl Into<PathBuf>,
+        id: &str,
+    ) -> JobResult<RuntimeJobSnapshot> {
+        let store = RuntimeJobStore::new(cache_root, DEFAULT_STALE_AFTER);
+        let _ = store.recover_stale_active()?;
+        store.read_record(id).map(|record| record.snapshot(false))
     }
 
     pub(crate) fn poll(&self, id: &str) -> JobResult<RuntimeJobSnapshot> {
@@ -638,27 +1002,22 @@ impl RuntimeJobService {
             record.finished_at_ms = Some(now_millis());
             record.warnings.push("stale heartbeat".to_string());
             self.store.write_record(&record)?;
-            self.store.release_active_lock_for(&record.id)?;
             self.remove_process(&record.id)?;
             return Ok(record.snapshot(false));
         }
 
         let cancel_requested = self.store.has_cancel_marker(id)?;
-        let (process_state, output, safe_cancel) =
-            self.observe_process(&record, cancel_requested)?;
-        self.store.write_logs(&record.id, &output)?;
-
-        if safe_cancel {
-            record.transition(RuntimeJobPhase::Cancelled)?;
-            record.cancelled = true;
-            record.finished_at_ms = Some(now_millis());
+        let request_safe_cancel = cancel_requested
+            && record.cancel_policy == CancelPolicy::Safe
+            && !record.cancel_attempted;
+        if request_safe_cancel {
+            if record.phase == RuntimeJobPhase::Running {
+                record.transition(RuntimeJobPhase::CancelRequested)?;
+            }
+            record.cancel_attempted = true;
             record.heartbeat_at_ms = Some(now_millis());
             self.store.write_record(&record)?;
-            self.store.release_active_lock_for(&record.id)?;
-            self.remove_process(&record.id)?;
-            return Ok(record.snapshot(false));
         }
-
         if cancel_requested && record.cancel_policy == CancelPolicy::Critical {
             match record.phase {
                 RuntimeJobPhase::Queued | RuntimeJobPhase::Running => {
@@ -676,7 +1035,12 @@ impl RuntimeJobService {
                 }
             }
             record.cancel_deferred = true;
+            record.unsafe_phase = Some(record.operation.clone());
+            record.heartbeat_at_ms = Some(now_millis());
+            self.store.write_record(&record)?;
         }
+        let (process_state, output) = self.observe_process(&record, request_safe_cancel)?;
+        self.store.write_logs(&record.id, &output)?;
 
         match process_state {
             RuntimeJobProcessState::Running => {
@@ -685,7 +1049,10 @@ impl RuntimeJobService {
                 Ok(record.snapshot(false))
             }
             RuntimeJobProcessState::Exited { exit_code } => {
-                let phase = if exit_code == 0 {
+                let phase = if cancel_requested && record.cancel_policy == CancelPolicy::Safe {
+                    record.cancelled = true;
+                    RuntimeJobPhase::Cancelled
+                } else if exit_code == 0 {
                     RuntimeJobPhase::Succeeded
                 } else {
                     RuntimeJobPhase::Failed
@@ -701,7 +1068,8 @@ impl RuntimeJobService {
         }
     }
 
-    pub(crate) fn wait(&self, id: &str, caller_timeout: Duration) -> JobResult<RuntimeJobSnapshot> {
+    #[cfg(test)]
+    fn wait(&self, id: &str, caller_timeout: Duration) -> JobResult<RuntimeJobSnapshot> {
         let started_at = Instant::now();
         let deadline = match started_at.checked_add(caller_timeout) {
             Some(deadline) => deadline,
@@ -721,16 +1089,32 @@ impl RuntimeJobService {
         }
     }
 
-    pub(crate) fn logs(&self, id: &str) -> JobResult<RuntimeJobLogs> {
-        let record = self.store.read_record(id)?;
-        let stdout = fs::read_to_string(self.store.stdout_path(&record.id)?)
-            .map_err(|error| io_error("read runtime job stdout log", &error))?;
-        let stderr = fs::read_to_string(self.store.stderr_path(&record.id)?)
-            .map_err(|error| io_error("read runtime job stderr log", &error))?;
-        Ok(RuntimeJobLogs { stdout, stderr })
+    #[cfg(test)]
+    fn logs(&self, id: &str) -> JobResult<RuntimeJobLogs> {
+        Self::logs_at(&self.store.cache_root, id, OUTPUT_TAIL_BYTES)
     }
 
-    pub(crate) fn cancel(&self, id: &str) -> JobResult<RuntimeJobSnapshot> {
+    pub(crate) fn logs_at(
+        cache_root: impl Into<PathBuf>,
+        id: &str,
+        tail_chars: usize,
+    ) -> JobResult<RuntimeJobLogs> {
+        let store = RuntimeJobStore::new(cache_root, DEFAULT_STALE_AFTER);
+        let record = store.read_record(id)?;
+        let stdout = fs::read_to_string(store.stdout_path(&record.id)?)
+            .map_err(|error| io_error("read runtime job stdout log", &error))?;
+        let stderr = fs::read_to_string(store.stderr_path(&record.id)?)
+            .map_err(|error| io_error("read runtime job stderr log", &error))?;
+        Ok(RuntimeJobLogs {
+            stdout: bounded_char_tail(&stdout, tail_chars),
+            stderr: bounded_char_tail(&stderr, tail_chars),
+            stdout_path: record.stdout_path,
+            stderr_path: record.stderr_path,
+        })
+    }
+
+    #[cfg(test)]
+    fn cancel(&self, id: &str) -> JobResult<RuntimeJobSnapshot> {
         let record = self.store.read_record(id)?;
         if record.phase.is_terminal() {
             return Ok(record.snapshot(false));
@@ -739,15 +1123,70 @@ impl RuntimeJobService {
         self.poll(id)
     }
 
-    pub(crate) fn list(&self) -> RuntimeJobList {
+    #[cfg(test)]
+    fn list(&self) -> RuntimeJobList {
         self.store.list()
+    }
+
+    pub(crate) fn list_at(cache_root: impl Into<PathBuf>) -> RuntimeJobList {
+        let store = RuntimeJobStore::new(cache_root, DEFAULT_STALE_AFTER);
+        let recovery_warning = store.recover_stale_active().err();
+        let mut list = store.list();
+        if let Some(warning) = recovery_warning {
+            list.warnings.push(warning);
+        }
+        list
+    }
+
+    pub(crate) fn request_cancel_at(
+        cache_root: impl Into<PathBuf>,
+        id: &str,
+    ) -> JobResult<RuntimeJobSnapshot> {
+        let store = RuntimeJobStore::new(cache_root, DEFAULT_STALE_AFTER);
+        let mut record = store.read_record(id)?;
+        if record.phase.is_terminal() {
+            return Ok(record.snapshot(false));
+        }
+        store.write_cancel_marker(id)?;
+        if record.phase == RuntimeJobPhase::Queued || record.phase == RuntimeJobPhase::Running {
+            record.transition(RuntimeJobPhase::CancelRequested)?;
+        }
+        if record.cancel_policy == CancelPolicy::Critical {
+            record.cancel_deferred = true;
+            record.unsafe_phase = Some(record.operation.clone());
+        }
+        record.heartbeat_at_ms = Some(now_millis());
+        store.write_record(&record)?;
+        Ok(record.snapshot(false))
+    }
+
+    pub(crate) fn wait_at(
+        cache_root: impl Into<PathBuf>,
+        id: &str,
+        caller_timeout: Duration,
+    ) -> JobResult<RuntimeJobSnapshot> {
+        let cache_root = cache_root.into();
+        let started_at = Instant::now();
+        let deadline = started_at.checked_add(caller_timeout).unwrap_or(started_at);
+        loop {
+            let snapshot = Self::status_at(cache_root.clone(), id)?;
+            if snapshot.phase.is_terminal() {
+                return Ok(snapshot);
+            }
+            if Instant::now() >= deadline {
+                let mut timed_out = snapshot;
+                timed_out.wait_timed_out = true;
+                return Ok(timed_out);
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
     }
 
     fn observe_process(
         &self,
         record: &RuntimeJobRecord,
-        cancel_requested: bool,
-    ) -> JobResult<(RuntimeJobProcessState, RuntimeJobOutput, bool)> {
+        request_safe_cancel: bool,
+    ) -> JobResult<(RuntimeJobProcessState, RuntimeJobOutput)> {
         let mut processes = self.lock_processes()?;
         if !processes.contains_key(&record.id) {
             let process_id = record.pid.ok_or_else(|| {
@@ -765,23 +1204,18 @@ impl RuntimeJobService {
             redacted_error(&format!("runtime job {} process is unavailable", record.id))
         })?;
 
-        let safe_cancel = cancel_requested && record.cancel_policy == CancelPolicy::Safe;
-        if safe_cancel {
+        if request_safe_cancel {
             process.cancel().map_err(|error| {
                 redacted_error(&format!("cancel runtime job {}: {error}", record.id))
             })?;
         }
-        let state = if safe_cancel {
-            RuntimeJobProcessState::Running
-        } else {
-            process.try_wait().map_err(|error| {
-                redacted_error(&format!("observe runtime job {}: {error}", record.id))
-            })?
-        };
+        let state = process.try_wait().map_err(|error| {
+            redacted_error(&format!("observe runtime job {}: {error}", record.id))
+        })?;
         let output = process.output_tails(OUTPUT_TAIL_BYTES).map_err(|error| {
             redacted_error(&format!("read runtime job {} output: {error}", record.id))
         })?;
-        Ok((state, output, safe_cancel))
+        Ok((state, output))
     }
 
     fn finish(
@@ -812,6 +1246,50 @@ impl RuntimeJobService {
         self.store.release_active_lock_for(&record.id)
     }
 
+    fn cleanup_activation_failure(
+        &self,
+        record: &mut RuntimeJobRecord,
+        process: &mut dyn RuntimeJobProcess,
+        activation_error: &str,
+    ) {
+        match cancel_and_reap(process) {
+            Ok(()) => {
+                if record.phase == RuntimeJobPhase::Running {
+                    let _ = record.transition(RuntimeJobPhase::Failed);
+                }
+                record.finished_at_ms = Some(now_millis());
+                record.heartbeat_at_ms = Some(now_millis());
+                record.warnings.push(redact_text(&format!(
+                    "worker activation failed after child spawn: {activation_error}"
+                )));
+                if self.store.write_record(record).is_ok() {
+                    let _ = self.store.release_active_lock_for(&record.id);
+                }
+            }
+            Err(cleanup_error) => {
+                if record.phase == RuntimeJobPhase::Running {
+                    let _ = record.transition(RuntimeJobPhase::Lost);
+                }
+                record.finished_at_ms = Some(now_millis());
+                record.heartbeat_at_ms = Some(now_millis());
+                record.warnings.push(redact_text(&format!(
+                    "worker activation lost child ownership: {activation_error}; cleanup: {cleanup_error}"
+                )));
+                // The lock intentionally remains: the child tree may still be mutating.
+                let _ = self.store.write_record(record);
+            }
+        }
+    }
+
+    fn append_warning(&self, id: &str, warning: &str) -> JobResult<()> {
+        let mut record = self.store.read_record(id)?;
+        if record.phase.is_terminal() {
+            record.warnings.push(redact_text(warning));
+            self.store.write_record(&record)?;
+        }
+        Ok(())
+    }
+
     fn lock_processes(
         &self,
     ) -> JobResult<std::sync::MutexGuard<'_, HashMap<String, Box<dyn RuntimeJobProcess>>>> {
@@ -824,6 +1302,157 @@ impl RuntimeJobService {
         let mut processes = self.lock_processes()?;
         processes.remove(id);
         Ok(())
+    }
+}
+
+pub(crate) fn run_worker_from_args(_args: &[String]) -> Result<(), String> {
+    let handoff: WorkerStartRequest = serde_json::from_reader(io::stdin())
+        .map_err(|error| redacted_error(&format!("read runtime job worker request: {error}")))?;
+    let runner = Arc::new(SystemRuntimeJobRunner {
+        program: handoff.program.clone(),
+        cwd: handoff.cwd.clone(),
+    });
+    run_worker_request(handoff, runner)
+}
+
+pub(crate) fn start_detached_worker(
+    cache_root: PathBuf,
+    program: PathBuf,
+    cwd: PathBuf,
+    request: RuntimeJobRequest,
+) -> JobResult<RuntimeJobSnapshot> {
+    let queued = RuntimeJobService::enqueue(cache_root.clone(), &request)?;
+    let handoff = WorkerStartRequest {
+        cache_root: cache_root.clone(),
+        job_id: queued.id.clone(),
+        program,
+        cwd,
+        operation: request.operation.label().to_string(),
+        argv: request.raw_argv.clone(),
+        safe_target: request.safe_target.clone(),
+        artifact_path: request.artifact_path.clone(),
+        timeout_reason: request.timeout_reason.clone(),
+    };
+    let mut worker = match Command::new(std::env::current_exe().map_err(|error| {
+        redacted_error(&format!("resolve runtime job worker executable: {error}"))
+    })?)
+    .arg("--runtime-job-worker")
+    .stdin(Stdio::piped())
+    .stdout(Stdio::null())
+    .stderr(Stdio::null())
+    .spawn()
+    {
+        Ok(worker) => worker,
+        Err(error) => {
+            let error = redacted_error(&format!("spawn runtime job worker: {error}"));
+            fail_queued_job(&cache_root, &queued.id, &error)?;
+            return Err(error);
+        }
+    };
+    let write_result = worker
+        .stdin
+        .take()
+        .ok_or_else(|| redacted_error("runtime job worker stdin is unavailable"))
+        .and_then(|mut stdin| {
+            serde_json::to_writer(&mut stdin, &handoff).map_err(|error| {
+                redacted_error(&format!("write runtime job worker request: {error}"))
+            })?;
+            stdin
+                .flush()
+                .map_err(|error| io_error("flush runtime job worker request", &error))
+        });
+    if let Err(error) = write_result {
+        let _ = worker.kill();
+        let _ = worker.wait();
+        fail_queued_job(&cache_root, &queued.id, &error)?;
+        return Err(error);
+    }
+    Ok(queued)
+}
+
+fn run_worker_request(
+    handoff: WorkerStartRequest,
+    runner: Arc<dyn RuntimeJobRunner>,
+) -> Result<(), String> {
+    let job_id = canonical_job_id(&handoff.job_id)?;
+    let request = handoff.runtime_request()?;
+    let worker_cwd = handoff.cwd.clone();
+    let operation = request.operation.label();
+    let service = RuntimeJobService::new(handoff.cache_root, runner);
+    service.activate_enqueued(&job_id, &request)?;
+
+    loop {
+        let snapshot = service.poll(&job_id)?;
+        if snapshot.phase.is_terminal() {
+            if snapshot.phase == RuntimeJobPhase::Succeeded {
+                if let Err(error) = apply_runtime_success_effects(&worker_cwd, operation, &job_id) {
+                    let _ = service.append_warning(&job_id, &error);
+                }
+            }
+            return Ok(());
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn apply_runtime_success_effects(cwd: &Path, operation: &str, job_id: &str) -> JobResult<()> {
+    let Some(event_kind) = runtime_event_kind(operation) else {
+        return Ok(());
+    };
+    let context = WorkspaceContext::discover(cwd.to_path_buf())?;
+    let events = vec![DomainEvent::new(
+        event_kind,
+        format!("runtime-job:{job_id}"),
+    )];
+    WorkspaceStateRepository::new(&context).report(
+        &context,
+        &events,
+        false,
+        CacheAccess {
+            reads: &[],
+            writes: &["workspace_graph", "metadata_graph"],
+        },
+    )?;
+    WorkspaceServiceManager::new().notify_invalidation(&context, &events);
+    Ok(())
+}
+
+fn fail_queued_job(cache_root: &Path, id: &str, error: &str) -> JobResult<()> {
+    let store = RuntimeJobStore::new(cache_root.to_path_buf(), DEFAULT_STALE_AFTER);
+    let mut record = store.read_record(id)?;
+    if record.phase != RuntimeJobPhase::Queued {
+        return Ok(());
+    }
+    record.transition(RuntimeJobPhase::Failed)?;
+    record.finished_at_ms = Some(now_millis());
+    record.heartbeat_at_ms = Some(now_millis());
+    record.warnings.push(redact_text(error));
+    store.write_record(&record)?;
+    store.release_active_lock_for(id)
+}
+
+fn cancel_and_reap(process: &mut dyn RuntimeJobProcess) -> JobResult<()> {
+    const REAP_TIMEOUT: Duration = Duration::from_secs(5);
+
+    process.cancel()?;
+    let deadline = Instant::now()
+        .checked_add(REAP_TIMEOUT)
+        .unwrap_or_else(Instant::now);
+    loop {
+        match process.try_wait()? {
+            RuntimeJobProcessState::Exited { .. } | RuntimeJobProcessState::TimedOut { .. } => {
+                // The process has been reaped. Reader failures cannot revive it,
+                // so they do not make lock release unsafe.
+                let _ = process.output_tails(OUTPUT_TAIL_BYTES);
+                return Ok(());
+            }
+            RuntimeJobProcessState::Running if Instant::now() >= deadline => {
+                return Err(redacted_error(
+                    "runtime job process did not exit after cancellation request",
+                ));
+            }
+            RuntimeJobProcessState::Running => thread::sleep(Duration::from_millis(10)),
+        }
     }
 }
 
@@ -874,9 +1503,9 @@ fn redact_argv(argv: &[String]) -> Vec<String> {
             let redact_argument = redact_next;
             redact_next = matches!(
                 lower.as_str(),
-                "password" | "pwd" | "token" | "secret" | "connection"
+                "password" | "pwd" | "token" | "secret" | "connection" | "c"
             );
-            if redact_argument {
+            if redact_argument || looks_like_connection_string(argument) {
                 "<redacted>".to_string()
             } else {
                 redact_text(argument)
@@ -885,16 +1514,49 @@ fn redact_argv(argv: &[String]) -> Vec<String> {
         .collect()
 }
 
+fn looks_like_connection_string(argument: &str) -> bool {
+    let lower = argument.to_ascii_lowercase();
+    [
+        "file=", "srvr=", "ref=", "usr=", "pwd=", "dbsrvr=", "dbname=",
+    ]
+    .iter()
+    .any(|marker| lower.contains(marker))
+}
+
 fn bounded_redacted_tail(text: &str, max_bytes: usize) -> String {
-    let redacted = redact_text(text);
-    if redacted.len() <= max_bytes {
-        return redacted;
+    bounded_tail(&redact_text(text), max_bytes)
+}
+
+fn append_tail(target: &Arc<Mutex<String>>, addition: &str) -> io::Result<()> {
+    let mut text = target
+        .lock()
+        .map_err(|_| io::Error::other("runtime job output lock is poisoned"))?;
+    text.push_str(addition);
+    if text.len() > OUTPUT_TAIL_BYTES {
+        *text = bounded_tail(&text, OUTPUT_TAIL_BYTES);
     }
-    let mut start = redacted.len().saturating_sub(max_bytes);
-    while start < redacted.len() && !redacted.is_char_boundary(start) {
+    Ok(())
+}
+
+fn bounded_tail(text: &str, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text.to_string();
+    }
+    let mut start = text.len().saturating_sub(max_bytes);
+    while start < text.len() && !text.is_char_boundary(start) {
         start = start.saturating_add(1);
     }
-    redacted[start..].to_string()
+    text[start..].to_string()
+}
+
+fn bounded_char_tail(text: &str, max_chars: usize) -> String {
+    let char_count = text.chars().count();
+    if char_count <= max_chars {
+        return text.to_string();
+    }
+    text.chars()
+        .skip(char_count.saturating_sub(max_chars))
+        .collect()
 }
 
 fn redact_text(text: &str) -> String {
@@ -914,6 +1576,7 @@ mod tests {
     use super::*;
     use std::{
         collections::HashMap,
+        io::Cursor,
         sync::atomic::{AtomicU32, Ordering},
     };
 
@@ -936,6 +1599,41 @@ mod tests {
             reconnected.poll(&job.id).expect("reconnected poll").phase,
             RuntimeJobPhase::Succeeded
         );
+    }
+
+    #[test]
+    fn detached_worker_owns_the_queued_record_until_terminal_state() {
+        let cache = TestCache::new();
+        let request = fake_request(RuntimeJobOperation::Test);
+        let queued = RuntimeJobService::enqueue(cache.path(), &request).expect("queue job");
+        assert_eq!(queued.phase, RuntimeJobPhase::Queued);
+
+        run_worker_request(
+            worker_request(&cache, &queued.id, &request),
+            Arc::new(FakeRunner::success_after(2)),
+        )
+        .expect("worker completes job");
+
+        let reconnected =
+            RuntimeJobService::new(cache.path(), Arc::new(FakeRunner::success_after(1)));
+        let terminal = reconnected.status(&queued.id).expect("read terminal job");
+        assert_eq!(terminal.phase, RuntimeJobPhase::Succeeded);
+        assert_eq!(terminal.operation, "test");
+        assert!(terminal.started_at_ms.is_some());
+        assert!(terminal.finished_at_ms.is_some());
+        assert!(!reconnected.store.active_lock_path().exists());
+    }
+
+    #[test]
+    fn worker_stream_tail_redacts_output_before_retaining_it() {
+        let mut tail = StreamTail::spawn(Cursor::new(
+            b"build started\nPwd=stream-secret\ncompleted\n".to_vec(),
+        ));
+        tail.finish().expect("finish output reader");
+        let output = tail.tail(OUTPUT_TAIL_BYTES).expect("read output tail");
+
+        assert!(output.contains("Pwd=<redacted>"));
+        assert!(!output.contains("stream-secret"));
     }
 
     #[test]
@@ -987,9 +1685,89 @@ mod tests {
             replacement
         );
         assert_eq!(
-            service.status(&stale.id).expect("read lost job").phase,
+            service
+                .store
+                .read_record(&stale.id)
+                .expect("read lost record")
+                .snapshot(false)
+                .phase,
             RuntimeJobPhase::Lost
         );
+    }
+
+    #[test]
+    fn stale_queued_job_is_lost_but_retains_the_active_lock() {
+        let cache = TestCache::new();
+        let request = fake_request(RuntimeJobOperation::Build);
+        let queued = RuntimeJobService::enqueue(cache.path(), &request).expect("queue stale job");
+        let store = RuntimeJobStore::new(cache.path(), DEFAULT_STALE_AFTER);
+        let mut record = store.read_record(&queued.id).expect("read queued record");
+        record.heartbeat_at_ms = Some(0);
+        store.write_record(&record).expect("age queued record");
+
+        let service = RuntimeJobService::new(cache.path(), Arc::new(FakeRunner::success_after(2)));
+        let recovered = RuntimeJobService::status_at(cache.path(), &queued.id)
+            .expect("status recovers stale job");
+        let error = service
+            .start(fake_request(RuntimeJobOperation::Test))
+            .expect_err("a possibly live orphan must continue to block replacement work");
+
+        assert_eq!(recovered.phase, RuntimeJobPhase::Lost);
+        assert!(error.contains(&queued.id), "{error}");
+        assert_eq!(
+            fs::read_to_string(store.active_lock_path())
+                .expect("read retained active lock")
+                .trim(),
+            queued.id
+        );
+        assert!(!store.recovery_lock_path().exists());
+    }
+
+    #[test]
+    fn recovery_releases_its_own_lock_for_a_persisted_terminal_job() {
+        let cache = TestCache::new();
+        let request = fake_request(RuntimeJobOperation::Test);
+        let queued = RuntimeJobService::enqueue(cache.path(), &request).expect("queue job");
+        let store = RuntimeJobStore::new(cache.path(), DEFAULT_STALE_AFTER);
+        let mut record = store.read_record(&queued.id).expect("read queued record");
+        record
+            .transition(RuntimeJobPhase::Failed)
+            .expect("mark terminal record");
+        record.finished_at_ms = Some(now_millis());
+        store
+            .write_record(&record)
+            .expect("persist terminal record");
+
+        let terminal =
+            RuntimeJobService::status_at(cache.path(), &queued.id).expect("recover terminal lock");
+
+        assert_eq!(terminal.phase, RuntimeJobPhase::Failed);
+        assert!(!store.active_lock_path().exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn system_cancellation_reaps_the_runtime_process_group() {
+        let cache = TestCache::new();
+        fs::create_dir_all(cache.path()).expect("create worker cwd");
+        let runner = SystemRuntimeJobRunner {
+            program: PathBuf::from("/bin/sh"),
+            cwd: cache.path().to_path_buf(),
+        };
+        let request = RuntimeJobRequest::new(
+            RuntimeJobOperation::Test,
+            vec!["-c".to_string(), "sleep 10 & wait".to_string()],
+            "workspace:test".to_string(),
+            None,
+        );
+        let mut process = runner.spawn(&request).expect("spawn process group");
+        let group = i32::try_from(process.id()).expect("pid is a Unix process id");
+
+        cancel_and_reap(&mut *process).expect("cancel and reap process group");
+
+        let state = unsafe { libc::kill(-group, 0) };
+        assert_eq!(state, -1, "the process group must no longer be alive");
+        assert_eq!(io::Error::last_os_error().raw_os_error(), Some(libc::ESRCH));
     }
 
     #[test]
@@ -1029,7 +1807,9 @@ mod tests {
                 .expect("read serialized record");
 
         assert_eq!(terminal.phase, RuntimeJobPhase::Failed);
+        assert_eq!(terminal.operation, "test");
         assert_eq!(terminal.exit_code, Some(17));
+        assert!(terminal.started_at_ms.is_some());
         assert_eq!(repeated.phase, terminal.phase);
         assert_eq!(repeated.exit_code, terminal.exit_code);
         assert_eq!(repeated.finished_at_ms, terminal.finished_at_ms);
@@ -1151,6 +1931,23 @@ mod tests {
     }
 
     #[test]
+    fn runner_timeout_becomes_terminal_without_a_process_exit_code() {
+        let cache = TestCache::new();
+        let runner = Arc::new(FakeRunner::times_out_after(1, "runner timeout"));
+        let service = RuntimeJobService::new(cache.path(), runner);
+        let job = service
+            .start(fake_request(RuntimeJobOperation::Test))
+            .expect("start job");
+
+        let terminal = service.poll(&job.id).expect("observe timeout");
+
+        assert_eq!(terminal.phase, RuntimeJobPhase::TimedOut);
+        assert_eq!(terminal.exit_code, None);
+        assert_eq!(terminal.timeout_reason.as_deref(), Some("runner timeout"));
+        assert!(!service.store.active_lock_path().exists());
+    }
+
+    #[test]
     fn caller_wait_timeout_does_not_stop_the_active_job() {
         let cache = TestCache::new();
         let runner = Arc::new(FakeRunner::success_after(3));
@@ -1190,6 +1987,7 @@ mod tests {
 
         assert_eq!(cancelled.phase, RuntimeJobPhase::Cancelled);
         assert!(cancelled.cancelled);
+        assert_eq!(cancelled.unsafe_phase, None);
         let process_id = job.pid.expect("persisted fake pid");
         assert_eq!(runner.cancel_calls(process_id).expect("cancel calls"), 1);
         assert!(!service.store.active_lock_path().exists());
@@ -1217,6 +2015,126 @@ mod tests {
         );
     }
 
+    #[test]
+    fn detached_critical_cancel_publishes_deferred_state_before_a_worker_polls() {
+        let cache = TestCache::new();
+        let request = fake_request(RuntimeJobOperation::Build);
+        let queued = RuntimeJobService::enqueue(cache.path(), &request).expect("queue job");
+
+        let deferred = RuntimeJobService::request_cancel_at(cache.path(), &queued.id)
+            .expect("request durable cancellation");
+
+        assert_eq!(deferred.phase, RuntimeJobPhase::CancelRequested);
+        assert!(deferred.cancel_deferred);
+        assert_eq!(deferred.unsafe_phase.as_deref(), Some("build"));
+        assert!(!deferred.cancelled);
+    }
+
+    #[test]
+    fn worker_does_not_spawn_a_job_cancelled_while_queued() {
+        let cache = TestCache::new();
+        let runner = Arc::new(FakeRunner::success_after(2));
+        let service = RuntimeJobService::new(cache.path(), runner.clone());
+        let request = fake_request(RuntimeJobOperation::Test);
+        let queued = RuntimeJobService::enqueue(cache.path(), &request).expect("queue job");
+        RuntimeJobService::request_cancel_at(cache.path(), &queued.id).expect("cancel queued job");
+
+        let cancelled = service
+            .activate_enqueued(&queued.id, &request)
+            .expect("observe queued cancellation");
+
+        assert_eq!(cancelled.phase, RuntimeJobPhase::Cancelled);
+        assert!(cancelled.cancelled);
+        assert!(cancelled.pid.is_none());
+        assert!(!service.store.active_lock_path().exists());
+        assert!(runner
+            .processes
+            .lock()
+            .expect("lock fake processes")
+            .is_empty());
+    }
+
+    #[test]
+    fn worker_handoff_never_persists_actual_argv_or_output_secrets() {
+        const REQUEST_SECRET: &str = "request-secret";
+        const OUTPUT_SECRET: &str = "output-secret";
+
+        let cache = TestCache::new();
+        let request = RuntimeJobRequest::new(
+            RuntimeJobOperation::Make,
+            vec![
+                "make".to_string(),
+                "--connection".to_string(),
+                format!("Pwd={REQUEST_SECRET}"),
+            ],
+            "workspace:test".to_string(),
+            None,
+        );
+        let queued = RuntimeJobService::enqueue(cache.path(), &request).expect("queue job");
+        let handoff = WorkerStartRequest {
+            cache_root: cache.path().to_path_buf(),
+            job_id: queued.id.clone(),
+            program: PathBuf::from("fake-v8-runner"),
+            cwd: cache.path().to_path_buf(),
+            operation: "make".to_string(),
+            argv: request.raw_argv.clone(),
+            safe_target: request.safe_target.clone(),
+            artifact_path: None,
+            timeout_reason: None,
+        };
+        let runner = Arc::new(FakeRunner::exits_after(
+            0,
+            0,
+            &format!("token={OUTPUT_SECRET}\\n"),
+            "",
+        ));
+
+        run_worker_request(handoff, runner).expect("run worker handoff");
+
+        let store = RuntimeJobStore::new(cache.path(), DEFAULT_STALE_AFTER);
+        let persisted = [
+            fs::read_to_string(store.record_path(&queued.id).expect("record path"))
+                .expect("read record"),
+            fs::read_to_string(store.stdout_path(&queued.id).expect("stdout path"))
+                .expect("read stdout"),
+            fs::read_to_string(store.stderr_path(&queued.id).expect("stderr path"))
+                .expect("read stderr"),
+        ]
+        .join("\\n");
+        assert!(!persisted.contains(REQUEST_SECRET), "{persisted}");
+        assert!(!persisted.contains(OUTPUT_SECRET), "{persisted}");
+        assert!(persisted.contains("<redacted>"), "{persisted}");
+    }
+
+    #[test]
+    fn persisted_command_redacts_a_launch_connection_string_completely() {
+        let cache = TestCache::new();
+        let service = RuntimeJobService::new(cache.path(), Arc::new(FakeRunner::success_after(1)));
+        let job = service
+            .start(RuntimeJobRequest::new(
+                RuntimeJobOperation::Launch,
+                vec![
+                    "v8-runner".to_string(),
+                    "launch".to_string(),
+                    "--c".to_string(),
+                    "Srvr=prod;Ref=finance;Usr=svc;Pwd=secret".to_string(),
+                ],
+                "workspace:demo",
+                None,
+            ))
+            .expect("start launch job");
+        let snapshot_json = serde_json::to_string(&job).expect("serialize snapshot");
+        let record_json =
+            fs::read_to_string(service.store.record_path(&job.id).expect("record path"))
+                .expect("read record");
+
+        for value in ["prod", "finance", "svc", "secret", "Srvr=", "Ref="] {
+            assert!(!snapshot_json.contains(value), "snapshot leaked {value}");
+            assert!(!record_json.contains(value), "record leaked {value}");
+        }
+        assert_eq!(job.redacted_argv[3], "<redacted>");
+    }
+
     fn fake_request(operation: RuntimeJobOperation) -> RuntimeJobRequest {
         RuntimeJobRequest::new(
             operation,
@@ -1224,6 +2142,24 @@ mod tests {
             "workspace:demo",
             None,
         )
+    }
+
+    fn worker_request(
+        cache: &TestCache,
+        job_id: &str,
+        request: &RuntimeJobRequest,
+    ) -> WorkerStartRequest {
+        WorkerStartRequest {
+            cache_root: cache.path(),
+            job_id: job_id.to_string(),
+            program: PathBuf::from("fake-runtime"),
+            cwd: cache.path(),
+            operation: request.operation.label().to_string(),
+            argv: request.raw_argv.clone(),
+            safe_target: request.safe_target.clone(),
+            artifact_path: request.artifact_path.clone(),
+            timeout_reason: request.timeout_reason.clone(),
+        }
     }
 
     struct TestCache {
@@ -1269,6 +2205,20 @@ mod tests {
                     result: FakeResult::Exit(exit_code),
                     stdout: stdout.to_string(),
                     stderr: stderr.to_string(),
+                    cancel_calls: 0,
+                },
+            }
+        }
+
+        fn times_out_after(polls: u32, reason: &str) -> Self {
+            Self {
+                next_id: Arc::new(AtomicU32::new(100)),
+                processes: Arc::new(Mutex::new(HashMap::new())),
+                initial: FakeProcessState {
+                    polls_until_exit: polls,
+                    result: FakeResult::TimedOut(reason.to_string()),
+                    stdout: String::new(),
+                    stderr: String::new(),
                     cancel_calls: 0,
                 },
             }
@@ -1366,6 +2316,8 @@ mod tests {
                 .lock()
                 .map_err(|error| redacted_error(&format!("lock fake process: {error}")))?;
             state.cancel_calls = state.cancel_calls.saturating_add(1);
+            state.polls_until_exit = 0;
+            state.result = FakeResult::Exit(143);
             Ok(())
         }
 

--- a/crates/unica-coder/src/infrastructure/runtime_jobs.rs
+++ b/crates/unica-coder/src/infrastructure/runtime_jobs.rs
@@ -1,0 +1,1383 @@
+//! Durable, private runtime-job state used by future runtime tool adapters.
+#![allow(dead_code)] // Wired to the public transport in the follow-up runtime-tools task.
+
+use super::redaction;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    fs::{self, File, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+    thread,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+use uuid::Uuid;
+
+const RECORD_SCHEMA_VERSION: u8 = 1;
+const OUTPUT_TAIL_BYTES: usize = 16 * 1024;
+const DEFAULT_STALE_AFTER: Duration = Duration::from_secs(5 * 60);
+
+type JobResult<T> = Result<T, String>;
+
+/// Classifies whether interrupting an operation can leave its workspace inconsistent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum CancelPolicy {
+    Safe,
+    Critical,
+}
+
+/// The operation classes deliberately accepted by the durable core.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RuntimeJobOperation {
+    Make,
+    Syntax,
+    Test,
+    ToolsDownload,
+    ConfigInit,
+    Init,
+    Build,
+    Dump,
+    Convert,
+    Load,
+    Launch,
+}
+
+impl RuntimeJobOperation {
+    pub(crate) fn cancel_policy(self) -> CancelPolicy {
+        match self {
+            Self::Make | Self::Syntax | Self::Test | Self::ToolsDownload => CancelPolicy::Safe,
+            Self::ConfigInit
+            | Self::Init
+            | Self::Build
+            | Self::Dump
+            | Self::Convert
+            | Self::Load
+            | Self::Launch => CancelPolicy::Critical,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Make => "make",
+            Self::Syntax => "syntax",
+            Self::Test => "test",
+            Self::ToolsDownload => "tools-download",
+            Self::ConfigInit => "config-init",
+            Self::Init => "init",
+            Self::Build => "build",
+            Self::Dump => "dump",
+            Self::Convert => "convert",
+            Self::Load => "load",
+            Self::Launch => "launch",
+        }
+    }
+}
+
+/// A request may carry raw arguments only in memory.  They are never persisted verbatim.
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimeJobRequest {
+    operation: RuntimeJobOperation,
+    raw_argv: Vec<String>,
+    safe_target: String,
+    artifact_path: Option<String>,
+    timeout_reason: Option<String>,
+}
+
+impl RuntimeJobRequest {
+    pub(crate) fn new(
+        operation: RuntimeJobOperation,
+        raw_argv: Vec<String>,
+        safe_target: impl Into<String>,
+        artifact_path: Option<String>,
+    ) -> Self {
+        Self {
+            operation,
+            raw_argv,
+            safe_target: safe_target.into(),
+            artifact_path,
+            timeout_reason: None,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn with_timeout_reason(mut self, timeout_reason: impl Into<String>) -> Self {
+        self.timeout_reason = Some(timeout_reason.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum RuntimeJobPhase {
+    Queued,
+    Running,
+    CancelRequested,
+    Succeeded,
+    Failed,
+    Cancelled,
+    TimedOut,
+    Lost,
+}
+
+impl RuntimeJobPhase {
+    fn is_terminal(self) -> bool {
+        match self {
+            Self::Queued | Self::Running | Self::CancelRequested => false,
+            Self::Succeeded | Self::Failed | Self::Cancelled | Self::TimedOut | Self::Lost => true,
+        }
+    }
+}
+
+/// A process exit is intentionally nonblocking.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RuntimeJobProcessState {
+    Running,
+    Exited { exit_code: i32 },
+    TimedOut { reason: String },
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RuntimeJobOutput {
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+}
+
+/// Process boundary for the core. Implementations must not expose shell snippets.
+pub(crate) trait RuntimeJobProcess: Send {
+    fn id(&self) -> u32;
+    fn try_wait(&mut self) -> JobResult<RuntimeJobProcessState>;
+    fn cancel(&mut self) -> JobResult<()>;
+    /// Return at most `max_bytes` of each stream. The core redacts the retained tails again.
+    fn output_tails(&mut self, max_bytes: usize) -> JobResult<RuntimeJobOutput>;
+}
+
+/// Runner boundary. `attach` reconnects to an existing process; it never starts it again.
+pub(crate) trait RuntimeJobRunner: Send + Sync {
+    fn spawn(&self, request: &RuntimeJobRequest) -> JobResult<Box<dyn RuntimeJobProcess>>;
+    fn attach(&self, process_id: u32) -> JobResult<Box<dyn RuntimeJobProcess>>;
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RuntimeJobSnapshot {
+    pub(crate) id: String,
+    pub(crate) phase: RuntimeJobPhase,
+    pub(crate) safe_target: String,
+    pub(crate) redacted_argv: Vec<String>,
+    pub(crate) created_at_ms: u64,
+    pub(crate) heartbeat_at_ms: Option<u64>,
+    pub(crate) finished_at_ms: Option<u64>,
+    pub(crate) pid: Option<u32>,
+    pub(crate) pid_identity: Option<String>,
+    pub(crate) exit_code: Option<i32>,
+    pub(crate) cancelled: bool,
+    pub(crate) cancel_deferred: bool,
+    pub(crate) unsafe_phase: Option<String>,
+    pub(crate) timeout_reason: Option<String>,
+    pub(crate) artifact_path: Option<String>,
+    pub(crate) stdout_path: String,
+    pub(crate) stderr_path: String,
+    pub(crate) warnings: Vec<String>,
+    pub(crate) wait_timed_out: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimeJobLogs {
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RuntimeJobList {
+    pub(crate) jobs: Vec<RuntimeJobSnapshot>,
+    pub(crate) warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct RuntimeJobRecord {
+    #[serde(rename = "schemaVersion")]
+    schema_version: u8,
+    id: String,
+    phase: RuntimeJobPhase,
+    safe_target: String,
+    redacted_argv: Vec<String>,
+    created_at_ms: u64,
+    started_at_ms: Option<u64>,
+    heartbeat_at_ms: Option<u64>,
+    finished_at_ms: Option<u64>,
+    pid: Option<u32>,
+    pid_identity: Option<String>,
+    exit_code: Option<i32>,
+    cancel_policy: CancelPolicy,
+    cancelled: bool,
+    cancel_deferred: bool,
+    unsafe_phase: Option<String>,
+    timeout_reason: Option<String>,
+    artifact_path: Option<String>,
+    stdout_path: String,
+    stderr_path: String,
+    warnings: Vec<String>,
+}
+
+impl RuntimeJobRecord {
+    fn queued(id: String, request: &RuntimeJobRequest) -> Self {
+        let now = now_millis();
+        Self {
+            schema_version: RECORD_SCHEMA_VERSION,
+            id: id.clone(),
+            phase: RuntimeJobPhase::Queued,
+            safe_target: redact_text(&request.safe_target),
+            redacted_argv: redact_argv(&request.raw_argv),
+            created_at_ms: now,
+            started_at_ms: None,
+            heartbeat_at_ms: Some(now),
+            finished_at_ms: None,
+            pid: None,
+            pid_identity: None,
+            exit_code: None,
+            cancel_policy: request.operation.cancel_policy(),
+            cancelled: false,
+            cancel_deferred: false,
+            unsafe_phase: Some(request.operation.label().to_string()),
+            timeout_reason: request.timeout_reason.as_deref().map(redact_text),
+            artifact_path: request.artifact_path.as_deref().map(redact_text),
+            stdout_path: format!("jobs/{id}/stdout.log"),
+            stderr_path: format!("jobs/{id}/stderr.log"),
+            warnings: Vec::new(),
+        }
+    }
+
+    fn snapshot(&self, wait_timed_out: bool) -> RuntimeJobSnapshot {
+        RuntimeJobSnapshot {
+            id: self.id.clone(),
+            phase: self.phase,
+            safe_target: self.safe_target.clone(),
+            redacted_argv: self.redacted_argv.clone(),
+            created_at_ms: self.created_at_ms,
+            heartbeat_at_ms: self.heartbeat_at_ms,
+            finished_at_ms: self.finished_at_ms,
+            pid: self.pid,
+            pid_identity: self.pid_identity.clone(),
+            exit_code: self.exit_code,
+            cancelled: self.cancelled,
+            cancel_deferred: self.cancel_deferred,
+            unsafe_phase: self.unsafe_phase.clone(),
+            timeout_reason: self.timeout_reason.clone(),
+            artifact_path: self.artifact_path.clone(),
+            stdout_path: self.stdout_path.clone(),
+            stderr_path: self.stderr_path.clone(),
+            warnings: self.warnings.clone(),
+            wait_timed_out,
+        }
+    }
+
+    fn transition(&mut self, next: RuntimeJobPhase) -> JobResult<()> {
+        let allowed = match self.phase {
+            RuntimeJobPhase::Queued => matches!(
+                next,
+                RuntimeJobPhase::Running
+                    | RuntimeJobPhase::Failed
+                    | RuntimeJobPhase::Cancelled
+                    | RuntimeJobPhase::Lost
+            ),
+            RuntimeJobPhase::Running => matches!(
+                next,
+                RuntimeJobPhase::CancelRequested
+                    | RuntimeJobPhase::Succeeded
+                    | RuntimeJobPhase::Failed
+                    | RuntimeJobPhase::Cancelled
+                    | RuntimeJobPhase::TimedOut
+                    | RuntimeJobPhase::Lost
+            ),
+            RuntimeJobPhase::CancelRequested => matches!(
+                next,
+                RuntimeJobPhase::Succeeded
+                    | RuntimeJobPhase::Failed
+                    | RuntimeJobPhase::Cancelled
+                    | RuntimeJobPhase::TimedOut
+                    | RuntimeJobPhase::Lost
+            ),
+            RuntimeJobPhase::Succeeded
+            | RuntimeJobPhase::Failed
+            | RuntimeJobPhase::Cancelled
+            | RuntimeJobPhase::TimedOut
+            | RuntimeJobPhase::Lost => false,
+        };
+
+        if allowed {
+            self.phase = next;
+            Ok(())
+        } else {
+            Err(redacted_error(&format!(
+                "runtime job {} cannot transition from {:?} to {:?}",
+                self.id, self.phase, next
+            )))
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CancelMarker {
+    requested_at_ms: u64,
+}
+
+#[derive(Debug, Clone)]
+struct RuntimeJobStore {
+    cache_root: PathBuf,
+    stale_after: Duration,
+}
+
+impl RuntimeJobStore {
+    fn new(cache_root: impl Into<PathBuf>, stale_after: Duration) -> Self {
+        Self {
+            cache_root: cache_root.into(),
+            stale_after,
+        }
+    }
+
+    fn jobs_root(&self) -> PathBuf {
+        self.cache_root.join("jobs")
+    }
+
+    fn active_lock_path(&self) -> PathBuf {
+        self.jobs_root().join("active.lock")
+    }
+
+    fn job_dir(&self, id: &str) -> JobResult<PathBuf> {
+        let id = canonical_job_id(id)?;
+        Ok(self.jobs_root().join(id))
+    }
+
+    fn record_path(&self, id: &str) -> JobResult<PathBuf> {
+        Ok(self.job_dir(id)?.join("record.json"))
+    }
+
+    fn stdout_path(&self, id: &str) -> JobResult<PathBuf> {
+        Ok(self.job_dir(id)?.join("stdout.log"))
+    }
+
+    fn stderr_path(&self, id: &str) -> JobResult<PathBuf> {
+        Ok(self.job_dir(id)?.join("stderr.log"))
+    }
+
+    fn cancel_path(&self, id: &str) -> JobResult<PathBuf> {
+        Ok(self.job_dir(id)?.join("cancel.json"))
+    }
+
+    fn acquire_active_lock(&self, id: &str) -> JobResult<()> {
+        fs::create_dir_all(self.jobs_root())
+            .map_err(|error| io_error("create runtime jobs directory", &error))?;
+        let mut lock = match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(self.active_lock_path())
+        {
+            Ok(lock) => lock,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                return Err(self.active_job_conflict());
+            }
+            Err(error) => return Err(io_error("create active runtime job lock", &error)),
+        };
+        lock.write_all(id.as_bytes())
+            .map_err(|error| io_error("write active runtime job lock", &error))?;
+        lock.sync_data()
+            .map_err(|error| io_error("sync active runtime job lock", &error))
+    }
+
+    fn active_job_conflict(&self) -> String {
+        match fs::read_to_string(self.active_lock_path()) {
+            Ok(id) => {
+                let id = id.trim();
+                let existing = if id.is_empty() { "unknown" } else { id };
+                redacted_error(&format!(
+                    "workspace already has active runtime job {existing}"
+                ))
+            }
+            Err(error) => io_error("read active runtime job lock", &error),
+        }
+    }
+
+    fn release_active_lock_for(&self, id: &str) -> JobResult<()> {
+        let lock_path = self.active_lock_path();
+        let contents = match fs::read_to_string(&lock_path) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(io_error("read active runtime job lock", &error)),
+        };
+        if contents.trim() == id {
+            match fs::remove_file(lock_path) {
+                Ok(()) => Ok(()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(io_error("remove active runtime job lock", &error)),
+            }
+        } else {
+            Ok(())
+        }
+    }
+
+    fn create_record(&self, id: &str, request: &RuntimeJobRequest) -> JobResult<RuntimeJobRecord> {
+        let id = canonical_job_id(id)?;
+        let directory = self.job_dir(&id)?;
+        fs::create_dir_all(&directory)
+            .map_err(|error| io_error("create runtime job directory", &error))?;
+        let record = RuntimeJobRecord::queued(id.clone(), request);
+        self.write_record(&record)?;
+        fs::write(directory.join("stdout.log"), "")
+            .map_err(|error| io_error("create runtime job stdout log", &error))?;
+        fs::write(directory.join("stderr.log"), "")
+            .map_err(|error| io_error("create runtime job stderr log", &error))?;
+        Ok(record)
+    }
+
+    fn read_record(&self, id: &str) -> JobResult<RuntimeJobRecord> {
+        let path = self.record_path(id)?;
+        let contents = fs::read_to_string(&path).map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                redacted_error(&format!("runtime job {id} record is missing"))
+            } else {
+                io_error("read runtime job record", &error)
+            }
+        })?;
+        let record: RuntimeJobRecord = serde_json::from_str(&contents).map_err(|error| {
+            redacted_error(&format!("runtime job {id} record is corrupt: {error}"))
+        })?;
+        if record.schema_version != RECORD_SCHEMA_VERSION {
+            return Err(redacted_error(&format!(
+                "runtime job {id} has unsupported schema version {}",
+                record.schema_version
+            )));
+        }
+        let canonical_id = canonical_job_id(&record.id)?;
+        if canonical_id != canonical_job_id(id)? {
+            return Err(redacted_error(&format!(
+                "runtime job {id} record id is corrupt"
+            )));
+        }
+        Ok(record)
+    }
+
+    fn write_record(&self, record: &RuntimeJobRecord) -> JobResult<()> {
+        let path = self.record_path(&record.id)?;
+        let parent = path
+            .parent()
+            .ok_or_else(|| redacted_error("runtime job record path has no parent"))?;
+        fs::create_dir_all(parent)
+            .map_err(|error| io_error("create runtime job record directory", &error))?;
+        let bytes = serde_json::to_vec_pretty(record)
+            .map_err(|error| redacted_error(&format!("serialize runtime job record: {error}")))?;
+        atomic_write(&path, &bytes)
+    }
+
+    fn write_logs(&self, id: &str, output: &RuntimeJobOutput) -> JobResult<()> {
+        let stdout = bounded_redacted_tail(&output.stdout, OUTPUT_TAIL_BYTES);
+        let stderr = bounded_redacted_tail(&output.stderr, OUTPUT_TAIL_BYTES);
+        fs::write(self.stdout_path(id)?, stdout)
+            .map_err(|error| io_error("write runtime job stdout log", &error))?;
+        fs::write(self.stderr_path(id)?, stderr)
+            .map_err(|error| io_error("write runtime job stderr log", &error))
+    }
+
+    fn write_cancel_marker(&self, id: &str) -> JobResult<()> {
+        let marker = CancelMarker {
+            requested_at_ms: now_millis(),
+        };
+        let bytes = serde_json::to_vec(&marker).map_err(|error| {
+            redacted_error(&format!("serialize runtime job cancellation: {error}"))
+        })?;
+        atomic_write(&self.cancel_path(id)?, &bytes)
+    }
+
+    fn has_cancel_marker(&self, id: &str) -> JobResult<bool> {
+        let path = self.cancel_path(id)?;
+        let contents = match fs::read_to_string(path) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => return Err(io_error("read runtime job cancellation", &error)),
+        };
+        serde_json::from_str::<CancelMarker>(&contents).map_err(|error| {
+            redacted_error(&format!("runtime job cancellation is corrupt: {error}"))
+        })?;
+        Ok(true)
+    }
+
+    fn list(&self) -> RuntimeJobList {
+        let entries = match fs::read_dir(self.jobs_root()) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return RuntimeJobList {
+                    jobs: Vec::new(),
+                    warnings: Vec::new(),
+                };
+            }
+            Err(error) => {
+                return RuntimeJobList {
+                    jobs: Vec::new(),
+                    warnings: vec![io_error("list runtime jobs", &error)],
+                };
+            }
+        };
+
+        let mut jobs = Vec::new();
+        let mut warnings = Vec::new();
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) => {
+                    warnings.push(io_error("read runtime jobs entry", &error));
+                    continue;
+                }
+            };
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(error) => {
+                    warnings.push(io_error("read runtime job entry type", &error));
+                    continue;
+                }
+            };
+            if !file_type.is_dir() {
+                continue;
+            }
+            let name = entry.file_name();
+            let Some(id) = name.to_str() else {
+                warnings.push(redacted_error(
+                    "runtime job directory name is not valid UTF-8",
+                ));
+                continue;
+            };
+            match self.read_record(id) {
+                Ok(record) => jobs.push(record.snapshot(false)),
+                Err(error) => warnings.push(error),
+            }
+        }
+        jobs.sort_by_key(|job| job.created_at_ms);
+        RuntimeJobList { jobs, warnings }
+    }
+
+    fn stale(&self, record: &RuntimeJobRecord) -> bool {
+        let Some(heartbeat) = record.heartbeat_at_ms else {
+            return false;
+        };
+        let threshold = duration_millis(self.stale_after);
+        now_millis().saturating_sub(heartbeat) > threshold
+    }
+}
+
+/// Durable job worker harness. A public transport adapter is deliberately outside this module.
+pub(crate) struct RuntimeJobService {
+    store: RuntimeJobStore,
+    runner: Arc<dyn RuntimeJobRunner>,
+    processes: Mutex<HashMap<String, Box<dyn RuntimeJobProcess>>>,
+}
+
+impl RuntimeJobService {
+    pub(crate) fn new(cache_root: impl Into<PathBuf>, runner: Arc<dyn RuntimeJobRunner>) -> Self {
+        Self::with_stale_after(cache_root, runner, DEFAULT_STALE_AFTER)
+    }
+
+    fn with_stale_after(
+        cache_root: impl Into<PathBuf>,
+        runner: Arc<dyn RuntimeJobRunner>,
+        stale_after: Duration,
+    ) -> Self {
+        Self {
+            store: RuntimeJobStore::new(cache_root, stale_after),
+            runner,
+            processes: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) fn start(&self, request: RuntimeJobRequest) -> JobResult<RuntimeJobSnapshot> {
+        let id = Uuid::new_v4().to_string();
+        self.store.acquire_active_lock(&id)?;
+        let mut record = match self.store.create_record(&id, &request) {
+            Ok(record) => record,
+            Err(error) => {
+                let _ = self.store.release_active_lock_for(&id);
+                return Err(error);
+            }
+        };
+        let process = match self.runner.spawn(&request) {
+            Ok(process) => process,
+            Err(error) => {
+                let error = redacted_error(&error);
+                let _ = self.fail_start(&mut record, &error);
+                return Err(error);
+            }
+        };
+        record.pid = Some(process.id());
+        record.pid_identity = Some(format!("pid:{}", process.id()));
+        record.started_at_ms = Some(now_millis());
+        record.heartbeat_at_ms = Some(now_millis());
+        record.transition(RuntimeJobPhase::Running)?;
+        if let Err(error) = self.store.write_record(&record) {
+            let _ = self.store.release_active_lock_for(&id);
+            return Err(error);
+        }
+        let mut processes = self.lock_processes()?;
+        processes.insert(id, process);
+        Ok(record.snapshot(false))
+    }
+
+    pub(crate) fn status(&self, id: &str) -> JobResult<RuntimeJobSnapshot> {
+        self.store
+            .read_record(id)
+            .map(|record| record.snapshot(false))
+    }
+
+    pub(crate) fn poll(&self, id: &str) -> JobResult<RuntimeJobSnapshot> {
+        let mut record = self.store.read_record(id)?;
+        if record.phase.is_terminal() {
+            return Ok(record.snapshot(false));
+        }
+        if self.store.stale(&record) {
+            record.transition(RuntimeJobPhase::Lost)?;
+            record.finished_at_ms = Some(now_millis());
+            record.warnings.push("stale heartbeat".to_string());
+            self.store.write_record(&record)?;
+            self.store.release_active_lock_for(&record.id)?;
+            self.remove_process(&record.id)?;
+            return Ok(record.snapshot(false));
+        }
+
+        let cancel_requested = self.store.has_cancel_marker(id)?;
+        let (process_state, output, safe_cancel) =
+            self.observe_process(&record, cancel_requested)?;
+        self.store.write_logs(&record.id, &output)?;
+
+        if safe_cancel {
+            record.transition(RuntimeJobPhase::Cancelled)?;
+            record.cancelled = true;
+            record.finished_at_ms = Some(now_millis());
+            record.heartbeat_at_ms = Some(now_millis());
+            self.store.write_record(&record)?;
+            self.store.release_active_lock_for(&record.id)?;
+            self.remove_process(&record.id)?;
+            return Ok(record.snapshot(false));
+        }
+
+        if cancel_requested && record.cancel_policy == CancelPolicy::Critical {
+            match record.phase {
+                RuntimeJobPhase::Queued | RuntimeJobPhase::Running => {
+                    record.transition(RuntimeJobPhase::CancelRequested)?;
+                }
+                RuntimeJobPhase::CancelRequested => {}
+                RuntimeJobPhase::Succeeded
+                | RuntimeJobPhase::Failed
+                | RuntimeJobPhase::Cancelled
+                | RuntimeJobPhase::TimedOut
+                | RuntimeJobPhase::Lost => {
+                    return Err(redacted_error(
+                        "terminal runtime job was observed as active",
+                    ));
+                }
+            }
+            record.cancel_deferred = true;
+        }
+
+        match process_state {
+            RuntimeJobProcessState::Running => {
+                record.heartbeat_at_ms = Some(now_millis());
+                self.store.write_record(&record)?;
+                Ok(record.snapshot(false))
+            }
+            RuntimeJobProcessState::Exited { exit_code } => {
+                let phase = if exit_code == 0 {
+                    RuntimeJobPhase::Succeeded
+                } else {
+                    RuntimeJobPhase::Failed
+                };
+                self.finish(&mut record, phase, Some(exit_code), None)
+            }
+            RuntimeJobProcessState::TimedOut { reason } => self.finish(
+                &mut record,
+                RuntimeJobPhase::TimedOut,
+                None,
+                Some(redact_text(&reason)),
+            ),
+        }
+    }
+
+    pub(crate) fn wait(&self, id: &str, caller_timeout: Duration) -> JobResult<RuntimeJobSnapshot> {
+        let started_at = Instant::now();
+        let deadline = match started_at.checked_add(caller_timeout) {
+            Some(deadline) => deadline,
+            None => started_at,
+        };
+        loop {
+            let snapshot = self.poll(id)?;
+            if snapshot.phase.is_terminal() {
+                return Ok(snapshot);
+            }
+            if Instant::now() >= deadline {
+                let mut timed_out = snapshot;
+                timed_out.wait_timed_out = true;
+                return Ok(timed_out);
+            }
+            thread::sleep(Duration::from_millis(1));
+        }
+    }
+
+    pub(crate) fn logs(&self, id: &str) -> JobResult<RuntimeJobLogs> {
+        let record = self.store.read_record(id)?;
+        let stdout = fs::read_to_string(self.store.stdout_path(&record.id)?)
+            .map_err(|error| io_error("read runtime job stdout log", &error))?;
+        let stderr = fs::read_to_string(self.store.stderr_path(&record.id)?)
+            .map_err(|error| io_error("read runtime job stderr log", &error))?;
+        Ok(RuntimeJobLogs { stdout, stderr })
+    }
+
+    pub(crate) fn cancel(&self, id: &str) -> JobResult<RuntimeJobSnapshot> {
+        let record = self.store.read_record(id)?;
+        if record.phase.is_terminal() {
+            return Ok(record.snapshot(false));
+        }
+        self.store.write_cancel_marker(id)?;
+        self.poll(id)
+    }
+
+    pub(crate) fn list(&self) -> RuntimeJobList {
+        self.store.list()
+    }
+
+    fn observe_process(
+        &self,
+        record: &RuntimeJobRecord,
+        cancel_requested: bool,
+    ) -> JobResult<(RuntimeJobProcessState, RuntimeJobOutput, bool)> {
+        let mut processes = self.lock_processes()?;
+        if !processes.contains_key(&record.id) {
+            let process_id = record.pid.ok_or_else(|| {
+                redacted_error(&format!(
+                    "runtime job {} has no persisted process id",
+                    record.id
+                ))
+            })?;
+            let process = self.runner.attach(process_id).map_err(|error| {
+                redacted_error(&format!("attach runtime job {}: {error}", record.id))
+            })?;
+            processes.insert(record.id.clone(), process);
+        }
+        let process = processes.get_mut(&record.id).ok_or_else(|| {
+            redacted_error(&format!("runtime job {} process is unavailable", record.id))
+        })?;
+
+        let safe_cancel = cancel_requested && record.cancel_policy == CancelPolicy::Safe;
+        if safe_cancel {
+            process.cancel().map_err(|error| {
+                redacted_error(&format!("cancel runtime job {}: {error}", record.id))
+            })?;
+        }
+        let state = if safe_cancel {
+            RuntimeJobProcessState::Running
+        } else {
+            process.try_wait().map_err(|error| {
+                redacted_error(&format!("observe runtime job {}: {error}", record.id))
+            })?
+        };
+        let output = process.output_tails(OUTPUT_TAIL_BYTES).map_err(|error| {
+            redacted_error(&format!("read runtime job {} output: {error}", record.id))
+        })?;
+        Ok((state, output, safe_cancel))
+    }
+
+    fn finish(
+        &self,
+        record: &mut RuntimeJobRecord,
+        phase: RuntimeJobPhase,
+        exit_code: Option<i32>,
+        timeout_reason: Option<String>,
+    ) -> JobResult<RuntimeJobSnapshot> {
+        record.transition(phase)?;
+        record.exit_code = exit_code;
+        if timeout_reason.is_some() {
+            record.timeout_reason = timeout_reason;
+        }
+        record.finished_at_ms = Some(now_millis());
+        record.heartbeat_at_ms = Some(now_millis());
+        self.store.write_record(record)?;
+        self.store.release_active_lock_for(&record.id)?;
+        self.remove_process(&record.id)?;
+        Ok(record.snapshot(false))
+    }
+
+    fn fail_start(&self, record: &mut RuntimeJobRecord, error: &str) -> JobResult<()> {
+        record.transition(RuntimeJobPhase::Failed)?;
+        record.finished_at_ms = Some(now_millis());
+        record.warnings.push(redact_text(error));
+        self.store.write_record(record)?;
+        self.store.release_active_lock_for(&record.id)
+    }
+
+    fn lock_processes(
+        &self,
+    ) -> JobResult<std::sync::MutexGuard<'_, HashMap<String, Box<dyn RuntimeJobProcess>>>> {
+        self.processes
+            .lock()
+            .map_err(|error| redacted_error(&format!("lock runtime job processes: {error}")))
+    }
+
+    fn remove_process(&self, id: &str) -> JobResult<()> {
+        let mut processes = self.lock_processes()?;
+        processes.remove(id);
+        Ok(())
+    }
+}
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> JobResult<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| redacted_error("atomic runtime job path has no parent"))?;
+    let temporary = parent.join(format!(".{}.{}.tmp", path_file_name(path), Uuid::new_v4()));
+    let mut file = File::create(&temporary)
+        .map_err(|error| io_error("create temporary runtime job file", &error))?;
+    file.write_all(bytes)
+        .map_err(|error| io_error("write temporary runtime job file", &error))?;
+    file.sync_data()
+        .map_err(|error| io_error("sync temporary runtime job file", &error))?;
+    fs::rename(&temporary, path)
+        .map_err(|error| io_error("atomically replace runtime job file", &error))
+}
+
+fn path_file_name(path: &Path) -> String {
+    match path.file_name().and_then(|name| name.to_str()) {
+        Some(name) => name.to_string(),
+        None => "runtime-job".to_string(),
+    }
+}
+
+fn canonical_job_id(id: &str) -> JobResult<String> {
+    Uuid::parse_str(id)
+        .map(|uuid| uuid.to_string())
+        .map_err(|_| redacted_error("runtime job id must be a UUID"))
+}
+
+fn now_millis() -> u64 {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => duration_millis(duration),
+        Err(_) => 0,
+    }
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn redact_argv(argv: &[String]) -> Vec<String> {
+    let mut redact_next = false;
+    argv.iter()
+        .map(|argument| {
+            let lower = argument.trim_start_matches('-').to_ascii_lowercase();
+            let redact_argument = redact_next;
+            redact_next = matches!(
+                lower.as_str(),
+                "password" | "pwd" | "token" | "secret" | "connection"
+            );
+            if redact_argument {
+                "<redacted>".to_string()
+            } else {
+                redact_text(argument)
+            }
+        })
+        .collect()
+}
+
+fn bounded_redacted_tail(text: &str, max_bytes: usize) -> String {
+    let redacted = redact_text(text);
+    if redacted.len() <= max_bytes {
+        return redacted;
+    }
+    let mut start = redacted.len().saturating_sub(max_bytes);
+    while start < redacted.len() && !redacted.is_char_boundary(start) {
+        start = start.saturating_add(1);
+    }
+    redacted[start..].to_string()
+}
+
+fn redact_text(text: &str) -> String {
+    redaction::redactor(text)
+}
+
+fn redacted_error(message: &str) -> String {
+    redact_text(message)
+}
+
+fn io_error(context: &str, error: &std::io::Error) -> String {
+    redacted_error(&format!("{context}: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        collections::HashMap,
+        sync::atomic::{AtomicU32, Ordering},
+    };
+
+    #[test]
+    fn long_success_survives_reconnect_from_a_new_service_instance() {
+        let cache = TestCache::new();
+        let runner = Arc::new(FakeRunner::success_after(2));
+        let service = RuntimeJobService::new(cache.path(), runner.clone());
+
+        let job = service
+            .start(fake_request(RuntimeJobOperation::Test))
+            .expect("start job");
+        assert_eq!(
+            service.poll(&job.id).expect("first poll").phase,
+            RuntimeJobPhase::Running
+        );
+
+        let reconnected = RuntimeJobService::new(cache.path(), runner);
+        assert_eq!(
+            reconnected.poll(&job.id).expect("reconnected poll").phase,
+            RuntimeJobPhase::Succeeded
+        );
+    }
+
+    #[test]
+    fn second_start_reports_the_active_job_id_as_a_conflict() {
+        let cache = TestCache::new();
+        let runner = Arc::new(FakeRunner::success_after(50));
+        let service = RuntimeJobService::new(cache.path(), runner);
+        let first = service
+            .start(fake_request(RuntimeJobOperation::Test))
+            .expect("start first job");
+
+        let error = service
+            .start(fake_request(RuntimeJobOperation::Test))
+            .expect_err("second active job must be rejected");
+
+        assert!(error.contains(&first.id), "{error}");
+        assert_eq!(
+            service.status(&first.id).expect("read first job").phase,
+            RuntimeJobPhase::Running
+        );
+    }
+
+    #[test]
+    fn stale_job_becomes_lost_without_removing_a_replacement_active_lock() {
+        let cache = TestCache::new();
+        let runner = Arc::new(FakeRunner::success_after(50));
+        let service =
+            RuntimeJobService::with_stale_after(cache.path(), runner, Duration::from_millis(1));
+        let stale = service
+            .start(fake_request(RuntimeJobOperation::Test))
+            .expect("start stale job");
+        let mut record = service
+            .store
+            .read_record(&stale.id)
+            .expect("read stale record");
+        record.heartbeat_at_ms = Some(0);
+        service.store.write_record(&record).expect("age record");
+
+        let replacement = Uuid::new_v4().to_string();
+        fs::write(service.store.active_lock_path(), &replacement).expect("replace active lock");
+
+        let lost = service.poll(&stale.id).expect("poll stale job");
+
+        assert_eq!(lost.phase, RuntimeJobPhase::Lost);
+        assert_eq!(
+            fs::read_to_string(service.store.active_lock_path())
+                .expect("read replacement active lock")
+                .trim(),
+            replacement
+        );
+        assert_eq!(
+            service.status(&stale.id).expect("read lost job").phase,
+            RuntimeJobPhase::Lost
+        );
+    }
+
+    #[test]
+    fn terminal_snapshot_and_persistence_are_redacted_and_keep_log_artifacts() {
+        const ARGV_SECRET: &str = "argv-secret";
+        const TARGET_SECRET: &str = "target-secret";
+        const ARTIFACT_SECRET: &str = "artifact-secret";
+        const STDOUT_SECRET: &str = "stdout-secret";
+        const STDERR_SECRET: &str = "stderr-secret";
+
+        let cache = TestCache::new();
+        let runner = Arc::new(FakeRunner::exits_after(
+            1,
+            17,
+            "stdout token=stdout-secret\n",
+            "stderr password=stderr-secret\n",
+        ));
+        let service = RuntimeJobService::new(cache.path(), runner);
+        let request = RuntimeJobRequest::new(
+            RuntimeJobOperation::Test,
+            vec![
+                "runner".to_string(),
+                "--token".to_string(),
+                ARGV_SECRET.to_string(),
+            ],
+            "workspace:token=target-secret",
+            Some("artifacts/token=artifact-secret".to_string()),
+        );
+        let job = service.start(request).expect("start job");
+
+        let terminal = service.poll(&job.id).expect("finish job");
+        let repeated = service.poll(&job.id).expect("read terminal job again");
+        let logs = service.logs(&job.id).expect("read redacted logs");
+        let snapshot_json = serde_json::to_string(&terminal).expect("serialize snapshot");
+        let record_json =
+            fs::read_to_string(service.store.record_path(&job.id).expect("record path"))
+                .expect("read serialized record");
+
+        assert_eq!(terminal.phase, RuntimeJobPhase::Failed);
+        assert_eq!(terminal.exit_code, Some(17));
+        assert_eq!(repeated.phase, terminal.phase);
+        assert_eq!(repeated.exit_code, terminal.exit_code);
+        assert_eq!(repeated.finished_at_ms, terminal.finished_at_ms);
+        assert!(terminal.artifact_path.is_some());
+        assert!(terminal.stdout_path.ends_with("stdout.log"));
+        assert!(terminal.stderr_path.ends_with("stderr.log"));
+        assert!(terminal.redacted_argv.iter().any(|arg| arg == "<redacted>"));
+        assert!(logs.stdout.contains("<redacted>"));
+        assert!(logs.stderr.contains("<redacted>"));
+
+        for secret in [
+            ARGV_SECRET,
+            TARGET_SECRET,
+            ARTIFACT_SECRET,
+            STDOUT_SECRET,
+            STDERR_SECRET,
+        ] {
+            assert!(!snapshot_json.contains(secret), "snapshot leaked {secret}");
+            assert!(!record_json.contains(secret), "record leaked {secret}");
+            assert!(!logs.stdout.contains(secret), "stdout leaked {secret}");
+            assert!(!logs.stderr.contains(secret), "stderr leaked {secret}");
+        }
+    }
+
+    #[test]
+    fn direct_status_rejects_corrupt_unknown_schema_and_non_uuid_without_touching_active_lock() {
+        let cache = TestCache::new();
+        let runner = Arc::new(FakeRunner::success_after(50));
+        let service = RuntimeJobService::new(cache.path(), runner);
+        let fresh = service
+            .start(fake_request(RuntimeJobOperation::Test))
+            .expect("start fresh job");
+
+        let corrupt_id = Uuid::new_v4().to_string();
+        let corrupt_path = service
+            .store
+            .record_path(&corrupt_id)
+            .expect("corrupt record path");
+        fs::create_dir_all(corrupt_path.parent().expect("corrupt record directory"))
+            .expect("create corrupt record directory");
+        fs::write(&corrupt_path, "{ token=corrupt-secret").expect("write corrupt record");
+
+        let schema_id = Uuid::new_v4().to_string();
+        let mut unsupported = service
+            .store
+            .read_record(&fresh.id)
+            .expect("read fresh record");
+        unsupported.id = schema_id.clone();
+        unsupported.schema_version = RECORD_SCHEMA_VERSION.saturating_add(1);
+        service
+            .store
+            .write_record(&unsupported)
+            .expect("write unsupported schema record");
+
+        let corrupt_error = service
+            .status(&corrupt_id)
+            .expect_err("corrupt status must fail");
+        let schema_error = service
+            .status(&schema_id)
+            .expect_err("unknown schema status must fail");
+        let id_error = service
+            .status("not-a-uuid")
+            .expect_err("non-UUID status must fail");
+
+        assert!(corrupt_error.contains("corrupt"), "{corrupt_error}");
+        assert!(!corrupt_error.contains("corrupt-secret"), "{corrupt_error}");
+        assert!(
+            schema_error.contains("unsupported schema version"),
+            "{schema_error}"
+        );
+        assert!(id_error.contains("UUID"), "{id_error}");
+        assert_eq!(
+            fs::read_to_string(service.store.active_lock_path())
+                .expect("read fresh active lock")
+                .trim(),
+            fresh.id
+        );
+    }
+
+    #[test]
+    fn list_skips_a_corrupt_record_and_redacts_its_warning() {
+        let cache = TestCache::new();
+        let service = RuntimeJobService::new(cache.path(), Arc::new(FakeRunner::success_after(1)));
+        let corrupt_id = Uuid::new_v4().to_string();
+        let corrupt_path = service
+            .store
+            .record_path(&corrupt_id)
+            .expect("corrupt record path");
+        fs::create_dir_all(corrupt_path.parent().expect("corrupt record directory"))
+            .expect("create corrupt record directory");
+        fs::write(&corrupt_path, "{ token=list-secret").expect("write corrupt record");
+
+        let list = service.list();
+
+        assert!(list.jobs.is_empty(), "{list:?}");
+        assert_eq!(list.warnings.len(), 1, "{list:?}");
+        assert!(list.warnings[0].contains("corrupt"), "{list:?}");
+        assert!(!list.warnings[0].contains("list-secret"), "{list:?}");
+    }
+
+    #[test]
+    fn long_failure_is_persisted_with_its_exit_code() {
+        let cache = TestCache::new();
+        let runner = Arc::new(FakeRunner::exits_after(2, 23, "", "compile failed"));
+        let service = RuntimeJobService::new(cache.path(), runner);
+        let job = service
+            .start(fake_request(RuntimeJobOperation::Test))
+            .expect("start job");
+
+        assert_eq!(
+            service.poll(&job.id).expect("first poll").phase,
+            RuntimeJobPhase::Running
+        );
+        let terminal = service.poll(&job.id).expect("terminal poll");
+
+        assert_eq!(terminal.phase, RuntimeJobPhase::Failed);
+        assert_eq!(terminal.exit_code, Some(23));
+        assert!(terminal.finished_at_ms.is_some());
+    }
+
+    #[test]
+    fn caller_wait_timeout_does_not_stop_the_active_job() {
+        let cache = TestCache::new();
+        let runner = Arc::new(FakeRunner::success_after(3));
+        let service = RuntimeJobService::new(cache.path(), runner);
+        let job = service
+            .start(fake_request(RuntimeJobOperation::Test))
+            .expect("start job");
+
+        let waiting = service.wait(&job.id, Duration::ZERO).expect("wait once");
+
+        assert_eq!(waiting.phase, RuntimeJobPhase::Running);
+        assert!(waiting.wait_timed_out);
+        assert_eq!(
+            service.status(&job.id).expect("status").phase,
+            RuntimeJobPhase::Running
+        );
+        assert_eq!(
+            service.poll(&job.id).expect("second poll").phase,
+            RuntimeJobPhase::Running
+        );
+        assert_eq!(
+            service.poll(&job.id).expect("third poll").phase,
+            RuntimeJobPhase::Succeeded
+        );
+    }
+
+    #[test]
+    fn safe_cancel_calls_the_process_and_becomes_cancelled() {
+        let cache = TestCache::new();
+        let runner = Arc::new(FakeRunner::success_after(50));
+        let service = RuntimeJobService::new(cache.path(), runner.clone());
+        let job = service
+            .start(fake_request(RuntimeJobOperation::Test))
+            .expect("start job");
+
+        let cancelled = service.cancel(&job.id).expect("cancel job");
+
+        assert_eq!(cancelled.phase, RuntimeJobPhase::Cancelled);
+        assert!(cancelled.cancelled);
+        let process_id = job.pid.expect("persisted fake pid");
+        assert_eq!(runner.cancel_calls(process_id).expect("cancel calls"), 1);
+        assert!(!service.store.active_lock_path().exists());
+    }
+
+    #[test]
+    fn critical_cancel_is_deferred_and_the_process_keeps_being_observed() {
+        let cache = TestCache::new();
+        let runner = Arc::new(FakeRunner::success_after(2));
+        let service = RuntimeJobService::new(cache.path(), runner.clone());
+        let job = service
+            .start(fake_request(RuntimeJobOperation::Build))
+            .expect("start job");
+
+        let deferred = service.cancel(&job.id).expect("request cancel");
+
+        assert_eq!(deferred.phase, RuntimeJobPhase::CancelRequested);
+        assert!(deferred.cancel_deferred);
+        assert_eq!(deferred.unsafe_phase.as_deref(), Some("build"));
+        let process_id = job.pid.expect("persisted fake pid");
+        assert_eq!(runner.cancel_calls(process_id).expect("cancel calls"), 0);
+        assert_eq!(
+            service.poll(&job.id).expect("observe completion").phase,
+            RuntimeJobPhase::Succeeded
+        );
+    }
+
+    fn fake_request(operation: RuntimeJobOperation) -> RuntimeJobRequest {
+        RuntimeJobRequest::new(
+            operation,
+            vec!["unica".to_string(), "test".to_string()],
+            "workspace:demo",
+            None,
+        )
+    }
+
+    struct TestCache {
+        root: PathBuf,
+    }
+
+    impl TestCache {
+        fn new() -> Self {
+            Self {
+                root: std::env::temp_dir().join(format!("unica-runtime-jobs-{}", Uuid::new_v4())),
+            }
+        }
+
+        fn path(&self) -> PathBuf {
+            self.root.clone()
+        }
+    }
+
+    impl Drop for TestCache {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    #[derive(Clone)]
+    struct FakeRunner {
+        next_id: Arc<AtomicU32>,
+        processes: Arc<Mutex<HashMap<u32, Arc<Mutex<FakeProcessState>>>>>,
+        initial: FakeProcessState,
+    }
+
+    impl FakeRunner {
+        fn success_after(polls: u32) -> Self {
+            Self::exits_after(polls, 0, "done", "")
+        }
+
+        fn exits_after(polls: u32, exit_code: i32, stdout: &str, stderr: &str) -> Self {
+            Self {
+                next_id: Arc::new(AtomicU32::new(100)),
+                processes: Arc::new(Mutex::new(HashMap::new())),
+                initial: FakeProcessState {
+                    polls_until_exit: polls,
+                    result: FakeResult::Exit(exit_code),
+                    stdout: stdout.to_string(),
+                    stderr: stderr.to_string(),
+                    cancel_calls: 0,
+                },
+            }
+        }
+
+        fn cancel_calls(&self, process_id: u32) -> JobResult<u32> {
+            let process = self
+                .processes
+                .lock()
+                .map_err(|error| redacted_error(&format!("lock fake runner: {error}")))?
+                .get(&process_id)
+                .cloned()
+                .ok_or_else(|| redacted_error("fake process is unavailable"))?;
+            let calls = process
+                .lock()
+                .map_err(|error| redacted_error(&format!("lock fake process: {error}")))?
+                .cancel_calls;
+            Ok(calls)
+        }
+    }
+
+    impl RuntimeJobRunner for FakeRunner {
+        fn spawn(&self, _request: &RuntimeJobRequest) -> JobResult<Box<dyn RuntimeJobProcess>> {
+            let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+            let state = Arc::new(Mutex::new(self.initial.clone()));
+            self.processes
+                .lock()
+                .map_err(|error| redacted_error(&format!("lock fake runner: {error}")))?
+                .insert(id, state.clone());
+            Ok(Box::new(FakeProcess { id, state }))
+        }
+
+        fn attach(&self, process_id: u32) -> JobResult<Box<dyn RuntimeJobProcess>> {
+            let state = self
+                .processes
+                .lock()
+                .map_err(|error| redacted_error(&format!("lock fake runner: {error}")))?
+                .get(&process_id)
+                .cloned()
+                .ok_or_else(|| redacted_error("fake process is unavailable"))?;
+            Ok(Box::new(FakeProcess {
+                id: process_id,
+                state,
+            }))
+        }
+    }
+
+    #[derive(Clone)]
+    struct FakeProcessState {
+        polls_until_exit: u32,
+        result: FakeResult,
+        stdout: String,
+        stderr: String,
+        cancel_calls: u32,
+    }
+
+    #[derive(Clone)]
+    enum FakeResult {
+        Exit(i32),
+        TimedOut(String),
+    }
+
+    struct FakeProcess {
+        id: u32,
+        state: Arc<Mutex<FakeProcessState>>,
+    }
+
+    impl RuntimeJobProcess for FakeProcess {
+        fn id(&self) -> u32 {
+            self.id
+        }
+
+        fn try_wait(&mut self) -> JobResult<RuntimeJobProcessState> {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|error| redacted_error(&format!("lock fake process: {error}")))?;
+            if state.polls_until_exit > 1 {
+                state.polls_until_exit -= 1;
+                return Ok(RuntimeJobProcessState::Running);
+            }
+            match &state.result {
+                FakeResult::Exit(exit_code) => Ok(RuntimeJobProcessState::Exited {
+                    exit_code: *exit_code,
+                }),
+                FakeResult::TimedOut(reason) => Ok(RuntimeJobProcessState::TimedOut {
+                    reason: reason.clone(),
+                }),
+            }
+        }
+
+        fn cancel(&mut self) -> JobResult<()> {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|error| redacted_error(&format!("lock fake process: {error}")))?;
+            state.cancel_calls = state.cancel_calls.saturating_add(1);
+            Ok(())
+        }
+
+        fn output_tails(&mut self, _max_bytes: usize) -> JobResult<RuntimeJobOutput> {
+            let state = self
+                .state
+                .lock()
+                .map_err(|error| redacted_error(&format!("lock fake process: {error}")))?;
+            Ok(RuntimeJobOutput {
+                stdout: state.stdout.clone(),
+                stderr: state.stderr.clone(),
+            })
+        }
+    }
+}

--- a/crates/unica-coder/src/interfaces/mcp.rs
+++ b/crates/unica-coder/src/interfaces/mcp.rs
@@ -155,6 +155,19 @@ mod tests {
         assert!(listed
             .iter()
             .any(|tool| tool["name"] == "unica.standards.explain"));
+        for name in [
+            "unica.runtime.job.start",
+            "unica.runtime.job.status",
+            "unica.runtime.job.wait",
+            "unica.runtime.job.logs",
+            "unica.runtime.job.cancel",
+            "unica.runtime.job.list",
+        ] {
+            assert!(
+                listed.iter().any(|tool| tool["name"] == name),
+                "missing {name}"
+            );
+        }
     }
 
     #[test]

--- a/crates/unica-coder/src/interfaces/mod.rs
+++ b/crates/unica-coder/src/interfaces/mod.rs
@@ -1,2 +1,3 @@
 pub mod mcp;
+pub mod runtime_job_worker;
 pub mod workspace_service;

--- a/crates/unica-coder/src/interfaces/runtime_job_worker.rs
+++ b/crates/unica-coder/src/interfaces/runtime_job_worker.rs
@@ -1,0 +1,3 @@
+pub fn run_from_args(args: &[String]) -> Result<(), String> {
+    crate::infrastructure::runtime_jobs::run_worker_from_args(args)
+}

--- a/crates/unica-coder/src/main.rs
+++ b/crates/unica-coder/src/main.rs
@@ -7,6 +7,13 @@ fn main() {
         }
         return;
     }
+    if args.iter().any(|arg| arg == "--runtime-job-worker") {
+        if let Err(error) = unica_coder::interfaces::runtime_job_worker::run_from_args(&args) {
+            eprintln!("{error}");
+            std::process::exit(1);
+        }
+        return;
+    }
 
     if std::env::args().any(|arg| arg == "--help" || arg == "-h") {
         println!("unica {}", env!("CARGO_PKG_VERSION"));

--- a/docs/superpowers/plans/2026-07-15-runtime-jobs.md
+++ b/docs/superpowers/plans/2026-07-15-runtime-jobs.md
@@ -1,0 +1,409 @@
+# Durable runtime jobs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Добавить durable, typed и безопасный lifecycle для долгих `v8-runner` операций без изменения `unica.runtime.execute`.
+
+**Architecture:** `unica.runtime.job.start` создаёт schema-versioned job record под workspace cache и запускает отдельный `unica --runtime-job-worker`; secret-bearing execution argv передаётся worker-у только по stdin. Worker владеет дочерним `v8-runner`, redacts bounded output, сохраняет ровно один terminal record. Новые job tools возвращают typed `OperationResult.job`; обычный runtime contract remains synchronous.
+
+**Tech Stack:** Rust 2021, std `Command`/pipes/threading, `serde_json`, `uuid`, existing `fs2`, MCP stdio, cargo test/clippy/fmt.
+
+---
+
+### Task 1: Общий bounded redaction для worker logs
+
+**Files:**
+- Create: `crates/unica-coder/src/infrastructure/redaction.rs`
+- Modify: `crates/unica-coder/src/infrastructure/mod.rs`
+- Modify: `crates/unica-coder/src/infrastructure/internal_adapters.rs:1-16,651-706`
+- Test: `crates/unica-coder/src/infrastructure/redaction.rs`
+
+- [ ] **Step 1: Write the failing tests for redaction and chunk boundaries**
+
+```rust
+#[test]
+fn stream_redactor_hides_secret_split_between_chunks() {
+    let mut redactor = StreamRedactor::new();
+    assert_eq!(redactor.push("starting; P"), "starting; ");
+    assert_eq!(redactor.push("wd=super-secret\nfinished\n"), "Pwd=<redacted>\nfinished\n");
+    assert_eq!(redactor.finish(), "");
+}
+
+#[test]
+fn stream_redactor_keeps_non_secret_text_and_truncates_only_after_limit() {
+    let mut redactor = StreamRedactor::new();
+    assert_eq!(redactor.push("build source-set main\n"), "build source-set main\n");
+    assert_eq!(redactor.finish(), "");
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `cargo test --locked -p unica-coder stream_redactor_ -- --nocapture`
+
+Expected: FAIL because module/type `StreamRedactor` does not exist.
+
+- [ ] **Step 3: Implement the minimal shared redactor**
+
+```rust
+pub(crate) fn redact_sensitive_text(text: &str) -> String {
+    let chars = text.chars().collect::<Vec<_>>();
+    let mut output = String::with_capacity(text.len());
+    let mut index = 0;
+    while index < chars.len() {
+        if secret_key_char(chars[index]) {
+            let key_start = index;
+            index += 1;
+            while index < chars.len() && secret_key_char(chars[index]) { index += 1; }
+            let key_end = index;
+            let mut separator = index;
+            while separator < chars.len() && chars[separator].is_whitespace() { separator += 1; }
+            if separator < chars.len() && matches!(chars[separator], '=' | ':') {
+                let mut value_start = separator + 1;
+                while value_start < chars.len() && chars[value_start].is_whitespace() { value_start += 1; }
+                let key = chars[key_start..key_end].iter().collect::<String>();
+                if is_secret_key(&key) {
+                    output.extend(chars[key_start..value_start].iter());
+                    output.push_str("<redacted>");
+                    index = value_start;
+                    while index < chars.len() && !secret_value_delimiter(chars[index]) { index += 1; }
+                    continue;
+                }
+            }
+            output.extend(chars[key_start..key_end].iter());
+            continue;
+        }
+        output.push(chars[index]);
+        index += 1;
+    }
+    output
+}
+
+fn secret_key_char(ch: char) -> bool { ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-') }
+fn secret_value_delimiter(ch: char) -> bool { matches!(ch, ';' | '&' | ',' | '\n' | '\r' | '}') }
+fn is_secret_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key == "connection" || key == "pwd" || key.contains("password") || key.contains("token") || key.contains("secret")
+}
+
+pub(crate) struct StreamRedactor { pending: String }
+
+impl StreamRedactor {
+    pub(crate) fn new() -> Self { Self { pending: String::new() } }
+    pub(crate) fn push(&mut self, chunk: &str) -> String {
+        self.pending.push_str(chunk);
+        let boundary = self.pending.rfind(['\n', '\r', ';', '&', ',']).map(|i| i + 1);
+        boundary.map(|end| redact_sensitive_text(&self.pending.drain(..end).collect::<String>())).unwrap_or_default()
+    }
+    pub(crate) fn finish(mut self) -> String { redact_sensitive_text(&std::mem::take(&mut self.pending)) }
+}
+```
+
+Keep `pending` private, use borrowed `&str`, and make the existing adapters import the shared function. Do not keep a second redaction implementation.
+
+- [ ] **Step 4: Run focused tests and the existing adapter redaction tests**
+
+Run: `cargo test --locked -p unica-coder redacts -- --nocapture`
+
+Expected: PASS; serialized outputs contain `<redacted>` and never the test secrets.
+
+- [ ] **Step 5: Commit the isolated implementation**
+
+```bash
+git add crates/unica-coder/src/infrastructure/{mod.rs,redaction.rs,internal_adapters.rs}
+git commit -m "refactor: вынести redaction runtime вывода"
+```
+
+### Task 2: Durable job record, state machine and worker core
+
+**Files:**
+- Create: `crates/unica-coder/src/infrastructure/runtime_jobs.rs`
+- Modify: `crates/unica-coder/src/infrastructure/mod.rs`
+- Test: `crates/unica-coder/src/infrastructure/runtime_jobs.rs`
+
+- [ ] **Step 1: Write failing fake-runner lifecycle tests**
+
+```rust
+#[test]
+fn worker_persists_long_success_for_reconnect() {
+    let fixture = JobFixture::new(FakeRunner::after_polls(2, JobExit::success("ok\n")));
+    let started = fixture.start("build").unwrap();
+    assert!(matches!(started.phase, RuntimeJobPhase::Queued | RuntimeJobPhase::Running));
+    assert_eq!(fixture.reconnected().status(&started.job_id).unwrap().phase, RuntimeJobPhase::Running);
+    let done = fixture.wait_until_terminal(&started.job_id);
+    assert_eq!(done.phase, RuntimeJobPhase::Succeeded);
+    assert_eq!(done.exit_code, Some(0));
+}
+
+#[test]
+fn safe_cancel_is_terminal_but_load_cancel_is_deferred() {
+    let fixture = JobFixture::new(FakeRunner::never_finishes());
+    let safe = fixture.start("test").unwrap();
+    assert_eq!(fixture.cancel(&safe.job_id).unwrap().phase, RuntimeJobPhase::CancelRequested);
+    assert_eq!(fixture.wait_until_terminal(&safe.job_id).phase, RuntimeJobPhase::Cancelled);
+    let critical = fixture.start_after_terminal("load").unwrap();
+    let deferred = fixture.cancel(&critical.job_id).unwrap();
+    assert!(deferred.cancel_deferred);
+    assert_eq!(deferred.unsafe_phase.as_deref(), Some("load"));
+}
+
+#[test]
+fn stale_running_record_becomes_lost_without_deleting_fresh_lock() {
+    let fixture = JobFixture::new(FakeRunner::never_finishes());
+    let stale = fixture.start("build").unwrap();
+    fixture.set_updated_at(&stale.job_id, 0).unwrap();
+    let replacement = fixture.write_active_lock("replacement-job").unwrap();
+    let recovered = fixture.reconnected().recover_stale().unwrap();
+    assert!(recovered.iter().any(|job| job.job_id == stale.job_id && job.phase == RuntimeJobPhase::Lost));
+    assert_eq!(fixture.read_active_lock().unwrap(), replacement);
+}
+```
+
+- [ ] **Step 2: Run the lifecycle tests and verify RED**
+
+Run: `cargo test --locked -p unica-coder runtime_jobs::tests -- --nocapture`
+
+Expected: FAIL because `runtime_jobs` does not exist.
+
+- [ ] **Step 3: Implement typed persistence and worker abstractions**
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum RuntimeJobPhase { Queued, Running, CancelRequested, Succeeded, Failed, Cancelled, TimedOut, Lost }
+
+impl RuntimeJobPhase {
+    fn is_terminal(self) -> bool { matches!(self, Self::Succeeded | Self::Failed | Self::Cancelled | Self::TimedOut | Self::Lost) }
+}
+
+pub(crate) trait RuntimeJobRunner: Send + Sync {
+    fn spawn(&self, command: &WorkerCommand) -> Result<Box<dyn RuntimeJobProcess>, String>;
+}
+pub(crate) trait RuntimeJobProcess: Send {
+    fn id(&self) -> Option<u32>;
+    fn try_wait(&mut self) -> Result<Option<JobExit>, String>;
+    fn cancel(&mut self) -> Result<(), String>;
+    fn read_output(&mut self) -> Result<JobOutput, String>;
+}
+```
+
+Implement `RuntimeJobStore` with `record.json` temp-file plus `rename`, strict UUID path lookup, one `active.lock` created with `create_new`, `cancel.json`, stale heartbeat recovery and exhaustive phase transition validation. Record stores schema version, timestamps, redacted argv, target, worker/runner identity, terminal data, paths and warnings—never actual argv. `RuntimeJobWorker::run` polls fake/system process, refreshes heartbeat, applies `CancelPolicy::{Safe,Critical}`, then writes exactly one terminal record and removes only its own active lock.
+
+- [ ] **Step 4: Add failing diagnostics and conflict tests, then implement their minimum**
+
+```rust
+#[test]
+fn active_job_conflict_names_existing_job_id() {
+    let fixture = JobFixture::new(FakeRunner::never_finishes());
+    let first = fixture.start("build").unwrap();
+    let error = fixture.start("test").unwrap_err();
+    assert!(error.contains(&first.job_id));
+}
+#[test]
+fn terminal_view_contains_redacted_argv_and_log_tails() {
+    let fixture = JobFixture::new(FakeRunner::after_polls(0, JobExit::success("Pwd=secret\n")));
+    let started = fixture.start_with_argv("build", &["--connection", "Pwd=secret"]).unwrap();
+    let terminal = fixture.wait_until_terminal(&started.job_id);
+    let serialized = serde_json::to_string(&terminal).unwrap();
+    assert!(serialized.contains("<redacted>"));
+    assert!(!serialized.contains("secret"));
+    assert_eq!(terminal.exit_code, Some(0));
+}
+#[test]
+fn caller_wait_timeout_leaves_job_running() {
+    let fixture = JobFixture::new(FakeRunner::after_polls(10, JobExit::success("ok\n")));
+    let started = fixture.start("test").unwrap();
+    let waited = fixture.wait(&started.job_id, Duration::ZERO).unwrap();
+    assert_eq!(waited.phase, RuntimeJobPhase::Running);
+    assert!(waited.wait_timed_out);
+}
+```
+
+Implement `RuntimeJobService::{start,status,wait,logs,cancel,list}` over the store. `wait` only limits its loop; it does not kill, fail or mutate a job. `logs` reads bounded sanitized tails. `list` excludes corrupt records but reports a redacted warning; direct status of corrupt/unknown schema is an error and does not remove lock.
+
+- [ ] **Step 5: Run all runtime-job unit tests and commit**
+
+Run: `cargo test --locked -p unica-coder runtime_jobs -- --nocapture`
+
+Expected: PASS with success, failure, reconnect, wait timeout, safe/deferred cancel, conflict, stale-lost and redaction cases.
+
+```bash
+git add crates/unica-coder/src/infrastructure/{mod.rs,runtime_jobs.rs}
+git commit -m "feat: добавить durable runtime job worker"
+```
+
+### Task 3: Public typed MCP tools and result envelope
+
+**Files:**
+- Modify: `crates/unica-coder/src/application/mod.rs:22-61,120-230,294-370,720-735`
+- Modify: `crates/unica-coder/src/application/ports.rs:1-95`
+- Modify: `crates/unica-coder/src/application/tool_contracts.rs:10-330,551-620,1180-1420`
+- Modify: `crates/unica-coder/src/infrastructure/internal_adapters.rs:223-348`
+- Test: `crates/unica-coder/src/application/mod.rs`
+- Test: `crates/unica-coder/src/application/tool_contracts.rs`
+
+- [ ] **Step 1: Write failing public contract tests**
+
+```rust
+#[test]
+fn runtime_job_tools_are_listed_and_keep_runtime_execute_unchanged() {
+    let names = tools().into_iter().map(|tool| tool.name).collect::<Vec<_>>();
+    assert!(names.contains(&"unica.runtime.job.start"));
+    assert!(names.contains(&"unica.runtime.job.status"));
+    assert!(names.contains(&"unica.runtime.job.wait"));
+    assert!(names.contains(&"unica.runtime.job.logs"));
+    assert!(names.contains(&"unica.runtime.job.cancel"));
+    assert!(names.contains(&"unica.runtime.job.list"));
+    assert!(names.contains(&"unica.runtime.execute"));
+}
+
+#[test]
+fn runtime_job_start_schema_reuses_typed_runtime_arguments() {
+    let schema = schema("unica.runtime.job.start");
+    assert_eq!(schema["additionalProperties"], false);
+    assert!(schema["properties"].get("operation").is_some());
+    assert!(schema["properties"].get("args").is_none());
+}
+
+#[test]
+fn runtime_job_wait_requires_job_id_and_bounded_timeout_seconds() {
+    let tool = tool("unica.runtime.job.wait");
+    assert!(validate_tool_arguments(tool, &json!({}).as_object().unwrap().clone(), false).is_err());
+    assert!(validate_tool_arguments(tool, &json!({"jobId":"00000000-0000-4000-8000-000000000001","timeoutSeconds":0}).as_object().unwrap().clone(), false).is_err());
+    assert!(validate_tool_arguments(tool, &json!({"jobId":"00000000-0000-4000-8000-000000000001","timeoutSeconds":61}).as_object().unwrap().clone(), false).is_err());
+}
+```
+
+- [ ] **Step 2: Run the contract tests and verify RED**
+
+Run: `cargo test --locked -p unica-coder runtime_job_ -- --nocapture`
+
+Expected: FAIL because none of the new tools/schemas exists.
+
+- [ ] **Step 3: Add the public boundary without altering existing runtime semantics**
+
+```rust
+#[derive(Debug, Clone, Copy)]
+pub enum RuntimeJobAction { Start, Status, Wait, Logs, Cancel, List }
+
+pub(crate) struct HandlerOutcome {
+    pub(crate) adapter: AdapterOutcome,
+    pub(crate) job: Option<Value>,
+}
+```
+
+Add `ToolHandler::RuntimeJob { action: RuntimeJobAction }`, six `ToolSpec`s, and optional `job: Option<Value>` to `OperationResult`. Change only `ApplicationPorts::invoke_handler` to return `HandlerOutcome`; wrap every old handler with `HandlerOutcome::plain` so current behavior is byte-for-byte equivalent. `RuntimeJobAdapter` resolves bundled `v8-runner`, builds both actual and redacted typed argv with existing `runtime_args`, and calls `RuntimeJobService`; no raw argument path is introduced.
+
+`tool_contracts` must allow start's existing runtime fields and validate it through `validate_runtime_arguments`; status/cancel/logs/wait only allow `jobId` plus their own typed argument. Require `jobId` for four tools, type `timeoutSeconds`/`tailChars` as integer, enforce 1..60 seconds and 1..32768 chars. `write_path_args` treats Start exactly like `RuntimeAdapter`.
+
+- [ ] **Step 4: Run contract and application tests, then commit**
+
+Run: `cargo test --locked -p unica-coder runtime_job -- --nocapture`
+
+Expected: PASS; no schema accepts `args`, no job control command accepts runtime execution arguments, and `OperationResult.job` is serialized only for job tools.
+
+```bash
+git add crates/unica-coder/src/application/{mod.rs,ports.rs,tool_contracts.rs} crates/unica-coder/src/infrastructure/internal_adapters.rs
+git commit -m "feat: открыть typed runtime job lifecycle"
+```
+
+### Task 4: Worker executable, cache completion and end-to-end verification
+
+**Files:**
+- Modify: `crates/unica-coder/src/main.rs:1-19`
+- Modify: `crates/unica-coder/src/infrastructure/runtime_jobs.rs`
+- Modify: `crates/unica-coder/src/domain/events.rs`
+- Modify: `crates/unica-coder/src/application/mod.rs:720-735`
+- Test: `crates/unica-coder/src/interfaces/mcp.rs`
+- Test: `crates/unica-coder/src/infrastructure/runtime_jobs.rs`
+
+- [ ] **Step 1: Write failing worker handoff and cache-event tests**
+
+```rust
+#[test]
+fn worker_request_never_persists_actual_connection_secret() {
+    let fixture = JobFixture::new(FakeRunner::after_polls(0, JobExit::success("Pwd=output-secret\n")));
+    let started = fixture.start_with_argv("build", &["--connection", "Pwd=request-secret"]).unwrap();
+    let _ = fixture.wait_until_terminal(&started.job_id);
+    let persisted = fixture.read_job_directory(&started.job_id).unwrap();
+    assert!(!persisted.contains("request-secret"));
+    assert!(!persisted.contains("output-secret"));
+}
+
+#[test]
+fn successful_runtime_job_applies_same_event_kind_as_runtime_execute() {
+    assert_eq!(runtime_event_kind("dump"), Some(DomainEventKind::SourceSetChanged));
+    assert_eq!(runtime_event_kind("build"), Some(DomainEventKind::BuildCompleted));
+}
+
+#[test]
+fn mcp_reconnect_reads_existing_job_snapshot() {
+    let fixture = JobFixture::new(FakeRunner::after_polls(1, JobExit::success("ok\n")));
+    let started = fixture.start("build").unwrap();
+    let first = fixture.application().call_tool("unica.runtime.job.status", &fixture.status_args(&started.job_id)).unwrap();
+    let second = fixture.reconnected_application().call_tool("unica.runtime.job.status", &fixture.status_args(&started.job_id)).unwrap();
+    assert_eq!(first.job.unwrap()["jobId"], second.job.unwrap()["jobId"]);
+}
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run: `cargo test --locked -p unica-coder 'worker_request|runtime_job_applies|mcp_reconnect' -- --nocapture`
+
+Expected: FAIL because main does not route the internal worker and runtime event mapping is not shared.
+
+- [ ] **Step 3: Implement worker process handoff and terminal cache effect**
+
+```rust
+if args.iter().any(|arg| arg == "--runtime-job-worker") {
+    if let Err(error) = unica_coder::infrastructure::runtime_jobs::run_worker_from_args(&args) {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+    return;
+}
+```
+
+Parent uses `current_exe`, `Stdio::piped` stdin and a JSON `WorkerStartRequest`; worker reads one request, closes stdin, and owns the actual child. Move runtime operation→`DomainEventKind` mapping into `domain::events::runtime_event_kind`; both synchronous application and worker use it. After `Succeeded`, worker calls `WorkspaceStateRepository::report` and `WorkspaceServiceManager::notify_invalidation`; it appends a redacted warning if cache reporting fails and never changes a terminal success into failure.
+
+- [ ] **Step 4: Run focused verification, then full verification**
+
+Run:
+
+```bash
+cargo fmt --check
+cargo clippy --locked -p unica-coder --all-targets -- -D warnings
+cargo test --locked -p unica-coder
+git diff --check
+```
+
+Expected: every command exits 0. Then use a disposable File IB through public `unica` MCP only: start an allowed long runtime operation, poll by jobId from a new MCP client process, call `wait` with a bounded timeout, and assert record/log redaction without changing a user IB.
+
+- [ ] **Step 5: Commit the integration slice**
+
+```bash
+git add crates/unica-coder/src/{main.rs,domain/events.rs,infrastructure/runtime_jobs.rs,application/mod.rs,interfaces/mcp.rs}
+git commit -m "feat: завершать runtime jobs отдельным worker"
+```
+
+### Task 5: Independent review gates and branch delivery
+
+**Files:**
+- Review: full diff from `c3b4372` to HEAD
+- Verify: Rust contracts, worker lifecycle tests, full Rust suite, Python/parity suite, public-MCP disposable-IB acceptance
+
+- [ ] **Step 1: Spec review**
+
+Dispatch a fresh reviewer with the exact design acceptance: six public tools; original execute untouched; worker survives MCP server; durable redacted record/logs; all eight phases; reconnect/wait/cancel/conflict/lost; cache mapping. Reviewer must identify missing or extra behavior with file/line evidence.
+
+- [ ] **Step 2: Fix every spec finding and request re-review**
+
+Run the exact focused test that proves each fix before asking reviewer again. Do not begin quality review until spec verdict is approved.
+
+- [ ] **Step 3: Rust quality review**
+
+Dispatch a fresh reviewer using `rust-expert-best-practices-code-review`. Require audit of no panic paths, `Result` propagation, exhaustive phase matches, owned/borrowed arguments, process/log boundedness, lock ownership, redaction and public compatibility.
+
+- [ ] **Step 4: Run completion evidence and deliver normally**
+
+Run all commands from Task 4 plus `uv run pytest -q` or repository's documented Python/parity command. Inspect clean `git status`, commit only verified changes, normal-push the feature branch to `korolevpavel/unica`, create/update a Russian draft PR to `IngvarConsulting/unica`, and leave the worktree intact. Do not merge or force-push.

--- a/docs/superpowers/plans/2026-07-15-runtime-jobs.md
+++ b/docs/superpowers/plans/2026-07-15-runtime-jobs.md
@@ -1,5 +1,7 @@
 # Durable runtime jobs Implementation Plan
 
+> Historical: this plan is preserved as execution context. Current source of truth is code/tests/package metadata, then `spec/`, not this plan.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Добавить durable, typed и безопасный lifecycle для долгих `v8-runner` операций без изменения `unica.runtime.execute`.

--- a/docs/superpowers/specs/2026-07-15-runtime-jobs-design.md
+++ b/docs/superpowers/specs/2026-07-15-runtime-jobs-design.md
@@ -1,0 +1,100 @@
+# Durable runtime jobs — design
+
+## Goal
+
+Добавить durable lifecycle для долгих typed-операций `v8-runner`, не меняя
+синхронный публичный контракт `unica.runtime.execute`.
+
+## Context and decision
+
+`unica.runtime.execute` удерживает дочерний процесс в MCP server process. При
+закрытии stdin этот server завершается, поэтому thread внутри него не сохраняет
+наблюдение за процессом. Выбран отдельный worker-процесс самого `unica`:
+`unica --runtime-job-worker`. Он продолжает работу независимо от жизненного
+цикла одного `tools/call` и обновляет durable record.
+
+Отклонённые варианты:
+
+1. Поток в MCP server — проще, но пропадает при закрытии stdio.
+2. Изменить `runtime.execute` на async — ломает его публичную синхронную
+   семантику и существующих клиентов.
+
+## Public contract
+
+Новые typed MCP tools:
+
+- `unica.runtime.job.start` — принимает те же typed runtime arguments, что
+  `unica.runtime.execute`, быстро возвращает `job` с `jobId`, operation,
+  `startedAt` и safe target.
+- `unica.runtime.job.status` — принимает `jobId`, возвращает snapshot.
+- `unica.runtime.job.wait` — принимает `jobId` и caller-side
+  `timeoutSeconds` (1..60); истечение ожидания не изменяет job.
+- `unica.runtime.job.logs` — принимает `jobId` и optional `tailChars`;
+  возвращает redacted stdout/stderr tails и пути логов.
+- `unica.runtime.job.cancel` — принимает `jobId`; безопасно отменяет только
+  safe operations, иначе возвращает `cancelDeferred` и `unsafePhase`.
+- `unica.runtime.job.list` — возвращает snapshots workspace jobs.
+
+Ответ `OperationResult` получает optional typed `job` JSON. Job tools не
+принимают raw argv. `runtime.execute` сохраняет нынешний schema и результат.
+
+## Persistence and state machine
+
+Данные расположены только в `<cacheRoot>/jobs/<jobId>/`:
+
+- `record.json` — atomically-replaced schema-versioned snapshot;
+- `stdout.log` и `stderr.log` — bounded, redacted output;
+- `cancel.json` — запрос отмены без секрета;
+- `<cacheRoot>/jobs/active.lock` — atomic one-active-job claim per workspace.
+
+`record.json` никогда не содержит actual argv или connection string. Родитель
+посылает actual program/argv/cwd worker-у через его stdin после spawn; record
+содержит только redacted argv and safe target.
+
+Phase is an exhaustive enum: `queued`, `running`, `cancelRequested`,
+`succeeded`, `failed`, `cancelled`, `timedOut`, `lost`. Terminal phases cannot
+transition again. Worker refreshes `updatedAt` heartbeat. A stale active
+record is atomically transitioned to `lost`; it is never automatically
+restarted.
+
+## Execution, cancellation and recovery
+
+The worker starts `v8-runner` without a new wrapper deadline; runner
+`execution_timeout` remains authoritative. It drains both output pipes in
+parallel to avoid a full-pipe deadlock, retains bounded output, redacts before
+writing logs, and publishes exactly one terminal exit result.
+
+Cancellation policy is a typed enum, not a boolean:
+
+- safe: `make`, `syntax`, `test`, `tools-download`; worker kills the direct
+  child and records `cancelled`.
+- critical: `config-init`, `init`, `build`, `dump`, `convert`, `load`;
+  record becomes `cancelRequested` with `cancelDeferred=true` and
+  `unsafePhase`, while worker keeps observing. `launch` is also deferred
+  because Unica cannot safely own its process tree.
+
+Second start sees a fresh active lock/record and returns a conflict with the
+first `jobId`. A new MCP server reads the same record. If the worker continues,
+status stays current; if heartbeat becomes stale, recovery records `lost`.
+
+## Diagnostics, cache and errors
+
+Terminal snapshot carries exit code, timeout/cancel reason, redacted argv,
+stdout/stderr tails, log paths and known `output` artifact path. Corrupt or
+unknown-schema record returns a controlled error without deleting a fresh
+lock. No `unwrap` or non-exhaustive phase match is allowed in production.
+
+Starting a job does not invalidate caches. After a successful terminal runtime
+operation worker applies the existing runtime event mapping and workspace
+cache/service invalidation. Cache update failure becomes a redacted warning,
+not a false job failure.
+
+## Tests
+
+TDD uses an injected fake worker runner for long success, long failure,
+reconnect via a new service instance, caller wait timeout, safe cancellation,
+critical deferred cancellation, active-job conflict, stale-worker `lost`,
+terminal diagnostics and secret redaction across output chunks. Contract tests
+assert typed schemas, unknown-argument rejection and unchanged
+`runtime.execute`. A disposable File IB public-MCP smoke test validates start,
+poll/reconnect and no user infobase mutation.


### PR DESCRIPTION
## Что сделано

- Добавлены инструменты unica.runtime.job.start, unica.runtime.job.status, unica.runtime.job.wait, unica.runtime.job.logs, unica.runtime.job.cancel и unica.runtime.job.list; существующий unica.runtime.execute не менялся.
- Долгая операция выполняется в отдельном worker; состояние, логи и отмена сохраняются в cache workspace без секретов.
- Для безопасной отмены добавлено завершение дерева процессов, а stale worker переводится в lost без разрешения параллельной операции.

## Проверки

- cargo test --locked -p unica-coder
- cargo clippy --locked -p unica-coder --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check