### PR TITLE
test(code.grep): lock in bounded large-response handling

### DIFF
--- a/crates/unica-coder/src/domain/project_sources.rs
+++ b/crates/unica-coder/src/domain/project_sources.rs
@@ -357,7 +357,10 @@ mod tests {
     use std::ffi::{OsStr, OsString};
     use std::fs;
     use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    static TEMP_WORKSPACE_NONCE: AtomicU64 = AtomicU64::new(0);
 
     #[test]
     fn detects_edt_configuration_and_platform_external_processor_source_sets() {
@@ -652,11 +655,15 @@ source-set:
     }
 
     fn temp_workspace(prefix: &str) -> PathBuf {
-        let nanos = SystemTime::now()
+        let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        let root = std::env::temp_dir().join(format!("{prefix}-{}-{nanos}", std::process::id()));
+        let nonce = TEMP_WORKSPACE_NONCE.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "{prefix}-{}-{timestamp}-{nonce}",
+            std::process::id()
+        ));
         fs::create_dir_all(&root).unwrap();
         root
     }

--- a/crates/unica-coder/src/domain/source_roots.rs
+++ b/crates/unica-coder/src/domain/source_roots.rs
@@ -207,7 +207,10 @@ mod tests {
     use crate::domain::workspace::WorkspaceContext;
     use std::fs;
     use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    static TEMP_WORKSPACE_NONCE: AtomicU64 = AtomicU64::new(0);
 
     #[test]
     fn uses_explicit_source_dir_relative_to_cwd() {
@@ -427,11 +430,15 @@ mod tests {
     }
 
     fn temp_workspace(prefix: &str) -> PathBuf {
-        let nanos = SystemTime::now()
+        let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        let root = std::env::temp_dir().join(format!("{prefix}-{}-{nanos}", std::process::id()));
+        let nonce = TEMP_WORKSPACE_NONCE.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "{prefix}-{}-{timestamp}-{nonce}",
+            std::process::id()
+        ));
         fs::create_dir_all(&root).unwrap();
         root
     }

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -4370,6 +4370,47 @@ mod tests {
     }
 
     #[test]
+    fn code_grep_adapter_applies_limit_globally_and_sets_process_timeout() {
+        let context = temp_context("grep-global-limit");
+        let index = FakeIndexRunner::default();
+        let grep = RecordingProcessRunner {
+            commands: RefCell::new(Vec::new()),
+            output: ProcessOutput {
+                status_success: true,
+                status: "exit status: 0".to_string(),
+                stdout: (0..25)
+                    .map(|index| format!("CommonModules/Module{index}/Ext/Module.bsl:1:Needle"))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+                stderr: String::new(),
+                timed_out: false,
+                cancelled: false,
+            },
+        };
+        let mut args = Map::new();
+        args.insert("query".to_string(), json!("Needle"));
+        args.insert("limit".to_string(), json!(5));
+
+        let outcome = CodeNavigationAdapter::with_runners(&index, &grep)
+            .invoke("unica.code.grep", &args, &context, false)
+            .unwrap();
+
+        assert!(outcome.ok);
+        let stdout = outcome.stdout.unwrap();
+        let matches = stdout
+            .strip_prefix("=== git-grep ===\n")
+            .unwrap()
+            .lines()
+            .collect::<Vec<_>>();
+        assert_eq!(matches.len(), 5);
+        assert!(matches[4].contains("Module4"));
+        assert!(!stdout.contains("Module5"));
+        let commands = grep.commands.borrow();
+        assert_eq!(commands[0].timeout, Some(DEFAULT_PROCESS_TIMEOUT));
+        cleanup_context(&context);
+    }
+
+    #[test]
     fn code_grep_adapter_rejects_path_escape_before_git_execution() {
         let context = temp_context("grep-escape");
         let index = FakeIndexRunner::default();
@@ -5198,6 +5239,56 @@ source-set:
         stderr.flush().unwrap();
         print!("large-stderr-complete");
         std::io::stdout().flush().unwrap();
+    }
+
+    #[test]
+    #[ignore = "helper process invoked by system_process_runner_drains_large_stdout_while_running"]
+    fn system_process_runner_large_stdout_helper() {
+        let chunk = [b'o'; 64 * 1024];
+        let mut stdout = std::io::stdout().lock();
+        for _ in 0..64 {
+            stdout.write_all(&chunk).unwrap();
+        }
+        stdout.write_all(b"large-stdout-complete").unwrap();
+        stdout.flush().unwrap();
+    }
+
+    #[test]
+    fn system_process_runner_drains_large_stdout_while_running() {
+        let output = SYSTEM_PROCESS_RUNNER
+            .run(&ProcessCommand {
+                program: std::env::current_exe().unwrap(),
+                args: vec![
+                    "--ignored".to_string(),
+                    "--exact".to_string(),
+                    "infrastructure::internal_adapters::tests::system_process_runner_large_stdout_helper"
+                        .to_string(),
+                    "--nocapture".to_string(),
+                ],
+                cwd: std::env::current_dir().unwrap(),
+                timeout: Some(Duration::from_secs(10)),
+                cancellation: CancellationToken::new(),
+            })
+            .unwrap();
+
+        assert!(
+            !output.timed_out,
+            "runner timed out after capturing {} stdout bytes",
+            output.stdout.len()
+        );
+        assert!(
+            !output.status_success,
+            "truncated stdout must not be reported as parseable success"
+        );
+        assert!(
+            output.stdout.contains("large-stdout-complete"),
+            "expected bounded stdout tail to contain completion marker"
+        );
+        assert!(
+            output.stderr.contains("stdout capture truncated"),
+            "expected structured truncation diagnostic, got {:?}",
+            output.stderr
+        );
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -1294,13 +1294,38 @@ impl<'a> CodeNavigationAdapter<'a> {
             ));
         }
         let body = grep_body(&output.stdout, mode, limit);
+        if output.timed_out {
+            let timeout_error = process_timeout_error("git grep", Some(DEFAULT_PROCESS_TIMEOUT));
+            let stderr_diagnostic = output.stderr.trim().to_string();
+            let mut warnings = vec![timeout_error.clone()];
+            if !body.is_empty() {
+                warnings.push("partial git grep matches are incomplete".to_string());
+            }
+            let mut errors = vec![timeout_error];
+            if !stderr_diagnostic.is_empty() {
+                errors.push(stderr_diagnostic);
+            }
+            return Ok(AdapterOutcome {
+                ok: false,
+                summary: format!("{tool_name} timed out through git grep"),
+                changes: Vec::new(),
+                warnings,
+                errors,
+                artifacts: Vec::new(),
+                stdout: Some(format_section("git-grep", &body)),
+                stderr: if output.stderr.trim().is_empty() {
+                    None
+                } else {
+                    Some(output.stderr)
+                },
+                command: Some(std::iter::once("git".to_string()).chain(git_args).collect()),
+            });
+        }
         let no_matches = body.is_empty()
             && !output.status_success
             && output.stderr.trim().is_empty()
-            && !output.timed_out
             && process_exit_code_is(&output.status, 1);
-        let partial_matches = output.timed_out && !body.is_empty();
-        if !output.status_success && !no_matches && !partial_matches {
+        if !output.status_success && !no_matches {
             let error = output.stderr.trim();
             let error = if error.is_empty() {
                 format!("git grep exited with status {}", output.status)
@@ -1329,11 +1354,7 @@ impl<'a> CodeNavigationAdapter<'a> {
             ok: true,
             summary: format!("{tool_name} completed through git grep"),
             changes: Vec::new(),
-            warnings: if output.timed_out {
-                vec!["git grep timed out".to_string()]
-            } else {
-                Vec::new()
-            },
+            warnings: Vec::new(),
             errors: Vec::new(),
             artifacts: Vec::new(),
             stdout: Some(format_section("git-grep", &stdout)),
@@ -4411,6 +4432,53 @@ mod tests {
     }
 
     #[test]
+    fn code_grep_adapter_reports_partial_timeout_as_failure() {
+        let context = temp_context("grep-partial-timeout");
+        let index = FakeIndexRunner::default();
+        let grep = FakeProcessRunner {
+            output: ProcessOutput {
+                status_success: false,
+                status: "timeout".to_string(),
+                stdout: "CommonModules/One.bsl:1:Needle\nCommonModules/Two.bsl:1:Needle\n"
+                    .to_string(),
+                stderr: "[unica: stdout capture truncated; result is not parseable]\n".to_string(),
+                timed_out: true,
+                cancelled: false,
+            },
+        };
+        let mut args = Map::new();
+        args.insert("query".to_string(), json!("Needle"));
+        args.insert("limit".to_string(), json!(5));
+
+        let outcome = CodeNavigationAdapter::with_runners(&index, &grep)
+            .invoke("unica.code.grep", &args, &context, false)
+            .unwrap();
+
+        assert!(!outcome.ok);
+        assert!(outcome
+            .errors
+            .iter()
+            .any(|error| error.contains("timed out after 120 seconds")));
+        assert!(outcome
+            .errors
+            .iter()
+            .any(|error| error.contains("stdout capture truncated")));
+        assert!(outcome
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("partial") && warning.contains("incomplete")));
+        assert!(outcome
+            .stdout
+            .as_deref()
+            .is_some_and(|stdout| stdout.contains("CommonModules/One.bsl")));
+        assert!(outcome
+            .stderr
+            .as_deref()
+            .is_some_and(|stderr| stderr.contains("stdout capture truncated")));
+        cleanup_context(&context);
+    }
+
+    #[test]
     fn code_grep_adapter_rejects_path_escape_before_git_execution() {
         let context = temp_context("grep-escape");
         let index = FakeIndexRunner::default();
@@ -5275,6 +5343,15 @@ source-set:
             !output.timed_out,
             "runner timed out after capturing {} stdout bytes",
             output.stdout.len()
+        );
+        assert!(
+            !output.cancelled,
+            "runner unexpectedly reported cancellation"
+        );
+        assert!(
+            process_exit_code_is(&output.status, 0),
+            "helper must exit successfully, got {}",
+            output.status
         );
         assert!(
             !output.status_success,


### PR DESCRIPTION
## Summary

- lock in the `unica.code.grep` contract that `limit` is global and every git
  grep call has the bounded 120-second process budget
- exercise the real `SystemProcessRunner` with 4 MiB of stdout, proving that it
  drains the pipe without timing out and reports bounded truncation explicitly
- return `ok: false` with an explicit 120-second timeout error whenever git grep
  times out, preserving partial stdout and stderr without promoting them to a
  successful result
- make source-root and project-source test workspaces process-unique so parallel
  tests cannot overwrite each other's `v8project.yaml`

## Reproduction and root cause

The original hang no longer reproduces on exact current `main` (`cee278e`). A
direct stdio `unica.code.grep` call over 83,353 bytes of raw `git grep` output
returned in 0.955 seconds with exactly the requested 50 result lines.

The issue comment points to unmerged commit `eac7f9f`, which fixed the old
`SystemProcessRunner` by draining stdout/stderr before waiting for child exit.
That commit is not an ancestor of `main`, but its root-cause fix was superseded
by the shared `ManagedChild`: both pipes are drained concurrently, capture is
bounded, cancellation and timeout terminate the process tree, and truncated
stdout is never reported as parseable success. This PR adds the missing
issue-specific regression coverage at the code-grep/process-runner boundary
instead of reintroducing the older duplicate process lifecycle.

Review then exposed a remaining production-contract bug: a timed-out process was
reported as successful whenever it had any partial stdout. This could promote a
truncated, non-parseable tail to `ok: true` and leave `errors` empty. The timeout
branch now always fails explicitly, retains partial matches for diagnosis, and
keeps truncation stderr in the structured errors.

During the full test run, a separate pre-existing fixture race reproduced: test
workspaces used only PID plus wall-clock nanoseconds. On a coarse clock,
parallel source-root tests selected the same directory and overwrote each
other's YAML. A process-local atomic nonce fixes both copied helpers; this is
test-only and does not change production source discovery.

## Verification

- direct stdio main reproduction: success in 0.955 s, 50/50 global results,
  no RPC error or stderr
- 4 MiB stdout process-runner regression: 10/10 repetitions passed
- timeout-with-partial-output regression failed first on `assert !outcome.ok`,
  then passed after the production fix; the helper now also proves exit code 0
  and no cancellation
- source-root failure reproduced on the first parallel run before the fix;
  after the fix, source-root and project-source modules each passed 20/20
  parallel repetitions
- `cargo test --workspace --all-targets --all-features`
  (552 passed, 2 helper tests ignored, 2 integration tests passed)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `python3.12 -m unittest discover -s tests/ci` (147 passed, 4 skipped)
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #97
