### PR TITLE
Consume prebuilt RLM toolchain assets

### DIFF
--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -87,19 +87,23 @@
       "repository": "https://github.com/Dach-Coin/rlm-tools-bsl",
       "sourceTag": "v1.26.0",
       "sourceCommit": "dcfff95ce678f49971b14d8acd82b042a6855470",
+      "assetRepository": "https://github.com/IngvarConsulting/unica-toolchain",
+      "assetTag": "rlm-tools-bsl-v1.26.0-build.2",
       "license": "MIT",
-      "assetStrategy": "pyinstaller-entrypoint",
+      "assetStrategy": "direct-release-asset",
       "binaryName": "rlm-tools-bsl",
-      "entrypoint": "rlm-tools-bsl",
       "assets": {
         "darwin-arm64": {
-          "assetName": "rlm-tools-bsl-darwin-arm64"
+          "assetName": "rlm-tools-bsl-darwin-arm64",
+          "sha256": "81a5817815d8f6a8aa38ede2dabc2d0693733722fb253400b3e879c5338b89c0"
         },
         "linux-x64": {
-          "assetName": "rlm-tools-bsl-linux-x64"
+          "assetName": "rlm-tools-bsl-linux-x64",
+          "sha256": "35c7acbbbcc1f8e32f4e4d9554ffba917a4f7ab4ee83ab95aa75bfe23378a517"
         },
         "win-x64": {
-          "assetName": "rlm-tools-bsl-win-x64.exe"
+          "assetName": "rlm-tools-bsl-win-x64.exe",
+          "sha256": "1f321e68375d9889c0f78716c31fe1e35b8a97444b32f4c6166f21b20185cb96"
         }
       }
     },
@@ -109,19 +113,23 @@
       "repository": "https://github.com/Dach-Coin/rlm-tools-bsl",
       "sourceTag": "v1.26.0",
       "sourceCommit": "dcfff95ce678f49971b14d8acd82b042a6855470",
+      "assetRepository": "https://github.com/IngvarConsulting/unica-toolchain",
+      "assetTag": "rlm-tools-bsl-v1.26.0-build.2",
       "license": "MIT",
-      "assetStrategy": "pyinstaller-entrypoint",
+      "assetStrategy": "direct-release-asset",
       "binaryName": "rlm-bsl-index",
-      "entrypoint": "rlm-bsl-index",
       "assets": {
         "darwin-arm64": {
-          "assetName": "rlm-bsl-index-darwin-arm64"
+          "assetName": "rlm-bsl-index-darwin-arm64",
+          "sha256": "7ec1bb3d3c6675033b560a9a2146f0b70d4d34f91522cf92def3ffabf9083975"
         },
         "linux-x64": {
-          "assetName": "rlm-bsl-index-linux-x64"
+          "assetName": "rlm-bsl-index-linux-x64",
+          "sha256": "5d7cb090281c6600ef9f477617a666a9b84270b46cbeb43d210a36b40c584b39"
         },
         "win-x64": {
-          "assetName": "rlm-bsl-index-win-x64.exe"
+          "assetName": "rlm-bsl-index-win-x64.exe",
+          "sha256": "ae9bc9bcb8bef71bdfee21e1b15920cc837e2e2fc692df8e9f63db92b7e8479d"
         }
       }
     },

--- a/scripts/ci/build-unica-tools.py
+++ b/scripts/ci/build-unica-tools.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import os
 import platform
 import shutil
 import subprocess
@@ -56,6 +55,12 @@ def download(url: str, dest: Path) -> None:
     print(f"download {url}", flush=True)
     with urllib.request.urlopen(url) as response, dest.open("wb") as out:
         shutil.copyfileobj(response, out)
+
+
+def release_asset_url(tool: dict, asset: dict) -> str:
+    repository = tool.get("assetRepository", tool["repository"])
+    tag = tool.get("assetTag", tool["sourceTag"])
+    return f"{repository}/releases/download/{tag}/{asset['assetName']}"
 
 
 def assert_host(target: str, targets: dict) -> None:
@@ -115,185 +120,6 @@ def extract_v8_runner(archive: Path, binary_name: str, dest: Path) -> None:
     if not matches:
         raise SystemExit(f"{binary_name} not found in {archive}")
     shutil.copy2(matches[0], dest)
-
-
-def verify_git_commit(source_dir: Path, expected_commit: str) -> None:
-    if not expected_commit:
-        return
-
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(source_dir), "rev-parse", "HEAD"],
-            check=True,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        return
-
-    actual = result.stdout.strip()
-    if actual != expected_commit:
-        raise SystemExit(f"{source_dir} is at {actual}, expected {expected_commit}")
-
-
-def checkout_source(tool: dict, work_dir: Path) -> Path:
-    source_dir = work_dir / "source" / tool["name"]
-    shutil.rmtree(source_dir, ignore_errors=True)
-    source_dir.parent.mkdir(parents=True, exist_ok=True)
-    run(
-        [
-            "git",
-            "clone",
-            "--depth",
-            "1",
-            "--branch",
-            tool["sourceTag"],
-            tool["repository"],
-            str(source_dir),
-        ]
-    )
-    verify_git_commit(source_dir, tool["sourceCommit"])
-    return source_dir
-
-
-def resolve_source(tool: dict, explicit_source: Path | None, work_dir: Path) -> Path:
-    if explicit_source is not None:
-        if not explicit_source.exists():
-            raise SystemExit(f"{tool['name']} source directory not found: {explicit_source}")
-        verify_git_commit(explicit_source, tool["sourceCommit"])
-        return explicit_source
-
-    return checkout_source(tool, work_dir)
-
-
-def create_python_env(source_dir: Path, work_dir: Path) -> Path:
-    if not source_dir.exists():
-        raise SystemExit(f"python tool source directory not found: {source_dir}")
-
-    venv_dir = (work_dir / "python-env").resolve()
-    if os.name == "nt":
-        venv_python = venv_dir / "Scripts" / "python.exe"
-    else:
-        venv_python = venv_dir / "bin" / "python"
-
-    if not venv_python.exists():
-        run([sys.executable, "-m", "venv", str(venv_dir)])
-
-    run([str(venv_python), "-m", "pip", "install", "--upgrade", "pip", "pyinstaller"])
-    run([str(venv_python), "-m", "pip", "install", str(source_dir)])
-    return venv_python
-
-
-def resolve_console_script_entrypoint(venv_python: Path, command_name: str) -> tuple[str, str]:
-    code = r"""
-import json
-import sys
-from importlib.metadata import entry_points
-
-command_name = sys.argv[1]
-eps = entry_points()
-if hasattr(eps, "select"):
-    candidates = eps.select(group="console_scripts", name=command_name)
-else:
-    candidates = [ep for ep in eps.get("console_scripts", []) if ep.name == command_name]
-
-matches = list(candidates)
-if not matches:
-    raise SystemExit(f"console_scripts entrypoint not found: {command_name}")
-
-entrypoint = matches[0]
-if not entrypoint.attr:
-    raise SystemExit(f"console_scripts entrypoint is not callable: {entrypoint.value}")
-
-print(json.dumps({"module": entrypoint.module, "attr": entrypoint.attr}))
-"""
-    try:
-        result = subprocess.run(
-            [str(venv_python), "-c", code, command_name],
-            check=True,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-    except subprocess.CalledProcessError as exc:
-        detail = (exc.stderr or exc.stdout).strip()
-        message = f": {detail}" if detail else ""
-        raise SystemExit(f"failed to resolve installed entrypoint {command_name}{message}") from exc
-
-    data = json.loads(result.stdout)
-    return data["module"], data["attr"]
-
-
-def write_entrypoint_stub(build_root: Path, command_name: str, module: str, attr: str) -> Path:
-    stub = build_root / f"{command_name}-entrypoint.py"
-    stub.write_text(
-        "\n".join(
-            [
-                "import importlib",
-                "import sys",
-                "",
-                f"MODULE = {module!r}",
-                f"CALLABLE = {attr!r}",
-                "",
-                "",
-                "def _load_entrypoint():",
-                "    obj = importlib.import_module(MODULE)",
-                "    for part in CALLABLE.split('.'):",
-                "        obj = getattr(obj, part)",
-                "    return obj",
-                "",
-                "",
-                "if __name__ == '__main__':",
-                "    sys.exit(_load_entrypoint()())",
-                "",
-            ]
-        ),
-        encoding="utf-8",
-    )
-    return stub
-
-
-def build_python_entrypoint(
-    tool: dict,
-    work_dir: Path,
-    out_dir: Path,
-    exe: str,
-    venv_python: Path,
-) -> Path:
-    command_name = tool["entrypoint"]
-    build_root = (work_dir / command_name).resolve()
-    shutil.rmtree(build_root, ignore_errors=True)
-    build_root.mkdir(parents=True)
-
-    module, attr = resolve_console_script_entrypoint(venv_python, command_name)
-    script = write_entrypoint_stub(build_root, command_name, module, attr)
-    collect_package = tool.get("collectAll", module.split(".", 1)[0])
-    run(
-        [
-            str(venv_python),
-            "-m",
-            "PyInstaller",
-            "--onefile",
-            "--clean",
-            "--noconfirm",
-            "--name",
-            command_name,
-            "--collect-all",
-            collect_package,
-            "--hidden-import",
-            module,
-            str(script),
-        ],
-        cwd=build_root,
-    )
-    produced = build_root / "dist" / f"{command_name}{exe}"
-    if not produced.exists():
-        raise SystemExit(f"PyInstaller output not found: {produced}")
-
-    dest = out_dir / f"{tool['binaryName']}{exe}"
-    shutil.copy2(produced, dest)
-    return dest
 
 
 def build_cargo_workspace_tool(
@@ -399,7 +225,6 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--target", required=True)
     parser.add_argument("--lock-file", type=Path, default=Path("plugins/unica/third-party/tools.lock.json"))
-    parser.add_argument("--rlm-source", type=Path)
     parser.add_argument("--repo-root", type=Path, default=Path("."))
     parser.add_argument("--out-dir", type=Path, required=True)
     parser.add_argument("--work-dir", type=Path, default=Path(".build/unica-tools"))
@@ -420,9 +245,6 @@ def main() -> None:
     downloads_dir.mkdir(parents=True, exist_ok=True)
 
     built_paths: dict[str, Path] = {}
-    python_env_cache: dict[Path, Path] = {}
-    source_cache: dict[tuple[str, str, str], Path] = {}
-
     for tool in lock["tools"]:
         strategy = tool["assetStrategy"]
         dest = target_bin_dir / f"{tool['binaryName']}{exe}"
@@ -431,7 +253,7 @@ def main() -> None:
             asset = tool["assets"].get(args.target)
             if not asset:
                 raise SystemExit(f"{tool['name']} has no asset for target {args.target}")
-            url = f"{tool['repository']}/releases/download/{tool['sourceTag']}/{asset['assetName']}"
+            url = release_asset_url(tool, asset)
             downloaded = downloads_dir / asset["assetName"]
             download(url, downloaded)
             verify_asset_checksum(downloaded, asset, tool_name=tool["name"], target=args.target)
@@ -440,26 +262,11 @@ def main() -> None:
             asset = tool["assets"].get(args.target)
             if not asset:
                 raise SystemExit(f"{tool['name']} has no asset for target {args.target}")
-            url = f"{tool['repository']}/releases/download/{tool['sourceTag']}/{asset['assetName']}"
+            url = release_asset_url(tool, asset)
             downloaded = downloads_dir / asset["assetName"]
             download(url, downloaded)
             verify_asset_checksum(downloaded, asset, tool_name=tool["name"], target=args.target)
             extract_v8_runner(downloaded, asset["archiveBinary"], dest)
-        elif strategy == "pyinstaller-entrypoint":
-            key = (tool["repository"], tool["sourceTag"], tool["sourceCommit"])
-            if key not in source_cache:
-                source_cache[key] = resolve_source(tool, args.rlm_source, args.work_dir / args.target)
-            source_dir = source_cache[key]
-            if source_dir not in python_env_cache:
-                python_env_cache[source_dir] = create_python_env(source_dir, args.work_dir / args.target)
-            venv_python = python_env_cache[source_dir]
-            dest = build_python_entrypoint(
-                tool,
-                args.work_dir / args.target / "pyinstaller",
-                target_bin_dir,
-                exe,
-                venv_python,
-            )
         elif strategy == "cargo-workspace":
             dest = build_cargo_workspace_tool(
                 tool,

--- a/tests/ci/test_build_unica_tools.py
+++ b/tests/ci/test_build_unica_tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import json
 import tarfile
 import tempfile
 import unittest
@@ -19,7 +20,45 @@ def load_build_module():
     return module
 
 
-class BuildPythonEntrypointTests(unittest.TestCase):
+class BuildUnicaToolsTests(unittest.TestCase):
+    def test_release_asset_url_can_differ_from_upstream_source(self) -> None:
+        module = load_build_module()
+
+        url = module.release_asset_url(
+            {
+                "repository": "https://github.com/Dach-Coin/rlm-tools-bsl",
+                "sourceTag": "v1.26.0",
+                "assetRepository": "https://github.com/IngvarConsulting/unica-toolchain",
+                "assetTag": "rlm-tools-bsl-v1.26.0-build.2",
+            },
+            {"assetName": "rlm-tools-bsl-linux-x64"},
+        )
+
+        self.assertEqual(
+            url,
+            "https://github.com/IngvarConsulting/unica-toolchain/releases/download/"
+            "rlm-tools-bsl-v1.26.0-build.2/rlm-tools-bsl-linux-x64",
+        )
+
+    def test_checked_in_rlm_tools_use_prebuilt_toolchain_assets(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        lock = json.loads(
+            (repo_root / "plugins" / "unica" / "third-party" / "tools.lock.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        rlm_tools = [tool for tool in lock["tools"] if tool["name"].startswith("rlm-")]
+
+        self.assertEqual(len(rlm_tools), 2)
+        for tool in rlm_tools:
+            self.assertEqual(tool["assetStrategy"], "direct-release-asset")
+            self.assertEqual(
+                tool["assetRepository"], "https://github.com/IngvarConsulting/unica-toolchain"
+            )
+            self.assertEqual(tool["assetTag"], "rlm-tools-bsl-v1.26.0-build.2")
+            for asset in tool["assets"].values():
+                self.assertRegex(asset["sha256"], r"^[0-9a-f]{64}$")
+
     def test_release_asset_checksum_mismatch_fails_before_use(self) -> None:
         module = load_build_module()
 
@@ -53,54 +92,6 @@ class BuildPythonEntrypointTests(unittest.TestCase):
                 module.extract_v8_runner(archive, "v8-runner", root / "v8-runner")
 
             self.assertFalse(outside.exists())
-
-    def test_pyinstaller_uses_generated_python_stub_for_entrypoint(self) -> None:
-        module = load_build_module()
-
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            work_dir = root / "pyinstaller"
-            out_dir = root / "out"
-            out_dir.mkdir()
-            calls = []
-
-            def fake_run(args, *, cwd=None):
-                calls.append((args, cwd))
-                dist = Path(cwd) / "dist"
-                dist.mkdir()
-                (dist / "rlm-tools-bsl.exe").write_bytes(b"frozen")
-
-            with (
-                patch.object(
-                    module,
-                    "resolve_console_script_entrypoint",
-                    return_value=("rlm_tools_bsl.server", "main"),
-                ),
-                patch.object(module, "run", side_effect=fake_run),
-            ):
-                dest = module.build_python_entrypoint(
-                    {
-                        "entrypoint": "rlm-tools-bsl",
-                        "binaryName": "rlm-tools-bsl",
-                    },
-                    work_dir,
-                    out_dir,
-                    ".exe",
-                    root / "venv" / "Scripts" / "python.exe",
-                )
-
-            stub = work_dir / "rlm-tools-bsl" / "rlm-tools-bsl-entrypoint.py"
-            self.assertEqual(dest, out_dir / "rlm-tools-bsl.exe")
-            self.assertEqual(dest.read_bytes(), b"frozen")
-            self.assertTrue(stub.exists())
-            self.assertIn("MODULE = 'rlm_tools_bsl.server'", stub.read_text(encoding="utf-8"))
-
-            args, cwd = calls[0]
-            self.assertEqual(cwd, (work_dir / "rlm-tools-bsl").resolve())
-            self.assertEqual(Path(args[-1]).resolve(), stub.resolve())
-            self.assertEqual(args[args.index("--collect-all") + 1], "rlm_tools_bsl")
-            self.assertEqual(args[args.index("--hidden-import") + 1], "rlm_tools_bsl.server")
-            self.assertFalse(str(args[-1]).endswith(".exe"))
 
     def test_cargo_workspace_tool_builds_from_repo_root(self) -> None:
         module = load_build_module()


### PR DESCRIPTION
## Что изменено

- RLM `1.26.0` больше не собирается PyInstaller внутри каждого платформенного workflow Unica.
- `tools.lock.json` сохраняет upstream repository/tag/commit как provenance, но скачивает бинарники из неизменяемого релиза `IngvarConsulting/unica-toolchain`.
- Все шесть платформенных assets зафиксированы SHA-256.
- Из сборщика Unica удалены ставшие недостижимыми clone/venv/PyInstaller paths и `--rlm-source`.

Toolchain release: https://github.com/IngvarConsulting/unica-toolchain/releases/tag/rlm-tools-bsl-v1.26.0-build.2

Остальные оптимизации CI вынесены в #148.

## Проверка

- `python3.12 -m unittest discover -s tests/ci` — 168 passed, 3 skipped
- `actionlint`
- полная локальная сборка `darwin-arm64` через `build-unica-tools.py`
- скачанные RLM assets прошли SHA-256 и оба native `--help` smoke tests
- toolchain GitHub Actions собрал и проверил macOS, Linux и Windows
