### PR TITLE
docs: rewrite v0.8 release notes in Russian

### DIFF
--- a/docs/releases/v0.8.0.md
+++ b/docs/releases/v0.8.0.md
@@ -1,39 +1,44 @@
 # Unica v0.8.0
 
-`v0.8.0` removes executable legacy-installation migration from the current
-source tree and release pipeline. The supported current path is the ordinary
-Git marketplace update from a canonical installation.
+`v0.8.0` — первый стабильный релиз после завершения перехода на публичный Git
+marketplace. Код прямой миграции старых установок удалён из текущего пакета и
+release pipeline. Для канонической установки поддерживается обычное обновление
+через Codex CLI.
 
-## Supported update boundary
+## Главное
 
-Direct ordinary marketplace updates are supported from:
+- Из текущего bootstrap удалены команды `migrate` и `migrate-preflight`.
+- Удалены поиск старых установок, резервное копирование, очистка, откат и
+  связанные исторические фикстуры Codex.
+- Удалены переходные installer-скрипты, их исходники и CI-задачи текущего
+  релиза.
+- Текущий релиз публикует только runtime-артефакты для macOS, Linux и Windows,
+  а также тонкий marketplace-пакет.
+- Стабильный мост `v0.7.8` сохранён неизменяемым вместе со скриптами миграции и
+  полной ручной регрессией.
 
-- canonical `v0.7.5`;
-- canonical `v0.7.6`, `v0.7.7`, or `v0.7.8`;
-- canonical technical `0.7.x` installations.
+## Обновление
 
-A version string alone is not sufficient. A canonical installation has the
-public `unica` marketplace, exactly one installed `unica@unica`, and no old
-local or duplicated registration.
+Обычное обновление через marketplace поддерживается для канонических установок
+`v0.7.5` и всех последующих `0.7.x`. Каноническая установка должна содержать
+публичный marketplace `unica`, ровно один установленный `unica@unica` и не
+содержать старых local- или duplicated-регистраций.
 
-Any local, duplicated, or otherwise legacy installation must first use the
-immutable `v0.7.8` bridge:
+Одной строки версии недостаточно: если установка локальная, дублированная или
+создана до публичного marketplace, сначала используйте неизменяемый мост
+`v0.7.8`:
 
 - [`install-unica.sh`](https://github.com/IngvarConsulting/unica/releases/download/v0.7.8/install-unica.sh)
 - [`install-unica.ps1`](https://github.com/IngvarConsulting/unica/releases/download/v0.7.8/install-unica.ps1)
 
-The bridge verifies the frozen `v0.7.8` snapshot and then performs the ordinary
-marketplace update documented in the README.
+Мост проверит замороженный снимок `v0.7.8`, нормализует установку и затем
+выполнит обычное обновление marketplace до текущей стабильной версии.
 
-## Removed from the current package
+## Проверка
 
-- `migrate` and `migrate-preflight` bootstrap commands;
-- legacy discovery, backup, cleanup, rollback, and Codex contract fixtures;
-- transition installer sources and their source-repository CI jobs;
-- legacy-only dependencies and test harnesses.
+Релиз прошёл контрактные тесты, сборку и проверку runtime для macOS, Linux и
+Windows, smoke-тест MCP, повторное скачивание опубликованных артефактов и
+проверку SHA-256. В marketplace проверены новая установка и обновление с
+предыдущей стабильной версии на всех трёх платформах.
 
-The frozen `v0.7.8` release assets remain available and unchanged. The
-`v0.8.0` release publishes only current runtime assets and the thin marketplace
-payload.
-
-Refs #135.
+Закрывает #135.

--- a/docs/releases/v0.8.1.md
+++ b/docs/releases/v0.8.1.md
@@ -1,8 +1,29 @@
 # Unica v0.8.1
 
-## Marketplace card links
+`v0.8.1` — стабильный patch-релиз, который обновляет ссылки в карточке Unica в
+публичном marketplace. Runtime и граница миграции, установленная в `v0.8.0`, не
+изменились.
 
-- The product website now points to the English Unica product page.
-- The privacy policy and terms of service now point to the Unica-specific English legal pages.
+## Главное
 
-This patch changes marketplace metadata only; the runtime and the `v0.7.8` legacy bridge boundary are unchanged.
+- Страница продукта ведёт на англоязычное описание Unica:
+  <https://ingvar.pro/products/unica/en>.
+- Политика конфиденциальности ведёт на отдельную страницу Unica:
+  <https://ingvar.pro/products/unica/privacy/en>.
+- Условия использования ведут на отдельную страницу Unica:
+  <https://ingvar.pro/products/unica/terms/en>.
+- Ссылки закреплены в versioned metadata плагина и опубликованы через новый
+  неизменяемый marketplace-тег `v0.8.1`.
+
+## Обновление
+
+Каноническая установка `v0.7.5` или новее обновляется обычными командами Codex
+CLI. Для старой, локальной или дублированной установки по-прежнему сначала
+используйте стабильный мост `v0.7.8`.
+
+## Проверка
+
+Все три страницы отвечают HTTP 200. Релиз прошёл контрактные тесты, сборку и
+проверку runtime для macOS, Linux и Windows, smoke-тесты новой установки и
+обновления с предыдущей стабильной версии, а также повторную проверку
+опубликованных артефактов.


### PR DESCRIPTION
## Что изменено
- описание стабильного `v0.8.0` переписано по-русски в структуре «Главное / Обновление / Проверка»
- описание patch-релиза `v0.8.1` переписано по-русски и содержит опубликованные ссылки карточки
- сохранены точная граница канонического обновления и неизменяемый мост `v0.7.8`

## Проверка
- `python3.12 -m unittest tests.ci.test_product_contracts tests.ci.test_legacy_migration_boundary -v` (21 passed)
- проверена одинаковая структура обоих release notes
- `git diff --check`