### PR TITLE
ci: establish a stable required gate

### DIFF
--- a/.github/workflows/publish-unica-marketplace.yml
+++ b/.github/workflows/publish-unica-marketplace.yml
@@ -34,6 +34,7 @@ jobs:
       github.event.workflow_run.event == 'push') ||
       (github.event_name == 'workflow_dispatch' && inputs.mode == 'stage')
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       GH_TOKEN: ${{ secrets.UNICA_MARKETPLACE_TOKEN }}
       SOURCE_RUN_ID: ${{ github.event.workflow_run.id || inputs.source_run_id }}
@@ -43,7 +44,7 @@ jobs:
         run: test -n "$GH_TOKEN"
       - name: Configure Git credentials
         run: gh auth setup-git
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Download verified thin payload
         run: gh run download "$SOURCE_RUN_ID" --repo IngvarConsulting/unica --name unica-thin-marketplace --dir payload
       - name: Require package contract files
@@ -77,6 +78,7 @@ jobs:
   promote:
     if: github.event_name == 'workflow_dispatch' && inputs.mode == 'promote'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       GH_TOKEN: ${{ secrets.UNICA_MARKETPLACE_TOKEN }}
       SOURCE_RUN_ID: ${{ inputs.source_run_id }}

--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -3,21 +3,6 @@ name: Build Unica Codex Plugin
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - ".agents/plugins/marketplace.json"
-      - ".github/workflows/unica-plugin-release.yml"
-      - ".github/workflows/publish-unica-marketplace.yml"
-      - "AGENTS.md"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "README.md"
-      - "crates/unica-bootstrap/**"
-      - "crates/unica-coder/**"
-      - "plugins/unica/**"
-      - "scripts/ci/**"
-      - "tests/ci/**"
-      - "tests/fixtures/**"
-      - "spec/**"
   push:
     tags:
       - "v*"
@@ -32,10 +17,11 @@ concurrency:
 jobs:
   classify-changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       release_artifacts: ${{ steps.scope.outputs.release_artifacts }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - id: scope
@@ -53,16 +39,17 @@ jobs:
   verify-source:
     name: Verify source guardrails
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - run: python -m pip install -r tests/ci/requirements.txt
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      - run: python -m unittest discover -s tests/ci
+      - run: python -m unittest discover -s tests/ci --durations 20
       - run: python -m py_compile scripts/ci/*.py tests/ci/*.py
       - run: python scripts/ci/check-version-contract.py
       - run: cargo fmt --all -- --check
@@ -72,18 +59,20 @@ jobs:
   test-rust-platforms:
     name: Rust tests (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         runner: [windows-latest, macos-14]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --workspace -- --test-threads=1
 
   build-tools:
     name: Build tools (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
     needs: [classify-changes, verify-source, test-rust-platforms]
     if: ${{ github.event_name != 'pull_request' || needs.classify-changes.outputs.release_artifacts == 'true' }}
     strategy:
@@ -97,8 +86,8 @@ jobs:
           - target: darwin-arm64
             runner: macos-14
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - uses: dtolnay/rust-toolchain@stable
@@ -123,7 +112,7 @@ jobs:
           python scripts/ci/smoke-unica-mcp.py \
             --binary "$executable" \
             --plugin-root ".build/tool-bundles/${{ matrix.target }}"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: unica-tools-${{ matrix.target }}
           path: .build/tool-bundles/${{ matrix.target }}
@@ -132,17 +121,18 @@ jobs:
   package-runtime:
     name: Package runtime (${{ matrix.target }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: build-tools
     strategy:
       fail-fast: false
       matrix:
         target: [darwin-arm64, linux-x64, win-x64]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: unica-tools-${{ matrix.target }}
           path: .build/bundle
@@ -150,7 +140,7 @@ jobs:
           python scripts/ci/package-unica-runtime.py
           --bundle-root .build/bundle
           --out-dir dist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: unica-runtime-${{ matrix.target }}
           path: |
@@ -161,20 +151,21 @@ jobs:
   package-thin:
     name: Package thin marketplace payload
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: package-runtime
     env:
       RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'v0.8.1' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: unica-runtime-*
           path: .build/runtime-metadata
           merge-multiple: true
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: unica-tools-*
           path: .build/bootstrap-root
@@ -187,7 +178,7 @@ jobs:
           --release-tag "$RELEASE_TAG"
           --source-commit "${{ github.sha }}"
           --out-dir dist/thin
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: unica-thin-marketplace
           path: dist/thin/marketplace
@@ -197,6 +188,7 @@ jobs:
   probe-thin-bootstrap:
     name: Probe thin bootstrap (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     needs: package-thin
     if: github.event_name == 'pull_request'
     strategy:
@@ -210,11 +202,11 @@ jobs:
           - target: darwin-arm64
             runner: macos-14
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: unica-thin-marketplace
           path: .build/thin
@@ -228,14 +220,15 @@ jobs:
   release-assessment:
     name: Assess Linux runtime on BSP
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: package-runtime
     if: ${{ always() && needs.package-runtime.result == 'success' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: unica-runtime-linux-x64
           path: dist/runtime
@@ -248,7 +241,7 @@ jobs:
           --bsp-ref 3.2.1.446
           --release-tag "${{ github.ref_name }}"
           --github-run-id "${{ github.run_id }}"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: unica-release-assessment
@@ -258,18 +251,19 @@ jobs:
   publish-release-assets:
     name: Publish runtime assets
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: package-runtime
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           pattern: unica-runtime-*
           path: dist/runtime
           merge-multiple: true
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: |
@@ -279,6 +273,7 @@ jobs:
   smoke-thin-plugin:
     name: Smoke published thin plugin (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     needs: [package-thin, publish-release-assets]
     if: startsWith(github.ref, 'refs/tags/')
     strategy:
@@ -292,11 +287,11 @@ jobs:
           - target: darwin-arm64
             runner: macos-14
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: unica-thin-marketplace
           path: .build/thin
@@ -309,6 +304,7 @@ jobs:
   verify-published-assets:
     name: Re-download and verify published bytes
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       - publish-release-assets
       - package-thin
@@ -316,8 +312,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Download release assets from GitHub
@@ -325,3 +321,27 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: gh release download "$GITHUB_REF_NAME" --pattern 'unica-runtime-*' --dir published
       - run: python scripts/ci/verify-release-assets.py --asset-dir published
+
+  unica-ci:
+    name: Unica CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always()
+    needs:
+      - classify-changes
+      - verify-source
+      - test-rust-platforms
+      - build-tools
+      - package-runtime
+      - package-thin
+      - probe-thin-bootstrap
+      - release-assessment
+      - publish-release-assets
+      - smoke-thin-plugin
+      - verify-published-assets
+    steps:
+      - uses: actions/checkout@v7
+      - name: Evaluate required CI results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: python scripts/ci/evaluate-ci-gate.py

--- a/scripts/ci/evaluate-ci-gate.py
+++ b/scripts/ci/evaluate-ci-gate.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Evaluate the stable aggregate result for the Unica GitHub Actions workflow."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+
+COMMON_JOBS = (
+    "classify-changes",
+    "verify-source",
+    "test-rust-platforms",
+)
+CONDITIONAL_JOBS = (
+    "build-tools",
+    "package-runtime",
+    "package-thin",
+    "release-assessment",
+)
+PUBLISH_JOBS = (
+    "publish-release-assets",
+    "smoke-thin-plugin",
+    "verify-published-assets",
+)
+
+
+class GateEvaluation(NamedTuple):
+    event_name: str
+    ref: str
+    release_artifacts: str
+    contour: str
+    results: dict[str, str]
+    expected: dict[str, str]
+    unexpected: dict[str, tuple[str, str]]
+    skipped_jobs: list[str]
+
+    @property
+    def ok(self) -> bool:
+        return not self.unexpected
+
+
+def expected_results(
+    event_name: str,
+    ref: str,
+    release_artifacts: str,
+) -> tuple[str, dict[str, str], dict[str, tuple[str, str]]]:
+    expected = {job: "success" for job in COMMON_JOBS}
+    invalid: dict[str, tuple[str, str]] = {}
+
+    if release_artifacts not in {"true", "false"}:
+        invalid["classification"] = (release_artifacts or "missing", "true or false")
+        return "invalid", expected, invalid
+
+    pipeline_result = "success" if release_artifacts == "true" else "skipped"
+    expected.update({job: pipeline_result for job in CONDITIONAL_JOBS})
+
+    if event_name == "pull_request":
+        contour = "full" if release_artifacts == "true" else "light"
+        expected["probe-thin-bootstrap"] = pipeline_result
+        expected.update({job: "skipped" for job in PUBLISH_JOBS})
+    elif event_name == "push" and ref.startswith("refs/tags/"):
+        contour = "release"
+        expected["probe-thin-bootstrap"] = "skipped"
+        expected.update({job: "success" for job in PUBLISH_JOBS})
+        if release_artifacts != "true":
+            invalid["classification"] = (release_artifacts, "true")
+    elif event_name == "workflow_dispatch":
+        contour = "full"
+        expected["probe-thin-bootstrap"] = "skipped"
+        expected.update({job: "skipped" for job in PUBLISH_JOBS})
+        if release_artifacts != "true":
+            invalid["classification"] = (release_artifacts, "true")
+    else:
+        contour = "invalid"
+        expected["probe-thin-bootstrap"] = "skipped"
+        expected.update({job: "skipped" for job in PUBLISH_JOBS})
+        invalid["event"] = (f"{event_name}:{ref}", "pull_request, tag push, or workflow_dispatch")
+
+    return contour, expected, invalid
+
+
+def evaluate_gate(
+    event_name: str,
+    ref: str,
+    release_artifacts: str,
+    results: dict[str, str],
+) -> GateEvaluation:
+    contour, expected, unexpected = expected_results(event_name, ref, release_artifacts)
+    unexpected = dict(unexpected)
+
+    for job, expected_result in expected.items():
+        actual_result = results.get(job, "missing")
+        if actual_result != expected_result:
+            unexpected[job] = (actual_result, expected_result)
+
+    skipped_jobs = [job for job in expected if results.get(job) == "skipped"]
+    return GateEvaluation(
+        event_name=event_name,
+        ref=ref,
+        release_artifacts=release_artifacts,
+        contour=contour,
+        results=dict(results),
+        expected=expected,
+        unexpected=unexpected,
+        skipped_jobs=skipped_jobs,
+    )
+
+
+def render_summary(evaluation: GateEvaluation) -> str:
+    lines = [
+        "## Unica CI",
+        "",
+        f"- Event: `{evaluation.event_name}`",
+        f"- Contour: `{evaluation.contour}`",
+        f"- Release artifacts: `{evaluation.release_artifacts or 'missing'}`",
+        f"- Gate: `{'success' if evaluation.ok else 'failure'}`",
+        "",
+        "| Job | Result | Expected |",
+        "| --- | --- | --- |",
+    ]
+    for job, expected_result in evaluation.expected.items():
+        actual_result = evaluation.results.get(job, "missing")
+        lines.append(f"| `{job}` | `{actual_result}` | `{expected_result}` |")
+
+    lines.extend(["", "### Skipped jobs", ""])
+    if evaluation.skipped_jobs:
+        lines.extend(f"- `{job}`" for job in evaluation.skipped_jobs)
+    else:
+        lines.append("- None")
+
+    if evaluation.unexpected:
+        lines.extend(["", "### Unexpected results", ""])
+        for item, (actual, expected) in evaluation.unexpected.items():
+            lines.append(f"- `{item}`: got `{actual}`, expected `{expected}`")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    needs = json.loads(os.environ["NEEDS_JSON"])
+    classifier = needs.get("classify-changes", {})
+    release_artifacts = classifier.get("outputs", {}).get("release_artifacts", "")
+    results = {
+        job: details.get("result", "missing")
+        for job, details in needs.items()
+        if isinstance(details, dict)
+    }
+    evaluation = evaluate_gate(
+        os.environ.get("GITHUB_EVENT_NAME", ""),
+        os.environ.get("GITHUB_REF", ""),
+        release_artifacts,
+        results,
+    )
+    summary = render_summary(evaluation)
+    print(summary, end="")
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with Path(summary_path).open("a", encoding="utf-8") as stream:
+            stream.write(summary)
+    return 0 if evaluation.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_evaluate_ci_gate.py
+++ b/tests/ci/test_evaluate_ci_gate.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "evaluate-ci-gate.py"
+
+
+def load_gate_module():
+    if not MODULE_PATH.exists():
+        return None
+    spec = importlib.util.spec_from_file_location("evaluate_ci_gate", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+COMMON_SUCCESS = {
+    "classify-changes": "success",
+    "verify-source": "success",
+    "test-rust-platforms": "success",
+}
+FULL_SUCCESS = {
+    "build-tools": "success",
+    "package-runtime": "success",
+    "package-thin": "success",
+    "release-assessment": "success",
+}
+PUBLISH_SKIPPED = {
+    "publish-release-assets": "skipped",
+    "smoke-thin-plugin": "skipped",
+    "verify-published-assets": "skipped",
+}
+
+
+class EvaluateCiGateTests(unittest.TestCase):
+    def module(self):
+        module = load_gate_module()
+        self.assertIsNotNone(module, f"missing gate evaluator: {MODULE_PATH}")
+        self.assertTrue(hasattr(module, "evaluate_gate"), "missing evaluate_gate")
+        self.assertTrue(hasattr(module, "render_summary"), "missing render_summary")
+        return module
+
+    def test_light_pr_accepts_only_classified_pipeline_skips(self) -> None:
+        module = self.module()
+        results = {
+            **COMMON_SUCCESS,
+            "build-tools": "skipped",
+            "package-runtime": "skipped",
+            "package-thin": "skipped",
+            "probe-thin-bootstrap": "skipped",
+            "release-assessment": "skipped",
+            **PUBLISH_SKIPPED,
+        }
+
+        evaluation = module.evaluate_gate("pull_request", "refs/pull/148/merge", "false", results)
+
+        self.assertTrue(evaluation.ok)
+        self.assertEqual("light", evaluation.contour)
+        self.assertEqual(set(results) - set(COMMON_SUCCESS), set(evaluation.skipped_jobs))
+        self.assertEqual({}, evaluation.unexpected)
+
+    def test_full_pr_requires_the_conditional_pipeline(self) -> None:
+        module = self.module()
+        results = {
+            **COMMON_SUCCESS,
+            **FULL_SUCCESS,
+            "probe-thin-bootstrap": "success",
+            **PUBLISH_SKIPPED,
+        }
+
+        evaluation = module.evaluate_gate("pull_request", "refs/pull/148/merge", "true", results)
+
+        self.assertTrue(evaluation.ok)
+        self.assertEqual("full", evaluation.contour)
+        self.assertEqual(set(PUBLISH_SKIPPED), set(evaluation.skipped_jobs))
+
+    def test_failure_cancelled_and_unexpected_skip_fail_the_gate(self) -> None:
+        module = self.module()
+        results = {
+            **COMMON_SUCCESS,
+            **FULL_SUCCESS,
+            "probe-thin-bootstrap": "success",
+            **PUBLISH_SKIPPED,
+            "verify-source": "cancelled",
+            "build-tools": "failure",
+            "package-runtime": "skipped",
+        }
+
+        evaluation = module.evaluate_gate("pull_request", "refs/pull/148/merge", "true", results)
+
+        self.assertFalse(evaluation.ok)
+        self.assertEqual(
+            {
+                "verify-source": ("cancelled", "success"),
+                "build-tools": ("failure", "success"),
+                "package-runtime": ("skipped", "success"),
+            },
+            evaluation.unexpected,
+        )
+
+    def test_tag_gate_requires_publication_but_skips_pr_probe(self) -> None:
+        module = self.module()
+        results = {
+            **COMMON_SUCCESS,
+            **FULL_SUCCESS,
+            "probe-thin-bootstrap": "skipped",
+            "publish-release-assets": "success",
+            "smoke-thin-plugin": "success",
+            "verify-published-assets": "success",
+        }
+
+        evaluation = module.evaluate_gate("push", "refs/tags/v0.8.1", "true", results)
+
+        self.assertTrue(evaluation.ok)
+        self.assertEqual("release", evaluation.contour)
+        self.assertEqual(["probe-thin-bootstrap"], evaluation.skipped_jobs)
+
+    def test_invalid_classifier_output_fails_closed(self) -> None:
+        module = self.module()
+        results = {**COMMON_SUCCESS, **FULL_SUCCESS, "probe-thin-bootstrap": "success", **PUBLISH_SKIPPED}
+
+        evaluation = module.evaluate_gate("pull_request", "refs/pull/148/merge", "", results)
+
+        self.assertFalse(evaluation.ok)
+        self.assertEqual("invalid", evaluation.contour)
+        self.assertIn("classification", evaluation.unexpected)
+
+    def test_summary_reports_contour_results_and_skipped_jobs(self) -> None:
+        module = self.module()
+        results = {
+            **COMMON_SUCCESS,
+            **FULL_SUCCESS,
+            "probe-thin-bootstrap": "success",
+            **PUBLISH_SKIPPED,
+        }
+        evaluation = module.evaluate_gate("pull_request", "refs/pull/148/merge", "true", results)
+
+        summary = module.render_summary(evaluation)
+
+        self.assertIn("Contour: `full`", summary)
+        self.assertIn("| `publish-release-assets` | `skipped` | `skipped` |", summary)
+        self.assertIn("Skipped jobs", summary)
+        self.assertIn("`verify-published-assets`", summary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import unittest
 from pathlib import Path
 
@@ -9,6 +10,20 @@ WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "unica-plugin-release.yml"
 PUBLISH_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "publish-unica-marketplace.yml"
 LEGACY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "unica-legacy-migration.yml"
+
+
+def job_block(workflow: str, job_id: str) -> str:
+    marker = f"  {job_id}:\n"
+    start = workflow.find(marker)
+    if start == -1:
+        return ""
+    next_job = re.search(r"(?m)^  [a-zA-Z0-9_-]+:\n", workflow[start + len(marker) :])
+    if next_job is None:
+        return workflow[start:]
+    end = start + len(marker) + next_job.start()
+    return workflow[start:end]
+
+
 class UnicaWorkflowGuardrailTests(unittest.TestCase):
     def release_text(self) -> str:
         return RELEASE_WORKFLOW.read_text(encoding="utf-8")
@@ -16,15 +31,85 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
     def publish_text(self) -> str:
         return PUBLISH_WORKFLOW.read_text(encoding="utf-8")
 
-    def test_source_gate_covers_both_rust_packages_and_full_workspace(self) -> None:
+    def test_source_gate_checks_the_full_rust_and_python_workspace(self) -> None:
         text = self.release_text()
 
-        self.assertIn('"crates/unica-bootstrap/**"', text)
-        self.assertIn('"crates/unica-coder/**"', text)
         self.assertIn("cargo clippy --workspace --all-targets --all-features -- -D warnings", text)
         self.assertIn("cargo test --workspace -- --test-threads=1", text)
-        self.assertIn("python -m unittest discover -s tests/ci", text)
+        self.assertIn("python -m unittest discover -s tests/ci --durations 20", text)
         self.assertIn("python scripts/ci/check-version-contract.py", text)
+
+    def test_every_pull_request_gets_a_stable_aggregate_gate(self) -> None:
+        text = self.release_text()
+        trigger = text[text.index("on:\n") : text.index("\npermissions:")]
+        gate = job_block(text, "unica-ci")
+
+        self.assertIn("  pull_request:\n", trigger)
+        self.assertNotIn("paths:", trigger)
+        self.assertIn("name: Unica CI", gate)
+        self.assertIn("if: always()", gate)
+        self.assertIn("python scripts/ci/evaluate-ci-gate.py", gate)
+        for upstream in (
+            "classify-changes",
+            "verify-source",
+            "test-rust-platforms",
+            "build-tools",
+            "package-runtime",
+            "package-thin",
+            "probe-thin-bootstrap",
+            "release-assessment",
+            "publish-release-assets",
+            "smoke-thin-plugin",
+            "verify-published-assets",
+        ):
+            with self.subTest(upstream=upstream):
+                self.assertIn(f"      - {upstream}", gate)
+
+    def test_javascript_actions_use_node24_compatible_majors(self) -> None:
+        release = self.release_text()
+        publish = self.publish_text()
+        combined = release + publish
+
+        self.assertIn("actions/checkout@v7", combined)
+        self.assertIn("actions/setup-python@v7", release)
+        self.assertIn("actions/upload-artifact@v7", release)
+        self.assertIn("actions/download-artifact@v8", release)
+        self.assertIn("softprops/action-gh-release@v3", release)
+        for stale in (
+            "actions/checkout@v4",
+            "actions/setup-python@v5",
+            "actions/upload-artifact@v4",
+            "actions/download-artifact@v4",
+            "softprops/action-gh-release@v2",
+        ):
+            with self.subTest(stale=stale):
+                self.assertNotIn(stale, combined)
+
+    def test_heavy_and_external_jobs_have_timeouts(self) -> None:
+        release = self.release_text()
+        publish = self.publish_text()
+
+        expected_release_timeouts = {
+            "classify-changes": 10,
+            "verify-source": 90,
+            "test-rust-platforms": 60,
+            "build-tools": 90,
+            "package-runtime": 30,
+            "package-thin": 30,
+            "probe-thin-bootstrap": 30,
+            "release-assessment": 60,
+            "publish-release-assets": 15,
+            "smoke-thin-plugin": 30,
+            "verify-published-assets": 15,
+            "unica-ci": 5,
+        }
+        for job_id, minutes in expected_release_timeouts.items():
+            with self.subTest(job_id=job_id):
+                self.assertIn(f"timeout-minutes: {minutes}", job_block(release, job_id))
+
+        for job_id in ("stage", "promote"):
+            with self.subTest(job_id=job_id):
+                self.assertIn("timeout-minutes: 20", job_block(publish, job_id))
 
     def test_runtime_matrix_builds_deterministic_assets_and_thin_payload(self) -> None:
         text = self.release_text()
@@ -100,7 +185,7 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
 
         self.assertNotIn("publish-assessment-pages", publish)
         self.assertIn("needs: package-runtime", publish)
-        self.assertIn("softprops/action-gh-release@v2", publish)
+        self.assertIn("softprops/action-gh-release@v3", publish)
         self.assertIn("unica-runtime-*.tar.gz", publish)
         self.assertIn("unica-runtime-*.json", publish)
         self.assertNotIn("install-unica", publish)


### PR DESCRIPTION
Closes #148.

## What changed

- run the Unica workflow for every pull request and add a stable aggregate `Unica CI` job
- validate full, light, manual, and release contours while rejecting failures, cancellations, and unexpected skips
- publish the selected contour and skipped-job results in the job summary
- move JavaScript actions to Node 24-compatible majors, add job timeouts, and report the 20 slowest Python contract tests
- add behavioral and workflow contract tests for the gate

## Root cause

The workflow-level `pull_request.paths` filter prevented a required check from being created for some pull requests, while conditional and matrix job names were not a stable branch-protection boundary.

## Validation

- `actionlint .github/workflows/unica-plugin-release.yml .github/workflows/publish-unica-marketplace.yml`
- `python3.12 -m unittest discover -s tests/ci --durations 20` (181 tests, 3 skipped)
- `python3.12 -m py_compile scripts/ci/*.py tests/ci/*.py`
- `git diff --check`
