### PR TITLE
test(process-runner): cover inherited-pipe descendants

### DIFF
--- a/crates/unica-coder/src/infrastructure/managed_child.rs
+++ b/crates/unica-coder/src/infrastructure/managed_child.rs
@@ -1321,8 +1321,8 @@ mod tests {
                 .as_nanos()
         ));
         let _pid_file_cleanup = FileCleanupGuard(pid_file.clone());
-        let started = Instant::now();
-        let output = ManagedChild::run(ManagedCommand {
+        let cancellation = CancellationToken::new();
+        let managed = ManagedChild::spawn(ManagedCommand {
             program: std::env::current_exe().unwrap(),
             args: vec![
                 "--exact".to_string(),
@@ -1341,11 +1341,15 @@ mod tests {
                 ),
             ],
             timeout: Some(Duration::from_millis(200)),
-            cancellation: CancellationToken::new(),
+            cancellation: cancellation.clone(),
         })
         .unwrap();
+        let mut managed_cleanup = ManagedChildCleanupGuard::new(managed, cancellation);
         let pids = read_helper_pids(&pid_file, Duration::from_secs(2));
         let mut cleanup = ProcessCleanupGuard(pids.clone());
+        let started = Instant::now();
+        let output = managed_cleanup.managed_mut().wait_for_output().unwrap();
+        managed_cleanup.disarm();
 
         assert!(output.timed_out);
         assert!(

--- a/crates/unica-coder/src/infrastructure/managed_child.rs
+++ b/crates/unica-coder/src/infrastructure/managed_child.rs
@@ -810,7 +810,8 @@ mod tests {
                 child.wait().unwrap();
             }
             "inherited_pipe_parent" => {
-                let _child = Command::new(std::env::current_exe().unwrap())
+                let pid_file = std::env::var_os(HELPER_PID_FILE_ENV).unwrap();
+                let child = Command::new(std::env::current_exe().unwrap())
                     .args([
                         "--exact",
                         "infrastructure::managed_child::tests::managed_child_test_helper",
@@ -819,6 +820,11 @@ mod tests {
                     .env(HELPER_ENV, "process_tree_child")
                     .spawn()
                     .unwrap();
+                std::fs::write(
+                    pid_file,
+                    format!("{}\n{}\n", std::process::id(), child.id()),
+                )
+                .unwrap();
                 print!("inherited-pipe-before-timeout");
                 std::io::Write::flush(&mut std::io::stdout()).unwrap();
                 thread::sleep(Duration::from_secs(10));
@@ -1306,13 +1312,40 @@ mod tests {
 
     #[test]
     fn inherited_pipe_descendant_does_not_block_timeout_collection() {
+        let pid_file = std::env::temp_dir().join(format!(
+            "unica-inherited-pipe-pids-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _pid_file_cleanup = FileCleanupGuard(pid_file.clone());
         let started = Instant::now();
-        let output = run_helper(
-            "inherited_pipe_parent",
-            Duration::from_millis(200),
-            CancellationToken::new(),
-        )
+        let output = ManagedChild::run(ManagedCommand {
+            program: std::env::current_exe().unwrap(),
+            args: vec![
+                "--exact".to_string(),
+                "infrastructure::managed_child::tests::managed_child_test_helper".to_string(),
+                "--nocapture".to_string(),
+            ],
+            cwd: std::env::current_dir().unwrap(),
+            env: vec![
+                (
+                    OsString::from(HELPER_ENV),
+                    OsString::from("inherited_pipe_parent"),
+                ),
+                (
+                    OsString::from(HELPER_PID_FILE_ENV),
+                    pid_file.clone().into_os_string(),
+                ),
+            ],
+            timeout: Some(Duration::from_millis(200)),
+            cancellation: CancellationToken::new(),
+        })
         .unwrap();
+        let pids = read_helper_pids(&pid_file, Duration::from_secs(2));
+        let mut cleanup = ProcessCleanupGuard(pids.clone());
 
         assert!(output.timed_out);
         assert!(
@@ -1321,6 +1354,9 @@ mod tests {
             output.stdout
         );
         assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(wait_until_dead(pids[0], Duration::from_secs(2)));
+        assert!(wait_until_dead(pids[1], Duration::from_secs(2)));
+        cleanup.disarm();
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/managed_child.rs
+++ b/crates/unica-coder/src/infrastructure/managed_child.rs
@@ -809,6 +809,20 @@ mod tests {
                 .unwrap();
                 child.wait().unwrap();
             }
+            "inherited_pipe_parent" => {
+                let _child = Command::new(std::env::current_exe().unwrap())
+                    .args([
+                        "--exact",
+                        "infrastructure::managed_child::tests::managed_child_test_helper",
+                        "--nocapture",
+                    ])
+                    .env(HELPER_ENV, "process_tree_child")
+                    .spawn()
+                    .unwrap();
+                print!("inherited-pipe-before-timeout");
+                std::io::Write::flush(&mut std::io::stdout()).unwrap();
+                thread::sleep(Duration::from_secs(10));
+            }
             "process_tree_child" => thread::sleep(Duration::from_secs(10)),
             "process_tree_detached_leader" => {
                 let pid_file = std::env::var_os(HELPER_PID_FILE_ENV).unwrap();
@@ -1288,6 +1302,25 @@ mod tests {
         assert!(wait_until_dead(parent_pid, Duration::from_secs(2)));
         assert!(wait_until_dead(child_pid, Duration::from_secs(2)));
         cleanup.disarm();
+    }
+
+    #[test]
+    fn inherited_pipe_descendant_does_not_block_timeout_collection() {
+        let started = Instant::now();
+        let output = run_helper(
+            "inherited_pipe_parent",
+            Duration::from_millis(200),
+            CancellationToken::new(),
+        )
+        .unwrap();
+
+        assert!(output.timed_out);
+        assert!(
+            output.stdout.contains("inherited-pipe-before-timeout"),
+            "{}",
+            output.stdout
+        );
+        assert!(started.elapsed() < Duration::from_secs(2));
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/managed_child.rs
+++ b/crates/unica-coder/src/infrastructure/managed_child.rs
@@ -820,13 +820,13 @@ mod tests {
                     .env(HELPER_ENV, "process_tree_child")
                     .spawn()
                     .unwrap();
+                print!("inherited-pipe-before-timeout");
+                std::io::Write::flush(&mut std::io::stdout()).unwrap();
                 std::fs::write(
                     pid_file,
                     format!("{}\n{}\n", std::process::id(), child.id()),
                 )
                 .unwrap();
-                print!("inherited-pipe-before-timeout");
-                std::io::Write::flush(&mut std::io::stdout()).unwrap();
                 thread::sleep(Duration::from_secs(10));
             }
             "process_tree_child" => thread::sleep(Duration::from_secs(10)),


### PR DESCRIPTION
## Summary

- add a cross-platform regression fixture whose descendant inherits the managed
  parent's stdout/stderr pipes
- assert timeout returns within a bounded interval, preserves output emitted
  before process-tree termination, and leaves neither parent nor descendant alive
- exercise the existing Unix process-group and Windows Job Object paths in CI

## Investigation

The issue no longer reproduces on current `main` (`63704c9`). The process-tree
implementation landed through #99 in commit `53427e6`, after this issue was opened,
but #106 remained open and its exact inherited-pipe edge case had no regression test.

Running the issue's exact Unix command on `main` through `ManagedChild` returned in
about 240 ms with `timed_out = true` and preserved `before` output. This PR does not
duplicate the already-present kill logic; it locks that behavior down with a portable
Rust fixture so Windows CI covers the equivalent descriptor-inheritance case too.

## Verification

- exact issue shell reproduction on `main`: passes in about 240 ms
- new regression test repeated 5 times: passes
- `cargo test --workspace --all-targets --all-features` (544 unit + 2 integration passed)
- `cargo clippy --package unica-coder --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `python3.12 -m unittest discover -s tests/ci` (147 passed, 4 skipped)
- `git diff --check`

Closes #106
