### PR TITLE
Consume all external tools from unica-toolchain

### DIFF
--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -36,21 +36,23 @@
       "repository": "https://github.com/itrous/bsl-analyzer",
       "sourceTag": "v0.2.55",
       "sourceCommit": "5a02bb44dedaf29e0e29af1f740279d279199854",
+      "assetRepository": "https://github.com/IngvarConsulting/unica-toolchain",
+      "assetTag": "bsl-analyzer-v0.2.55-build.1",
       "license": "LGPL-3.0-or-later",
       "assetStrategy": "direct-release-asset",
       "binaryName": "bsl-analyzer",
       "assets": {
         "darwin-arm64": {
-          "assetName": "bsl-analyzer-app-darwin-arm64",
-          "sha256": "e744747e19572035218b5fc1b9ab52c74ffa1d5d238b59aadecfdfa89ddd767b"
+          "assetName": "bsl-analyzer-darwin-arm64",
+          "sha256": "c9ce4cf5281ae9599a99aac06818420252b26e8ad40fb522a954ab144d2aa6cc"
         },
         "linux-x64": {
-          "assetName": "bsl-analyzer-app-linux-amd64",
-          "sha256": "407d618c1f400b9a287ef6debe9b7bbd39deeb8edbf6d96529c1c9579f138708"
+          "assetName": "bsl-analyzer-linux-x64",
+          "sha256": "ca1f4177bfb11e9cb8e2550bb17a6d83f69b3d5496dc5c233996fc08bd7cb5e9"
         },
         "win-x64": {
-          "assetName": "bsl-analyzer-app-windows-amd64.exe",
-          "sha256": "b9f3ed200901a0c33efca51941e7495b07325eae5d0aeb3f6185da4aa62cf3c5"
+          "assetName": "bsl-analyzer-win-x64.exe",
+          "sha256": "f024f6d03ad58bfed18cefaf38e4a6e593a1c37b22bc6926d8d270e631bc8703"
         }
       }
     },
@@ -60,24 +62,23 @@
       "repository": "https://github.com/alkoleft/v8-runner-rust",
       "sourceTag": "v0.5.1",
       "sourceCommit": "ad72f64222ab0a7e6dfd391adb437a956c0a2428",
-      "license": "NOASSERTION",
-      "assetStrategy": "archive-release-asset",
+      "assetRepository": "https://github.com/IngvarConsulting/unica-toolchain",
+      "assetTag": "v8-runner-v0.5.1-build.1",
+      "license": "MIT",
+      "assetStrategy": "direct-release-asset",
       "binaryName": "v8-runner",
       "assets": {
         "darwin-arm64": {
-          "assetName": "v8-runner-macos-aarch64.tar.gz",
-          "archiveBinary": "v8-runner",
-          "sha256": "6a5c30e67a354746c3b91586e4b59a45186b258293fe4b54057a1fd3b92c63b8"
+          "assetName": "v8-runner-darwin-arm64",
+          "sha256": "31e7735ee3c7680ae597c61c3f00e4ce780f486c2d9875aeaacf00984a1a1a21"
         },
         "linux-x64": {
-          "assetName": "v8-runner-linux-x86_64-musl.tar.gz",
-          "archiveBinary": "v8-runner",
-          "sha256": "032c6fbfe6b9db0c3ad285ade12bfdf2c5265577274d23b80b685d49532a3866"
+          "assetName": "v8-runner-linux-x64",
+          "sha256": "17e6d96e42cf89d59f880b83cc335486ed85944c70d177292ea4ab4336822151"
         },
         "win-x64": {
-          "assetName": "v8-runner-windows-x86_64.zip",
-          "archiveBinary": "v8-runner.exe",
-          "sha256": "0cf1b5b93f79dca19db79cad2610a2a611e73dc1d7b6f5a55879caf1e3b94b34"
+          "assetName": "v8-runner-win-x64.exe",
+          "sha256": "67251d36f9e1babbf4fadfee16be0490b0205a7a2bd279795d7e5fc8012a02e1"
         }
       }
     },
@@ -88,22 +89,22 @@
       "sourceTag": "v1.26.0",
       "sourceCommit": "dcfff95ce678f49971b14d8acd82b042a6855470",
       "assetRepository": "https://github.com/IngvarConsulting/unica-toolchain",
-      "assetTag": "rlm-tools-bsl-v1.26.0-build.2",
+      "assetTag": "rlm-tools-bsl-v1.26.0-build.3",
       "license": "MIT",
       "assetStrategy": "direct-release-asset",
       "binaryName": "rlm-tools-bsl",
       "assets": {
         "darwin-arm64": {
           "assetName": "rlm-tools-bsl-darwin-arm64",
-          "sha256": "81a5817815d8f6a8aa38ede2dabc2d0693733722fb253400b3e879c5338b89c0"
+          "sha256": "8eeb0abaf8a08f4a7eab1d13fa603101720577f322cef73af1c908fca09920aa"
         },
         "linux-x64": {
           "assetName": "rlm-tools-bsl-linux-x64",
-          "sha256": "35c7acbbbcc1f8e32f4e4d9554ffba917a4f7ab4ee83ab95aa75bfe23378a517"
+          "sha256": "9e08e45fcd3b770b6810bf18b2575cef4d827266595b33f5c5303b02d517ad0f"
         },
         "win-x64": {
           "assetName": "rlm-tools-bsl-win-x64.exe",
-          "sha256": "1f321e68375d9889c0f78716c31fe1e35b8a97444b32f4c6166f21b20185cb96"
+          "sha256": "02e13273694f0dc5ec4e185acef2b030e95b6191d7390daf3bb9b1cc9853702d"
         }
       }
     },
@@ -114,22 +115,22 @@
       "sourceTag": "v1.26.0",
       "sourceCommit": "dcfff95ce678f49971b14d8acd82b042a6855470",
       "assetRepository": "https://github.com/IngvarConsulting/unica-toolchain",
-      "assetTag": "rlm-tools-bsl-v1.26.0-build.2",
+      "assetTag": "rlm-tools-bsl-v1.26.0-build.3",
       "license": "MIT",
       "assetStrategy": "direct-release-asset",
       "binaryName": "rlm-bsl-index",
       "assets": {
         "darwin-arm64": {
           "assetName": "rlm-bsl-index-darwin-arm64",
-          "sha256": "7ec1bb3d3c6675033b560a9a2146f0b70d4d34f91522cf92def3ffabf9083975"
+          "sha256": "6876a26eba795ec8cb73bd62a2d6d2ead73a982f45f703406b82ffad3af93b8c"
         },
         "linux-x64": {
           "assetName": "rlm-bsl-index-linux-x64",
-          "sha256": "5d7cb090281c6600ef9f477617a666a9b84270b46cbeb43d210a36b40c584b39"
+          "sha256": "f899111f5e7313cdc99f0cd98e70593e20efcddb4ddaeeaeb014b49841400cab"
         },
         "win-x64": {
           "assetName": "rlm-bsl-index-win-x64.exe",
-          "sha256": "ae9bc9bcb8bef71bdfee21e1b15920cc837e2e2fc692df8e9f63db92b7e8479d"
+          "sha256": "7e7c43c6991cbe658fb974d4a3e0afc2e0adb37a300ae87688a9d4cfb1882f65"
         }
       }
     },

--- a/scripts/ci/build-unica-tools.py
+++ b/scripts/ci/build-unica-tools.py
@@ -10,9 +10,7 @@ import platform
 import shutil
 import subprocess
 import sys
-import tarfile
 import urllib.request
-import zipfile
 from pathlib import Path
 
 
@@ -72,54 +70,6 @@ def assert_host(target: str, targets: dict) -> None:
         expected = f"{cfg['hostSystem']} {sorted(supported_machines)}"
         actual = f"{system} {machine}"
         raise SystemExit(f"target {target} must be built on {expected}; current runner is {actual}")
-
-
-def extract_v8_runner(archive: Path, binary_name: str, dest: Path) -> None:
-    extract_dir = archive.parent / f"{archive.name}.extract"
-    shutil.rmtree(extract_dir, ignore_errors=True)
-    extract_dir.mkdir(parents=True)
-    extract_root = extract_dir.resolve()
-
-    def safe_member_path(member_name: str) -> Path:
-        target = (extract_dir / member_name).resolve()
-        try:
-            target.relative_to(extract_root)
-        except ValueError as exc:
-            raise SystemExit(f"unsafe archive member in {archive}: {member_name}") from exc
-        return target
-
-    if archive.suffix == ".zip":
-        with zipfile.ZipFile(archive) as zf:
-            for member in zf.infolist():
-                target = safe_member_path(member.filename)
-                if member.is_dir():
-                    target.mkdir(parents=True, exist_ok=True)
-                    continue
-                target.parent.mkdir(parents=True, exist_ok=True)
-                with zf.open(member) as source, target.open("wb") as out:
-                    shutil.copyfileobj(source, out)
-    else:
-        with tarfile.open(archive) as tf:
-            for member in tf.getmembers():
-                target = safe_member_path(member.name)
-                if member.issym() or member.islnk():
-                    raise SystemExit(f"unsafe archive member in {archive}: {member.name}")
-                if member.isdir():
-                    target.mkdir(parents=True, exist_ok=True)
-                    continue
-                if not member.isfile():
-                    continue
-                target.parent.mkdir(parents=True, exist_ok=True)
-                source = tf.extractfile(member)
-                if source is None:
-                    continue
-                with source, target.open("wb") as out:
-                    shutil.copyfileobj(source, out)
-
-    matches = [p for p in extract_dir.rglob(binary_name) if p.is_file()]
-    if not matches:
-        raise SystemExit(f"{binary_name} not found in {archive}")
-    shutil.copy2(matches[0], dest)
 
 
 def build_cargo_workspace_tool(
@@ -258,15 +208,6 @@ def main() -> None:
             download(url, downloaded)
             verify_asset_checksum(downloaded, asset, tool_name=tool["name"], target=args.target)
             shutil.copy2(downloaded, dest)
-        elif strategy == "archive-release-asset":
-            asset = tool["assets"].get(args.target)
-            if not asset:
-                raise SystemExit(f"{tool['name']} has no asset for target {args.target}")
-            url = release_asset_url(tool, asset)
-            downloaded = downloads_dir / asset["assetName"]
-            download(url, downloaded)
-            verify_asset_checksum(downloaded, asset, tool_name=tool["name"], target=args.target)
-            extract_v8_runner(downloaded, asset["archiveBinary"], dest)
         elif strategy == "cargo-workspace":
             dest = build_cargo_workspace_tool(
                 tool,

--- a/tests/ci/test_build_unica_tools.py
+++ b/tests/ci/test_build_unica_tools.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
-import io
 import json
-import tarfile
 import tempfile
 import unittest
 from pathlib import Path
@@ -26,38 +24,47 @@ class BuildUnicaToolsTests(unittest.TestCase):
 
         url = module.release_asset_url(
             {
-                "repository": "https://github.com/Dach-Coin/rlm-tools-bsl",
-                "sourceTag": "v1.26.0",
+                "repository": "https://github.com/example/upstream",
+                "sourceTag": "v1.2.3",
                 "assetRepository": "https://github.com/IngvarConsulting/unica-toolchain",
-                "assetTag": "rlm-tools-bsl-v1.26.0-build.2",
+                "assetTag": "example-v1.2.3-build.7",
             },
-            {"assetName": "rlm-tools-bsl-linux-x64"},
+            {"assetName": "example-linux-x64"},
         )
 
         self.assertEqual(
             url,
             "https://github.com/IngvarConsulting/unica-toolchain/releases/download/"
-            "rlm-tools-bsl-v1.26.0-build.2/rlm-tools-bsl-linux-x64",
+            "example-v1.2.3-build.7/example-linux-x64",
         )
 
-    def test_checked_in_rlm_tools_use_prebuilt_toolchain_assets(self) -> None:
+    def test_all_checked_in_external_tools_use_independent_toolchain_assets(self) -> None:
         repo_root = Path(__file__).resolve().parents[2]
         lock = json.loads(
             (repo_root / "plugins" / "unica" / "third-party" / "tools.lock.json").read_text(
                 encoding="utf-8"
             )
         )
-        rlm_tools = [tool for tool in lock["tools"] if tool["name"].startswith("rlm-")]
+        external_tools = [tool for tool in lock["tools"] if tool["name"] != "unica"]
+        expected_tags = {
+            "bsl-analyzer": "bsl-analyzer-v0.2.55-build.1",
+            "v8-runner": "v8-runner-v0.5.1-build.1",
+            "rlm-tools-bsl": "rlm-tools-bsl-v1.26.0-build.3",
+            "rlm-bsl-index": "rlm-tools-bsl-v1.26.0-build.3",
+        }
 
-        self.assertEqual(len(rlm_tools), 2)
-        for tool in rlm_tools:
+        self.assertEqual({tool["name"] for tool in external_tools}, set(expected_tags))
+        for tool in external_tools:
             self.assertEqual(tool["assetStrategy"], "direct-release-asset")
             self.assertEqual(
                 tool["assetRepository"], "https://github.com/IngvarConsulting/unica-toolchain"
             )
-            self.assertEqual(tool["assetTag"], "rlm-tools-bsl-v1.26.0-build.2")
-            for asset in tool["assets"].values():
+            self.assertEqual(tool["assetTag"], expected_tags[tool["name"]])
+            for target, asset in tool["assets"].items():
+                exe = ".exe" if target == "win-x64" else ""
+                self.assertEqual(asset["assetName"], f"{tool['binaryName']}-{target}{exe}")
                 self.assertRegex(asset["sha256"], r"^[0-9a-f]{64}$")
+                self.assertNotIn("archiveBinary", asset)
 
     def test_release_asset_checksum_mismatch_fails_before_use(self) -> None:
         module = load_build_module()
@@ -74,24 +81,15 @@ class BuildUnicaToolsTests(unittest.TestCase):
                     target="linux-x64",
                 )
 
-    def test_archive_extraction_rejects_path_traversal_members(self) -> None:
+    def test_bundle_builder_has_no_archive_asset_dependency_path(self) -> None:
         module = load_build_module()
+        source = (
+            Path(__file__).resolve().parents[2] / "scripts" / "ci" / "build-unica-tools.py"
+        ).read_text(encoding="utf-8")
 
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            archive = root / "v8-runner.tar.gz"
-            outside = root / "escape"
-            payload = b"owned"
-
-            with tarfile.open(archive, "w:gz") as tf:
-                info = tarfile.TarInfo("../escape")
-                info.size = len(payload)
-                tf.addfile(info, io.BytesIO(payload))
-
-            with self.assertRaisesRegex(SystemExit, "unsafe archive member"):
-                module.extract_v8_runner(archive, "v8-runner", root / "v8-runner")
-
-            self.assertFalse(outside.exists())
+        self.assertFalse(hasattr(module, "extract_v8_runner"))
+        self.assertNotIn("archive-release-asset", source)
+        self.assertNotIn("archiveBinary", source)
 
     def test_cargo_workspace_tool_builds_from_repo_root(self) -> None:
         module = load_build_module()


### PR DESCRIPTION
## What changed

- switch bsl-analyzer, v8-runner, rlm-tools-bsl, and rlm-bsl-index to immutable releases from `IngvarConsulting/unica-toolchain`
- pin normalized per-target asset names and SHA-256 values for macOS arm64, Linux x64, and Windows x64
- retain each upstream repository, source tag, and exact source commit as runtime provenance
- remove the v8-runner archive download and extraction path because every external asset is now a direct executable
- replace the RLM-only test contract with a contract covering every external runtime tool

## Why

Third-party source compilation and patch ownership now live in `unica-toolchain`. Unica package CI should consume verified release assets instead of rebuilding or transforming upstream artifacts.

## Impact

Unica release jobs still build the internal `unica` and bootstrap binaries, but external tools are now downloaded as independently versioned, checksummed executables. Updating one external tool no longer requires rebuilding the others in the toolchain repository.

## Validation

- `python3.12 -m unittest discover -s tests/ci` — 168 passed, 3 skipped
- `cargo test --workspace -- --test-threads=1` — all workspace, integration, and doc tests passed
- `python3.12 -m py_compile scripts/ci/build-unica-tools.py tests/ci/test_build_unica_tools.py`
- `python3.12 -m json.tool plugins/unica/third-party/tools.lock.json`
- `actionlint`
- `git diff --check`
- real Darwin bundle build downloaded all four external assets, verified lock checksums, built internal binaries, and executed native version smoke checks
- all three toolchain releases were re-downloaded and verified for exact file sets, checksums, provenance, and native Darwin execution
