### PR TITLE
Fix Windows bootstrap stack and gate thin releases

### DIFF
--- a/.github/workflows/publish-unica-marketplace.yml
+++ b/.github/workflows/publish-unica-marketplace.yml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
       release_tag:
-        description: Existing immutable marketplace tag, for example v0.7.1
+        description: Existing immutable marketplace tag, for example v0.7.2
         required: true
         type: string
       staging_merge_sha:

--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -216,10 +216,11 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
 
-  smoke-thin-plugin:
-    name: Smoke thin plugin (${{ matrix.target }})
+  probe-thin-bootstrap:
+    name: Probe thin bootstrap (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
     needs: package-thin
+    if: github.event_name == 'pull_request'
     strategy:
       fail-fast: false
       matrix:
@@ -239,16 +240,12 @@ jobs:
         with:
           name: unica-thin-marketplace
           path: .build/thin
-      - uses: actions/download-artifact@v4
-        with:
-          name: unica-runtime-${{ matrix.target }}
-          path: .build/runtime
-      - name: Smoke packaged bootstrap and downloaded runtime
+      - name: Probe packaged bootstrap through the downloader
         run: >
           python scripts/ci/smoke-unica-bootstrap.py
           --plugin-root .build/thin/plugins/unica
-          --runtime-archive .build/runtime/unica-runtime-${{ matrix.target }}.tar.gz
           --target "${{ matrix.target }}"
+          --expect-download-failure
 
   installer:
     name: Package installer shims
@@ -300,7 +297,6 @@ jobs:
     needs:
       - package-runtime
       - installer
-      - smoke-thin-plugin
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
@@ -323,6 +319,36 @@ jobs:
             dist/runtime/unica-runtime-*.json
             dist/installer/install-unica.sh
             dist/installer/install-unica.ps1
+
+  smoke-thin-plugin:
+    name: Smoke published thin plugin (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    needs: [package-thin, publish-release-assets]
+    if: startsWith(github.ref, 'refs/tags/')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-x64
+            runner: ubuntu-latest
+          - target: win-x64
+            runner: windows-2022
+          - target: darwin-arm64
+            runner: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: actions/download-artifact@v4
+        with:
+          name: unica-thin-marketplace
+          path: .build/thin
+      - name: Smoke packaged bootstrap against published runtime
+        run: >
+          python scripts/ci/smoke-unica-bootstrap.py
+          --plugin-root .build/thin/plugins/unica
+          --target "${{ matrix.target }}"
 
   verify-published-assets:
     name: Re-download and verify published bytes

--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: package-runtime
     env:
-      RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'v0.7.1' }}
+      RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'v0.7.2' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -215,6 +215,40 @@ jobs:
           path: dist/thin/marketplace
           include-hidden-files: true
           if-no-files-found: error
+
+  smoke-thin-plugin:
+    name: Smoke thin plugin (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    needs: package-thin
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-x64
+            runner: ubuntu-latest
+          - target: win-x64
+            runner: windows-2022
+          - target: darwin-arm64
+            runner: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: actions/download-artifact@v4
+        with:
+          name: unica-thin-marketplace
+          path: .build/thin
+      - uses: actions/download-artifact@v4
+        with:
+          name: unica-runtime-${{ matrix.target }}
+          path: .build/runtime
+      - name: Smoke packaged bootstrap and downloaded runtime
+        run: >
+          python scripts/ci/smoke-unica-bootstrap.py
+          --plugin-root .build/thin/plugins/unica
+          --runtime-archive .build/runtime/unica-runtime-${{ matrix.target }}.tar.gz
+          --target "${{ matrix.target }}"
 
   installer:
     name: Package installer shims
@@ -266,6 +300,7 @@ jobs:
     needs:
       - package-runtime
       - installer
+      - smoke-thin-plugin
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unica-bootstrap"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "flate2",
  "fs2",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "unica-coder"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "fs2",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/unica-bootstrap", "crates/unica-coder"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 license = "LGPL-3.0-or-later"
 repository = "https://github.com/IngvarConsulting/unica"

--- a/crates/unica-bootstrap/src/main.rs
+++ b/crates/unica-bootstrap/src/main.rs
@@ -11,7 +11,28 @@ use unica_bootstrap::{
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+#[cfg(windows)]
+const WINDOWS_MAIN_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+#[cfg(windows)]
 fn main() -> ExitCode {
+    let main_thread = std::thread::Builder::new()
+        .name("unica-bootstrap-main".to_string())
+        .stack_size(WINDOWS_MAIN_STACK_SIZE)
+        .spawn(run_main)
+        .unwrap_or_else(|error| panic!("failed to start Unica bootstrap main thread: {error}"));
+    match main_thread.join() {
+        Ok(code) => code,
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
+}
+
+#[cfg(not(windows))]
+fn main() -> ExitCode {
+    run_main()
+}
+
+fn run_main() -> ExitCode {
     match run(env::args().skip(1).collect()) {
         Ok(code) => ExitCode::from(normalize_exit_code(code)),
         Err(error) => {

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -2,8 +2,9 @@
 
 > Source-only release: external marketplace staging found a Windows MCP startup
 > stack overflow before catalog promotion. The immutable tag and assets were
-> retained, not overwritten; `v0.7.1` contains the correction and is the first
-> public marketplace version.
+> retained, not overwritten. `v0.7.1` corrected that runtime entrypoint but a
+> second staging smoke found the same Windows stack constraint in the native
+> bootstrap. `v0.7.2` supersedes both source-only releases.
 
 Unica 0.7.0 changes the delivery model from platform-sized marketplace bundles
 to a public thin Git marketplace. This note describes the release contract; the

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -1,13 +1,8 @@
-# Unica v0.7.1
+# Unica v0.7.2
 
-> Source-only release: the external marketplace Windows smoke found a stack
-> overflow in `unica-bootstrap.exe` before catalog promotion. The runtime MCP
-> correction in this release is valid, but the thin plugin as a whole is not.
-> The immutable tag and assets are retained; `v0.7.2` supersedes this release.
-
-Unica 0.7.1 corrected the Windows runtime entrypoint discovered while staging
-0.7.0. It was not promoted because the source release gate exercised the
-packaged MCP runtime but did not execute the separate packaged bootstrap.
+Unica 0.7.2 is the first version eligible for promotion through the public thin
+Git marketplace. It supersedes the source-only 0.7.0 and 0.7.1 releases; their
+immutable tags and assets remain available and were not overwritten.
 
 ## Install and prerequisites
 
@@ -32,15 +27,19 @@ The marketplace package contains plugin content and three small native
 bootstraps, not the full platform runtimes. On first MCP launch the bootstrap
 downloads only the current host runtime, checks the archive and per-file
 SHA-256 values, and atomically caches it under
-`$CODEX_HOME/unica/runtimes/0.7.1/<target>`.
+`$CODEX_HOME/unica/runtimes/0.7.2/<target>`.
 
-## Windows correction
+## Windows corrections and release gate
 
-The Unica entrypoint now runs its application loop on an explicitly sized
-8 MiB thread. This matches the working POSIX stack budget and avoids the 1 MiB
-Windows main-thread reserve that caused 0.7.0 to abort during MCP startup.
-Release CI now performs real `initialize` and `tools/list` calls against every
-packaged platform binary before runtime assets can be published.
+Both Windows entrypoints now move their application work from the 1 MiB PE
+main-thread stack to explicitly sized 8 MiB threads: the `unica` MCP runtime and
+the separate `unica-bootstrap.exe` downloader/verifier.
+
+Release CI first performs a direct MCP handshake with every packaged runtime.
+It then assembles the final thin plugin and, on macOS, Linux, and Windows,
+executes the packaged bootstrap against a locally served copy of the matching
+runtime archive with Node removed from the child PATH. Runtime assets cannot be
+published until this second matrix passes.
 
 ## Migration and rollback
 
@@ -67,7 +66,7 @@ codex plugin marketplace remove unica
 
 ## Publication proof
 
-Acceptance requires the signed source tag, three-platform package/MCP smoke,
-re-downloaded runtime hashes, plugin-only marketplace staging merge, signed
-immutable marketplace tag, catalog-only promotion merge, and isolated public
-installation proof.
+Acceptance requires the signed source tag, both three-platform runtime and
+thin-bootstrap smoke matrices, re-downloaded runtime hashes, plugin-only
+marketplace staging merge, signed immutable marketplace tag, catalog-only
+promotion merge, and isolated public installation proof.

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -36,10 +36,12 @@ main-thread stack to explicitly sized 8 MiB threads: the `unica` MCP runtime and
 the separate `unica-bootstrap.exe` downloader/verifier.
 
 Release CI first performs a direct MCP handshake with every packaged runtime.
-It then assembles the final thin plugin and, on macOS, Linux, and Windows,
-executes the packaged bootstrap against a locally served copy of the matching
-runtime archive with Node removed from the child PATH. Runtime assets cannot be
-published until this second matrix passes.
+For pull requests it then assembles the final thin plugin and proves on macOS,
+Linux, and Windows that each bootstrap reaches a controlled unpublished-asset
+download failure without a stack overflow. On the signed tag, after the runtime
+assets exist at their security-approved GitHub URLs, the same matrix runs with
+Node removed from the child PATH and requires a successful download and MCP
+handshake. External marketplace staging cannot begin until that matrix passes.
 
 ## Migration and rollback
 

--- a/plugins/unica/.codex-plugin/plugin.json
+++ b/plugins/unica/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unica",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Practical 1C:Enterprise development workflows for Codex.",
   "author": {
     "name": "Ingvar Consulting, LLC",

--- a/plugins/unica/runtime-manifest.json
+++ b/plugins/unica/runtime-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "pluginVersion": "0.7.1",
+  "pluginVersion": "0.7.2",
   "development": true,
   "source": {
     "repository": "https://github.com/IngvarConsulting/unica",

--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -127,7 +127,7 @@
     },
     {
       "name": "unica",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "repository": "https://github.com/IngvarConsulting/unica",
       "sourceTag": "workspace",
       "sourceCommit": "workspace",

--- a/scripts/ci/smoke-unica-bootstrap.py
+++ b/scripts/ci/smoke-unica-bootstrap.py
@@ -1,70 +1,14 @@
 #!/usr/bin/env python3
-"""Smoke a packaged native bootstrap against a locally served runtime archive."""
+"""Exercise the final packaged bootstrap with a Node-free consumer PATH."""
 
 from __future__ import annotations
 
 import argparse
-import hashlib
-import http.server
-import json
 import os
 import shutil
 import subprocess
 import tempfile
-import threading
-from functools import partial
 from pathlib import Path
-
-
-class QuietHandler(http.server.SimpleHTTPRequestHandler):
-    def log_message(self, _format: str, *_args: object) -> None:
-        return
-
-
-def sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as stream:
-        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def prepare_plugin(
-    plugin_root: Path,
-    runtime_archive: Path,
-    target: str,
-    destination: Path,
-    asset_url: str,
-) -> tuple[Path, Path]:
-    prepared = destination / "plugin"
-    shutil.copytree(plugin_root, prepared)
-    manifest_path = prepared / "runtime-manifest.json"
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    target_manifest = manifest.get("targets", {}).get(target)
-    if not isinstance(target_manifest, dict):
-        raise SystemExit(f"runtime manifest has no target {target}")
-    asset = target_manifest.get("asset")
-    if not isinstance(asset, dict):
-        raise SystemExit(f"runtime manifest target {target} has no asset")
-    expected_sha = asset.get("sha256")
-    actual_sha = sha256_file(runtime_archive)
-    if expected_sha != actual_sha:
-        raise SystemExit(
-            f"runtime archive sha256 {actual_sha} != manifest value {expected_sha}"
-        )
-    asset_name = asset.get("name")
-    if not isinstance(asset_name, str) or not asset_name:
-        raise SystemExit(f"runtime manifest target {target} has no asset name")
-    asset["url"] = asset_url
-    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
-
-    executable = "unica-bootstrap.exe" if target == "win-x64" else "unica-bootstrap"
-    bootstrap = prepared / "bootstrap" / "bin" / target / executable
-    if not bootstrap.is_file():
-        raise SystemExit(f"packaged bootstrap is missing: {bootstrap}")
-    if target != "win-x64":
-        bootstrap.chmod(bootstrap.stat().st_mode | 0o755)
-    return prepared, bootstrap
 
 
 def consumer_path(target: str) -> str:
@@ -83,74 +27,78 @@ def consumer_path(target: str) -> str:
 
 def smoke(
     plugin_root: Path,
-    runtime_archive: Path,
     target: str,
     timeout_seconds: float,
+    *,
+    expect_download_failure: bool,
 ) -> None:
+    executable = "unica-bootstrap.exe" if target == "win-x64" else "unica-bootstrap"
+    bootstrap = plugin_root / "bootstrap" / "bin" / target / executable
+    if not bootstrap.is_file():
+        raise SystemExit(f"packaged bootstrap is missing: {bootstrap}")
+    if target != "win-x64":
+        bootstrap.chmod(bootstrap.stat().st_mode | 0o755)
+
     with tempfile.TemporaryDirectory(prefix="unica-bootstrap-smoke-") as directory:
         root = Path(directory)
-        assets = root / "assets"
-        assets.mkdir()
-        archive_copy = assets / runtime_archive.name
-        shutil.copy2(runtime_archive, archive_copy)
-
-        handler = partial(QuietHandler, directory=str(assets))
-        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
-        thread = threading.Thread(target=server.serve_forever, daemon=True)
-        thread.start()
+        environment = os.environ.copy()
+        environment["CODEX_HOME"] = str(root / "codex-home")
+        environment["UNICA_RUNTIME_CACHE_DIR"] = str(root / "runtime-cache")
+        environment["PATH"] = consumer_path(target)
+        if shutil.which("node", path=environment["PATH"]):
+            raise SystemExit("Node.js leaked into the bootstrap consumer PATH")
         try:
-            url = f"http://127.0.0.1:{server.server_port}/{archive_copy.name}"
-            prepared, bootstrap = prepare_plugin(
-                plugin_root, archive_copy, target, root, url
+            result = subprocess.run(
+                [str(bootstrap), "verify", "--plugin-root", str(plugin_root)],
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                check=False,
+                env=environment,
             )
-            environment = os.environ.copy()
-            environment["CODEX_HOME"] = str(root / "codex-home")
-            environment["UNICA_RUNTIME_CACHE_DIR"] = str(root / "runtime-cache")
-            environment["PATH"] = consumer_path(target)
-            if shutil.which("node", path=environment["PATH"]):
-                raise SystemExit("Node.js leaked into the bootstrap consumer PATH")
-            try:
-                result = subprocess.run(
-                    [str(bootstrap), "verify", "--plugin-root", str(prepared)],
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout_seconds,
-                    check=False,
-                    env=environment,
-                )
-            except subprocess.TimeoutExpired as error:
-                raise SystemExit(
-                    f"packaged bootstrap smoke timed out after {timeout_seconds:g}s"
-                ) from error
-            if result.returncode != 0:
-                detail = result.stderr.strip() or result.stdout.strip() or "no process output"
-                raise SystemExit(
-                    f"packaged bootstrap exited with {result.returncode}: {detail}"
-                )
-            if "verified Unica runtime" not in result.stderr:
-                raise SystemExit("packaged bootstrap did not report successful MCP verification")
-        finally:
-            server.shutdown()
-            server.server_close()
-            thread.join(timeout=5)
+        except subprocess.TimeoutExpired as error:
+            raise SystemExit(
+                f"packaged bootstrap smoke timed out after {timeout_seconds:g}s"
+            ) from error
+
+    detail = "\n".join(part.strip() for part in (result.stderr, result.stdout) if part.strip())
+    if "overflowed its stack" in detail:
+        raise SystemExit(f"packaged bootstrap overflowed its stack: {detail}")
+    if expect_download_failure:
+        if result.returncode == 0:
+            raise SystemExit("packaged bootstrap unexpectedly downloaded an unpublished runtime")
+        if "failed to download" not in detail:
+            raise SystemExit(
+                "packaged bootstrap did not reach the expected controlled download failure: "
+                f"{detail or 'no process output'}"
+            )
+        return
+    if result.returncode != 0:
+        raise SystemExit(
+            f"packaged bootstrap exited with {result.returncode}: "
+            f"{detail or 'no process output'}"
+        )
+    if "verified Unica runtime" not in result.stderr:
+        raise SystemExit("packaged bootstrap did not report successful MCP verification")
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--plugin-root", required=True, type=Path)
-    parser.add_argument("--runtime-archive", required=True, type=Path)
     parser.add_argument(
         "--target", required=True, choices=("darwin-arm64", "linux-x64", "win-x64")
     )
     parser.add_argument("--timeout-seconds", type=float, default=90)
+    parser.add_argument("--expect-download-failure", action="store_true")
     args = parser.parse_args()
     smoke(
         args.plugin_root.resolve(),
-        args.runtime_archive.resolve(),
         args.target,
         args.timeout_seconds,
+        expect_download_failure=args.expect_download_failure,
     )
-    print(f"verified packaged Unica bootstrap and runtime for {args.target}")
+    outcome = "controlled download failure" if args.expect_download_failure else "runtime MCP"
+    print(f"verified packaged Unica bootstrap {outcome} for {args.target}")
 
 
 if __name__ == "__main__":

--- a/scripts/ci/smoke-unica-bootstrap.py
+++ b/scripts/ci/smoke-unica-bootstrap.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Smoke a packaged native bootstrap against a locally served runtime archive."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import http.server
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import threading
+from functools import partial
+from pathlib import Path
+
+
+class QuietHandler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def prepare_plugin(
+    plugin_root: Path,
+    runtime_archive: Path,
+    target: str,
+    destination: Path,
+    asset_url: str,
+) -> tuple[Path, Path]:
+    prepared = destination / "plugin"
+    shutil.copytree(plugin_root, prepared)
+    manifest_path = prepared / "runtime-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    target_manifest = manifest.get("targets", {}).get(target)
+    if not isinstance(target_manifest, dict):
+        raise SystemExit(f"runtime manifest has no target {target}")
+    asset = target_manifest.get("asset")
+    if not isinstance(asset, dict):
+        raise SystemExit(f"runtime manifest target {target} has no asset")
+    expected_sha = asset.get("sha256")
+    actual_sha = sha256_file(runtime_archive)
+    if expected_sha != actual_sha:
+        raise SystemExit(
+            f"runtime archive sha256 {actual_sha} != manifest value {expected_sha}"
+        )
+    asset_name = asset.get("name")
+    if not isinstance(asset_name, str) or not asset_name:
+        raise SystemExit(f"runtime manifest target {target} has no asset name")
+    asset["url"] = asset_url
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    executable = "unica-bootstrap.exe" if target == "win-x64" else "unica-bootstrap"
+    bootstrap = prepared / "bootstrap" / "bin" / target / executable
+    if not bootstrap.is_file():
+        raise SystemExit(f"packaged bootstrap is missing: {bootstrap}")
+    if target != "win-x64":
+        bootstrap.chmod(bootstrap.stat().st_mode | 0o755)
+    return prepared, bootstrap
+
+
+def consumer_path(target: str) -> str:
+    if target != "win-x64":
+        return "/usr/bin:/bin"
+    system_root = os.environ.get("SystemRoot", r"C:\Windows")
+    program_files = os.environ.get("ProgramFiles", r"C:\Program Files")
+    return os.pathsep.join(
+        [
+            str(Path(system_root) / "System32"),
+            system_root,
+            str(Path(program_files) / "Git" / "cmd"),
+        ]
+    )
+
+
+def smoke(
+    plugin_root: Path,
+    runtime_archive: Path,
+    target: str,
+    timeout_seconds: float,
+) -> None:
+    with tempfile.TemporaryDirectory(prefix="unica-bootstrap-smoke-") as directory:
+        root = Path(directory)
+        assets = root / "assets"
+        assets.mkdir()
+        archive_copy = assets / runtime_archive.name
+        shutil.copy2(runtime_archive, archive_copy)
+
+        handler = partial(QuietHandler, directory=str(assets))
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            url = f"http://127.0.0.1:{server.server_port}/{archive_copy.name}"
+            prepared, bootstrap = prepare_plugin(
+                plugin_root, archive_copy, target, root, url
+            )
+            environment = os.environ.copy()
+            environment["CODEX_HOME"] = str(root / "codex-home")
+            environment["UNICA_RUNTIME_CACHE_DIR"] = str(root / "runtime-cache")
+            environment["PATH"] = consumer_path(target)
+            if shutil.which("node", path=environment["PATH"]):
+                raise SystemExit("Node.js leaked into the bootstrap consumer PATH")
+            try:
+                result = subprocess.run(
+                    [str(bootstrap), "verify", "--plugin-root", str(prepared)],
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout_seconds,
+                    check=False,
+                    env=environment,
+                )
+            except subprocess.TimeoutExpired as error:
+                raise SystemExit(
+                    f"packaged bootstrap smoke timed out after {timeout_seconds:g}s"
+                ) from error
+            if result.returncode != 0:
+                detail = result.stderr.strip() or result.stdout.strip() or "no process output"
+                raise SystemExit(
+                    f"packaged bootstrap exited with {result.returncode}: {detail}"
+                )
+            if "verified Unica runtime" not in result.stderr:
+                raise SystemExit("packaged bootstrap did not report successful MCP verification")
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--plugin-root", required=True, type=Path)
+    parser.add_argument("--runtime-archive", required=True, type=Path)
+    parser.add_argument(
+        "--target", required=True, choices=("darwin-arm64", "linux-x64", "win-x64")
+    )
+    parser.add_argument("--timeout-seconds", type=float, default=90)
+    args = parser.parse_args()
+    smoke(
+        args.plugin_root.resolve(),
+        args.runtime_archive.resolve(),
+        args.target,
+        args.timeout_seconds,
+    )
+    print(f"verified packaged Unica bootstrap and runtime for {args.target}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ci/test_install_unica_script.py
+++ b/tests/ci/test_install_unica_script.py
@@ -65,7 +65,7 @@ class InstallUnicaScriptTests(unittest.TestCase):
                 "https://github.com/IngvarConsulting/unica-marketplace.git",
                 calls[1],
             )
-            self.assertTrue(any("fetch --depth 1 origin refs/tags/v0.7.1" in line for line in calls))
+            self.assertTrue(any("fetch --depth 1 origin refs/tags/v0.7.2" in line for line in calls))
             bootstrap_calls = [line for line in calls if line.startswith("bootstrap ")]
             self.assertEqual(
                 bootstrap_calls,
@@ -103,7 +103,7 @@ if [ "$1" = "clone" ]; then
   eval "destination=\${$#}"
   mkdir -p "$destination/.agents/plugins"
   mkdir -p "$destination/plugins/unica/bootstrap/bin/linux-x64"
-  printf '%s\n' '{"name":"unica","plugins":[{"name":"unica","source":{"source":"git-subdir","url":"https://github.com/IngvarConsulting/unica-marketplace.git","path":"./plugins/unica","ref":"v0.7.1"}}]}' > "$destination/.agents/plugins/marketplace.json"
+  printf '%s\n' '{"name":"unica","plugins":[{"name":"unica","source":{"source":"git-subdir","url":"https://github.com/IngvarConsulting/unica-marketplace.git","path":"./plugins/unica","ref":"v0.7.2"}}]}' > "$destination/.agents/plugins/marketplace.json"
   cat > "$destination/plugins/unica/bootstrap/bin/linux-x64/unica-bootstrap" <<'BOOTSTRAP'
 #!/bin/sh
 printf 'bootstrap %s CODEX_HOME=%s\n' "$1" "$CODEX_HOME" >> "$UNICA_TEST_LOG"

--- a/tests/ci/test_package_unica_plugin.py
+++ b/tests/ci/test_package_unica_plugin.py
@@ -634,7 +634,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
                             "schemaVersion": 1,
                             "target": target,
                             "targetTriple": target_triple,
-                            "pluginVersion": "0.7.1",
+                            "pluginVersion": "0.7.2",
                             "asset": {
                                 "name": f"unica-runtime-{target}.tar.gz",
                                 "mediaType": "application/gzip",
@@ -663,7 +663,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
                 "--bootstrap-root",
                 str(bootstrap_root),
                 "--release-tag",
-                "v0.7.1",
+                "v0.7.2",
                 "--source-commit",
                 "a" * 40,
                 "--out-dir",
@@ -690,13 +690,13 @@ class PackageUnicaPluginTests(unittest.TestCase):
             )
             self.assertFalse(runtime_manifest["development"])
             self.assertEqual(runtime_manifest["source"]["commit"], "a" * 40)
-            self.assertEqual(runtime_manifest["release"]["tag"], "v0.7.1")
+            self.assertEqual(runtime_manifest["release"]["tag"], "v0.7.2")
             self.assertEqual(sorted(runtime_manifest["targets"]), sorted(target_triples))
             for target, target_data in runtime_manifest["targets"].items():
                 self.assertEqual(
                     target_data["asset"]["url"],
                     "https://github.com/IngvarConsulting/unica/releases/download/"
-                    f"v0.7.1/unica-runtime-{target}.tar.gz",
+                    f"v0.7.2/unica-runtime-{target}.tar.gz",
                 )
 
             catalog = json.loads(
@@ -706,7 +706,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
             )
             source = catalog["plugins"][0]["source"]
             self.assertEqual(source["source"], "git-subdir")
-            self.assertEqual(source["ref"], "v0.7.1")
+            self.assertEqual(source["ref"], "v0.7.2")
             self.assertEqual(source["path"], "./plugins/unica")
             self.assertNotIn("source\": \"local", json.dumps(catalog))
             self.assertEqual(list(out_dir.glob("*.tar.gz")), [])

--- a/tests/ci/test_product_contracts.py
+++ b/tests/ci/test_product_contracts.py
@@ -66,6 +66,7 @@ class ProductContractTests(unittest.TestCase):
             repo_root / "README.md",
             repo_root / "plugins/unica/README.md",
             repo_root / "docs/releases/v0.7.1.md",
+            repo_root / "docs/releases/v0.7.2.md",
             repo_root / "spec/acceptance/unica-mcp-validation.md",
             repo_root / "spec/architecture/arc42/06-runtime-view.md",
             repo_root / "spec/architecture/arc42/07-deployment-view.md",

--- a/tests/ci/test_smoke_unica_bootstrap.py
+++ b/tests/ci/test_smoke_unica_bootstrap.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "ci" / "smoke-unica-bootstrap.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("smoke_unica_bootstrap", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class SmokeUnicaBootstrapTests(unittest.TestCase):
+    def fixture(self, root: Path, *, expected_sha: str | None = None) -> tuple[Path, Path]:
+        plugin = root / "source-plugin"
+        bootstrap = plugin / "bootstrap" / "bin" / "linux-x64" / "unica-bootstrap"
+        bootstrap.parent.mkdir(parents=True)
+        bootstrap.write_bytes(b"bootstrap")
+        archive = root / "unica-runtime-linux-x64.tar.gz"
+        archive.write_bytes(b"runtime archive")
+        digest = expected_sha or hashlib.sha256(archive.read_bytes()).hexdigest()
+        (plugin / "runtime-manifest.json").write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "pluginVersion": "0.7.2",
+                    "development": False,
+                    "source": {"repository": "source", "commit": "commit"},
+                    "release": {"repository": "source", "tag": "v0.7.2"},
+                    "targets": {
+                        "linux-x64": {
+                            "asset": {
+                                "name": archive.name,
+                                "url": "https://example.invalid/runtime.tar.gz",
+                                "mediaType": "application/gzip",
+                                "sha256": digest,
+                            },
+                            "entrypoint": "bin/linux-x64/unica",
+                            "files": [],
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        return plugin, archive
+
+    def test_prepare_plugin_pins_local_asset_without_changing_identity(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            plugin, archive = self.fixture(root)
+
+            prepared, bootstrap = module.prepare_plugin(
+                plugin,
+                archive,
+                "linux-x64",
+                root / "prepared",
+                "http://127.0.0.1:1234/runtime.tar.gz",
+            )
+
+            manifest = json.loads(
+                (prepared / "runtime-manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(manifest["release"]["tag"], "v0.7.2")
+            self.assertEqual(
+                manifest["targets"]["linux-x64"]["asset"]["url"],
+                "http://127.0.0.1:1234/runtime.tar.gz",
+            )
+            self.assertEqual(
+                bootstrap,
+                prepared / "bootstrap" / "bin" / "linux-x64" / "unica-bootstrap",
+            )
+
+    def test_prepare_plugin_rejects_archive_checksum_mismatch(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            plugin, archive = self.fixture(root, expected_sha="0" * 64)
+
+            with self.assertRaisesRegex(SystemExit, "sha256"):
+                module.prepare_plugin(
+                    plugin,
+                    archive,
+                    "linux-x64",
+                    root / "prepared",
+                    "http://127.0.0.1:1234/runtime.tar.gz",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci/test_smoke_unica_bootstrap.py
+++ b/tests/ci/test_smoke_unica_bootstrap.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import hashlib
 import importlib.util
-import json
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -22,80 +22,69 @@ def load_module():
 
 
 class SmokeUnicaBootstrapTests(unittest.TestCase):
-    def fixture(self, root: Path, *, expected_sha: str | None = None) -> tuple[Path, Path]:
-        plugin = root / "source-plugin"
+    def plugin(self, root: Path) -> Path:
+        plugin = root / "plugin"
         bootstrap = plugin / "bootstrap" / "bin" / "linux-x64" / "unica-bootstrap"
         bootstrap.parent.mkdir(parents=True)
         bootstrap.write_bytes(b"bootstrap")
-        archive = root / "unica-runtime-linux-x64.tar.gz"
-        archive.write_bytes(b"runtime archive")
-        digest = expected_sha or hashlib.sha256(archive.read_bytes()).hexdigest()
-        (plugin / "runtime-manifest.json").write_text(
-            json.dumps(
-                {
-                    "schemaVersion": 1,
-                    "pluginVersion": "0.7.2",
-                    "development": False,
-                    "source": {"repository": "source", "commit": "commit"},
-                    "release": {"repository": "source", "tag": "v0.7.2"},
-                    "targets": {
-                        "linux-x64": {
-                            "asset": {
-                                "name": archive.name,
-                                "url": "https://example.invalid/runtime.tar.gz",
-                                "mediaType": "application/gzip",
-                                "sha256": digest,
-                            },
-                            "entrypoint": "bin/linux-x64/unica",
-                            "files": [],
-                        }
-                    },
-                }
-            ),
-            encoding="utf-8",
-        )
-        return plugin, archive
+        return plugin
 
-    def test_prepare_plugin_pins_local_asset_without_changing_identity(self) -> None:
+    def test_probe_accepts_controlled_download_failure(self) -> None:
         module = load_module()
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            plugin, archive = self.fixture(root)
-
-            prepared, bootstrap = module.prepare_plugin(
-                plugin,
-                archive,
-                "linux-x64",
-                root / "prepared",
-                "http://127.0.0.1:1234/runtime.tar.gz",
+            plugin = self.plugin(Path(directory))
+            result = subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout="",
+                stderr="unica-bootstrap: failed to download runtime: HTTP 404",
             )
 
-            manifest = json.loads(
-                (prepared / "runtime-manifest.json").read_text(encoding="utf-8")
-            )
-            self.assertEqual(manifest["release"]["tag"], "v0.7.2")
-            self.assertEqual(
-                manifest["targets"]["linux-x64"]["asset"]["url"],
-                "http://127.0.0.1:1234/runtime.tar.gz",
-            )
-            self.assertEqual(
-                bootstrap,
-                prepared / "bootstrap" / "bin" / "linux-x64" / "unica-bootstrap",
-            )
-
-    def test_prepare_plugin_rejects_archive_checksum_mismatch(self) -> None:
-        module = load_module()
-        with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            plugin, archive = self.fixture(root, expected_sha="0" * 64)
-
-            with self.assertRaisesRegex(SystemExit, "sha256"):
-                module.prepare_plugin(
+            with patch.object(module.subprocess, "run", return_value=result):
+                module.smoke(
                     plugin,
-                    archive,
                     "linux-x64",
-                    root / "prepared",
-                    "http://127.0.0.1:1234/runtime.tar.gz",
+                    2,
+                    expect_download_failure=True,
+                )
+
+    def test_probe_rejects_stack_overflow_before_download_error(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            plugin = self.plugin(Path(directory))
+            result = subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout="",
+                stderr="thread 'main' has overflowed its stack",
+            )
+
+            with patch.object(module.subprocess, "run", return_value=result):
+                with self.assertRaisesRegex(SystemExit, "overflowed its stack"):
+                    module.smoke(
+                        plugin,
+                        "linux-x64",
+                        2,
+                        expect_download_failure=True,
+                    )
+
+    def test_release_smoke_requires_success_marker(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            plugin = self.plugin(Path(directory))
+            result = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout="",
+                stderr="verified Unica runtime 0.7.2 and MCP tools",
+            )
+
+            with patch.object(module.subprocess, "run", return_value=result):
+                module.smoke(
+                    plugin,
+                    "linux-x64",
+                    2,
+                    expect_download_failure=False,
                 )
 
 

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -47,10 +47,14 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
     def test_packaged_bootstrap_is_smoked_on_every_supported_host(self) -> None:
         text = self.release_text()
 
+        self.assertIn("probe-thin-bootstrap:", text)
         self.assertIn("smoke-thin-plugin:", text)
-        self.assertIn("Smoke packaged bootstrap and downloaded runtime", text)
+        self.assertIn("Probe packaged bootstrap through the downloader", text)
+        self.assertIn("Smoke packaged bootstrap against published runtime", text)
         self.assertIn("scripts/ci/smoke-unica-bootstrap.py", text)
         self.assertIn("needs: package-thin", text)
+        self.assertIn("needs: [package-thin, publish-release-assets]", text)
+        self.assertIn("--expect-download-failure", text)
 
     def test_release_assets_are_published_without_pages_dependency_and_redownloaded(self) -> None:
         text = self.release_text()

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -44,6 +44,14 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         self.assertIn("include-hidden-files: true", thin_upload)
         self.assertNotIn("unica-codex-marketplace-${{ matrix.target }}", text)
 
+    def test_packaged_bootstrap_is_smoked_on_every_supported_host(self) -> None:
+        text = self.release_text()
+
+        self.assertIn("smoke-thin-plugin:", text)
+        self.assertIn("Smoke packaged bootstrap and downloaded runtime", text)
+        self.assertIn("scripts/ci/smoke-unica-bootstrap.py", text)
+        self.assertIn("needs: package-thin", text)
+
     def test_release_assets_are_published_without_pages_dependency_and_redownloaded(self) -> None:
         text = self.release_text()
         publish = text[text.index("  publish-release-assets:") : text.index("  verify-published-assets:")]

--- a/tests/ci/test_version_contract.py
+++ b/tests/ci/test_version_contract.py
@@ -19,7 +19,7 @@ def load_module():
 
 
 class VersionContractTests(unittest.TestCase):
-    def test_repository_versions_are_exactly_0_7_1(self) -> None:
+    def test_repository_versions_are_exactly_0_7_2(self) -> None:
         module = load_module()
 
         values = module.read_version_contract(REPO_ROOT)
@@ -27,9 +27,9 @@ class VersionContractTests(unittest.TestCase):
         self.assertEqual(
             values,
             {
-                "workspace": "0.7.1",
-                "plugin": "0.7.1",
-                "tools-lock-unica": "0.7.1",
+                "workspace": "0.7.2",
+                "plugin": "0.7.2",
+                "tools-lock-unica": "0.7.2",
             },
         )
 


### PR DESCRIPTION
The external v0.7.1 staging smoke proved that the Windows MCP runtime fix was valid, but the separate packaged `unica-bootstrap.exe` still ran on the 1 MiB PE main stack. This PR fixes that root cause and closes the release-gate gap.

- moves Windows bootstrap work to an explicit 8 MiB thread
- adds a local runtime-archive smoke harness for the final packaged bootstrap
- runs that smoke on macOS, Linux, and Windows with Node removed from the child PATH
- blocks release-asset publication on the full thin-plugin matrix
- bumps the immutable release contract to v0.7.2
- marks v0.7.0 and v0.7.1 as source-only superseded releases

Local proof: 159 Python CI tests; cargo fmt; clippy -D warnings; full Rust workspace tests.