### PR TITLE
release: stabilize Windows and MCP release gates for v0.7.4

### DIFF
--- a/.github/workflows/publish-unica-marketplace.yml
+++ b/.github/workflows/publish-unica-marketplace.yml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
       release_tag:
-        description: Existing immutable marketplace tag, for example v0.7.3
+        description: Existing immutable marketplace tag, for example v0.7.4
         required: true
         type: string
       staging_merge_sha:

--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: package-runtime
     env:
-      RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'v0.7.3' }}
+      RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'v0.7.4' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unica-bootstrap"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "flate2",
  "fs2",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "unica-coder"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "fs2",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/unica-bootstrap", "crates/unica-coder"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 license = "LGPL-3.0-or-later"
 repository = "https://github.com/IngvarConsulting/unica"

--- a/crates/unica-bootstrap/src/main.rs
+++ b/crates/unica-bootstrap/src/main.rs
@@ -291,14 +291,14 @@ mod tests {
     fn prompt_proof_searches_nested_skill_names_and_normalized_paths() {
         let proof = serde_json::json!({
             "content": [{
-                "text": r"- unica:code-search (file: C:\Codex\plugins\cache\unica\unica\0.7.3\skills\code-search\SKILL.md)"
+                "text": r"- unica:code-search (file: C:\Codex\plugins\cache\unica\unica\0.7.4\skills\code-search\SKILL.md)"
             }]
         });
 
         assert!(json_contains_text(&proof, "unica:code-search"));
         assert!(json_contains_normalized_path(
             &proof,
-            "c:/codex/plugins/cache/unica/unica/0.7.3/skills"
+            "c:/codex/plugins/cache/unica/unica/0.7.4/skills"
         ));
     }
 }

--- a/crates/unica-coder/src/domain/source_roots.rs
+++ b/crates/unica-coder/src/domain/source_roots.rs
@@ -203,6 +203,8 @@ fn normalize_lexically(path: &Path) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(windows)]
+    use super::strip_windows_extended_length_prefix;
     use super::{normalize_path_identity, resolve_source_root};
     use crate::domain::workspace::WorkspaceContext;
     use std::fs;
@@ -392,12 +394,12 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn extended_length_unc_paths_use_regular_unc_identity() {
+    fn extended_length_unc_prefix_is_stripped_without_filesystem_access() {
         let extended = PathBuf::from(r"\\?\UNC\server\share\source");
 
         assert_eq!(
             PathBuf::from(r"\\server\share\source"),
-            normalize_path_identity(&extended).unwrap()
+            strip_windows_extended_length_prefix(&extended)
         );
     }
 

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -4,7 +4,7 @@
 > stack overflow before catalog promotion. The immutable tag and assets were
 > retained, not overwritten. `v0.7.1` corrected that runtime entrypoint but a
 > second staging smoke found the same Windows stack constraint in the native
-> bootstrap. `v0.7.3` supersedes both source-only releases.
+> bootstrap. `v0.7.4` supersedes both source-only releases.
 
 Unica 0.7.0 changes the delivery model from platform-sized marketplace bundles
 to a public thin Git marketplace. This note describes the release contract; the

--- a/docs/releases/v0.7.1.md
+++ b/docs/releases/v0.7.1.md
@@ -3,7 +3,7 @@
 > Source-only release: the external marketplace Windows smoke found a stack
 > overflow in `unica-bootstrap.exe` before catalog promotion. The runtime MCP
 > correction in this release is valid, but the thin plugin as a whole is not.
-> The immutable tag and assets are retained; `v0.7.3` supersedes this release.
+> The immutable tag and assets are retained; `v0.7.4` supersedes this release.
 
 Unica 0.7.1 corrected the Windows runtime entrypoint discovered while staging
 0.7.0. It was not promoted because the source release gate exercised the

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -1,6 +1,6 @@
 # Unica v0.7.2
 
-> The immutable release remains available. Unica v0.7.3 supersedes it because
+> The immutable release remains available. Unica v0.7.4 supersedes it because
 > migration could leave an inactive legacy config entry and cache directories.
 
 Unica 0.7.2 is the first version eligible for promotion through the public thin

--- a/docs/releases/v0.7.3.md
+++ b/docs/releases/v0.7.3.md
@@ -1,5 +1,8 @@
 # Unica v0.7.3
 
+> The signed source tag is retained, but its Windows tag workflow failed before
+> any GitHub Release or marketplace publication. Unica v0.7.4 supersedes it.
+
 Unica 0.7.3 completes the public marketplace migration contract. It keeps the
 thin, Node-free runtime delivery introduced in 0.7.2 and fixes cleanup of
 legacy local installations whose inactive state is no longer returned by Codex

--- a/docs/releases/v0.7.4.md
+++ b/docs/releases/v0.7.4.md
@@ -1,0 +1,47 @@
+# Unica v0.7.4
+
+Unica 0.7.4 is the public release of the marketplace migration contract prepared
+in 0.7.3. The signed 0.7.3 source tag did not publish a GitHub Release because a
+Windows unit test accidentally probed a synthetic UNC network path. The test now
+exercises prefix normalization without filesystem or network access; production
+runtime behavior is unchanged.
+
+## Install and prerequisites
+
+Consumers need a compatible Codex CLI and standard Git (Git for Windows on
+Windows). Node.js, Python, HTTP download utilities, JSON utilities, and archive
+utilities are not installation prerequisites.
+
+```sh
+codex plugin marketplace add IngvarConsulting/unica-marketplace --ref main
+codex plugin add unica@unica
+```
+
+Open a new Codex task after installation.
+
+## Migration cleanup and rollback
+
+Preflight combines Codex JSON discovery with inspection of the two exact
+documented legacy cache locations and the old plugin config table. Before any
+mutation, the transaction copies the exact config and identified legacy paths
+into a private timestamped `$CODEX_HOME/unica/migration-backups/` directory.
+
+The transaction installs and checksum-verifies the pinned runtime, checks MCP
+`initialize` and `tools/list`, and verifies installed skills through a fresh
+`codex debug prompt-input` process before deleting legacy paths. Any failure
+restores the saved config, marketplace checkout, plugin cache, permissions, and
+legacy directories. A completed migration is idempotent.
+
+## Runtime and update
+
+The marketplace package remains thin and contains three native bootstrap
+binaries. The first MCP start downloads only the current host runtime and caches
+it atomically under `$CODEX_HOME/unica/runtimes/0.7.4/<target>`.
+
+```sh
+codex plugin marketplace upgrade unica
+codex plugin remove unica@unica
+codex plugin add unica@unica
+```
+
+Open a new Codex task after update.

--- a/plugins/unica/.codex-plugin/plugin.json
+++ b/plugins/unica/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unica",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Practical 1C:Enterprise development workflows for Codex.",
   "author": {
     "name": "Ingvar Consulting, LLC",

--- a/plugins/unica/runtime-manifest.json
+++ b/plugins/unica/runtime-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "pluginVersion": "0.7.3",
+  "pluginVersion": "0.7.4",
   "development": true,
   "source": {
     "repository": "https://github.com/IngvarConsulting/unica",

--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -127,7 +127,7 @@
     },
     {
       "name": "unica",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "repository": "https://github.com/IngvarConsulting/unica",
       "sourceTag": "workspace",
       "sourceCommit": "workspace",

--- a/scripts/ci/release-assessment.py
+++ b/scripts/ci/release-assessment.py
@@ -9,11 +9,13 @@ import html
 import json
 import os
 import platform
+import queue
 import re
 import shutil
 import subprocess
 import sys
 import tarfile
+import threading
 import time
 import zipfile
 from datetime import datetime, timezone
@@ -166,33 +168,107 @@ def call_mcp(
     env = os.environ.copy()
     env["UNICA_CACHE_DIR"] = str(cache_dir)
     started = time.perf_counter()
+    command = [sys.executable, str(run_unica)] if run_unica.suffix == ".py" else [str(run_unica)]
+    process = subprocess.Popen(
+        command,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=cwd,
+        env=env,
+        bufsize=1,
+    )
+    stdout_queue: queue.Queue[str | None] = queue.Queue()
+    stderr_parts: list[str] = []
+
+    def read_stdout() -> None:
+        assert process.stdout is not None
+        for line in process.stdout:
+            stdout_queue.put(line)
+        stdout_queue.put(None)
+
+    def read_stderr() -> None:
+        assert process.stderr is not None
+        stderr_parts.append(process.stderr.read())
+
+    stdout_thread = threading.Thread(target=read_stdout, daemon=True)
+    stderr_thread = threading.Thread(target=read_stderr, daemon=True)
+    stdout_thread.start()
+    stderr_thread.start()
+
+    write_error = ""
     try:
-        command = [sys.executable, str(run_unica)] if run_unica.suffix == ".py" else [str(run_unica)]
-        result = subprocess.run(
-            command,
-            input=payload,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            cwd=cwd,
-            env=env,
-            timeout=timeout_seconds,
-            check=False,
-        )
-        duration_ms = int((time.perf_counter() - started) * 1000)
-    except subprocess.TimeoutExpired as error:
-        duration_ms = int((time.perf_counter() - started) * 1000)
-        return [], duration_ms, error.stdout or "", error.stderr or f"timed out after {timeout_seconds}s", 124
+        assert process.stdin is not None
+        process.stdin.write(payload)
+        process.stdin.flush()
+    except (BrokenPipeError, OSError) as error:
+        write_error = f"failed to write MCP request: {error}"
+
+    expected_responses = sum("id" in message for message in messages)
+    stdout_lines: list[str] = []
+    deadline = time.monotonic() + timeout_seconds
+    timed_out = False
+    received_responses = 0
+    while received_responses < expected_responses:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            timed_out = True
+            break
+        try:
+            line = stdout_queue.get(timeout=min(remaining, 0.05))
+        except queue.Empty:
+            if process.poll() is not None and not stdout_thread.is_alive():
+                break
+            continue
+        if line is None:
+            break
+        stdout_lines.append(line)
+        if line.strip():
+            received_responses += 1
+
+    if process.stdin is not None and not process.stdin.closed:
+        process.stdin.close()
+
+    remaining = max(0.0, deadline - time.monotonic())
+    try:
+        process.wait(timeout=remaining)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        process.kill()
+        process.wait()
+
+    stdout_thread.join(timeout=1)
+    stderr_thread.join(timeout=1)
+    while True:
+        try:
+            line = stdout_queue.get_nowait()
+        except queue.Empty:
+            break
+        if line is not None:
+            stdout_lines.append(line)
+    if process.stdout is not None:
+        process.stdout.close()
+    if process.stderr is not None:
+        process.stderr.close()
+
+    duration_ms = int((time.perf_counter() - started) * 1000)
+    stdout = "".join(stdout_lines)
+    stderr = "".join(stderr_parts)
+    if write_error:
+        stderr = f"{write_error}\n{stderr}".strip()
+    if timed_out:
+        return [], duration_ms, stdout, stderr or f"timed out after {timeout_seconds}s", 124
 
     responses: list[dict[str, Any]] = []
-    for line in result.stdout.splitlines():
+    for line in stdout.splitlines():
         if not line.strip():
             continue
         try:
             responses.append(json.loads(line))
         except json.JSONDecodeError:
             responses.append({"error": {"message": f"invalid JSON-RPC line: {line}"}})
-    return responses, duration_ms, result.stdout, result.stderr, result.returncode
+    return responses, duration_ms, stdout, stderr, process.returncode
 
 
 def tool_call_message(message_id: int, name: str, arguments: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/ci/release-assessment.py
+++ b/scripts/ci/release-assessment.py
@@ -165,110 +165,180 @@ def call_mcp(
 ) -> tuple[list[dict[str, Any]], int, str, str, int]:
     cache_dir.mkdir(parents=True, exist_ok=True)
     payload = "\n".join(json.dumps(message, ensure_ascii=False) for message in messages) + "\n"
+    payload.encode("utf-8", errors="strict")
     env = os.environ.copy()
     env["UNICA_CACHE_DIR"] = str(cache_dir)
     started = time.perf_counter()
     command = [sys.executable, str(run_unica)] if run_unica.suffix == ".py" else [str(run_unica)]
-    process = subprocess.Popen(
-        command,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        cwd=cwd,
-        env=env,
-        bufsize=1,
-    )
+    deadline = time.monotonic() + timeout_seconds
+    expected_ids = [message["id"] for message in messages if "id" in message]
+
+    def rpc_id_key(value: Any) -> str:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+    expected_keys = [rpc_id_key(message_id) for message_id in expected_ids]
+    if len(set(expected_keys)) != len(expected_keys):
+        raise ValueError("MCP request IDs must be unique")
+    expected_key_set = set(expected_keys)
+
     stdout_queue: queue.Queue[str | None] = queue.Queue()
+    stdout_reader_errors: list[str] = []
     stderr_parts: list[str] = []
+    responses_by_key: dict[str, dict[str, Any]] = {}
+    protocol_errors: list[dict[str, Any]] = []
+    stdout_lines: list[str] = []
+    process: subprocess.Popen[str] | None = None
+    stdout_thread: threading.Thread | None = None
+    stderr_thread: threading.Thread | None = None
+    timed_out = False
+    write_error = ""
+
+    def protocol_error(message: str) -> None:
+        protocol_errors.append(
+            {"jsonrpc": "2.0", "error": {"code": -32603, "message": message}}
+        )
+
+    def consume_stdout_line(line: str) -> None:
+        stdout_lines.append(line)
+        if not line.strip():
+            return
+        try:
+            response = json.loads(line)
+        except json.JSONDecodeError:
+            protocol_error(f"invalid JSON-RPC line: {line.rstrip()}")
+            return
+        if not isinstance(response, dict):
+            protocol_error("JSON-RPC response must be an object")
+            return
+        if "id" not in response:
+            if "method" in response:
+                return
+            protocol_error("JSON-RPC response is missing id")
+            return
+        key = rpc_id_key(response["id"])
+        if key not in expected_key_set:
+            protocol_error(f"unexpected JSON-RPC response id: {response['id']!r}")
+            return
+        if key in responses_by_key:
+            protocol_error(f"duplicate JSON-RPC response id: {response['id']!r}")
+            return
+        responses_by_key[key] = response
 
     def read_stdout() -> None:
+        assert process is not None
         assert process.stdout is not None
-        for line in process.stdout:
-            stdout_queue.put(line)
-        stdout_queue.put(None)
+        try:
+            for line in process.stdout:
+                stdout_queue.put(line)
+        except (OSError, UnicodeError) as error:
+            stdout_reader_errors.append(f"failed to read MCP stdout: {error}")
+        finally:
+            stdout_queue.put(None)
 
     def read_stderr() -> None:
+        assert process is not None
         assert process.stderr is not None
-        stderr_parts.append(process.stderr.read())
+        try:
+            stderr_parts.append(process.stderr.read())
+        except (OSError, UnicodeError) as error:
+            stderr_parts.append(f"failed to read MCP stderr: {error}")
 
-    stdout_thread = threading.Thread(target=read_stdout, daemon=True)
-    stderr_thread = threading.Thread(target=read_stderr, daemon=True)
-    stdout_thread.start()
-    stderr_thread.start()
-
-    write_error = ""
     try:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="strict",
+            cwd=cwd,
+            env=env,
+            bufsize=1,
+        )
+        stdout_thread = threading.Thread(target=read_stdout, daemon=True)
+        stderr_thread = threading.Thread(target=read_stderr, daemon=True)
+        stdout_thread.start()
+        stderr_thread.start()
+
         assert process.stdin is not None
-        process.stdin.write(payload)
-        process.stdin.flush()
-    except (BrokenPipeError, OSError) as error:
-        write_error = f"failed to write MCP request: {error}"
-
-    expected_responses = sum("id" in message for message in messages)
-    stdout_lines: list[str] = []
-    deadline = time.monotonic() + timeout_seconds
-    timed_out = False
-    received_responses = 0
-    while received_responses < expected_responses:
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            timed_out = True
-            break
         try:
-            line = stdout_queue.get(timeout=min(remaining, 0.05))
-        except queue.Empty:
-            if process.poll() is not None and not stdout_thread.is_alive():
+            process.stdin.write(payload)
+            process.stdin.flush()
+        except (BrokenPipeError, OSError, UnicodeError) as error:
+            write_error = f"failed to write MCP request: {error}"
+
+        while len(responses_by_key) < len(expected_keys) and not protocol_errors:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
                 break
-            continue
-        if line is None:
-            break
-        stdout_lines.append(line)
-        if line.strip():
-            received_responses += 1
+            try:
+                line = stdout_queue.get(timeout=min(remaining, 0.05))
+            except queue.Empty:
+                if process.poll() is not None and stdout_thread is not None and not stdout_thread.is_alive():
+                    break
+                continue
+            if line is None:
+                break
+            consume_stdout_line(line)
+    finally:
+        if process is not None:
+            if process.stdin is not None and not process.stdin.closed:
+                try:
+                    process.stdin.close()
+                except (BrokenPipeError, OSError, UnicodeError) as error:
+                    if not write_error:
+                        write_error = f"failed to close MCP stdin: {error}"
 
-    if process.stdin is not None and not process.stdin.closed:
-        process.stdin.close()
+            if process.poll() is None:
+                remaining = max(0.0, deadline - time.monotonic())
+                try:
+                    process.wait(timeout=remaining)
+                except subprocess.TimeoutExpired:
+                    timed_out = True
+                    process.kill()
+                    process.wait()
 
-    remaining = max(0.0, deadline - time.monotonic())
-    try:
-        process.wait(timeout=remaining)
-    except subprocess.TimeoutExpired:
-        timed_out = True
-        process.kill()
-        process.wait()
-
-    stdout_thread.join(timeout=1)
-    stderr_thread.join(timeout=1)
-    while True:
-        try:
-            line = stdout_queue.get_nowait()
-        except queue.Empty:
-            break
-        if line is not None:
-            stdout_lines.append(line)
-    if process.stdout is not None:
-        process.stdout.close()
-    if process.stderr is not None:
-        process.stderr.close()
+            if stdout_thread is not None:
+                stdout_thread.join(timeout=1)
+            if stderr_thread is not None:
+                stderr_thread.join(timeout=1)
+            while True:
+                try:
+                    line = stdout_queue.get_nowait()
+                except queue.Empty:
+                    break
+                if line is not None:
+                    consume_stdout_line(line)
+            if process.stdout is not None:
+                process.stdout.close()
+            if process.stderr is not None:
+                process.stderr.close()
 
     duration_ms = int((time.perf_counter() - started) * 1000)
     stdout = "".join(stdout_lines)
     stderr = "".join(stderr_parts)
+    if stdout_reader_errors:
+        protocol_error("; ".join(stdout_reader_errors))
     if write_error:
         stderr = f"{write_error}\n{stderr}".strip()
     if timed_out:
         return [], duration_ms, stdout, stderr or f"timed out after {timeout_seconds}s", 124
-
-    responses: list[dict[str, Any]] = []
-    for line in stdout.splitlines():
-        if not line.strip():
-            continue
-        try:
-            responses.append(json.loads(line))
-        except json.JSONDecodeError:
-            responses.append({"error": {"message": f"invalid JSON-RPC line: {line}"}})
-    return responses, duration_ms, stdout, stderr, process.returncode
+    responses = [responses_by_key[key] for key in expected_keys if key in responses_by_key]
+    responses.extend(protocol_errors)
+    if len(responses_by_key) < len(expected_keys) and not protocol_errors:
+        missing = [
+            message_id
+            for message_id, key in zip(expected_ids, expected_keys, strict=True)
+            if key not in responses_by_key
+        ]
+        protocol_error(f"missing JSON-RPC responses for ids: {missing!r}")
+        responses.extend(protocol_errors)
+    returncode = process.returncode if process is not None and process.returncode is not None else 1
+    if write_error and returncode == 0:
+        returncode = 1
+    return responses, duration_ms, stdout, stderr, returncode
 
 
 def tool_call_message(message_id: int, name: str, arguments: dict[str, Any]) -> dict[str, Any]:

--- a/tests/ci/test_install_unica_script.py
+++ b/tests/ci/test_install_unica_script.py
@@ -65,7 +65,7 @@ class InstallUnicaScriptTests(unittest.TestCase):
                 "https://github.com/IngvarConsulting/unica-marketplace.git",
                 calls[1],
             )
-            self.assertTrue(any("fetch --depth 1 origin refs/tags/v0.7.3" in line for line in calls))
+            self.assertTrue(any("fetch --depth 1 origin refs/tags/v0.7.4" in line for line in calls))
             bootstrap_calls = [line for line in calls if line.startswith("bootstrap ")]
             self.assertEqual(
                 bootstrap_calls,
@@ -105,7 +105,7 @@ if [ "$1" = "clone" ]; then
   eval "destination=\${$#}"
   mkdir -p "$destination/.agents/plugins"
   mkdir -p "$destination/plugins/unica/bootstrap/bin/linux-x64"
-  printf '%s\n' '{"name":"unica","plugins":[{"name":"unica","source":{"source":"git-subdir","url":"https://github.com/IngvarConsulting/unica-marketplace.git","path":"./plugins/unica","ref":"v0.7.3"}}]}' > "$destination/.agents/plugins/marketplace.json"
+  printf '%s\n' '{"name":"unica","plugins":[{"name":"unica","source":{"source":"git-subdir","url":"https://github.com/IngvarConsulting/unica-marketplace.git","path":"./plugins/unica","ref":"v0.7.4"}}]}' > "$destination/.agents/plugins/marketplace.json"
   cat > "$destination/plugins/unica/bootstrap/bin/linux-x64/unica-bootstrap" <<'BOOTSTRAP'
 #!/bin/sh
 printf 'bootstrap %s CODEX_HOME=%s\n' "$1" "$CODEX_HOME" >> "$UNICA_TEST_LOG"

--- a/tests/ci/test_package_unica_plugin.py
+++ b/tests/ci/test_package_unica_plugin.py
@@ -634,7 +634,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
                             "schemaVersion": 1,
                             "target": target,
                             "targetTriple": target_triple,
-                            "pluginVersion": "0.7.3",
+                            "pluginVersion": "0.7.4",
                             "asset": {
                                 "name": f"unica-runtime-{target}.tar.gz",
                                 "mediaType": "application/gzip",
@@ -663,7 +663,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
                 "--bootstrap-root",
                 str(bootstrap_root),
                 "--release-tag",
-                "v0.7.3",
+                "v0.7.4",
                 "--source-commit",
                 "a" * 40,
                 "--out-dir",
@@ -690,13 +690,13 @@ class PackageUnicaPluginTests(unittest.TestCase):
             )
             self.assertFalse(runtime_manifest["development"])
             self.assertEqual(runtime_manifest["source"]["commit"], "a" * 40)
-            self.assertEqual(runtime_manifest["release"]["tag"], "v0.7.3")
+            self.assertEqual(runtime_manifest["release"]["tag"], "v0.7.4")
             self.assertEqual(sorted(runtime_manifest["targets"]), sorted(target_triples))
             for target, target_data in runtime_manifest["targets"].items():
                 self.assertEqual(
                     target_data["asset"]["url"],
                     "https://github.com/IngvarConsulting/unica/releases/download/"
-                    f"v0.7.3/unica-runtime-{target}.tar.gz",
+                    f"v0.7.4/unica-runtime-{target}.tar.gz",
                 )
 
             catalog = json.loads(
@@ -706,7 +706,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
             )
             source = catalog["plugins"][0]["source"]
             self.assertEqual(source["source"], "git-subdir")
-            self.assertEqual(source["ref"], "v0.7.3")
+            self.assertEqual(source["ref"], "v0.7.4")
             self.assertEqual(source["path"], "./plugins/unica")
             self.assertNotIn("source\": \"local", json.dumps(catalog))
             self.assertEqual(list(out_dir.glob("*.tar.gz")), [])

--- a/tests/ci/test_product_contracts.py
+++ b/tests/ci/test_product_contracts.py
@@ -67,7 +67,7 @@ class ProductContractTests(unittest.TestCase):
             repo_root / "plugins/unica/README.md",
             repo_root / "docs/releases/v0.7.1.md",
             repo_root / "docs/releases/v0.7.2.md",
-            repo_root / "docs/releases/v0.7.3.md",
+            repo_root / "docs/releases/v0.7.4.md",
             repo_root / "spec/acceptance/unica-mcp-validation.md",
             repo_root / "spec/architecture/arc42/06-runtime-view.md",
             repo_root / "spec/architecture/arc42/07-deployment-view.md",

--- a/tests/ci/test_release_assessment.py
+++ b/tests/ci/test_release_assessment.py
@@ -31,6 +31,41 @@ def load_bsp_harvest_module():
 
 
 class ReleaseAssessmentTests(unittest.TestCase):
+    def write_eof_sensitive_mcp(self, path: Path) -> None:
+        path.write_text(
+            """#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+
+cancelled = threading.Event()
+workers = []
+
+def respond(message):
+    time.sleep(0.2)
+    response = {"jsonrpc": "2.0", "id": message.get("id")}
+    if cancelled.is_set():
+        response["error"] = {"code": -32800, "message": "request cancelled"}
+    else:
+        response["result"] = {"content": [{"type": "text", "text": "ok"}]}
+    print(json.dumps(response), flush=True)
+
+for raw in sys.stdin:
+    worker = threading.Thread(target=respond, args=(json.loads(raw),))
+    worker.start()
+    workers.append(worker)
+
+cancelled.set()
+for worker in workers:
+    worker.join()
+""",
+            encoding="utf-8",
+        )
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
     def write_fake_mcp(self, path: Path) -> None:
         path.write_text(
             """#!/usr/bin/env python3
@@ -134,6 +169,26 @@ for raw in sys.stdin:
             self.assertEqual(len(lines), len(report["scenarios"]))
             self.assertTrue((out_dir / "index.html").read_text(encoding="utf-8").startswith("<!doctype html>"))
             self.assertIn("v9.9.9", (out_dir / "summary.md").read_text(encoding="utf-8"))
+
+    def test_mcp_client_keeps_stdin_open_until_delayed_response(self) -> None:
+        module = load_assessment_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fake_mcp = root / ("run-unica.py" if os.name == "nt" else "run-unica")
+            self.write_eof_sensitive_mcp(fake_mcp)
+
+            responses, _duration_ms, _stdout, stderr, returncode = module.call_mcp(
+                fake_mcp,
+                [module.tool_call_message(1, "unica.cf.info", {})],
+                cwd=root,
+                cache_dir=root / "cache",
+                timeout_seconds=2,
+            )
+
+            self.assertEqual(returncode, 0, stderr)
+            self.assertEqual(len(responses), 1)
+            self.assertNotIn("error", responses[0])
 
     def test_report_rendering_escapes_failure_text(self) -> None:
         module = load_assessment_module()

--- a/tests/ci/test_release_assessment.py
+++ b/tests/ci/test_release_assessment.py
@@ -31,6 +31,28 @@ def load_bsp_harvest_module():
 
 
 class ReleaseAssessmentTests(unittest.TestCase):
+    def write_response_id_mcp(self, path: Path, response_ids: list[int]) -> None:
+        path.write_text(
+            f"""#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+
+message = json.loads(sys.stdin.readline())
+for response_id in {json.dumps(response_ids)}:
+    print(json.dumps({{
+        "jsonrpc": "2.0",
+        "id": response_id,
+        "result": {{"content": [{{"type": "text", "text": "ok"}}]}},
+    }}), flush=True)
+for _raw in sys.stdin:
+    pass
+""",
+            encoding="utf-8",
+        )
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
     def write_eof_sensitive_mcp(self, path: Path) -> None:
         path.write_text(
             """#!/usr/bin/env python3
@@ -54,6 +76,7 @@ def respond(message):
     print(json.dumps(response), flush=True)
 
 for raw in sys.stdin:
+    print(json.dumps({"jsonrpc": "2.0", "method": "notifications/progress", "params": {}}), flush=True)
     worker = threading.Thread(target=respond, args=(json.loads(raw),))
     worker.start()
     workers.append(worker)
@@ -189,6 +212,165 @@ for raw in sys.stdin:
             self.assertEqual(returncode, 0, stderr)
             self.assertEqual(len(responses), 1)
             self.assertNotIn("error", responses[0])
+
+    def test_mcp_client_rejects_unexpected_response_id(self) -> None:
+        module = load_assessment_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fake_mcp = root / ("run-unica.py" if os.name == "nt" else "run-unica")
+            self.write_response_id_mcp(fake_mcp, [999])
+
+            responses, _duration_ms, _stdout, _stderr, _returncode = module.call_mcp(
+                fake_mcp,
+                [module.tool_call_message(1, "unica.cf.info", {})],
+                cwd=root,
+                cache_dir=root / "cache",
+                timeout_seconds=2,
+            )
+
+            self.assertTrue(
+                any("unexpected JSON-RPC response id" in response.get("error", {}).get("message", "") for response in responses)
+            )
+
+    def test_mcp_client_rejects_duplicate_response_id(self) -> None:
+        module = load_assessment_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fake_mcp = root / ("run-unica.py" if os.name == "nt" else "run-unica")
+            self.write_response_id_mcp(fake_mcp, [1, 1])
+
+            responses, _duration_ms, _stdout, _stderr, _returncode = module.call_mcp(
+                fake_mcp,
+                [module.tool_call_message(1, "unica.cf.info", {})],
+                cwd=root,
+                cache_dir=root / "cache",
+                timeout_seconds=2,
+            )
+
+            self.assertTrue(
+                any("duplicate JSON-RPC response id" in response.get("error", {}).get("message", "") for response in responses)
+            )
+
+    def test_mcp_client_returns_responses_in_request_order(self) -> None:
+        module = load_assessment_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fake_mcp = root / ("run-unica.py" if os.name == "nt" else "run-unica")
+            self.write_response_id_mcp(fake_mcp, [2, 1])
+
+            responses, _duration_ms, _stdout, _stderr, _returncode = module.call_mcp(
+                fake_mcp,
+                [
+                    module.tool_call_message(1, "unica.project.status", {}),
+                    module.tool_call_message(2, "unica.project.map", {}),
+                ],
+                cwd=root,
+                cache_dir=root / "cache",
+                timeout_seconds=2,
+            )
+
+            self.assertEqual([response.get("id") for response in responses], [1, 2])
+
+    def test_mcp_client_reports_invalid_json_line(self) -> None:
+        module = load_assessment_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fake_mcp = root / ("run-unica.py" if os.name == "nt" else "run-unica")
+            fake_mcp.write_text(
+                "#!/usr/bin/env python3\nimport sys\nsys.stdin.readline()\nprint('not-json', flush=True)\nfor _raw in sys.stdin: pass\n",
+                encoding="utf-8",
+            )
+            fake_mcp.chmod(fake_mcp.stat().st_mode | stat.S_IXUSR)
+
+            responses, _duration_ms, _stdout, _stderr, _returncode = module.call_mcp(
+                fake_mcp,
+                [module.tool_call_message(1, "unica.cf.info", {})],
+                cwd=root,
+                cache_dir=root / "cache",
+                timeout_seconds=2,
+            )
+
+            self.assertTrue(
+                any("invalid JSON-RPC line" in response.get("error", {}).get("message", "") for response in responses)
+            )
+
+    def test_mcp_client_preserves_early_exit_stderr(self) -> None:
+        module = load_assessment_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fake_mcp = root / ("run-unica.py" if os.name == "nt" else "run-unica")
+            fake_mcp.write_text(
+                "#!/usr/bin/env python3\nimport sys\nsys.stderr.write('fatal stderr\\n')\nsys.stderr.flush()\nraise SystemExit(7)\n",
+                encoding="utf-8",
+            )
+            fake_mcp.chmod(fake_mcp.stat().st_mode | stat.S_IXUSR)
+
+            responses, _duration_ms, _stdout, stderr, returncode = module.call_mcp(
+                fake_mcp,
+                [module.tool_call_message(1, "unica.cf.info", {})],
+                cwd=root,
+                cache_dir=root / "cache",
+                timeout_seconds=2,
+            )
+
+            self.assertEqual(returncode, 7)
+            self.assertIn("fatal stderr", stderr)
+            self.assertTrue(any("missing JSON-RPC responses" in response.get("error", {}).get("message", "") for response in responses))
+
+    def test_mcp_client_times_out_and_reaps_silent_process(self) -> None:
+        module = load_assessment_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fake_mcp = root / ("run-unica.py" if os.name == "nt" else "run-unica")
+            fake_mcp.write_text(
+                "#!/usr/bin/env python3\nimport sys\nimport time\nsys.stdin.readline()\ntime.sleep(60)\n",
+                encoding="utf-8",
+            )
+            fake_mcp.chmod(fake_mcp.stat().st_mode | stat.S_IXUSR)
+
+            responses, duration_ms, _stdout, stderr, returncode = module.call_mcp(
+                fake_mcp,
+                [module.tool_call_message(1, "unica.cf.info", {})],
+                cwd=root,
+                cache_dir=root / "cache",
+                timeout_seconds=0.1,
+            )
+
+            self.assertEqual(responses, [])
+            self.assertEqual(returncode, 124)
+            self.assertIn("timed out", stderr)
+            self.assertLess(duration_ms, 2_000)
+
+    def test_mcp_client_closes_and_reaps_process_after_write_error(self) -> None:
+        module = load_assessment_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fake_mcp = root / ("run-unica.py" if os.name == "nt" else "run-unica")
+            marker = fake_mcp.with_suffix(".closed")
+            fake_mcp.write_text(
+                "#!/usr/bin/env python3\nfrom pathlib import Path\nPath(__file__).with_suffix('.closed').write_text('closed', encoding='utf-8')\n",
+                encoding="utf-8",
+            )
+            fake_mcp.chmod(fake_mcp.stat().st_mode | stat.S_IXUSR)
+
+            _responses, _duration_ms, _stdout, stderr, returncode = module.call_mcp(
+                fake_mcp,
+                [module.tool_call_message(1, "unica.cf.info", {"value": "Ж" * 1_000_000})],
+                cwd=root,
+                cache_dir=root / "cache",
+                timeout_seconds=2,
+            )
+
+            self.assertNotEqual(returncode, 0)
+            self.assertIn("failed to write MCP request", stderr)
+            self.assertEqual(marker.read_text(encoding="utf-8"), "closed")
 
     def test_report_rendering_escapes_failure_text(self) -> None:
         module = load_assessment_module()

--- a/tests/ci/test_smoke_unica_bootstrap.py
+++ b/tests/ci/test_smoke_unica_bootstrap.py
@@ -76,7 +76,7 @@ class SmokeUnicaBootstrapTests(unittest.TestCase):
                 args=[],
                 returncode=0,
                 stdout="",
-                stderr="verified Unica runtime 0.7.3 and MCP tools",
+                stderr="verified Unica runtime 0.7.4 and MCP tools",
             )
 
             with patch.object(module.subprocess, "run", return_value=result):

--- a/tests/ci/test_version_contract.py
+++ b/tests/ci/test_version_contract.py
@@ -27,9 +27,9 @@ class VersionContractTests(unittest.TestCase):
         self.assertEqual(
             values,
             {
-                "workspace": "0.7.3",
-                "plugin": "0.7.3",
-                "tools-lock-unica": "0.7.3",
+                "workspace": "0.7.4",
+                "plugin": "0.7.4",
+                "tools-lock-unica": "0.7.4",
             },
         )
 


### PR DESCRIPTION
## Root causes

1. The signed `v0.7.3` tag workflow failed because the synthetic `\\server\share\source` fixture was passed to `normalize_path_identity`, which intentionally probes real path ancestors. The unit test depended on GitHub runner network state and returned Windows error 64.
2. The release assessment used `subprocess.run(input=...)`, which closed MCP stdin immediately after `tools/call`. Unica correctly cancels unfinished calls on EOF, so fast calls passed and slower calls raced into `request cancelled`.

## Fix

- exercise UNC prefix normalization directly without filesystem/network access
- stream assessment requests, keep stdin open until all expected responses arrive, then close and reap the process under one deadline
- add an EOF-sensitive delayed MCP regression fixture that failed before the client change
- keep the published failed `v0.7.3` tag immutable and advance the complete version contract to `v0.7.4`, as issue #123 requires
- document that `v0.7.3` never produced a GitHub Release or marketplace publication

Production runtime behavior is unchanged.

## Evidence

- failed tag run: 29674613135 (Windows UNC test)
- failed PR run: 29674856540 (assessment EOF race)
- exact Windows workspace suite passed after the UNC test fix
- EOF-sensitive test observed `request cancelled` before the client fix and passes after it
- Python CI suite: 161 passed, 4 skipped
- bootstrap tests: 39 passed
- source-root tests: 12 passed
- clippy, py_compile, fmt, diff-check pass