### PR TITLE
fix(forms): close event matrix review gaps

### DIFF
--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -5930,6 +5930,37 @@ mod tests {
     }
 
     #[test]
+    fn form_compile_dry_run_rejects_output_escape_like_apply() {
+        let root = test_workspace_root("unica-form-compile-preview-path-policy");
+        let workspace = root.join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let json_path = workspace.join("form.json");
+        std::fs::write(&json_path, "{}").unwrap();
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(true));
+        args.insert(
+            "JsonPath".to_string(),
+            Value::String(json_path.display().to_string()),
+        );
+        args.insert(
+            "OutputPath".to_string(),
+            Value::String("../outside.xml".to_string()),
+        );
+
+        let error = UnicaApplication::new()
+            .call_tool("unica.form.compile", &args)
+            .expect_err("form preview must enforce the same output path policy as apply");
+
+        assert!(error.contains("outside workspace root"), "{error}");
+        assert!(!root.join("outside.xml").exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn detailed_compile_dry_run_rejects_edt_source_set_like_apply() {
         let root = test_workspace_root("unica-compile-preview-edt-guard");
         let workspace = root.join("workspace");
@@ -5969,6 +6000,49 @@ mod tests {
 
         assert!(error.contains("sourceFormat=edt"), "{error}");
         assert!(error.contains("platform_xml"), "{error}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn form_compile_dry_run_rejects_edt_source_set_like_apply() {
+        let root = test_workspace_root("unica-form-compile-preview-edt-guard");
+        let workspace = root.join("workspace");
+        std::fs::create_dir_all(workspace.join("src/Configuration")).unwrap();
+        std::fs::write(
+            workspace.join("v8project.yaml"),
+            "format: EDT\nsource-set:\n  - name: main\n    type: CONFIGURATION\n    path: src\n",
+        )
+        .unwrap();
+        std::fs::write(workspace.join("src/.project"), "<projectDescription/>").unwrap();
+        std::fs::write(
+            workspace.join("src/Configuration/Configuration.mdo"),
+            "<mdclass:Configuration/>",
+        )
+        .unwrap();
+        let json_path = workspace.join("form.json");
+        std::fs::write(&json_path, "{}").unwrap();
+        let mut args = Map::new();
+        args.insert(
+            "cwd".to_string(),
+            Value::String(workspace.display().to_string()),
+        );
+        args.insert("dryRun".to_string(), Value::Bool(true));
+        args.insert(
+            "JsonPath".to_string(),
+            Value::String(json_path.display().to_string()),
+        );
+        args.insert(
+            "OutputPath".to_string(),
+            Value::String("src/Form.xml".to_string()),
+        );
+
+        let error = UnicaApplication::new()
+            .call_tool("unica.form.compile", &args)
+            .expect_err("form preview must enforce the same source-format guard as apply");
+
+        assert!(error.contains("sourceFormat=edt"), "{error}");
+        assert!(error.contains("platform_xml"), "{error}");
+        assert!(!workspace.join("src/Form.xml").exists());
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/crates/unica-coder/src/application/tool_contracts.rs
+++ b/crates/unica-coder/src/application/tool_contracts.rs
@@ -1336,7 +1336,7 @@ fn validates_compile_preview_like_apply(tool: ToolSpec) -> bool {
     matches!(
         tool.handler,
         ToolHandler::NativeOperation {
-            operation: "meta-compile" | "role-compile" | "subsystem-compile",
+            operation: "form-compile" | "meta-compile" | "role-compile" | "subsystem-compile",
             ..
         }
     )

--- a/crates/unica-coder/src/infrastructure/native_operations/form.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/form.rs
@@ -1180,6 +1180,7 @@ pub(crate) fn form_valid_cfg_prefixes() -> &'static [&'static str] {
         "AccumulationRegisterRecordSet",
         "BusinessProcessObject",
         "BusinessProcessRef",
+        "CalculationRegisterRecordSet",
         "CatalogObject",
         "CatalogRef",
         "ChartOfAccountsObject",
@@ -3490,77 +3491,35 @@ pub(crate) fn replace_form_default_property(
     )
 }
 
+struct FormCompilePlan {
+    output_label: String,
+    output_path: PathBuf,
+    stdout: String,
+    xml: String,
+    stats: FormCompileStats,
+}
+
 pub(crate) fn compile_form(
     args: &Map<String, Value>,
     context: &WorkspaceContext,
 ) -> AdapterOutcome {
-    let write_result = (|| -> Result<(String, PathBuf), String> {
-        let json_path_raw = path_arg(args, &["jsonPath", "JsonPath"]);
-        let from_object = bool_arg(args, &["fromObject", "FromObject"]);
-        if from_object && json_path_raw.is_some() {
-            return Err("Cannot use both -JsonPath and -FromObject. Choose one mode.".to_string());
-        }
-        if !from_object && json_path_raw.is_none() {
-            return Err("Either -JsonPath or -FromObject is required.".to_string());
-        }
-
-        let mut output_label = string_arg(args, &["outputPath", "OutputPath"])
-            .ok_or_else(|| "missing required OutputPath argument".to_string())?
-            .to_string();
-        let mut stdout = String::new();
-        if from_object {
-            if let Some((normalized, resolved_line)) =
-                form_compile_normalize_from_object_output_label(&output_label)
-            {
-                output_label = normalized;
-                stdout.push_str(&resolved_line);
-            }
-        }
-        let output_path = absolutize(PathBuf::from(&output_label), &context.cwd);
-        let defn = if from_object {
-            let (defn, from_object_stdout) =
-                form_compile_definition_from_object(args, context, &output_path)?;
-            stdout.push_str(&from_object_stdout);
-            defn
-        } else {
-            let json_path_raw = json_path_raw
-                .ok_or_else(|| "Either -JsonPath or -FromObject is required.".to_string())?;
-            let json_path = absolutize(json_path_raw.clone(), &context.cwd);
-            if !json_path.exists() {
-                return Err(format!("File not found: {}", json_path_raw.display()));
-            }
-            let json_text = fs::read_to_string(&json_path)
-                .map_err(|err| format!("failed to read {}: {err}", json_path.display()))?;
-            serde_json::from_str(json_text.trim_start_matches('\u{feff}'))
-                .map_err(|err| format!("failed to parse Form JSON: {err}"))?
-        };
-
-        let format_version = detect_format_version(output_path.parent().unwrap_or(&context.cwd));
-        let (xml, stats) = form_compile_xml(&defn, &format_version)?;
-
+    let write_result = plan_form_compile(args, context).and_then(|mut plan| {
+        let output_path = plan.output_path.clone();
         if let Some(parent) = output_path.parent() {
             fs::create_dir_all(parent)
                 .map_err(|err| format!("failed to create {}: {err}", parent.display()))?;
         }
-        write_utf8_bom(&output_path, &xml)?;
+        write_utf8_bom(&output_path, &plan.xml)?;
 
         if let Some(registered) = register_form_in_parent_object(&output_path)? {
-            stdout.push_str(&registered);
+            plan.stdout.push_str(&registered);
         }
-        stdout.push_str(&format!("[OK] Compiled: {output_label}\n"));
-        stdout.push_str(&format!("     Elements+IDs: {}\n", stats.element_ids));
-        if stats.attributes > 0 {
-            stdout.push_str(&format!("     Attributes: {}\n", stats.attributes));
-        }
-        if stats.commands > 0 {
-            stdout.push_str(&format!("     Commands: {}\n", stats.commands));
-        }
-        if stats.parameters > 0 {
-            stdout.push_str(&format!("     Parameters: {}\n", stats.parameters));
-        }
+        plan.stdout
+            .push_str(&format!("[OK] Compiled: {}\n", plan.output_label));
+        append_form_compile_stats(&mut plan.stdout, &plan.stats);
 
-        Ok((stdout, output_path))
-    })();
+        Ok((plan.stdout, output_path))
+    });
 
     match write_result {
         Ok((stdout, output_path)) => AdapterOutcome {
@@ -3585,6 +3544,109 @@ pub(crate) fn compile_form(
             stderr: Some(format!("{error}\n")),
             command: None,
         },
+    }
+}
+
+pub(crate) fn preview_form_compile(
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> Result<AdapterOutcome, String> {
+    let mut plan = plan_form_compile(args, context)?;
+    plan.stdout
+        .push_str(&format!("[DRY-RUN] Would compile: {}\n", plan.output_label));
+    append_form_compile_stats(&mut plan.stdout, &plan.stats);
+    Ok(AdapterOutcome {
+        ok: true,
+        summary: "dry run: unica.form.compile planned native managed form compilation".to_string(),
+        changes: vec![format!("would update {}", plan.output_path.display())],
+        warnings: Vec::new(),
+        errors: Vec::new(),
+        artifacts: Vec::new(),
+        stdout: Some(plan.stdout),
+        stderr: None,
+        command: None,
+    })
+}
+
+pub(crate) fn has_compile_payload(args: &Map<String, Value>) -> bool {
+    const KEYS: &[&str] = &[
+        "JsonPath",
+        "jsonPath",
+        "FromObject",
+        "fromObject",
+        "ObjectPath",
+        "objectPath",
+        "OutputPath",
+        "outputPath",
+    ];
+    KEYS.iter().any(|key| args.contains_key(*key))
+}
+
+fn plan_form_compile(
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> Result<FormCompilePlan, String> {
+    let json_path_raw = path_arg(args, &["jsonPath", "JsonPath"]);
+    let from_object = bool_arg(args, &["fromObject", "FromObject"]);
+    if from_object && json_path_raw.is_some() {
+        return Err("Cannot use both -JsonPath and -FromObject. Choose one mode.".to_string());
+    }
+    if !from_object && json_path_raw.is_none() {
+        return Err("Either -JsonPath or -FromObject is required.".to_string());
+    }
+
+    let mut output_label = string_arg(args, &["outputPath", "OutputPath"])
+        .ok_or_else(|| "missing required OutputPath argument".to_string())?
+        .to_string();
+    let mut stdout = String::new();
+    if from_object {
+        if let Some((normalized, resolved_line)) =
+            form_compile_normalize_from_object_output_label(&output_label)
+        {
+            output_label = normalized;
+            stdout.push_str(&resolved_line);
+        }
+    }
+    let output_path = absolutize(PathBuf::from(&output_label), &context.cwd);
+    let defn = if from_object {
+        let (defn, from_object_stdout) =
+            form_compile_definition_from_object(args, context, &output_path)?;
+        stdout.push_str(&from_object_stdout);
+        defn
+    } else {
+        let json_path_raw = json_path_raw
+            .ok_or_else(|| "Either -JsonPath or -FromObject is required.".to_string())?;
+        let json_path = absolutize(json_path_raw.clone(), &context.cwd);
+        if !json_path.exists() {
+            return Err(format!("File not found: {}", json_path_raw.display()));
+        }
+        let json_text = fs::read_to_string(&json_path)
+            .map_err(|err| format!("failed to read {}: {err}", json_path.display()))?;
+        serde_json::from_str(json_text.trim_start_matches('\u{feff}'))
+            .map_err(|err| format!("failed to parse Form JSON: {err}"))?
+    };
+
+    let format_version = detect_format_version(output_path.parent().unwrap_or(&context.cwd));
+    let (xml, stats) = form_compile_xml(&defn, &format_version)?;
+    Ok(FormCompilePlan {
+        output_label,
+        output_path,
+        stdout,
+        xml,
+        stats,
+    })
+}
+
+fn append_form_compile_stats(stdout: &mut String, stats: &FormCompileStats) {
+    stdout.push_str(&format!("     Elements+IDs: {}\n", stats.element_ids));
+    if stats.attributes > 0 {
+        stdout.push_str(&format!("     Attributes: {}\n", stats.attributes));
+    }
+    if stats.commands > 0 {
+        stdout.push_str(&format!("     Commands: {}\n", stats.commands));
+    }
+    if stats.parameters > 0 {
+        stdout.push_str(&format!("     Parameters: {}\n", stats.parameters));
     }
 }
 
@@ -7353,6 +7415,7 @@ pub(crate) fn emit_form_single_type(lines: &mut Vec<String>, type_name: &str, in
         || normalized.starts_with("InformationRegisterRecordManager.")
         || normalized.starts_with("AccumulationRegisterRecordSet.")
         || normalized.starts_with("AccountingRegisterRecordSet.")
+        || normalized.starts_with("CalculationRegisterRecordSet.")
         || normalized.starts_with("ConstantsSet.")
         || normalized.starts_with("DataProcessorObject.")
         || normalized.starts_with("ReportObject.")
@@ -9523,6 +9586,34 @@ mod tests {
     }
 
     #[test]
+    fn form_compile_accepts_persistent_object_and_record_event_families() {
+        for main_type in [
+            "ChartOfAccountsObject.Main",
+            "ChartOfCalculationTypesObject.Payroll",
+            "AccumulationRegisterRecordSet.Stock",
+            "AccountingRegisterRecordSet.Accounting",
+            "CalculationRegisterRecordSet.Payroll",
+        ] {
+            let definition = json!({
+                "attributes": [{"name": "Object", "type": main_type, "main": true}],
+                "events": {"OnReadAtServer": "ObjectOnReadAtServer"}
+            });
+
+            let (xml, _) = form_compile_xml(&definition, "2.20")
+                .unwrap_or_else(|error| panic!("{main_type}: {error}"));
+
+            assert!(
+                xml.contains(&format!("<v8:Type>cfg:{main_type}</v8:Type>")),
+                "{main_type}: {xml}"
+            );
+            assert!(
+                xml.contains("<Event name=\"OnReadAtServer\">ObjectOnReadAtServer</Event>"),
+                "{main_type}: {xml}"
+            );
+        }
+    }
+
+    #[test]
     fn form_compile_rejects_invalid_root_events_before_writing() {
         let context = temp_context("compile-invalid-root-events");
         let definition_path = context.cwd.join("form.json");
@@ -9595,6 +9686,93 @@ mod tests {
             assert!(outcome.stdout.is_none(), "{name}: {outcome:?}");
             assert_eq!(fs::read(&form_path).unwrap(), original, "{name}");
         }
+
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
+    fn form_compile_dry_run_rejects_invalid_root_event_without_writing() {
+        let context = temp_context("compile-invalid-root-event-dry-run");
+        let definition_path = context.cwd.join("form.json");
+        let form_path = context.cwd.join("Form.xml");
+        let original = b"do-not-replace-invalid-form";
+        write_file(&definition_path, r#"{"events":{"Opening":"OnOpening"}}"#);
+        fs::write(&form_path, original).unwrap();
+        let args = Map::from_iter([
+            (
+                "JsonPath".to_string(),
+                json!(definition_path.display().to_string()),
+            ),
+            (
+                "OutputPath".to_string(),
+                json!(form_path.display().to_string()),
+            ),
+        ]);
+
+        let outcome = NativeOperationAdapter::invoke(
+            "form-compile",
+            "unica.form.compile",
+            &args,
+            &context,
+            true,
+            true,
+        )
+        .unwrap();
+
+        assert!(!outcome.ok, "{outcome:?}");
+        assert!(
+            outcome
+                .errors
+                .iter()
+                .any(|error| error.contains("FORM_EVENT_NOT_ALLOWED")),
+            "{outcome:?}"
+        );
+        assert!(outcome.changes.is_empty(), "{outcome:?}");
+        assert_eq!(fs::read(&form_path).unwrap(), original);
+
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
+    fn form_compile_dry_run_plans_valid_root_event_without_writing() {
+        let context = temp_context("compile-valid-root-event-dry-run");
+        let definition_path = context.cwd.join("form.json");
+        let form_path = context.cwd.join("Form.xml");
+        let original = b"do-not-replace-valid-form-during-preview";
+        write_file(
+            &definition_path,
+            r#"{"events":{"OnCreateAtServer":"OnCreateAtServer"}}"#,
+        );
+        fs::write(&form_path, original).unwrap();
+        let args = Map::from_iter([
+            (
+                "JsonPath".to_string(),
+                json!(definition_path.display().to_string()),
+            ),
+            (
+                "OutputPath".to_string(),
+                json!(form_path.display().to_string()),
+            ),
+        ]);
+
+        let outcome = NativeOperationAdapter::invoke(
+            "form-compile",
+            "unica.form.compile",
+            &args,
+            &context,
+            true,
+            true,
+        )
+        .unwrap();
+
+        assert!(outcome.ok, "{outcome:?}");
+        assert_eq!(outcome.changes.len(), 1, "{outcome:?}");
+        assert!(
+            outcome.changes[0].contains("would update")
+                && outcome.changes[0].contains(&form_path.display().to_string()),
+            "{outcome:?}"
+        );
+        assert_eq!(fs::read(&form_path).unwrap(), original);
 
         let _ = fs::remove_dir_all(&context.cwd);
     }

--- a/crates/unica-coder/src/infrastructure/native_operations/form_event_registry.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/form_event_registry.rs
@@ -136,12 +136,17 @@ const NAMED_PERSISTENT_OBJECT_TYPES: &[&str] = &[
     "BusinessProcessObject",
     "TaskObject",
     "ExchangePlanObject",
+    "ChartOfAccountsObject",
     "ChartOfCharacteristicTypesObject",
+    "ChartOfCalculationTypesObject",
 ];
 
 const NAMED_PERSISTENT_RECORD_TYPES: &[&str] = &[
     "InformationRegisterRecordManager",
     "InformationRegisterRecordSet",
+    "AccumulationRegisterRecordSet",
+    "AccountingRegisterRecordSet",
+    "CalculationRegisterRecordSet",
 ];
 
 /// Distinguishes a configuration form from an extension form without a
@@ -974,18 +979,39 @@ mod tests {
 
     #[test]
     fn classifies_known_main_attribute_families() {
-        assert_eq!(
-            MainAttributeKind::from_type_name("cfg:DocumentObject.Order"),
-            MainAttributeKind::PersistentObject
-        );
+        for persistent_object in [
+            "cfg:CatalogObject.Goods",
+            "cfg:DocumentObject.Order",
+            "cfg:BusinessProcessObject.Approval",
+            "cfg:TaskObject.Review",
+            "cfg:ExchangePlanObject.Sync",
+            "cfg:ChartOfAccountsObject.Main",
+            "cfg:ChartOfCharacteristicTypesObject.Properties",
+            "cfg:ChartOfCalculationTypesObject.Payroll",
+        ] {
+            assert_eq!(
+                MainAttributeKind::from_type_name(persistent_object),
+                MainAttributeKind::PersistentObject,
+                "{persistent_object} must support persistent object form events"
+            );
+        }
         assert_eq!(
             MainAttributeKind::from_type_name("cfg:ConstantsSet"),
             MainAttributeKind::PersistentObject
         );
-        assert_eq!(
-            MainAttributeKind::from_type_name("cfg:InformationRegisterRecordSet.Prices"),
-            MainAttributeKind::PersistentRecord
-        );
+        for persistent_record in [
+            "cfg:InformationRegisterRecordManager.Prices",
+            "cfg:InformationRegisterRecordSet.Prices",
+            "cfg:AccumulationRegisterRecordSet.Stock",
+            "cfg:AccountingRegisterRecordSet.Accounting",
+            "cfg:CalculationRegisterRecordSet.Payroll",
+        ] {
+            assert_eq!(
+                MainAttributeKind::from_type_name(persistent_record),
+                MainAttributeKind::PersistentRecord,
+                "{persistent_record} must support persistent record form events"
+            );
+        }
         assert_eq!(
             MainAttributeKind::from_type_name("cfg:DynamicList"),
             MainAttributeKind::DynamicList
@@ -1013,12 +1039,10 @@ mod tests {
             );
         }
         for unsupported in [
-            "cfg:ChartOfAccountsObject.Main",
-            "cfg:ChartOfCalculationTypesObject.Payroll",
-            "cfg:AccumulationRegisterRecordSet.Stock",
-            "cfg:AccountingRegisterRecordSet.Accounting",
-            "cfg:CalculationRegisterRecordSet.Payroll",
             "cfg:ReportObject.Sales",
+            "cfg:DataProcessorObject.Import",
+            "cfg:ExternalReportObject.Sales",
+            "cfg:ExternalDataProcessorObject.Import",
         ] {
             assert_eq!(
                 MainAttributeKind::from_type_name(unsupported),

--- a/crates/unica-coder/src/infrastructure/native_operations/registry.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/registry.rs
@@ -35,9 +35,12 @@ pub(crate) fn invoke_preview(
     args: &Map<String, Value>,
     context: &WorkspaceContext,
 ) -> Option<PreviewInvocation> {
+    if operation == "form-compile" && !form::has_compile_payload(args) {
+        return None;
+    }
     if !matches!(
         operation,
-        "meta-compile" | "role-compile" | "subsystem-compile"
+        "form-compile" | "meta-compile" | "role-compile" | "subsystem-compile"
     ) {
         return None;
     }
@@ -45,6 +48,7 @@ pub(crate) fn invoke_preview(
         return Some(PreviewInvocation::Unavailable(reason));
     }
     let planned = match operation {
+        "form-compile" => form::preview_form_compile(args, context),
         "meta-compile" => meta::preview_meta_compile(args, context),
         "role-compile" => role::preview_role_compile(args, context),
         "subsystem-compile" => subsystem::preview_subsystem_compile(args, context),
@@ -58,6 +62,9 @@ fn compile_preview_unavailable(
     args: &Map<String, Value>,
     context: &WorkspaceContext,
 ) -> Option<String> {
+    if operation == "form-compile" {
+        return None;
+    }
     if string_arg(args, &["OutputDir", "outputDir"]).is_none() {
         return Some("missing required OutputDir argument".to_string());
     }

--- a/plugins/unica/skills/form-compile/SKILL.md
+++ b/plugins/unica/skills/form-compile/SKILL.md
@@ -333,7 +333,7 @@ allowed-tools:
 | `"AccumulationRegisterRecordSet.XXX"` | Набор записей регистра накопления |
 | `"DynamicList"` | Динамический список |
 
-Также допустимы: `ChartOfAccountsRef/Object`, `ChartOfCharacteristicTypesRef/Object`, `ChartOfCalculationTypesRef/Object`, `ExchangePlanRef/Object`, `BusinessProcessRef/Object`, `TaskRef/Object`, `AccountingRegisterRecordSet`, `InformationRegisterRecordManager`, `ConstantsSet`.
+Также допустимы: `ChartOfAccountsRef/Object`, `ChartOfCharacteristicTypesRef/Object`, `ChartOfCalculationTypesRef/Object`, `ExchangePlanRef/Object`, `BusinessProcessRef/Object`, `TaskRef/Object`, `AccountingRegisterRecordSet`, `CalculationRegisterRecordSet`, `InformationRegisterRecordManager`, `ConstantsSet`.
 
 **Платформенные:**
 

--- a/tests/ci/test_unica_mcp_script_parity.py
+++ b/tests/ci/test_unica_mcp_script_parity.py
@@ -4169,6 +4169,137 @@ class UnicaMcpScriptParityTests(unittest.TestCase):
             self.assertEqual(result.get("changes"), [])
             self.assertEqual(form_path.read_bytes(), before)
 
+    def test_form_edit_accepts_extended_persistent_event_families(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="unica-issue77-persistent-events-") as temp:
+            temp_root = Path(temp)
+            workspace = temp_root / "workspace"
+            cache = temp_root / "cache"
+            workspace.mkdir()
+            persistent_types = [
+                "ChartOfAccountsObject.Main",
+                "ChartOfCalculationTypesObject.Payroll",
+                "AccumulationRegisterRecordSet.Stock",
+                "AccountingRegisterRecordSet.Accounting",
+                "CalculationRegisterRecordSet.Payroll",
+            ]
+
+            for index, persistent_type in enumerate(persistent_types, start=1):
+                with self.subTest(persistent_type=persistent_type):
+                    form_path = workspace / f"Form{index}.xml"
+                    form_path.write_text(
+                        f"""<?xml version="1.0" encoding="UTF-8"?>
+<Form xmlns="http://v8.1c.ru/8.3/xcf/logform"
+      xmlns:cfg="http://v8.1c.ru/8.1/data/enterprise/current-config"
+      xmlns:v8="http://v8.1c.ru/8.1/data/core" version="2.20">
+\t<AutoCommandBar name="FormCommandBar" id="-1"/>
+\t<ChildItems/>
+\t<Attributes>
+\t\t<Attribute name="Object" id="1">
+\t\t\t<Type><v8:Type>cfg:{persistent_type}</v8:Type></Type>
+\t\t\t<MainAttribute>true</MainAttribute>
+\t\t</Attribute>
+\t</Attributes>
+\t<Commands/>
+</Form>""",
+                        encoding="utf-8",
+                    )
+
+                    edit = self.call_mcp_tool(
+                        "unica.form.edit",
+                        {
+                            "FormPath": form_path.name,
+                            "definition": {
+                                "formEvents": [
+                                    {"name": "OnReadAtServer", "handler": "ObjectOnReadAtServer"}
+                                ]
+                            },
+                        },
+                        workspace,
+                        cache,
+                    )
+
+                    self.assertTrue(edit["ok"], json.dumps(edit, ensure_ascii=False, indent=2))
+                    updated = form_path.read_text(encoding="utf-8-sig")
+                    self.assertEqual(updated.count('name="OnReadAtServer"'), 1)
+
+                    validate = self.call_mcp_tool(
+                        "unica.form.validate",
+                        {"FormPath": form_path.name},
+                        workspace,
+                        cache,
+                    )
+                    self.assertTrue(
+                        validate["ok"], json.dumps(validate, ensure_ascii=False, indent=2)
+                    )
+
+    def test_form_compile_dry_run_uses_event_registry_without_writing(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="unica-issue77-compile-preview-") as temp:
+            temp_root = Path(temp)
+            workspace = temp_root / "workspace"
+            cache = temp_root / "cache"
+            workspace.mkdir()
+            invalid_definition = workspace / "invalid.json"
+            valid_definition = workspace / "valid.json"
+            invalid_definition.write_text(
+                json.dumps({"events": {"Opening": "OnOpening"}}),
+                encoding="utf-8",
+            )
+            valid_definition.write_text(
+                json.dumps({"events": {"OnCreateAtServer": "OnCreateAtServer"}}),
+                encoding="utf-8",
+            )
+            invalid_output = workspace / "InvalidForm.xml"
+            valid_output = workspace / "ValidForm.xml"
+            invalid_before = b"invalid-preview-sentinel"
+            valid_before = b"valid-preview-sentinel"
+            invalid_output.write_bytes(invalid_before)
+            valid_output.write_bytes(valid_before)
+            messages = [
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "unica.form.compile",
+                        "arguments": {
+                            "cwd": str(workspace),
+                            "JsonPath": "invalid.json",
+                            "OutputPath": "InvalidForm.xml",
+                            "dryRun": True,
+                        },
+                    },
+                },
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "unica.form.compile",
+                        "arguments": {
+                            "cwd": str(workspace),
+                            "JsonPath": "valid.json",
+                            "OutputPath": "ValidForm.xml",
+                            "dryRun": True,
+                        },
+                    },
+                },
+            ]
+
+            responses = self.call_mcp_messages(messages, cache)
+            invalid = json.loads(responses[1]["result"]["content"][0]["text"])
+            valid = json.loads(responses[2]["result"]["content"][0]["text"])
+
+            self.assertFalse(invalid["ok"], json.dumps(invalid, ensure_ascii=False, indent=2))
+            self.assertIn("FORM_EVENT_NOT_ALLOWED", "\n".join(invalid.get("errors", [])))
+            self.assertEqual(invalid.get("changes"), [])
+            self.assertTrue(valid["ok"], json.dumps(valid, ensure_ascii=False, indent=2))
+            self.assertTrue(
+                any("would update" in change and "ValidForm.xml" in change for change in valid["changes"]),
+                json.dumps(valid, ensure_ascii=False, indent=2),
+            )
+            self.assertEqual(invalid_output.read_bytes(), invalid_before)
+            self.assertEqual(valid_output.read_bytes(), valid_before)
+
     def test_bsp_skd_edit_parity_covers_documented_operations(self) -> None:
         covered = set()
         for scenario in SCENARIOS:
@@ -4196,13 +4327,12 @@ class UnicaMcpScriptParityTests(unittest.TestCase):
                 encoding="utf-8",
             )
             for example in examples:
-                if example.skill != "form-edit":
-                    continue
                 arguments = example.payload["params"]["arguments"]
-                form_path = workspace / arguments["FormPath"]
-                form_path.parent.mkdir(parents=True, exist_ok=True)
-                form_path.write_text(
-                    """<?xml version="1.0" encoding="UTF-8"?>
+                if example.skill == "form-edit":
+                    form_path = workspace / arguments["FormPath"]
+                    form_path.parent.mkdir(parents=True, exist_ok=True)
+                    form_path.write_text(
+                        """<?xml version="1.0" encoding="UTF-8"?>
 <Form xmlns="http://v8.1c.ru/8.3/xcf/logform" version="2.20">
 \t<AutoCommandBar name="FormCommandBar" id="-1"/>
 \t<ChildItems/>
@@ -4210,11 +4340,35 @@ class UnicaMcpScriptParityTests(unittest.TestCase):
 \t<Commands/>
 </Form>
 """,
-                    encoding="utf-8",
-                )
-                json_path = workspace / arguments["JsonPath"]
-                json_path.parent.mkdir(parents=True, exist_ok=True)
-                json_path.write_text("{}\n", encoding="utf-8")
+                        encoding="utf-8",
+                    )
+                    json_path = workspace / arguments["JsonPath"]
+                    json_path.parent.mkdir(parents=True, exist_ok=True)
+                    json_path.write_text("{}\n", encoding="utf-8")
+                elif example.skill == "form-compile":
+                    output_path = (
+                        workspace
+                        / "src"
+                        / "cf"
+                        / "Catalogs"
+                        / "SkillExample"
+                        / "Forms"
+                        / f"Form{example.line}"
+                        / "Ext"
+                        / "Form.xml"
+                    )
+                    arguments["OutputPath"] = str(output_path.relative_to(workspace))
+                    if arguments.get("FromObject") is True:
+                        object_path = workspace / "src" / "cf" / "Catalogs" / "Валюты.xml"
+                        object_path.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.copyfile(FIXTURES_ROOT / BSP_META_CATALOG_FIXTURE, object_path)
+                        arguments["ObjectPath"] = str(object_path.relative_to(workspace))
+                        arguments["Purpose"] = "Item"
+                    else:
+                        json_path = workspace / "fixtures" / f"form-{example.line}.json"
+                        json_path.parent.mkdir(parents=True, exist_ok=True)
+                        json_path.write_text("{}\n", encoding="utf-8")
+                        arguments["JsonPath"] = str(json_path.relative_to(workspace))
             messages = [
                 dry_run_message_for_example(example, index + 1, workspace)
                 for index, example in enumerate(examples)


### PR DESCRIPTION
Closes #77

## Summary

- complete the persistent form event context matrix for chart objects and all supported register record-set families
- make `unica.form.compile` apply and detailed dry-run share one parser/planner, so invalid events receive the same typed rejection before any write
- route detailed form previews through the same workspace path and platform-XML source-set guards as apply
- keep payload-free dry-run compatibility while materializing documented form-compile examples for real planner coverage
- add Rust and public MCP regressions for valid persistent families, invalid root `Opening`, valid `OnCreateAtServer`, byte-stable dry-run behavior, path escape, and EDT rejection

This is the follow-up to merged PR #85 after independent review found remaining P2 gaps. The issue body’s unconditional `OnReadAtServer` rejection is superseded by its later clarification: the event is context-dependent.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-targets --all-features --locked` (559 passed, 2 ignored, plus 2 integration tests passed)
- `python3.12 -m unittest discover -s tests/ci -p "test_*.py" -v` (149 passed, 4 skipped)
- public MCP regression: persistent family edit+validate; form.compile dry-run planned change/typed rejection with unchanged sentinel bytes

## Platform basis

The expanded families follow the official 1C SSL type matrix for data objects and register record sets used with `BeforeWrite` / `OnReadAtServer`: https://1c-dn.com/library/tutorials/1c_standard_subsystems_library_3_1_11/