### PR TITLE
fix(release): preserve thin contracts and repair Windows MCP startup

### DIFF
--- a/.github/workflows/publish-unica-marketplace.yml
+++ b/.github/workflows/publish-unica-marketplace.yml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
       release_tag:
-        description: Existing immutable marketplace tag, for example v0.7.0
+        description: Existing immutable marketplace tag, for example v0.7.1
         required: true
         type: string
       staging_merge_sha:

--- a/.github/workflows/publish-unica-marketplace.yml
+++ b/.github/workflows/publish-unica-marketplace.yml
@@ -44,6 +44,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Download verified thin payload
         run: gh run download "$SOURCE_RUN_ID" --repo IngvarConsulting/unica --name unica-thin-marketplace --dir payload
+      - name: Require package contract files
+        run: |
+          test -f payload/plugins/unica/.codex-plugin/plugin.json
+          test -f payload/plugins/unica/.mcp.json
+          test -f payload/plugins/unica/runtime-manifest.json
+          test -f payload/.agents/plugins/marketplace.json
       - name: Read the pinned release identity
         run: |
           release_tag="$(sed -n 's/.*"tag"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' payload/plugins/unica/runtime-manifest.json | head -n 1)"
@@ -84,6 +90,8 @@ jobs:
           test "$tag_commit" = "$STAGING_MERGE_SHA"
       - name: Download catalog candidate
         run: gh run download "$SOURCE_RUN_ID" --repo IngvarConsulting/unica --name unica-thin-marketplace --dir payload
+      - name: Require stable catalog candidate
+        run: test -f payload/.agents/plugins/marketplace.json
       - name: Open catalog-only promotion PR
         run: |
           set -euo pipefail

--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -137,6 +137,14 @@ jobs:
           python scripts/ci/check-tool-contracts.py
           --target "${{ matrix.target }}"
           --tools-dir ".build/tool-bundles/${{ matrix.target }}/bin/${{ matrix.target }}"
+      - name: Smoke packaged Unica MCP
+        shell: bash
+        run: |
+          executable=".build/tool-bundles/${{ matrix.target }}/bin/${{ matrix.target }}/unica"
+          if [ "${{ matrix.target }}" = "win-x64" ]; then executable="${executable}.exe"; fi
+          python scripts/ci/smoke-unica-mcp.py \
+            --binary "$executable" \
+            --plugin-root ".build/tool-bundles/${{ matrix.target }}"
       - uses: actions/upload-artifact@v4
         with:
           name: unica-tools-${{ matrix.target }}
@@ -177,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: package-runtime
     env:
-      RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'v0.7.0' }}
+      RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'v0.7.1' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -205,6 +205,7 @@ jobs:
         with:
           name: unica-thin-marketplace
           path: dist/thin/marketplace
+          include-hidden-files: true
           if-no-files-found: error
 
   installer:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unica-bootstrap"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "flate2",
  "fs2",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "unica-coder"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "fs2",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/unica-bootstrap", "crates/unica-coder"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "LGPL-3.0-or-later"
 repository = "https://github.com/IngvarConsulting/unica"

--- a/crates/unica-coder/src/main.rs
+++ b/crates/unica-coder/src/main.rs
@@ -1,4 +1,24 @@
+#[cfg(windows)]
+const WINDOWS_MAIN_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+#[cfg(windows)]
 fn main() {
+    let main_thread = std::thread::Builder::new()
+        .name("unica-main".to_string())
+        .stack_size(WINDOWS_MAIN_STACK_SIZE)
+        .spawn(run)
+        .unwrap_or_else(|error| panic!("failed to start Unica main thread: {error}"));
+    if let Err(panic) = main_thread.join() {
+        std::panic::resume_unwind(panic);
+    }
+}
+
+#[cfg(not(windows))]
+fn main() {
+    run();
+}
+
+fn run() {
     let args = std::env::args().collect::<Vec<_>>();
     if args.iter().any(|arg| arg == "--workspace-service") {
         if let Err(error) = unica_coder::interfaces::workspace_service::run_from_args(&args) {

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -1,5 +1,10 @@
 # Unica v0.7.0
 
+> Source-only release: external marketplace staging found a Windows MCP startup
+> stack overflow before catalog promotion. The immutable tag and assets were
+> retained, not overwritten; `v0.7.1` contains the correction and is the first
+> public marketplace version.
+
 Unica 0.7.0 changes the delivery model from platform-sized marketplace bundles
 to a public thin Git marketplace. This note describes the release contract; the
 release is considered published only after the source release, runtime bytes,

--- a/docs/releases/v0.7.1.md
+++ b/docs/releases/v0.7.1.md
@@ -1,0 +1,70 @@
+# Unica v0.7.1
+
+Unica 0.7.1 is the first version promoted through the public thin Git
+marketplace. It supersedes the source-only 0.7.0 release, whose external
+staging smoke exposed a Windows main-thread stack overflow before its catalog
+entry was promoted. The immutable 0.7.0 assets and tag were not overwritten.
+
+## Install and prerequisites
+
+Consumers need a compatible Codex CLI and standard Git (Git for Windows on
+Windows). Node.js, Python, HTTP download utilities, JSON utilities, and archive
+utilities are not installation prerequisites.
+
+```sh
+codex plugin marketplace add IngvarConsulting/unica-marketplace --ref main
+codex plugin add unica@unica
+```
+
+Open a new Codex task after installation.
+
+## Runtime artifacts
+
+The source release publishes one runtime archive and matching JSON metadata for
+each of `darwin-arm64`, `linux-x64`, and `win-x64`, plus the POSIX and
+PowerShell transition shims.
+
+The marketplace package contains plugin content and three small native
+bootstraps, not the full platform runtimes. On first MCP launch the bootstrap
+downloads only the current host runtime, checks the archive and per-file
+SHA-256 values, and atomically caches it under
+`$CODEX_HOME/unica/runtimes/0.7.1/<target>`.
+
+## Windows correction
+
+The Unica entrypoint now runs its application loop on an explicitly sized
+8 MiB thread. This matches the working POSIX stack budget and avoids the 1 MiB
+Windows main-thread reserve that caused 0.7.0 to abort during MCP startup.
+Release CI now performs real `initialize` and `tools/list` calls against every
+packaged platform binary before runtime assets can be published.
+
+## Migration and rollback
+
+Transition shims use Git to fetch the stable catalog and invoke the same native
+transaction engine on POSIX and Windows. Preflight runs before mutation. Each
+successful step is journaled; on failure inverse Codex commands run in reverse
+order and the exact saved configuration is restored atomically. The retained
+backup path is printed, and rerunning a completed migration is safe.
+
+## Update and uninstall
+
+```sh
+codex plugin marketplace upgrade unica
+codex plugin remove unica@unica
+codex plugin add unica@unica
+```
+
+Open a new Codex task after update. To uninstall:
+
+```sh
+codex plugin remove unica@unica
+codex plugin marketplace remove unica
+```
+
+## Publication proof
+
+Acceptance requires the signed source tag, three-platform package/MCP smoke,
+re-downloaded runtime hashes, plugin-only marketplace staging merge, signed
+immutable marketplace tag, catalog-only promotion merge, and isolated public
+installation proof.
+

--- a/plugins/unica/.codex-plugin/plugin.json
+++ b/plugins/unica/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unica",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Practical 1C:Enterprise development workflows for Codex.",
   "author": {
     "name": "Ingvar Consulting, LLC",

--- a/plugins/unica/runtime-manifest.json
+++ b/plugins/unica/runtime-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "pluginVersion": "0.7.0",
+  "pluginVersion": "0.7.1",
   "development": true,
   "source": {
     "repository": "https://github.com/IngvarConsulting/unica",

--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -127,7 +127,7 @@
     },
     {
       "name": "unica",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "repository": "https://github.com/IngvarConsulting/unica",
       "sourceTag": "workspace",
       "sourceCommit": "workspace",

--- a/scripts/ci/smoke-unica-mcp.py
+++ b/scripts/ci/smoke-unica-mcp.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Run a packaged Unica binary through MCP initialize and tools/list."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REQUIRED_TOOLS = {
+    "unica.project.status",
+    "unica.standards.search",
+    "unica.standards.explain",
+}
+
+
+def smoke(command: list[str], plugin_root: Path, timeout_seconds: float) -> None:
+    messages = [
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "unica-release-smoke", "version": "1"},
+            },
+        },
+        {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+        {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+    ]
+    request = "".join(json.dumps(message, separators=(",", ":")) + "\n" for message in messages)
+    environment = os.environ.copy()
+    environment["UNICA_PLUGIN_ROOT"] = str(plugin_root.resolve())
+    try:
+        result = subprocess.run(
+            command,
+            input=request,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+            env=environment,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise SystemExit(f"Unica MCP smoke timed out after {timeout_seconds:g}s") from error
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no process output"
+        raise SystemExit(f"Unica MCP exited with {result.returncode}: {detail}")
+
+    responses: dict[int, dict] = {}
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise SystemExit(f"Unica MCP emitted invalid JSON: {error}: {line}") from error
+        if isinstance(value, dict) and isinstance(value.get("id"), int):
+            responses[value["id"]] = value
+
+    initialize = responses.get(1, {})
+    if "result" not in initialize:
+        raise SystemExit("Unica MCP initialize response is missing")
+    tools = responses.get(2, {}).get("result", {}).get("tools")
+    if not isinstance(tools, list):
+        raise SystemExit("Unica MCP tools/list response is missing")
+    names = {
+        tool.get("name")
+        for tool in tools
+        if isinstance(tool, dict) and isinstance(tool.get("name"), str)
+    }
+    missing = sorted(REQUIRED_TOOLS - names)
+    if missing:
+        raise SystemExit(f"Unica MCP tools/list is missing: {', '.join(missing)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", required=True)
+    parser.add_argument("--binary-arg", action="append", default=[])
+    parser.add_argument("--plugin-root", required=True, type=Path)
+    parser.add_argument("--timeout-seconds", type=float, default=20)
+    args = parser.parse_args()
+    smoke([args.binary, *args.binary_arg], args.plugin_root, args.timeout_seconds)
+    print("verified Unica MCP initialize and tools/list")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/ci/test_install_unica_script.py
+++ b/tests/ci/test_install_unica_script.py
@@ -65,7 +65,7 @@ class InstallUnicaScriptTests(unittest.TestCase):
                 "https://github.com/IngvarConsulting/unica-marketplace.git",
                 calls[1],
             )
-            self.assertTrue(any("fetch --depth 1 origin refs/tags/v0.7.0" in line for line in calls))
+            self.assertTrue(any("fetch --depth 1 origin refs/tags/v0.7.1" in line for line in calls))
             bootstrap_calls = [line for line in calls if line.startswith("bootstrap ")]
             self.assertEqual(
                 bootstrap_calls,
@@ -103,7 +103,7 @@ if [ "$1" = "clone" ]; then
   eval "destination=\${$#}"
   mkdir -p "$destination/.agents/plugins"
   mkdir -p "$destination/plugins/unica/bootstrap/bin/linux-x64"
-  printf '%s\n' '{"name":"unica","plugins":[{"name":"unica","source":{"source":"git-subdir","url":"https://github.com/IngvarConsulting/unica-marketplace.git","path":"./plugins/unica","ref":"v0.7.0"}}]}' > "$destination/.agents/plugins/marketplace.json"
+  printf '%s\n' '{"name":"unica","plugins":[{"name":"unica","source":{"source":"git-subdir","url":"https://github.com/IngvarConsulting/unica-marketplace.git","path":"./plugins/unica","ref":"v0.7.1"}}]}' > "$destination/.agents/plugins/marketplace.json"
   cat > "$destination/plugins/unica/bootstrap/bin/linux-x64/unica-bootstrap" <<'BOOTSTRAP'
 #!/bin/sh
 printf 'bootstrap %s CODEX_HOME=%s\n' "$1" "$CODEX_HOME" >> "$UNICA_TEST_LOG"

--- a/tests/ci/test_package_unica_plugin.py
+++ b/tests/ci/test_package_unica_plugin.py
@@ -634,7 +634,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
                             "schemaVersion": 1,
                             "target": target,
                             "targetTriple": target_triple,
-                            "pluginVersion": "0.7.0",
+                            "pluginVersion": "0.7.1",
                             "asset": {
                                 "name": f"unica-runtime-{target}.tar.gz",
                                 "mediaType": "application/gzip",
@@ -663,7 +663,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
                 "--bootstrap-root",
                 str(bootstrap_root),
                 "--release-tag",
-                "v0.7.0",
+                "v0.7.1",
                 "--source-commit",
                 "a" * 40,
                 "--out-dir",
@@ -690,13 +690,13 @@ class PackageUnicaPluginTests(unittest.TestCase):
             )
             self.assertFalse(runtime_manifest["development"])
             self.assertEqual(runtime_manifest["source"]["commit"], "a" * 40)
-            self.assertEqual(runtime_manifest["release"]["tag"], "v0.7.0")
+            self.assertEqual(runtime_manifest["release"]["tag"], "v0.7.1")
             self.assertEqual(sorted(runtime_manifest["targets"]), sorted(target_triples))
             for target, target_data in runtime_manifest["targets"].items():
                 self.assertEqual(
                     target_data["asset"]["url"],
                     "https://github.com/IngvarConsulting/unica/releases/download/"
-                    f"v0.7.0/unica-runtime-{target}.tar.gz",
+                    f"v0.7.1/unica-runtime-{target}.tar.gz",
                 )
 
             catalog = json.loads(
@@ -706,7 +706,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
             )
             source = catalog["plugins"][0]["source"]
             self.assertEqual(source["source"], "git-subdir")
-            self.assertEqual(source["ref"], "v0.7.0")
+            self.assertEqual(source["ref"], "v0.7.1")
             self.assertEqual(source["path"], "./plugins/unica")
             self.assertNotIn("source\": \"local", json.dumps(catalog))
             self.assertEqual(list(out_dir.glob("*.tar.gz")), [])

--- a/tests/ci/test_product_contracts.py
+++ b/tests/ci/test_product_contracts.py
@@ -65,7 +65,7 @@ class ProductContractTests(unittest.TestCase):
         paths = [
             repo_root / "README.md",
             repo_root / "plugins/unica/README.md",
-            repo_root / "docs/releases/v0.7.0.md",
+            repo_root / "docs/releases/v0.7.1.md",
             repo_root / "spec/acceptance/unica-mcp-validation.md",
             repo_root / "spec/architecture/arc42/06-runtime-view.md",
             repo_root / "spec/architecture/arc42/07-deployment-view.md",

--- a/tests/ci/test_smoke_unica_mcp.py
+++ b/tests/ci/test_smoke_unica_mcp.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SMOKE_SCRIPT = REPO_ROOT / "scripts" / "ci" / "smoke-unica-mcp.py"
+
+
+class SmokeUnicaMcpTests(unittest.TestCase):
+    def run_smoke(self, server_source: str) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            server = root / "server.py"
+            server.write_text(textwrap.dedent(server_source), encoding="utf-8")
+            return subprocess.run(
+                [
+                    sys.executable,
+                    str(SMOKE_SCRIPT),
+                    "--binary",
+                    sys.executable,
+                    "--binary-arg",
+                    str(server),
+                    "--plugin-root",
+                    str(root),
+                    "--timeout-seconds",
+                    "2",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+    def test_accepts_initialize_and_required_tool_responses(self) -> None:
+        result = self.run_smoke(
+            """
+            import json
+            import sys
+
+            for line in sys.stdin:
+                message = json.loads(line)
+                if message.get("method") == "initialize":
+                    print(json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}), flush=True)
+                elif message.get("method") == "tools/list":
+                    tools = [
+                        {"name": "unica.project.status"},
+                        {"name": "unica.standards.search"},
+                        {"name": "unica.standards.explain"},
+                    ]
+                    print(json.dumps({"jsonrpc": "2.0", "id": 2, "result": {"tools": tools}}), flush=True)
+            """
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("verified Unica MCP initialize and tools/list", result.stdout)
+
+    def test_rejects_runtime_missing_a_required_tool(self) -> None:
+        result = self.run_smoke(
+            """
+            import json
+            import sys
+
+            for line in sys.stdin:
+                message = json.loads(line)
+                if message.get("method") == "initialize":
+                    print(json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}), flush=True)
+                elif message.get("method") == "tools/list":
+                    print(json.dumps({"jsonrpc": "2.0", "id": 2, "result": {"tools": []}}), flush=True)
+            """
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unica.standards.explain", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -36,6 +36,7 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         self.assertIn("scripts/ci/build-unica-tools.py", text)
         self.assertIn("scripts/ci/package-unica-runtime.py", text)
         self.assertIn("scripts/ci/package-unica-plugin.py", text)
+        self.assertIn("scripts/ci/smoke-unica-mcp.py", text)
         self.assertIn("--runtime-metadata-root", text)
         self.assertIn("--bootstrap-root", text)
         self.assertIn("name: unica-thin-marketplace", text)

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -39,6 +39,8 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         self.assertIn("--runtime-metadata-root", text)
         self.assertIn("--bootstrap-root", text)
         self.assertIn("name: unica-thin-marketplace", text)
+        thin_upload = text[text.index("name: unica-thin-marketplace") :]
+        self.assertIn("include-hidden-files: true", thin_upload)
         self.assertNotIn("unica-codex-marketplace-${{ matrix.target }}", text)
 
     def test_release_assets_are_published_without_pages_dependency_and_redownloaded(self) -> None:
@@ -86,6 +88,9 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         self.assertIn("codex/promote-", text)
         self.assertIn("git ls-remote", text)
         self.assertIn("refs/tags/", text)
+        self.assertIn("payload/plugins/unica/.codex-plugin/plugin.json", text)
+        self.assertIn("payload/plugins/unica/.mcp.json", text)
+        self.assertIn("payload/.agents/plugins/marketplace.json", text)
         self.assertNotIn("git tag -f", text)
         self.assertNotIn("--force", text)
 

--- a/tests/ci/test_version_contract.py
+++ b/tests/ci/test_version_contract.py
@@ -19,7 +19,7 @@ def load_module():
 
 
 class VersionContractTests(unittest.TestCase):
-    def test_repository_versions_are_exactly_0_7_0(self) -> None:
+    def test_repository_versions_are_exactly_0_7_1(self) -> None:
         module = load_module()
 
         values = module.read_version_contract(REPO_ROOT)
@@ -27,9 +27,9 @@ class VersionContractTests(unittest.TestCase):
         self.assertEqual(
             values,
             {
-                "workspace": "0.7.0",
-                "plugin": "0.7.0",
-                "tools-lock-unica": "0.7.0",
+                "workspace": "0.7.1",
+                "plugin": "0.7.1",
+                "tools-lock-unica": "0.7.1",
             },
         )
 


### PR DESCRIPTION
Follow-up to #123 after published-runtime staging proof.

Two release blockers were found before stable catalog promotion:

1. `actions/upload-artifact@v4` excludes dotfiles unless explicitly enabled, so preserve `.mcp.json`, `.codex-plugin/plugin.json`, and `.agents/plugins/marketplace.json`, with pre-publication guards.
2. The immutable `v0.7.0` Windows executable reserves a 1 MiB main stack and aborts while constructing the MCP application. Run the Windows application loop on an explicit 8 MiB thread and add a real packaged `initialize`/`tools/list` smoke to every build target.

Bumps the unified contract to `0.7.1`; `v0.7.0` remains immutable and was never promoted in the marketplace.