### PR TITLE
test(process-runner): cover large stderr drain

### DIFF
--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -3350,6 +3350,7 @@ mod tests {
     use serde_json::json;
     use std::cell::RefCell;
     use std::fs;
+    use std::io::Write;
     use std::path::Path;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -4985,6 +4986,55 @@ source-set:
             .unwrap()
             .contains("token-secret"));
         cleanup_context(&context);
+    }
+
+    #[test]
+    #[ignore = "helper process invoked by system_process_runner_drains_large_stderr_while_running"]
+    fn system_process_runner_large_stderr_helper() {
+        let chunk = [b'e'; 64 * 1024];
+        let mut stderr = std::io::stderr().lock();
+        for _ in 0..8 {
+            stderr.write_all(&chunk).unwrap();
+        }
+        stderr.flush().unwrap();
+        print!("large-stderr-complete");
+        std::io::stdout().flush().unwrap();
+    }
+
+    #[test]
+    fn system_process_runner_drains_large_stderr_while_running() {
+        let output = SYSTEM_PROCESS_RUNNER
+            .run(&ProcessCommand {
+                program: std::env::current_exe().unwrap(),
+                args: vec![
+                    "--ignored".to_string(),
+                    "--exact".to_string(),
+                    "infrastructure::internal_adapters::tests::system_process_runner_large_stderr_helper"
+                        .to_string(),
+                    "--nocapture".to_string(),
+                ],
+                cwd: std::env::current_dir().unwrap(),
+                timeout: Some(Duration::from_secs(10)),
+                cancellation: CancellationToken::new(),
+            })
+            .unwrap();
+
+        assert!(
+            !output.timed_out,
+            "runner timed out after capturing {} stderr bytes",
+            output.stderr.len()
+        );
+        assert!(output.status_success, "status was {}", output.status);
+        assert!(
+            output.stdout.contains("large-stderr-complete"),
+            "{}",
+            output.stdout
+        );
+        assert!(
+            output.stderr.contains("earlier stderr diagnostics omitted"),
+            "expected bounded stderr diagnostic, got {} bytes",
+            output.stderr.len()
+        );
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -4993,7 +4993,7 @@ source-set:
     fn system_process_runner_large_stderr_helper() {
         let chunk = [b'e'; 64 * 1024];
         let mut stderr = std::io::stderr().lock();
-        for _ in 0..8 {
+        for _ in 0..64 {
             stderr.write_all(&chunk).unwrap();
         }
         stderr.flush().unwrap();


### PR DESCRIPTION
## Summary

- add a cross-platform `SystemProcessRunner` regression fixture that writes
  4 MiB to stderr before exiting
- assert the runner completes without timing out and preserves the stdout marker
- assert bounded stderr capture remains explicit through its truncation diagnostic

## Investigation

The issue no longer reproduces on current `main` (`4cb7a82`). The old
`SystemProcessRunner` implementation did poll `try_wait()` before reading either
pipe, exactly as reported, but concurrent draining landed in `5a75ae9` and reached
`main` through #99 after this issue was opened.

The existing inner `ManagedChild` noisy-output test passed on the exact current
`main` in about 40 ms, but there was no equivalent regression at the
`SystemProcessRunner` boundary named in #105. This PR adds that missing boundary
coverage without duplicating or changing the already-correct production path.

The issue's original expectation of retaining unlimited complete output is no
longer the active contract: later hardening deliberately bounds stdout/stderr
capture. The new test therefore verifies both deadlock freedom and the current
explicit truncation contract.

## Verification

- exact current-main noisy `ManagedChild` reproduction: passes in about 40 ms
- new `SystemProcessRunner` regression repeated 10 times: passes
- `cargo test --workspace --all-targets --all-features`
  (545 passed, 1 helper ignored, 2 integration passed)
- `cargo clippy --package unica-coder --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #105
