### PR TITLE
Fix marketplace cross-repository Git authentication

### DIFF
--- a/.github/workflows/publish-unica-marketplace.yml
+++ b/.github/workflows/publish-unica-marketplace.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - name: Require explicit cross-repository credential
         run: test -n "$GH_TOKEN"
+      - name: Configure Git credentials
+        run: gh auth setup-git
       - uses: actions/checkout@v4
       - name: Download verified thin payload
         run: gh run download "$SOURCE_RUN_ID" --repo IngvarConsulting/unica --name unica-thin-marketplace --dir payload
@@ -88,6 +90,8 @@ jobs:
           tag_commit="$(git ls-remote --exit-code --tags https://github.com/IngvarConsulting/unica-marketplace.git \
             "refs/tags/${RELEASE_TAG}^{}" | cut -f1)"
           test "$tag_commit" = "$STAGING_MERGE_SHA"
+      - name: Configure Git credentials
+        run: gh auth setup-git
       - name: Download catalog candidate
         run: gh run download "$SOURCE_RUN_ID" --repo IngvarConsulting/unica --name unica-thin-marketplace --dir payload
       - name: Require stable catalog candidate

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -76,6 +76,11 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         self.assertIn("GH_TOKEN: ${{ secrets.UNICA_MARKETPLACE_TOKEN }}", publish)
         self.assertNotIn("pull-requests: write", publish)
 
+    def test_cross_repository_push_configures_git_credentials(self) -> None:
+        publish = self.publish_text()
+
+        self.assertGreaterEqual(publish.count("gh auth setup-git"), 2)
+
     def test_staging_and_promotion_are_explicit_separate_jobs(self) -> None:
         text = self.publish_text()
 


### PR DESCRIPTION
Fixes the root cause found in the first v0.7.1 staging attempt: `GH_TOKEN` authenticated `gh`, but plain `git push` had no credential helper.

- configures Git through `gh auth setup-git` in both staging and promotion jobs
- adds a regression guard for both write paths

This does not change the already verified v0.7.1 runtime or plugin payload.