### PR TITLE
fix(release): align published bootstrap smoke contract

### DIFF
--- a/.github/workflows/publish-unica-marketplace.yml
+++ b/.github/workflows/publish-unica-marketplace.yml
@@ -16,7 +16,7 @@ on:
         required: true
         type: string
       release_tag:
-        description: Existing immutable marketplace tag, for example v0.7.4
+        description: Existing immutable marketplace tag, for example v0.7.5
         required: true
         type: string
       staging_merge_sha:

--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: package-runtime
     env:
-      RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'v0.7.4' }}
+      RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'v0.7.5' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unica-bootstrap"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "flate2",
  "fs2",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "unica-coder"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "fs2",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/unica-bootstrap", "crates/unica-coder"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 license = "LGPL-3.0-or-later"
 repository = "https://github.com/IngvarConsulting/unica"

--- a/crates/unica-bootstrap/src/main.rs
+++ b/crates/unica-bootstrap/src/main.rs
@@ -291,14 +291,14 @@ mod tests {
     fn prompt_proof_searches_nested_skill_names_and_normalized_paths() {
         let proof = serde_json::json!({
             "content": [{
-                "text": r"- unica:code-search (file: C:\Codex\plugins\cache\unica\unica\0.7.4\skills\code-search\SKILL.md)"
+                "text": r"- unica:code-search (file: C:\Codex\plugins\cache\unica\unica\0.7.5\skills\code-search\SKILL.md)"
             }]
         });
 
         assert!(json_contains_text(&proof, "unica:code-search"));
         assert!(json_contains_normalized_path(
             &proof,
-            "c:/codex/plugins/cache/unica/unica/0.7.4/skills"
+            "c:/codex/plugins/cache/unica/unica/0.7.5/skills"
         ));
     }
 }

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -4,7 +4,7 @@
 > stack overflow before catalog promotion. The immutable tag and assets were
 > retained, not overwritten. `v0.7.1` corrected that runtime entrypoint but a
 > second staging smoke found the same Windows stack constraint in the native
-> bootstrap. `v0.7.4` supersedes both source-only releases.
+> bootstrap. `v0.7.5` supersedes both source-only releases.
 
 Unica 0.7.0 changes the delivery model from platform-sized marketplace bundles
 to a public thin Git marketplace. This note describes the release contract; the

--- a/docs/releases/v0.7.1.md
+++ b/docs/releases/v0.7.1.md
@@ -3,7 +3,7 @@
 > Source-only release: the external marketplace Windows smoke found a stack
 > overflow in `unica-bootstrap.exe` before catalog promotion. The runtime MCP
 > correction in this release is valid, but the thin plugin as a whole is not.
-> The immutable tag and assets are retained; `v0.7.4` supersedes this release.
+> The immutable tag and assets are retained; `v0.7.5` supersedes this release.
 
 Unica 0.7.1 corrected the Windows runtime entrypoint discovered while staging
 0.7.0. It was not promoted because the source release gate exercised the

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -1,6 +1,6 @@
 # Unica v0.7.2
 
-> The immutable release remains available. Unica v0.7.4 supersedes it because
+> The immutable release remains available. Unica v0.7.5 supersedes it because
 > migration could leave an inactive legacy config entry and cache directories.
 
 Unica 0.7.2 is the first version eligible for promotion through the public thin

--- a/docs/releases/v0.7.3.md
+++ b/docs/releases/v0.7.3.md
@@ -1,7 +1,7 @@
 # Unica v0.7.3
 
 > The signed source tag is retained, but its Windows tag workflow failed before
-> any GitHub Release or marketplace publication. Unica v0.7.4 supersedes it.
+> any GitHub Release or marketplace publication. Unica v0.7.5 supersedes it.
 
 Unica 0.7.3 completes the public marketplace migration contract. It keeps the
 thin, Node-free runtime delivery introduced in 0.7.2 and fixes cleanup of

--- a/docs/releases/v0.7.5.md
+++ b/docs/releases/v0.7.5.md
@@ -1,17 +1,11 @@
-# Unica v0.7.4
+# Unica v0.7.5
 
-> Source-only release: the signed tag and GitHub Release assets are retained,
-> but the public marketplace was not staged. The published-runtime gate used an
-> obsolete success string after the bootstrap output contract changed. All three
-> native runtimes completed package, checksum, and MCP verification; only the CI
-> marker assertion failed. Unica v0.7.5 corrects that gate and supersedes this
-> release without overwriting any v0.7.4 bytes.
-
-Unica 0.7.4 prepared the public marketplace migration contract from 0.7.3. The
-signed 0.7.3 source tag did not publish a GitHub Release because a Windows unit
-test accidentally probed a synthetic UNC network path. The test now exercises
-prefix normalization without filesystem or network access; production runtime
-behavior is unchanged.
+Unica 0.7.5 is the public release of the Git marketplace migration contract.
+It preserves the immutable v0.7.4 source release and corrects its final
+published-runtime gate: the native bootstrap reported a successful package,
+runtime, and MCP verification using its current message, while CI still looked
+for the older `verified Unica runtime` prefix. The gate now tests the actual
+bootstrap output contract before marketplace staging.
 
 ## Install and prerequisites
 
@@ -43,7 +37,7 @@ legacy directories. A completed migration is idempotent.
 
 The marketplace package remains thin and contains three native bootstrap
 binaries. The first MCP start downloads only the current host runtime and caches
-it atomically under `$CODEX_HOME/unica/runtimes/0.7.4/<target>`.
+it atomically under `$CODEX_HOME/unica/runtimes/0.7.5/<target>`.
 
 ```sh
 codex plugin marketplace upgrade unica

--- a/plugins/unica/.codex-plugin/plugin.json
+++ b/plugins/unica/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unica",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Practical 1C:Enterprise development workflows for Codex.",
   "author": {
     "name": "Ingvar Consulting, LLC",

--- a/plugins/unica/runtime-manifest.json
+++ b/plugins/unica/runtime-manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "pluginVersion": "0.7.4",
+  "pluginVersion": "0.7.5",
   "development": true,
   "source": {
     "repository": "https://github.com/IngvarConsulting/unica",

--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -127,7 +127,7 @@
     },
     {
       "name": "unica",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "repository": "https://github.com/IngvarConsulting/unica",
       "sourceTag": "workspace",
       "sourceCommit": "workspace",

--- a/scripts/ci/smoke-unica-bootstrap.py
+++ b/scripts/ci/smoke-unica-bootstrap.py
@@ -78,7 +78,10 @@ def smoke(
             f"packaged bootstrap exited with {result.returncode}: "
             f"{detail or 'no process output'}"
         )
-    if "verified Unica runtime" not in result.stderr:
+    if not (
+        "verified Unica " in result.stderr
+        and " package, runtime, and MCP tools at " in result.stderr
+    ):
         raise SystemExit("packaged bootstrap did not report successful MCP verification")
 
 

--- a/tests/ci/test_install_unica_script.py
+++ b/tests/ci/test_install_unica_script.py
@@ -65,7 +65,7 @@ class InstallUnicaScriptTests(unittest.TestCase):
                 "https://github.com/IngvarConsulting/unica-marketplace.git",
                 calls[1],
             )
-            self.assertTrue(any("fetch --depth 1 origin refs/tags/v0.7.4" in line for line in calls))
+            self.assertTrue(any("fetch --depth 1 origin refs/tags/v0.7.5" in line for line in calls))
             bootstrap_calls = [line for line in calls if line.startswith("bootstrap ")]
             self.assertEqual(
                 bootstrap_calls,
@@ -105,7 +105,7 @@ if [ "$1" = "clone" ]; then
   eval "destination=\${$#}"
   mkdir -p "$destination/.agents/plugins"
   mkdir -p "$destination/plugins/unica/bootstrap/bin/linux-x64"
-  printf '%s\n' '{"name":"unica","plugins":[{"name":"unica","source":{"source":"git-subdir","url":"https://github.com/IngvarConsulting/unica-marketplace.git","path":"./plugins/unica","ref":"v0.7.4"}}]}' > "$destination/.agents/plugins/marketplace.json"
+  printf '%s\n' '{"name":"unica","plugins":[{"name":"unica","source":{"source":"git-subdir","url":"https://github.com/IngvarConsulting/unica-marketplace.git","path":"./plugins/unica","ref":"v0.7.5"}}]}' > "$destination/.agents/plugins/marketplace.json"
   cat > "$destination/plugins/unica/bootstrap/bin/linux-x64/unica-bootstrap" <<'BOOTSTRAP'
 #!/bin/sh
 printf 'bootstrap %s CODEX_HOME=%s\n' "$1" "$CODEX_HOME" >> "$UNICA_TEST_LOG"

--- a/tests/ci/test_package_unica_plugin.py
+++ b/tests/ci/test_package_unica_plugin.py
@@ -634,7 +634,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
                             "schemaVersion": 1,
                             "target": target,
                             "targetTriple": target_triple,
-                            "pluginVersion": "0.7.4",
+                            "pluginVersion": "0.7.5",
                             "asset": {
                                 "name": f"unica-runtime-{target}.tar.gz",
                                 "mediaType": "application/gzip",
@@ -663,7 +663,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
                 "--bootstrap-root",
                 str(bootstrap_root),
                 "--release-tag",
-                "v0.7.4",
+                "v0.7.5",
                 "--source-commit",
                 "a" * 40,
                 "--out-dir",
@@ -690,13 +690,13 @@ class PackageUnicaPluginTests(unittest.TestCase):
             )
             self.assertFalse(runtime_manifest["development"])
             self.assertEqual(runtime_manifest["source"]["commit"], "a" * 40)
-            self.assertEqual(runtime_manifest["release"]["tag"], "v0.7.4")
+            self.assertEqual(runtime_manifest["release"]["tag"], "v0.7.5")
             self.assertEqual(sorted(runtime_manifest["targets"]), sorted(target_triples))
             for target, target_data in runtime_manifest["targets"].items():
                 self.assertEqual(
                     target_data["asset"]["url"],
                     "https://github.com/IngvarConsulting/unica/releases/download/"
-                    f"v0.7.4/unica-runtime-{target}.tar.gz",
+                    f"v0.7.5/unica-runtime-{target}.tar.gz",
                 )
 
             catalog = json.loads(
@@ -706,7 +706,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
             )
             source = catalog["plugins"][0]["source"]
             self.assertEqual(source["source"], "git-subdir")
-            self.assertEqual(source["ref"], "v0.7.4")
+            self.assertEqual(source["ref"], "v0.7.5")
             self.assertEqual(source["path"], "./plugins/unica")
             self.assertNotIn("source\": \"local", json.dumps(catalog))
             self.assertEqual(list(out_dir.glob("*.tar.gz")), [])

--- a/tests/ci/test_product_contracts.py
+++ b/tests/ci/test_product_contracts.py
@@ -67,7 +67,7 @@ class ProductContractTests(unittest.TestCase):
             repo_root / "plugins/unica/README.md",
             repo_root / "docs/releases/v0.7.1.md",
             repo_root / "docs/releases/v0.7.2.md",
-            repo_root / "docs/releases/v0.7.4.md",
+            repo_root / "docs/releases/v0.7.5.md",
             repo_root / "spec/acceptance/unica-mcp-validation.md",
             repo_root / "spec/architecture/arc42/06-runtime-view.md",
             repo_root / "spec/architecture/arc42/07-deployment-view.md",

--- a/tests/ci/test_smoke_unica_bootstrap.py
+++ b/tests/ci/test_smoke_unica_bootstrap.py
@@ -76,7 +76,10 @@ class SmokeUnicaBootstrapTests(unittest.TestCase):
                 args=[],
                 returncode=0,
                 stdout="",
-                stderr="verified Unica runtime 0.7.4 and MCP tools",
+                stderr=(
+                    "verified Unica 0.7.5 package, runtime, and MCP tools at "
+                    "/tmp/unica/runtimes/0.7.5/linux-x64"
+                ),
             )
 
             with patch.object(module.subprocess, "run", return_value=result):

--- a/tests/ci/test_version_contract.py
+++ b/tests/ci/test_version_contract.py
@@ -27,9 +27,9 @@ class VersionContractTests(unittest.TestCase):
         self.assertEqual(
             values,
             {
-                "workspace": "0.7.4",
-                "plugin": "0.7.4",
-                "tools-lock-unica": "0.7.4",
+                "workspace": "0.7.5",
+                "plugin": "0.7.5",
+                "tools-lock-unica": "0.7.5",
             },
         )
 


### PR DESCRIPTION
## Root cause

The v0.7.4 published-runtime gate searched stderr for the obsolete literal `verified Unica runtime`. The current native bootstrap successfully reports `verified Unica <version> package, runtime, and MCP tools at <path>`, so all three platform jobs false-failed after the runtimes had already passed checksum and MCP verification. The unit test repeated the stale string instead of the real executable output.

## Fix

- assert the current bootstrap verification contract without pinning a version;
- make the regression test use the exact real output shape;
- advance the immutable release contract to v0.7.5;
- document v0.7.4 as retained source-only bytes rather than overwriting its tag/assets.

## Verification

- 168 Python CI tests: pass (4 skipped)
- `cargo fmt --all -- --check`: pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: pass
- `cargo test --workspace -- --test-threads=1`: pass
- published v0.7.4 thin package + darwin runtime through corrected smoke, Node-free PATH: pass
- version contract: 0.7.5

Closes the release-gate defect found while completing #123; #123 remains open through marketplace promotion and consumer migration proof.