### PR TITLE
release: add Unica marketplace product links

### DIFF
--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -164,7 +164,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: package-runtime
     env:
-      RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'v0.8.0' }}
+      RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'v0.8.1' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unica-bootstrap"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "flate2",
  "fs2",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "unica-coder"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "fs2",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/unica-bootstrap", "crates/unica-coder"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 license = "LGPL-3.0-or-later"
 repository = "https://github.com/IngvarConsulting/unica"

--- a/docs/releases/v0.8.1.md
+++ b/docs/releases/v0.8.1.md
@@ -1,0 +1,8 @@
+# Unica v0.8.1
+
+## Marketplace card links
+
+- The product website now points to the English Unica product page.
+- The privacy policy and terms of service now point to the Unica-specific English legal pages.
+
+This patch changes marketplace metadata only; the runtime and the `v0.7.8` legacy bridge boundary are unchanged.

--- a/plugins/unica/.codex-plugin/plugin.json
+++ b/plugins/unica/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unica",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Practical 1C:Enterprise development workflows for Codex.",
   "author": {
     "name": "Ingvar Consulting, LLC",
@@ -38,9 +38,9 @@
       "Read",
       "Write"
     ],
-    "websiteURL": "https://ingvar.pro",
-    "privacyPolicyURL": "https://ingvar.pro/privacy",
-    "termsOfServiceURL": "https://ingvar.pro/terms",
+    "websiteURL": "https://ingvar.pro/products/unica/en",
+    "privacyPolicyURL": "https://ingvar.pro/products/unica/privacy/en",
+    "termsOfServiceURL": "https://ingvar.pro/products/unica/terms/en",
     "defaultPrompt": [
       "Создай внешнюю обработку 1С и собери EPF",
       "Добавь объект метаданных и форму в конфигурацию 1С",

--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -127,7 +127,7 @@
     },
     {
       "name": "unica",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "repository": "https://github.com/IngvarConsulting/unica",
       "sourceTag": "workspace",
       "sourceCommit": "workspace",

--- a/tests/ci/test_legacy_migration_boundary.py
+++ b/tests/ci/test_legacy_migration_boundary.py
@@ -70,7 +70,7 @@ class LegacyMigrationBoundaryTests(unittest.TestCase):
             with self.subTest(marker=marker):
                 self.assertNotIn(marker, release)
 
-    def test_v080_metadata_and_docs_keep_only_the_frozen_v078_bridge(self) -> None:
+    def test_v08x_metadata_and_docs_keep_only_the_frozen_v078_bridge(self) -> None:
         metadata = json.loads(
             (REPO_ROOT / "plugins/unica/.codex-plugin/plugin.json").read_text(
                 encoding="utf-8"
@@ -88,7 +88,7 @@ class LegacyMigrationBoundaryTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
         release_note = REPO_ROOT / "docs/releases/v0.8.0.md"
 
-        self.assertEqual("0.8.0", metadata["version"])
+        self.assertRegex(metadata["version"], r"^0\.8\.\d+$")
         for filename in ("install-unica.sh", "install-unica.ps1"):
             frozen_url = f"releases/download/v0.7.8/{filename}"
             obsolete_url = f"releases/download/v0.7.7/{filename}"

--- a/tests/ci/test_package_unica_plugin.py
+++ b/tests/ci/test_package_unica_plugin.py
@@ -625,7 +625,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
                             "schemaVersion": 1,
                             "target": target,
                             "targetTriple": target_triple,
-                            "pluginVersion": "0.8.0",
+                            "pluginVersion": "0.8.1",
                             "asset": {
                                 "name": f"unica-runtime-{target}.tar.gz",
                                 "mediaType": "application/gzip",
@@ -654,7 +654,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
                 "--bootstrap-root",
                 str(bootstrap_root),
                 "--release-tag",
-                "v0.8.0",
+                "v0.8.1",
                 "--source-commit",
                 "a" * 40,
                 "--out-dir",
@@ -681,13 +681,13 @@ class PackageUnicaPluginTests(unittest.TestCase):
             )
             self.assertFalse(runtime_manifest["development"])
             self.assertEqual(runtime_manifest["source"]["commit"], "a" * 40)
-            self.assertEqual(runtime_manifest["release"]["tag"], "v0.8.0")
+            self.assertEqual(runtime_manifest["release"]["tag"], "v0.8.1")
             self.assertEqual(sorted(runtime_manifest["targets"]), sorted(target_triples))
             for target, target_data in runtime_manifest["targets"].items():
                 self.assertEqual(
                     target_data["asset"]["url"],
                     "https://github.com/IngvarConsulting/unica/releases/download/"
-                    f"v0.8.0/unica-runtime-{target}.tar.gz",
+                    f"v0.8.1/unica-runtime-{target}.tar.gz",
                 )
 
             catalog = json.loads(
@@ -697,7 +697,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
             )
             source = catalog["plugins"][0]["source"]
             self.assertEqual(source["source"], "git-subdir")
-            self.assertEqual(source["ref"], "v0.8.0")
+            self.assertEqual(source["ref"], "v0.8.1")
             self.assertEqual(source["path"], "./plugins/unica")
             self.assertNotIn("source\": \"local", json.dumps(catalog))
             self.assertEqual(list(out_dir.glob("*.tar.gz")), [])

--- a/tests/ci/test_product_contracts.py
+++ b/tests/ci/test_product_contracts.py
@@ -30,6 +30,27 @@ class ProductContractTests(unittest.TestCase):
         "esac\n"
     )
 
+    def test_marketplace_card_uses_unica_product_legal_links(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        plugin = json.loads(
+            (repo_root / "plugins/unica/.codex-plugin/plugin.json").read_text(
+                encoding="utf-8"
+            )
+        )
+
+        self.assertEqual(
+            plugin["interface"]["websiteURL"],
+            "https://ingvar.pro/products/unica/en",
+        )
+        self.assertEqual(
+            plugin["interface"]["privacyPolicyURL"],
+            "https://ingvar.pro/products/unica/privacy/en",
+        )
+        self.assertEqual(
+            plugin["interface"]["termsOfServiceURL"],
+            "https://ingvar.pro/products/unica/terms/en",
+        )
+
     def test_ai_entrypoints_document_source_of_truth_and_ignored_corpus(self) -> None:
         repo_root = Path(__file__).resolve().parents[2]
         entrypoint = repo_root / "AGENTS.md"

--- a/tests/ci/test_version_contract.py
+++ b/tests/ci/test_version_contract.py
@@ -19,7 +19,7 @@ def load_module():
 
 
 class VersionContractTests(unittest.TestCase):
-    def test_repository_versions_are_exactly_0_8_0(self) -> None:
+    def test_repository_versions_are_exactly_0_8_1(self) -> None:
         module = load_module()
 
         values = module.read_version_contract(REPO_ROOT)
@@ -27,9 +27,9 @@ class VersionContractTests(unittest.TestCase):
         self.assertEqual(
             values,
             {
-                "workspace": "0.8.0",
-                "plugin": "0.8.0",
-                "tools-lock-unica": "0.8.0",
+                "workspace": "0.8.1",
+                "plugin": "0.8.1",
+                "tools-lock-unica": "0.8.1",
             },
         )
 


### PR DESCRIPTION
## Summary
- point the marketplace card to the Unica English product page
- use Unica-specific English privacy and terms pages
- bump release-facing metadata to v0.8.1 so the immutable marketplace can consume the card update
- keep the v0.7.8 legacy bridge boundary unchanged

## Verification
- all three URLs return HTTP 200
- `python3.12 -m unittest discover -s tests/ci` (172 passed, 3 skipped)
- `cargo clippy --package unica-coder --all-targets --all-features -- -D warnings`
- `cargo test --package unica-coder` (562 tests plus integration tests)
- `cargo fmt --all -- --check`
- `python3.12 scripts/ci/check-version-contract.py --expected 0.8.1`
- `git diff --check`