### PR TITLE
ci: route PR checks by change contour and platform impact

### DIFF
--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -3,6 +3,7 @@ name: Build Unica Codex Plugin
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     tags:
       - "v*"
@@ -19,22 +20,30 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      release_artifacts: ${{ steps.scope.outputs.release_artifacts }}
+      rust_changed: ${{ steps.scope.outputs.rust_changed }}
+      platform_changed: ${{ steps.scope.outputs.platform_changed }}
+      toolchain_changed: ${{ steps.scope.outputs.toolchain_changed }}
+      package_changed: ${{ steps.scope.outputs.package_changed }}
+      plugin_content_changed: ${{ steps.scope.outputs.plugin_content_changed }}
+      ci_changed: ${{ steps.scope.outputs.ci_changed }}
+      release_required: ${{ steps.scope.outputs.release_required }}
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - id: scope
         shell: bash
+        env:
+          FORCE_FULL: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:full') }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "release_artifacts=true" >> "$GITHUB_OUTPUT"
+          if [ "$FORCE_FULL" = "true" ]; then
+            python scripts/ci/classify-workflow-changes.py --force-full </dev/null >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
-          git diff --name-only FETCH_HEAD...HEAD | python scripts/ci/classify-workflow-changes.py |
-            sed 's/^/release_artifacts=/' >> "$GITHUB_OUTPUT"
+          git diff --name-only FETCH_HEAD...HEAD |
+            python scripts/ci/classify-workflow-changes.py >> "$GITHUB_OUTPUT"
 
   verify-source:
     name: Verify source guardrails
@@ -46,12 +55,27 @@ jobs:
         with:
           python-version: "3.12"
       - run: python -m pip install -r tests/ci/requirements.txt
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
       - run: python -m unittest discover -s tests/ci --durations 20
       - run: python -m py_compile scripts/ci/*.py tests/ci/*.py
       - run: python scripts/ci/check-version-contract.py
+
+  test-rust-primary:
+    name: Rust tests (macos-14 primary)
+    runs-on: macos-14
+    timeout-minutes: 60
+    needs: classify-changes
+    if: >-
+      ${{
+        needs.classify-changes.outputs.rust_changed == 'true' &&
+        needs.classify-changes.outputs.platform_changed == 'false' &&
+        needs.classify-changes.outputs.toolchain_changed == 'false' &&
+        needs.classify-changes.outputs.ci_changed == 'false'
+      }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - run: cargo test --workspace -- --test-threads=1
@@ -60,21 +84,41 @@ jobs:
     name: Rust tests (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
+    needs: classify-changes
+    if: >-
+      ${{
+        needs.classify-changes.outputs.platform_changed == 'true' ||
+        needs.classify-changes.outputs.toolchain_changed == 'true' ||
+        needs.classify-changes.outputs.ci_changed == 'true'
+      }}
     strategy:
       fail-fast: false
       matrix:
-        runner: [windows-latest, macos-14]
+        runner: [ubuntu-latest, windows-latest, macos-14]
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - run: cargo test --workspace -- --test-threads=1
 
   build-tools:
     name: Build tools (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
-    needs: [classify-changes, verify-source, test-rust-platforms]
-    if: ${{ github.event_name != 'pull_request' || needs.classify-changes.outputs.release_artifacts == 'true' }}
+    needs: [classify-changes, verify-source, test-rust-primary, test-rust-platforms]
+    if: >-
+      ${{
+        always() &&
+        needs.classify-changes.result == 'success' &&
+        needs.verify-source.result == 'success' &&
+        (needs.test-rust-primary.result == 'success' || needs.test-rust-primary.result == 'skipped') &&
+        (needs.test-rust-platforms.result == 'success' || needs.test-rust-platforms.result == 'skipped') &&
+        (needs.classify-changes.outputs.release_required == 'true' ||
+         needs.classify-changes.outputs.ci_changed == 'true')
+      }}
     strategy:
       fail-fast: false
       matrix:
@@ -190,7 +234,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     needs: package-thin
-    if: github.event_name == 'pull_request'
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     strategy:
       fail-fast: false
       matrix:
@@ -330,6 +374,7 @@ jobs:
     needs:
       - classify-changes
       - verify-source
+      - test-rust-primary
       - test-rust-platforms
       - build-tools
       - package-runtime

--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -169,6 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: build-tools
+    if: ${{ always() && needs.build-tools.result == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -199,6 +200,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: package-runtime
+    if: ${{ always() && needs.package-runtime.result == 'success' }}
     env:
       RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'v0.8.1' }}
     steps:
@@ -236,7 +238,12 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     needs: package-thin
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+    if: >-
+      ${{
+        always() &&
+        needs.package-thin.result == 'success' &&
+        (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+      }}
     strategy:
       fail-fast: false
       matrix:
@@ -299,7 +306,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: package-runtime
-    if: startsWith(github.ref, 'refs/tags/')
+    if: >-
+      ${{
+        always() &&
+        needs.package-runtime.result == 'success' &&
+        startsWith(github.ref, 'refs/tags/')
+      }}
     permissions:
       contents: write
     steps:
@@ -321,7 +333,13 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     needs: [package-thin, publish-release-assets]
-    if: startsWith(github.ref, 'refs/tags/')
+    if: >-
+      ${{
+        always() &&
+        needs.package-thin.result == 'success' &&
+        needs.publish-release-assets.result == 'success' &&
+        startsWith(github.ref, 'refs/tags/')
+      }}
     strategy:
       fail-fast: false
       matrix:
@@ -354,7 +372,13 @@ jobs:
     needs:
       - publish-release-assets
       - package-thin
-    if: startsWith(github.ref, 'refs/tags/')
+    if: >-
+      ${{
+        always() &&
+        needs.package-thin.result == 'success' &&
+        needs.publish-release-assets.result == 'success' &&
+        startsWith(github.ref, 'refs/tags/')
+      }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -100,8 +100,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      - run: cargo fmt --all -- --check
-      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - if: matrix.runner == 'macos-14'
+        run: cargo fmt --all -- --check
+      - if: matrix.runner == 'macos-14'
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - run: cargo test --workspace -- --test-threads=1
 
   build-tools:

--- a/scripts/ci/classify-workflow-changes.py
+++ b/scripts/ci/classify-workflow-changes.py
@@ -1,63 +1,180 @@
 #!/usr/bin/env python3
-"""Classify changed paths for the Unica GitHub Actions workflow."""
+"""Classify changed paths into typed Unica CI routing contours."""
 
 from __future__ import annotations
 
+import argparse
 import sys
 from collections.abc import Iterable
-from typing import TextIO
+from pathlib import PurePosixPath
+from typing import NamedTuple, TextIO
 
 
-RELEASE_ARTIFACT_PATHS = {
-    ".agents/plugins/marketplace.json",
-    ".github/workflows/unica-plugin-release.yml",
-    ".github/workflows/publish-unica-marketplace.yml",
+OUTPUT_NAMES = (
+    "rust_changed",
+    "platform_changed",
+    "toolchain_changed",
+    "package_changed",
+    "plugin_content_changed",
+    "ci_changed",
+    "release_required",
+)
+
+TOOLCHAIN_PATHS = {
     "Cargo.toml",
     "Cargo.lock",
-    "crates/unica-coder/Cargo.toml",
-    "crates/unica-bootstrap/Cargo.toml",
+    "rust-toolchain",
+    "rust-toolchain.toml",
+}
+PACKAGE_PATHS = {
+    ".agents/plugins/marketplace.json",
     "plugins/unica/.codex-plugin/plugin.json",
     "plugins/unica/.mcp.json",
+    "plugins/unica/bootstrap/launch.sh",
+    "plugins/unica/runtime-manifest.json",
     "plugins/unica/third-party/tools.lock.json",
     "plugins/unica/third-party/manifest.json",
     "scripts/ci/build-unica-tools.py",
     "scripts/ci/check-tool-contracts.py",
-    "scripts/ci/release-assessment.py",
     "scripts/ci/package-unica-plugin.py",
     "scripts/ci/package-unica-runtime.py",
+    "scripts/ci/release-assessment.py",
     "scripts/ci/smoke-unica-bootstrap.py",
+    "scripts/ci/smoke-unica-mcp.py",
     "scripts/ci/verify-release-assets.py",
 }
-
-RELEASE_ARTIFACT_PREFIXES = (
-    "crates/unica-bootstrap/",
-    "crates/unica-coder/",
+CI_CONTRACT_PATHS = {
+    "scripts/ci/classify-workflow-changes.py",
+    "scripts/ci/evaluate-ci-gate.py",
+    "tests/ci/test_classify_workflow_changes.py",
+    "tests/ci/test_evaluate_ci_gate.py",
+    "tests/ci/test_unica_workflow.py",
+}
+PLATFORM_CONTRACT_PATHS = {
+    "scripts/ci/check-rust-platform-boundary.py",
+    "tests/ci/test_rust_platform_boundary.py",
+}
+PLATFORM_PREFIXES = (
+    "crates/unica-coder/src/infrastructure/platform/",
+    "crates/unica-bootstrap/src/platform/",
 )
 
 
+class Classification(NamedTuple):
+    rust_changed: bool = False
+    platform_changed: bool = False
+    toolchain_changed: bool = False
+    package_changed: bool = False
+    plugin_content_changed: bool = False
+    ci_changed: bool = False
+    release_required: bool = False
+
+    def as_dict(self) -> dict[str, bool]:
+        return dict(zip(OUTPUT_NAMES, self, strict=True))
+
+    def as_github_output(self) -> str:
+        return "\n".join(
+            f"{name}={str(value).lower()}" for name, value in self.as_dict().items()
+        )
+
+
 def normalize_path(path: str) -> str:
-    path = path.strip()
-    if path.startswith("./"):
-        return path[2:]
-    return path
+    normalized = path.strip().replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
 
 
-def needs_release_artifacts(paths: Iterable[str]) -> bool:
-    for path in paths:
-        normalized = normalize_path(path)
-        if normalized in RELEASE_ARTIFACT_PATHS:
-            return True
-        if normalized.startswith(RELEASE_ARTIFACT_PREFIXES):
-            return True
-    return False
+def _is_rust_path(path: str) -> bool:
+    candidate = PurePosixPath(path)
+    return len(candidate.parts) >= 2 and candidate.parts[0] == "crates" and candidate.suffix == ".rs"
 
 
-def classify_stdin(stdin: TextIO) -> str:
-    return "true" if needs_release_artifacts(stdin) else "false"
+def _is_toolchain_path(path: str) -> bool:
+    candidate = PurePosixPath(path)
+    return (
+        path in TOOLCHAIN_PATHS
+        or path.startswith(".cargo/")
+        or (len(candidate.parts) >= 3 and candidate.parts[0] == "crates" and candidate.name == "Cargo.toml")
+    )
+
+
+def _is_platform_path(path: str) -> bool:
+    candidate = PurePosixPath(path)
+    platform_test_directory = (
+        len(candidate.parts) >= 5
+        and candidate.parts[0] == "crates"
+        and candidate.parts[2] == "tests"
+        and candidate.parts[3] == "platform"
+    )
+    platform_test_wrapper = (
+        len(candidate.parts) == 4
+        and candidate.parts[0] == "crates"
+        and candidate.parts[2] == "tests"
+        and candidate.name.startswith("platform_")
+    )
+    return (
+        path in PLATFORM_CONTRACT_PATHS
+        or path.startswith(PLATFORM_PREFIXES)
+        or platform_test_directory
+        or platform_test_wrapper
+    )
+
+
+def _is_ci_contract_path(path: str) -> bool:
+    return path.startswith(".github/workflows/") or path in CI_CONTRACT_PATHS or path in PLATFORM_CONTRACT_PATHS
+
+
+def classify_paths(paths: Iterable[str], *, force_full: bool = False) -> Classification:
+    if force_full:
+        return Classification(*([True] * len(OUTPUT_NAMES)))
+
+    rust_changed = False
+    platform_changed = False
+    toolchain_changed = False
+    package_changed = False
+    plugin_content_changed = False
+    ci_changed = False
+
+    for raw_path in paths:
+        path = normalize_path(raw_path)
+        if not path:
+            continue
+        rust_changed |= _is_rust_path(path)
+        platform_changed |= _is_platform_path(path)
+        toolchain_changed |= _is_toolchain_path(path)
+        package_changed |= path in PACKAGE_PATHS or _is_toolchain_path(path)
+        plugin_content_changed |= path.startswith("plugins/unica/")
+        ci_changed |= _is_ci_contract_path(path)
+
+    # The platform boundary is the source of truth. Unknown files inside it
+    # must route conservatively even when their extension is not yet known.
+    rust_changed |= platform_changed or toolchain_changed
+    release_required = rust_changed or package_changed
+    return Classification(
+        rust_changed=rust_changed,
+        platform_changed=platform_changed,
+        toolchain_changed=toolchain_changed,
+        package_changed=package_changed,
+        plugin_content_changed=plugin_content_changed,
+        ci_changed=ci_changed,
+        release_required=release_required,
+    )
+
+
+def classify_stdin(stdin: TextIO, *, force_full: bool = False) -> str:
+    return classify_paths(stdin, force_full=force_full).as_github_output()
 
 
 def main() -> None:
-    print(classify_stdin(sys.stdin))
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--force-full",
+        action="store_true",
+        help="enable every contour for tags, manual runs, or the ci:full label",
+    )
+    args = parser.parse_args()
+    print(classify_stdin(sys.stdin, force_full=args.force_full))
 
 
 if __name__ == "__main__":

--- a/scripts/ci/evaluate-ci-gate.py
+++ b/scripts/ci/evaluate-ci-gate.py
@@ -1,21 +1,30 @@
 #!/usr/bin/env python3
-"""Evaluate the stable aggregate result for the Unica GitHub Actions workflow."""
+"""Evaluate the stable aggregate result for the routed Unica CI workflow."""
 
 from __future__ import annotations
 
 import json
 import os
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 from typing import NamedTuple
 
 
-COMMON_JOBS = (
+CLASSIFICATION_OUTPUTS = (
+    "rust_changed",
+    "platform_changed",
+    "toolchain_changed",
+    "package_changed",
+    "plugin_content_changed",
+    "ci_changed",
+    "release_required",
+)
+ALWAYS_JOBS = (
     "classify-changes",
     "verify-source",
-    "test-rust-platforms",
 )
-CONDITIONAL_JOBS = (
+PACKAGE_JOBS = (
     "build-tools",
     "package-runtime",
     "package-thin",
@@ -31,7 +40,7 @@ PUBLISH_JOBS = (
 class GateEvaluation(NamedTuple):
     event_name: str
     ref: str
-    release_artifacts: str
+    classification: dict[str, str]
     contour: str
     results: dict[str, str]
     expected: dict[str, str]
@@ -43,42 +52,87 @@ class GateEvaluation(NamedTuple):
         return not self.unexpected
 
 
+def _validated_classification(
+    outputs: Mapping[str, str],
+) -> tuple[dict[str, bool], tuple[str, str] | None]:
+    invalid = [
+        f"{name}={outputs.get(name, 'missing')}"
+        for name in CLASSIFICATION_OUTPUTS
+        if outputs.get(name) not in {"true", "false"}
+    ]
+    if invalid:
+        return {}, (", ".join(invalid), "all typed outputs are true or false")
+
+    values = {name: outputs[name] == "true" for name in CLASSIFICATION_OUTPUTS}
+    contradictions: list[str] = []
+    if values["platform_changed"] and not (values["rust_changed"] or values["ci_changed"]):
+        contradictions.append("platform_changed requires rust_changed or ci_changed")
+    if values["toolchain_changed"] and not (
+        values["rust_changed"] and values["package_changed"] and values["release_required"]
+    ):
+        contradictions.append("toolchain_changed requires rust/package/release contours")
+    if values["package_changed"] and not values["release_required"]:
+        contradictions.append("package_changed requires release_required")
+    if contradictions:
+        return values, ("; ".join(contradictions), "a consistent classification")
+    return values, None
+
+
 def expected_results(
     event_name: str,
     ref: str,
-    release_artifacts: str,
+    classification: Mapping[str, str],
 ) -> tuple[str, dict[str, str], dict[str, tuple[str, str]]]:
-    expected = {job: "success" for job in COMMON_JOBS}
+    expected = {job: "success" for job in ALWAYS_JOBS}
     invalid: dict[str, tuple[str, str]] = {}
+    values, classification_error = _validated_classification(classification)
 
-    if release_artifacts not in {"true", "false"}:
-        invalid["classification"] = (release_artifacts or "missing", "true or false")
-        return "invalid", expected, invalid
+    if classification_error is not None:
+        invalid["classification"] = classification_error
+        values = {name: False for name in CLASSIFICATION_OUTPUTS}
 
-    pipeline_result = "success" if release_artifacts == "true" else "skipped"
-    expected.update({job: pipeline_result for job in CONDITIONAL_JOBS})
-
-    if event_name == "pull_request":
-        contour = "full" if release_artifacts == "true" else "light"
-        expected["probe-thin-bootstrap"] = pipeline_result
-        expected.update({job: "skipped" for job in PUBLISH_JOBS})
-    elif event_name == "push" and ref.startswith("refs/tags/"):
-        contour = "release"
-        expected["probe-thin-bootstrap"] = "skipped"
-        expected.update({job: "success" for job in PUBLISH_JOBS})
-        if release_artifacts != "true":
-            invalid["classification"] = (release_artifacts, "true")
-    elif event_name == "workflow_dispatch":
-        contour = "full"
-        expected["probe-thin-bootstrap"] = "skipped"
-        expected.update({job: "skipped" for job in PUBLISH_JOBS})
-        if release_artifacts != "true":
-            invalid["classification"] = (release_artifacts, "true")
-    else:
-        contour = "invalid"
-        expected["probe-thin-bootstrap"] = "skipped"
-        expected.update({job: "skipped" for job in PUBLISH_JOBS})
+    is_tag = event_name == "push" and ref.startswith("refs/tags/")
+    is_manual = event_name == "workflow_dispatch"
+    is_pr = event_name == "pull_request"
+    if not (is_tag or is_manual or is_pr):
         invalid["event"] = (f"{event_name}:{ref}", "pull_request, tag push, or workflow_dispatch")
+
+    if (is_tag or is_manual) and not all(values.values()):
+        invalid["classification"] = (
+            ", ".join(name for name, enabled in values.items() if not enabled) or "invalid",
+            "all contours enabled for tag or workflow_dispatch",
+        )
+
+    full_matrix = values["platform_changed"] or values["toolchain_changed"] or values["ci_changed"]
+    primary_rust = values["rust_changed"] and not full_matrix
+    package_pipeline = values["release_required"] or values["ci_changed"]
+
+    expected["test-rust-primary"] = "success" if primary_rust else "skipped"
+    expected["test-rust-platforms"] = "success" if full_matrix else "skipped"
+    expected.update({job: "success" if package_pipeline else "skipped" for job in PACKAGE_JOBS})
+    expected["probe-thin-bootstrap"] = (
+        "success" if package_pipeline and (is_pr or is_manual) else "skipped"
+    )
+    expected.update({job: "success" if is_tag else "skipped" for job in PUBLISH_JOBS})
+
+    if is_tag:
+        contour = "release"
+    elif is_manual:
+        contour = "full"
+    elif not is_pr:
+        contour = "invalid"
+    elif all(values.values()) or values["ci_changed"]:
+        contour = "full"
+    elif values["platform_changed"]:
+        contour = "platform"
+    elif values["toolchain_changed"]:
+        contour = "toolchain"
+    elif values["rust_changed"]:
+        contour = "rust"
+    elif package_pipeline:
+        contour = "package"
+    else:
+        contour = "source"
 
     return contour, expected, invalid
 
@@ -86,10 +140,10 @@ def expected_results(
 def evaluate_gate(
     event_name: str,
     ref: str,
-    release_artifacts: str,
-    results: dict[str, str],
+    classification: Mapping[str, str],
+    results: Mapping[str, str],
 ) -> GateEvaluation:
-    contour, expected, unexpected = expected_results(event_name, ref, release_artifacts)
+    contour, expected, unexpected = expected_results(event_name, ref, classification)
     unexpected = dict(unexpected)
 
     for job, expected_result in expected.items():
@@ -101,7 +155,7 @@ def evaluate_gate(
     return GateEvaluation(
         event_name=event_name,
         ref=ref,
-        release_artifacts=release_artifacts,
+        classification={name: classification.get(name, "") for name in CLASSIFICATION_OUTPUTS},
         contour=contour,
         results=dict(results),
         expected=expected,
@@ -116,12 +170,24 @@ def render_summary(evaluation: GateEvaluation) -> str:
         "",
         f"- Event: `{evaluation.event_name}`",
         f"- Contour: `{evaluation.contour}`",
-        f"- Release artifacts: `{evaluation.release_artifacts or 'missing'}`",
         f"- Gate: `{'success' if evaluation.ok else 'failure'}`",
         "",
-        "| Job | Result | Expected |",
-        "| --- | --- | --- |",
+        "### Classification",
+        "",
     ]
+    for name in CLASSIFICATION_OUTPUTS:
+        label = name.replace("_", " ").capitalize()
+        lines.append(f"- {label}: `{evaluation.classification.get(name) or 'missing'}`")
+
+    lines.extend(
+        [
+            "",
+            "### Job results",
+            "",
+            "| Job | Result | Expected |",
+            "| --- | --- | --- |",
+        ]
+    )
     for job, expected_result in evaluation.expected.items():
         actual_result = evaluation.results.get(job, "missing")
         lines.append(f"| `{job}` | `{actual_result}` | `{expected_result}` |")
@@ -143,7 +209,11 @@ def render_summary(evaluation: GateEvaluation) -> str:
 def main() -> int:
     needs = json.loads(os.environ["NEEDS_JSON"])
     classifier = needs.get("classify-changes", {})
-    release_artifacts = classifier.get("outputs", {}).get("release_artifacts", "")
+    outputs = classifier.get("outputs", {}) if isinstance(classifier, dict) else {}
+    classification = {
+        name: outputs.get(name, "") if isinstance(outputs, dict) else ""
+        for name in CLASSIFICATION_OUTPUTS
+    }
     results = {
         job: details.get("result", "missing")
         for job, details in needs.items()
@@ -152,7 +222,7 @@ def main() -> int:
     evaluation = evaluate_gate(
         os.environ.get("GITHUB_EVENT_NAME", ""),
         os.environ.get("GITHUB_REF", ""),
-        release_artifacts,
+        classification,
         results,
     )
     summary = render_summary(evaluation)

--- a/tests/ci/test_classify_workflow_changes.py
+++ b/tests/ci/test_classify_workflow_changes.py
@@ -16,57 +16,147 @@ def load_classifier_module():
     return module
 
 
-class ClassifyWorkflowChangesTests(unittest.TestCase):
-    def test_release_artifacts_are_needed_for_package_surface_changes(self) -> None:
-        module = load_classifier_module()
+OUTPUT_NAMES = (
+    "rust_changed",
+    "platform_changed",
+    "toolchain_changed",
+    "package_changed",
+    "plugin_content_changed",
+    "ci_changed",
+    "release_required",
+)
 
-        release_paths = [
-            ".agents/plugins/marketplace.json",
-            ".github/workflows/unica-plugin-release.yml",
-            ".github/workflows/publish-unica-marketplace.yml",
-            "Cargo.toml",
-            "Cargo.lock",
-            "crates/unica-coder/Cargo.toml",
-            "crates/unica-bootstrap/Cargo.toml",
-            "crates/unica-bootstrap/src/main.rs",
-            "crates/unica-coder/build.rs",
-            "crates/unica-coder/src/application/mod.rs",
-            "crates/unica-coder/src/infrastructure/internal_adapters.rs",
-            "plugins/unica/.codex-plugin/plugin.json",
+
+class ClassifyWorkflowChangesTests(unittest.TestCase):
+    def assert_classification(self, paths: list[str], **expected: bool) -> None:
+        module = load_classifier_module()
+        classification = module.classify_paths(paths)
+        actual = classification.as_dict()
+        self.assertEqual(set(OUTPUT_NAMES), set(actual))
+        self.assertEqual({name: expected.get(name, False) for name in OUTPUT_NAMES}, actual)
+
+    def test_skill_or_provenance_only_change_stays_in_source_contour(self) -> None:
+        self.assert_classification(
+            [
+                "plugins/unica/skills/meta-compile/SKILL.md",
+                "plugins/unica/provenance/skill-upstreams.json",
+            ],
+            plugin_content_changed=True,
+        )
+
+    def test_platform_independent_domain_or_application_rust_uses_primary_rust_contour(self) -> None:
+        for path in (
+            "crates/unica-coder/src/domain/cache.rs",
+            "crates/unica-coder/src/application/ports.rs",
+        ):
+            with self.subTest(path=path):
+                self.assert_classification([path], rust_changed=True, release_required=True)
+
+    def test_platform_facade_and_platform_tests_require_platform_matrix(self) -> None:
+        for path in (
+            "crates/unica-coder/src/infrastructure/platform/filesystem.rs",
+            "crates/unica-bootstrap/src/platform/mod.rs",
+            "crates/unica-coder/tests/platform/new_contract.rs",
+            "crates/unica-coder/tests/platform_external_init.rs",
+            "crates/unica-coder/src/infrastructure/platform/unknown.future",
+        ):
+            with self.subTest(path=path):
+                self.assert_classification(
+                    [path],
+                    rust_changed=True,
+                    platform_changed=True,
+                    release_required=True,
+                )
+
+    def test_cargo_and_toolchain_changes_require_full_rust_and_package_contours(self) -> None:
+        for path in ("Cargo.toml", "Cargo.lock", "crates/unica-coder/Cargo.toml", "rust-toolchain.toml"):
+            with self.subTest(path=path):
+                self.assert_classification(
+                    [path],
+                    rust_changed=True,
+                    toolchain_changed=True,
+                    package_changed=True,
+                    release_required=True,
+                )
+
+    def test_package_contract_changes_require_package_contour(self) -> None:
+        for path in (
             "plugins/unica/.mcp.json",
             "plugins/unica/third-party/tools.lock.json",
-            "plugins/unica/third-party/manifest.json",
-            "scripts/ci/check-tool-contracts.py",
-            "scripts/ci/release-assessment.py",
-            "scripts/ci/build-unica-tools.py",
-            "scripts/ci/package-unica-plugin.py",
             "scripts/ci/package-unica-runtime.py",
-            "scripts/ci/smoke-unica-bootstrap.py",
-            "scripts/ci/verify-release-assets.py",
-        ]
-
-        for path in release_paths:
+        ):
             with self.subTest(path=path):
-                self.assertTrue(module.needs_release_artifacts([path]))
+                self.assert_classification(
+                    [path],
+                    package_changed=True,
+                    plugin_content_changed=path.startswith("plugins/unica/"),
+                    release_required=True,
+                )
 
-    def test_release_artifacts_are_not_needed_for_source_only_pr_changes(self) -> None:
+    def test_classifier_workflow_and_platform_guard_changes_fail_closed(self) -> None:
+        cases = {
+            ".github/workflows/unica-plugin-release.yml": {"ci_changed": True},
+            "scripts/ci/classify-workflow-changes.py": {"ci_changed": True},
+            "tests/ci/test_classify_workflow_changes.py": {"ci_changed": True},
+            "scripts/ci/check-rust-platform-boundary.py": {
+                "rust_changed": True,
+                "platform_changed": True,
+                "ci_changed": True,
+                "release_required": True,
+            },
+            "tests/ci/test_rust_platform_boundary.py": {
+                "rust_changed": True,
+                "platform_changed": True,
+                "ci_changed": True,
+                "release_required": True,
+            },
+        }
+        for path, expected in cases.items():
+            with self.subTest(path=path):
+                self.assert_classification([path], **expected)
+
+    def test_mixed_changes_union_their_contours(self) -> None:
+        self.assert_classification(
+            [
+                "plugins/unica/skills/meta-compile/SKILL.md",
+                "crates/unica-coder/src/infrastructure/platform/process.rs",
+                "plugins/unica/.codex-plugin/plugin.json",
+            ],
+            rust_changed=True,
+            platform_changed=True,
+            package_changed=True,
+            plugin_content_changed=True,
+            release_required=True,
+        )
+
+    def test_forced_full_contour_enables_every_output(self) -> None:
         module = load_classifier_module()
 
-        source_only_paths = [
-            "plugins/unica/skills/meta-compile/SKILL.md",
-            "plugins/unica/references/tooling/internal-package.md",
-            "spec/architecture/invariants.md",
-            "tests/ci/test_unica_workflow.py",
-            "tests/fixtures/unica_mcp_script_parity/meta-catalog.json",
-        ]
+        classification = module.classify_paths([], force_full=True)
 
-        self.assertFalse(module.needs_release_artifacts(source_only_paths))
+        self.assertEqual({name: True for name in OUTPUT_NAMES}, classification.as_dict())
 
-    def test_cli_prints_boolean_from_stdin_paths(self) -> None:
+    def test_cli_prints_github_outputs_from_stdin_paths(self) -> None:
         module = load_classifier_module()
-
         with tempfile.TemporaryFile("w+", encoding="utf-8") as stdin:
-            stdin.write("tests/ci/test_unica_workflow.py\ncrates/unica-bootstrap/src/main.rs\n")
+            stdin.write("plugins/unica/skills/meta-compile/SKILL.md\ncrates/unica-bootstrap/src/main.rs\n")
             stdin.seek(0)
 
-            self.assertEqual(module.classify_stdin(stdin), "true")
+            output = module.classify_stdin(stdin)
+
+        self.assertEqual(
+            {
+                "rust_changed=true",
+                "platform_changed=false",
+                "toolchain_changed=false",
+                "package_changed=false",
+                "plugin_content_changed=true",
+                "ci_changed=false",
+                "release_required=true",
+            },
+            set(output.splitlines()),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci/test_evaluate_ci_gate.py
+++ b/tests/ci/test_evaluate_ci_gate.py
@@ -9,22 +9,25 @@ MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "evaluate
 
 
 def load_gate_module():
-    if not MODULE_PATH.exists():
-        return None
     spec = importlib.util.spec_from_file_location("evaluate_ci_gate", MODULE_PATH)
     if spec is None or spec.loader is None:
-        return None
+        raise RuntimeError(f"failed to load {MODULE_PATH}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
 
-COMMON_SUCCESS = {
-    "classify-changes": "success",
-    "verify-source": "success",
-    "test-rust-platforms": "success",
-}
-FULL_SUCCESS = {
+OUTPUT_NAMES = (
+    "rust_changed",
+    "platform_changed",
+    "toolchain_changed",
+    "package_changed",
+    "plugin_content_changed",
+    "ci_changed",
+    "release_required",
+)
+ALWAYS_SUCCESS = {"classify-changes": "success", "verify-source": "success"}
+PACKAGE_SUCCESS = {
     "build-tools": "success",
     "package-runtime": "success",
     "package-thin": "success",
@@ -37,115 +40,167 @@ PUBLISH_SKIPPED = {
 }
 
 
+def classification(**enabled: bool) -> dict[str, str]:
+    return {name: str(enabled.get(name, False)).lower() for name in OUTPUT_NAMES}
+
+
+def source_results() -> dict[str, str]:
+    return {
+        **ALWAYS_SUCCESS,
+        "test-rust-primary": "skipped",
+        "test-rust-platforms": "skipped",
+        "build-tools": "skipped",
+        "package-runtime": "skipped",
+        "package-thin": "skipped",
+        "probe-thin-bootstrap": "skipped",
+        "release-assessment": "skipped",
+        **PUBLISH_SKIPPED,
+    }
+
+
 class EvaluateCiGateTests(unittest.TestCase):
-    def module(self):
+    def test_source_only_pr_accepts_only_classified_skips(self) -> None:
         module = load_gate_module()
-        self.assertIsNotNone(module, f"missing gate evaluator: {MODULE_PATH}")
-        self.assertTrue(hasattr(module, "evaluate_gate"), "missing evaluate_gate")
-        self.assertTrue(hasattr(module, "render_summary"), "missing render_summary")
-        return module
+        outputs = classification(plugin_content_changed=True)
+        results = source_results()
 
-    def test_light_pr_accepts_only_classified_pipeline_skips(self) -> None:
-        module = self.module()
-        results = {
-            **COMMON_SUCCESS,
-            "build-tools": "skipped",
-            "package-runtime": "skipped",
-            "package-thin": "skipped",
-            "probe-thin-bootstrap": "skipped",
-            "release-assessment": "skipped",
-            **PUBLISH_SKIPPED,
-        }
-
-        evaluation = module.evaluate_gate("pull_request", "refs/pull/148/merge", "false", results)
+        evaluation = module.evaluate_gate("pull_request", "refs/pull/155/merge", outputs, results)
 
         self.assertTrue(evaluation.ok)
-        self.assertEqual("light", evaluation.contour)
-        self.assertEqual(set(results) - set(COMMON_SUCCESS), set(evaluation.skipped_jobs))
-        self.assertEqual({}, evaluation.unexpected)
+        self.assertEqual("source", evaluation.contour)
+        self.assertEqual(set(results) - set(ALWAYS_SUCCESS), set(evaluation.skipped_jobs))
 
-    def test_full_pr_requires_the_conditional_pipeline(self) -> None:
-        module = self.module()
+    def test_platform_independent_rust_uses_primary_macos_and_package_pipeline(self) -> None:
+        module = load_gate_module()
+        outputs = classification(rust_changed=True, release_required=True)
         results = {
-            **COMMON_SUCCESS,
-            **FULL_SUCCESS,
+            **source_results(),
+            "test-rust-primary": "success",
+            **PACKAGE_SUCCESS,
             "probe-thin-bootstrap": "success",
-            **PUBLISH_SKIPPED,
         }
 
-        evaluation = module.evaluate_gate("pull_request", "refs/pull/148/merge", "true", results)
+        evaluation = module.evaluate_gate("pull_request", "refs/pull/155/merge", outputs, results)
+
+        self.assertTrue(evaluation.ok)
+        self.assertEqual("rust", evaluation.contour)
+        self.assertEqual("skipped", evaluation.expected["test-rust-platforms"])
+
+    def test_platform_rust_uses_full_matrix_instead_of_primary_job(self) -> None:
+        module = load_gate_module()
+        outputs = classification(rust_changed=True, platform_changed=True, release_required=True)
+        results = {
+            **source_results(),
+            "test-rust-platforms": "success",
+            **PACKAGE_SUCCESS,
+            "probe-thin-bootstrap": "success",
+        }
+
+        evaluation = module.evaluate_gate("pull_request", "refs/pull/155/merge", outputs, results)
+
+        self.assertTrue(evaluation.ok)
+        self.assertEqual("platform", evaluation.contour)
+        self.assertEqual("skipped", evaluation.expected["test-rust-primary"])
+
+    def test_ci_full_pr_runs_all_validation_and_package_jobs_without_publication(self) -> None:
+        module = load_gate_module()
+        outputs = classification(**{name: True for name in OUTPUT_NAMES})
+        results = {
+            **source_results(),
+            "test-rust-platforms": "success",
+            **PACKAGE_SUCCESS,
+            "probe-thin-bootstrap": "success",
+        }
+
+        evaluation = module.evaluate_gate("pull_request", "refs/pull/155/merge", outputs, results)
 
         self.assertTrue(evaluation.ok)
         self.assertEqual("full", evaluation.contour)
-        self.assertEqual(set(PUBLISH_SKIPPED), set(evaluation.skipped_jobs))
+        self.assertEqual({"test-rust-primary", *PUBLISH_SKIPPED}, set(evaluation.skipped_jobs))
 
-    def test_failure_cancelled_and_unexpected_skip_fail_the_gate(self) -> None:
-        module = self.module()
-        results = {
-            **COMMON_SUCCESS,
-            **FULL_SUCCESS,
+    def test_manual_full_contour_runs_probe_but_tag_publishes_instead(self) -> None:
+        module = load_gate_module()
+        outputs = classification(**{name: True for name in OUTPUT_NAMES})
+        manual = {
+            **source_results(),
+            "test-rust-platforms": "success",
+            **PACKAGE_SUCCESS,
             "probe-thin-bootstrap": "success",
-            **PUBLISH_SKIPPED,
-            "verify-source": "cancelled",
-            "build-tools": "failure",
-            "package-runtime": "skipped",
         }
-
-        evaluation = module.evaluate_gate("pull_request", "refs/pull/148/merge", "true", results)
-
-        self.assertFalse(evaluation.ok)
-        self.assertEqual(
-            {
-                "verify-source": ("cancelled", "success"),
-                "build-tools": ("failure", "success"),
-                "package-runtime": ("skipped", "success"),
-            },
-            evaluation.unexpected,
-        )
-
-    def test_tag_gate_requires_publication_but_skips_pr_probe(self) -> None:
-        module = self.module()
-        results = {
-            **COMMON_SUCCESS,
-            **FULL_SUCCESS,
+        tag = {
+            **manual,
             "probe-thin-bootstrap": "skipped",
             "publish-release-assets": "success",
             "smoke-thin-plugin": "success",
             "verify-published-assets": "success",
         }
 
-        evaluation = module.evaluate_gate("push", "refs/tags/v0.8.1", "true", results)
+        manual_evaluation = module.evaluate_gate("workflow_dispatch", "refs/heads/main", outputs, manual)
+        tag_evaluation = module.evaluate_gate("push", "refs/tags/v0.8.1", outputs, tag)
 
-        self.assertTrue(evaluation.ok)
-        self.assertEqual("release", evaluation.contour)
-        self.assertEqual(["probe-thin-bootstrap"], evaluation.skipped_jobs)
+        self.assertTrue(manual_evaluation.ok)
+        self.assertEqual("full", manual_evaluation.contour)
+        self.assertTrue(tag_evaluation.ok)
+        self.assertEqual("release", tag_evaluation.contour)
 
-    def test_invalid_classifier_output_fails_closed(self) -> None:
-        module = self.module()
-        results = {**COMMON_SUCCESS, **FULL_SUCCESS, "probe-thin-bootstrap": "success", **PUBLISH_SKIPPED}
+    def test_missing_invalid_or_inconsistent_classification_fails_closed(self) -> None:
+        module = load_gate_module()
+        invalid_cases = (
+            {},
+            {**classification(), "rust_changed": "maybe"},
+            classification(platform_changed=True),
+            classification(package_changed=True),
+        )
+        for outputs in invalid_cases:
+            with self.subTest(outputs=outputs):
+                evaluation = module.evaluate_gate(
+                    "pull_request", "refs/pull/155/merge", outputs, source_results()
+                )
+                self.assertFalse(evaluation.ok)
+                self.assertIn("classification", evaluation.unexpected)
 
-        evaluation = module.evaluate_gate("pull_request", "refs/pull/148/merge", "", results)
+    def test_failure_cancelled_and_unexpected_skip_fail_the_gate(self) -> None:
+        module = load_gate_module()
+        outputs = classification(**{name: True for name in OUTPUT_NAMES})
+        results = {
+            **source_results(),
+            "verify-source": "cancelled",
+            "test-rust-platforms": "failure",
+            **PACKAGE_SUCCESS,
+            "package-runtime": "skipped",
+            "probe-thin-bootstrap": "success",
+        }
+
+        evaluation = module.evaluate_gate("pull_request", "refs/pull/155/merge", outputs, results)
 
         self.assertFalse(evaluation.ok)
-        self.assertEqual("invalid", evaluation.contour)
-        self.assertIn("classification", evaluation.unexpected)
+        self.assertEqual(
+            {
+                "verify-source": ("cancelled", "success"),
+                "test-rust-platforms": ("failure", "success"),
+                "package-runtime": ("skipped", "success"),
+            },
+            {key: value for key, value in evaluation.unexpected.items() if key != "classification"},
+        )
 
-    def test_summary_reports_contour_results_and_skipped_jobs(self) -> None:
-        module = self.module()
+    def test_summary_reports_classification_results_and_skipped_jobs(self) -> None:
+        module = load_gate_module()
+        outputs = classification(rust_changed=True, release_required=True)
         results = {
-            **COMMON_SUCCESS,
-            **FULL_SUCCESS,
+            **source_results(),
+            "test-rust-primary": "success",
+            **PACKAGE_SUCCESS,
             "probe-thin-bootstrap": "success",
-            **PUBLISH_SKIPPED,
         }
-        evaluation = module.evaluate_gate("pull_request", "refs/pull/148/merge", "true", results)
+        evaluation = module.evaluate_gate("pull_request", "refs/pull/155/merge", outputs, results)
 
         summary = module.render_summary(evaluation)
 
-        self.assertIn("Contour: `full`", summary)
-        self.assertIn("| `publish-release-assets` | `skipped` | `skipped` |", summary)
+        self.assertIn("Contour: `rust`", summary)
+        self.assertIn("Rust changed: `true`", summary)
+        self.assertIn("Platform changed: `false`", summary)
+        self.assertIn("| `test-rust-platforms` | `skipped` | `skipped` |", summary)
         self.assertIn("Skipped jobs", summary)
-        self.assertIn("`verify-published-assets`", summary)
 
 
 if __name__ == "__main__":

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -45,6 +45,8 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         gate = job_block(text, "unica-ci")
 
         self.assertIn("  pull_request:\n", trigger)
+        self.assertIn("labeled", trigger)
+        self.assertIn("unlabeled", trigger)
         self.assertNotIn("paths:", trigger)
         self.assertIn("name: Unica CI", gate)
         self.assertIn("if: always()", gate)
@@ -52,6 +54,7 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         for upstream in (
             "classify-changes",
             "verify-source",
+            "test-rust-primary",
             "test-rust-platforms",
             "build-tools",
             "package-runtime",
@@ -64,6 +67,52 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         ):
             with self.subTest(upstream=upstream):
                 self.assertIn(f"      - {upstream}", gate)
+
+    def test_classifier_exposes_typed_contours_and_ci_full_override(self) -> None:
+        text = self.release_text()
+        classifier = job_block(text, "classify-changes")
+
+        for output in (
+            "rust_changed",
+            "platform_changed",
+            "toolchain_changed",
+            "package_changed",
+            "plugin_content_changed",
+            "ci_changed",
+            "release_required",
+        ):
+            with self.subTest(output=output):
+                self.assertIn(f"      {output}:", classifier)
+        self.assertIn("contains(github.event.pull_request.labels.*.name, 'ci:full')", classifier)
+        self.assertIn("--force-full", classifier)
+
+    def test_rust_jobs_route_primary_and_platform_contours(self) -> None:
+        text = self.release_text()
+        source = job_block(text, "verify-source")
+        primary = job_block(text, "test-rust-primary")
+        platforms = job_block(text, "test-rust-platforms")
+
+        self.assertNotIn("cargo test", source)
+        self.assertNotIn("dtolnay/rust-toolchain", source)
+        self.assertIn("runs-on: macos-14", primary)
+        self.assertIn("rust_changed == 'true'", primary)
+        self.assertIn("platform_changed == 'false'", primary)
+        self.assertIn("runner: [ubuntu-latest, windows-latest, macos-14]", platforms)
+        self.assertIn("platform_changed == 'true'", platforms)
+        self.assertIn("toolchain_changed == 'true'", platforms)
+        self.assertIn("ci_changed == 'true'", platforms)
+
+    def test_package_contour_and_pr_smoke_do_not_publish_release_assets(self) -> None:
+        text = self.release_text()
+        build = job_block(text, "build-tools")
+        probe = job_block(text, "probe-thin-bootstrap")
+        publish = job_block(text, "publish-release-assets")
+
+        self.assertIn("release_required == 'true'", build)
+        self.assertIn("ci_changed == 'true'", build)
+        self.assertIn("github.event_name == 'pull_request'", probe)
+        self.assertIn("github.event_name == 'workflow_dispatch'", probe)
+        self.assertIn("if: startsWith(github.ref, 'refs/tags/')", publish)
 
     def test_javascript_actions_use_node24_compatible_majors(self) -> None:
         release = self.release_text()
@@ -92,6 +141,7 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         expected_release_timeouts = {
             "classify-changes": 10,
             "verify-source": 90,
+            "test-rust-primary": 60,
             "test-rust-platforms": 60,
             "build-tools": 90,
             "package-runtime": 30,

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -101,6 +101,7 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         self.assertIn("platform_changed == 'true'", platforms)
         self.assertIn("toolchain_changed == 'true'", platforms)
         self.assertIn("ci_changed == 'true'", platforms)
+        self.assertEqual(2, platforms.count("if: matrix.runner == 'macos-14'"))
 
     def test_package_contour_and_pr_smoke_do_not_publish_release_assets(self) -> None:
         text = self.release_text()

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -113,7 +113,32 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         self.assertIn("ci_changed == 'true'", build)
         self.assertIn("github.event_name == 'pull_request'", probe)
         self.assertIn("github.event_name == 'workflow_dispatch'", probe)
-        self.assertIn("if: startsWith(github.ref, 'refs/tags/')", publish)
+        self.assertIn("startsWith(github.ref, 'refs/tags/')", publish)
+
+    def test_conditional_pipeline_breaks_transitive_skip_propagation(self) -> None:
+        text = self.release_text()
+        dependencies = {
+            "package-runtime": ("needs.build-tools.result == 'success'",),
+            "package-thin": ("needs.package-runtime.result == 'success'",),
+            "probe-thin-bootstrap": ("needs.package-thin.result == 'success'",),
+            "release-assessment": ("needs.package-runtime.result == 'success'",),
+            "publish-release-assets": ("needs.package-runtime.result == 'success'",),
+            "smoke-thin-plugin": (
+                "needs.package-thin.result == 'success'",
+                "needs.publish-release-assets.result == 'success'",
+            ),
+            "verify-published-assets": (
+                "needs.package-thin.result == 'success'",
+                "needs.publish-release-assets.result == 'success'",
+            ),
+        }
+
+        for job_id, dependency_results in dependencies.items():
+            with self.subTest(job_id=job_id):
+                job = job_block(text, job_id)
+                self.assertIn("always()", job)
+                for dependency_result in dependency_results:
+                    self.assertIn(dependency_result, job)
 
     def test_javascript_actions_use_node24_compatible_majors(self) -> None:
         release = self.release_text()


### PR DESCRIPTION
Closes #155.

## What changed

- replace the single `release_artifacts` flag with typed Rust, platform, toolchain, package, plugin-content, CI, and release contours
- route platform-independent Rust through the primary macOS job and platform/toolchain/CI changes through the macOS/Linux/Windows matrix
- add the `ci:full` PR-label override and rerun on `labeled` / `unlabeled` events
- keep package, smoke, manual, tag, and publication contours separate so PRs never publish release assets
- make the stable `Unica CI` gate validate classifier consistency, expected skips, failures, cancellations, and missing jobs
- report classification and skipped-job diagnostics in the job summary

## Root cause

The workflow only knew whether release artifacts were required. It could not distinguish platform-independent Rust from changes inside the platform boundary established by #159, so every Rust PR paid for the same platform checks and the aggregate gate could not validate contour-specific skips.

## Routing contract

- skill/provenance/plugin-content only: source contracts, no Rust or package matrix
- platform-independent Rust: primary macOS Rust job; Linux/Windows Rust matrix skipped
- platform facade/tests: macOS/Linux/Windows Rust matrix
- Cargo/toolchain and CI-routing contract changes: conservative full contour
- package/runtime contract: target build, package, assessment, and PR bootstrap probe
- `ci:full`, tag, and manual runs: every validation contour; release publication remains tag-only

## Validation

Local:

- `actionlint .github/workflows/unica-plugin-release.yml`
- `python3.12 -m py_compile scripts/ci/*.py tests/ci/*.py`
- `cargo fmt --all -- --check`
- `python3.12 -m unittest discover -s tests/ci --durations 20` — 212 tests passed, 3 skipped
- `git diff --check`

GitHub Actions:

- [successful full run caused by applying `ci:full`](https://github.com/IngvarConsulting/unica/actions/runs/29733661438): 8m12s end-to-end
- classifier: 8s; source guardrails: 2m12s
- Rust: Ubuntu 1m13s, macOS 1m53s, Windows 2m16s
- target builds: macOS 2m25s, Linux 2m29s, Windows 4m26s
- runtime packages: 16–25s; bootstrap probes: 13–19s; final `Unica CI`: 3s
- release publication, published-plugin smoke, and published-byte verification were skipped as required for a PR

This PR changes the classifier/workflow itself, so both its normal run and its `ci:full` run must use the conservative full contour. Platform-independent and platform-dependent routing are covered by executable classifier, workflow, and aggregate-gate contract tests here; obtaining standalone GitHub timings for those contours requires separate benchmark PRs after this routing contract is merged.
