### PR TITLE
Optimize CI build cache and artifact flow

### DIFF
--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -136,7 +136,15 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
-      - uses: dtolnay/rust-toolchain@stable
+      - id: rust-toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - id: cargo-cache
+        name: Restore Cargo target cache
+        continue-on-error: true
+        uses: actions/cache@v5
+        with:
+          path: .build/tool-work/${{ matrix.target }}/cargo-target
+          key: cargo-${{ runner.os }}-${{ matrix.target }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('Cargo.lock') }}
       - name: Build target bundle and bootstrap
         run: >
           python scripts/ci/build-unica-tools.py
@@ -144,7 +152,33 @@ jobs:
           --target "${{ matrix.target }}"
           --lock-file plugins/unica/third-party/tools.lock.json
           --out-dir ".build/tool-bundles/${{ matrix.target }}"
-          --work-dir ".build/tool-work/${{ matrix.target }}"
+          --work-dir .build/tool-work
+          --metrics-file ".build/cargo-metrics/${{ matrix.target }}.json"
+      - name: Report Cargo cache and build metrics
+        if: always()
+        shell: bash
+        env:
+          CACHE_STEP_OUTCOME: ${{ steps.cargo-cache.outcome }}
+          CACHE_HIT: ${{ steps.cargo-cache.outputs.cache-hit }}
+          METRICS_FILE: .build/cargo-metrics/${{ matrix.target }}.json
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -u
+          cache_outcome=miss
+          if [ "$CACHE_STEP_OUTCOME" != "success" ]; then
+            cache_outcome=error
+          elif [ "$CACHE_HIT" = "true" ]; then
+            cache_outcome=exact-hit
+          fi
+          cargo_seconds="$(python -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["cargoBuildSeconds"])' "$METRICS_FILE" 2>/dev/null || true)"
+          if [ -z "$cargo_seconds" ]; then cargo_seconds=unavailable; fi
+          {
+            echo "### Cargo build ($TARGET)"
+            echo
+            echo "- Target: \`$TARGET\`"
+            echo "- Cache outcome: \`$cache_outcome\`"
+            echo "- Cargo build duration: \`$cargo_seconds\` seconds"
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Check bundled tool contracts
         run: >
           python scripts/ci/check-tool-contracts.py
@@ -158,51 +192,56 @@ jobs:
           python scripts/ci/smoke-unica-mcp.py \
             --binary "$executable" \
             --plugin-root ".build/tool-bundles/${{ matrix.target }}"
-      - uses: actions/upload-artifact@v7
-        with:
-          name: unica-tools-${{ matrix.target }}
-          path: .build/tool-bundles/${{ matrix.target }}
-          if-no-files-found: error
-
-  package-runtime:
-    name: Package runtime (${{ matrix.target }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs: build-tools
-    if: ${{ always() && needs.build-tools.result == 'success' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [darwin-arm64, linux-x64, win-x64]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-      - uses: actions/download-artifact@v8
-        with:
-          name: unica-tools-${{ matrix.target }}
-          path: .build/bundle
-      - run: >
+      - name: Package deterministic runtime
+        run: >
           python scripts/ci/package-unica-runtime.py
-          --bundle-root .build/bundle
-          --out-dir dist
-      - uses: actions/upload-artifact@v7
+          --bundle-root ".build/tool-bundles/${{ matrix.target }}"
+          --out-dir ".build/runtime-assets/${{ matrix.target }}"
+      - name: Verify local runtime asset pair
+        run: >
+          python scripts/ci/verify-release-assets.py
+          --asset-dir ".build/runtime-assets/${{ matrix.target }}"
+          --target "${{ matrix.target }}"
+      - name: Stage exact bootstrap payload
+        shell: bash
+        run: |
+          bootstrap_name=unica-bootstrap
+          if [ "${{ matrix.target }}" = "win-x64" ]; then bootstrap_name="${bootstrap_name}.exe"; fi
+          destination=".build/bootstrap-artifacts/${{ matrix.target }}/bootstrap/bin/${{ matrix.target }}"
+          mkdir -p "$destination"
+          cp ".build/tool-bundles/${{ matrix.target }}/bootstrap/bin/${{ matrix.target }}/${bootstrap_name}" "$destination/"
+      - name: Upload runtime metadata
+        uses: actions/upload-artifact@v7
+        with:
+          name: unica-runtime-metadata-${{ matrix.target }}
+          path: .build/runtime-assets/${{ matrix.target }}/unica-runtime-${{ matrix.target }}.json
+          if-no-files-found: error
+          retention-days: 1
+      - name: Upload bootstrap payload
+        uses: actions/upload-artifact@v7
+        with:
+          name: unica-bootstrap-${{ matrix.target }}
+          path: .build/bootstrap-artifacts/${{ matrix.target }}
+          if-no-files-found: error
+          retention-days: 1
+      - name: Upload required runtime archive
+        if: ${{ matrix.target == 'linux-x64' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) }}
+        uses: actions/upload-artifact@v7
         with:
           name: unica-runtime-${{ matrix.target }}
-          path: |
-            dist/unica-runtime-${{ matrix.target }}.tar.gz
-            dist/unica-runtime-${{ matrix.target }}.json
+          path: .build/runtime-assets/${{ matrix.target }}/unica-runtime-${{ matrix.target }}.tar.gz
           if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
 
   package-thin:
     name: Package thin marketplace payload
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: package-runtime
-    if: ${{ always() && needs.package-runtime.result == 'success' }}
+    needs: build-tools
+    if: ${{ always() && needs.build-tools.result == 'success' }}
     env:
-      RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'v0.8.1' }}
+      RELEASE_TAG: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.ref_name || 'v0.8.1' }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -210,12 +249,12 @@ jobs:
           python-version: "3.12"
       - uses: actions/download-artifact@v8
         with:
-          pattern: unica-runtime-*
+          pattern: unica-runtime-metadata-*
           path: .build/runtime-metadata
           merge-multiple: true
       - uses: actions/download-artifact@v8
         with:
-          pattern: unica-tools-*
+          pattern: unica-bootstrap-*
           path: .build/bootstrap-root
           merge-multiple: true
       - run: >
@@ -232,6 +271,7 @@ jobs:
           path: dist/thin/marketplace
           include-hidden-files: true
           if-no-files-found: error
+          retention-days: 90
 
   probe-thin-bootstrap:
     name: Probe thin bootstrap (${{ matrix.target }})
@@ -274,8 +314,8 @@ jobs:
     name: Assess Linux runtime on BSP
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: package-runtime
-    if: ${{ always() && needs.package-runtime.result == 'success' }}
+    needs: build-tools
+    if: ${{ always() && needs.build-tools.result == 'success' }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -300,16 +340,18 @@ jobs:
           name: unica-release-assessment
           path: dist/release-assessment
           if-no-files-found: warn
+          retention-days: 1
 
   publish-release-assets:
     name: Publish runtime assets
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: package-runtime
+    needs: build-tools
     if: >-
       ${{
         always() &&
-        needs.package-runtime.result == 'success' &&
+        needs.build-tools.result == 'success' &&
+        github.event_name == 'push' &&
         startsWith(github.ref, 'refs/tags/')
       }}
     permissions:
@@ -338,6 +380,7 @@ jobs:
         always() &&
         needs.package-thin.result == 'success' &&
         needs.publish-release-assets.result == 'success' &&
+        github.event_name == 'push' &&
         startsWith(github.ref, 'refs/tags/')
       }}
     strategy:
@@ -377,6 +420,7 @@ jobs:
         always() &&
         needs.package-thin.result == 'success' &&
         needs.publish-release-assets.result == 'success' &&
+        github.event_name == 'push' &&
         startsWith(github.ref, 'refs/tags/')
       }}
     permissions:
@@ -403,7 +447,6 @@ jobs:
       - test-rust-primary
       - test-rust-platforms
       - build-tools
-      - package-runtime
       - package-thin
       - probe-thin-bootstrap
       - release-assessment

--- a/scripts/ci/build-unica-tools.py
+++ b/scripts/ci/build-unica-tools.py
@@ -10,6 +10,7 @@ import platform
 import shutil
 import subprocess
 import sys
+import time
 import urllib.request
 from pathlib import Path
 
@@ -72,62 +73,46 @@ def assert_host(target: str, targets: dict) -> None:
         raise SystemExit(f"target {target} must be built on {expected}; current runner is {actual}")
 
 
-def build_cargo_workspace_tool(
-    tool: dict,
-    repo_root: Path,
-    target_dir: Path,
-    out_dir: Path,
-    exe: str,
-) -> Path:
-    package = tool["cargoPackage"]
-    binary_name = tool.get("cargoBin", tool["binaryName"])
-    run(
-        [
-            "cargo",
-            "build",
-            "--release",
-            "--package",
-            package,
-            "--bin",
-            binary_name,
-            "--target-dir",
-            str(target_dir),
-        ],
-        cwd=repo_root,
-    )
-
-    produced = target_dir / "release" / f"{binary_name}{exe}"
-    if not produced.exists():
-        raise SystemExit(f"cargo build output not found: {produced}")
-
-    dest = out_dir / f"{tool['binaryName']}{exe}"
-    shutil.copy2(produced, dest)
-    return dest
-
-
-def build_bootstrap(
+def build_cargo_workspace_binaries(
+    cargo_tools: list[dict],
     *,
     repo_root: Path,
     target_dir: Path,
+    target_bin_dir: Path,
     bundle_root: Path,
     target: str,
     exe: str,
-) -> Path:
-    """Build package infrastructure without exposing it as a runtime tool."""
-    run(
-        [
-            "cargo",
-            "build",
-            "--release",
-            "--package",
-            "unica-bootstrap",
-            "--bin",
-            "unica-bootstrap",
-            "--target-dir",
-            str(target_dir),
-        ],
-        cwd=repo_root,
+) -> tuple[dict[str, Path], Path, float]:
+    """Build runtime and package infrastructure in one locked Cargo invocation."""
+    packages = list(dict.fromkeys([tool["cargoPackage"] for tool in cargo_tools]))
+    packages.append("unica-bootstrap")
+    binary_names = list(
+        dict.fromkeys([tool.get("cargoBin", tool["binaryName"]) for tool in cargo_tools])
     )
+    binary_names.append("unica-bootstrap")
+
+    command = ["cargo", "build", "--release", "--locked"]
+    for package in packages:
+        command.extend(["--package", package])
+    for binary_name in binary_names:
+        command.extend(["--bin", binary_name])
+    command.extend(["--target-dir", str(target_dir)])
+
+    started_at = time.monotonic()
+    run(command, cwd=repo_root)
+    cargo_build_seconds = time.monotonic() - started_at
+
+    target_bin_dir.mkdir(parents=True, exist_ok=True)
+    built_paths: dict[str, Path] = {}
+    for tool in cargo_tools:
+        binary_name = tool.get("cargoBin", tool["binaryName"])
+        produced = target_dir / "release" / f"{binary_name}{exe}"
+        if not produced.exists():
+            raise SystemExit(f"cargo build output not found: {produced}")
+        destination = target_bin_dir / f"{tool['binaryName']}{exe}"
+        shutil.copy2(produced, destination)
+        built_paths[tool["name"]] = destination
+
     produced = target_dir / "release" / f"unica-bootstrap{exe}"
     if not produced.exists():
         raise SystemExit(f"cargo build output not found: {produced}")
@@ -137,7 +122,28 @@ def build_bootstrap(
     shutil.copy2(produced, destination)
     if not destination.name.endswith(".exe"):
         destination.chmod(destination.stat().st_mode | 0o755)
-    return destination
+    return built_paths, destination, cargo_build_seconds
+
+
+def write_build_metrics(
+    path: Path,
+    *,
+    target: str,
+    cargo_build_seconds: float,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schemaVersion": 1,
+                "target": target,
+                "cargoBuildSeconds": round(cargo_build_seconds, 3),
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
 
 def tool_entry(
@@ -178,6 +184,7 @@ def main() -> None:
     parser.add_argument("--repo-root", type=Path, default=Path("."))
     parser.add_argument("--out-dir", type=Path, required=True)
     parser.add_argument("--work-dir", type=Path, default=Path(".build/unica-tools"))
+    parser.add_argument("--metrics-file", type=Path)
     args = parser.parse_args()
 
     lock = load_lock(args.lock_file)
@@ -195,6 +202,7 @@ def main() -> None:
     downloads_dir.mkdir(parents=True, exist_ok=True)
 
     built_paths: dict[str, Path] = {}
+    cargo_tools: list[dict] = []
     for tool in lock["tools"]:
         strategy = tool["assetStrategy"]
         dest = target_bin_dir / f"{tool['binaryName']}{exe}"
@@ -209,17 +217,29 @@ def main() -> None:
             verify_asset_checksum(downloaded, asset, tool_name=tool["name"], target=args.target)
             shutil.copy2(downloaded, dest)
         elif strategy == "cargo-workspace":
-            dest = build_cargo_workspace_tool(
-                tool,
-                args.repo_root.resolve(),
-                args.work_dir / args.target / "cargo-target",
-                target_bin_dir,
-                exe,
-            )
+            cargo_tools.append(tool)
+            continue
         else:
             raise SystemExit(f"unsupported assetStrategy for {tool['name']}: {strategy}")
 
         built_paths[tool["name"]] = dest
+
+    cargo_paths, _, cargo_build_seconds = build_cargo_workspace_binaries(
+        cargo_tools,
+        repo_root=args.repo_root.resolve(),
+        target_dir=args.work_dir / args.target / "cargo-target",
+        target_bin_dir=target_bin_dir,
+        bundle_root=args.out_dir,
+        target=args.target,
+        exe=exe,
+    )
+    built_paths.update(cargo_paths)
+    if args.metrics_file is not None:
+        write_build_metrics(
+            args.metrics_file,
+            target=args.target,
+            cargo_build_seconds=cargo_build_seconds,
+        )
 
     for path in target_bin_dir.iterdir():
         if path.is_file() and not path.name.endswith(".exe"):
@@ -240,14 +260,6 @@ def main() -> None:
         )
         for tool in lock["tools"]
     ]
-
-    build_bootstrap(
-        repo_root=args.repo_root.resolve(),
-        target_dir=args.work_dir / args.target / "bootstrap-cargo-target",
-        bundle_root=args.out_dir,
-        target=args.target,
-        exe=exe,
-    )
 
     (args.out_dir / "tools.json").write_text(
         json.dumps(

--- a/scripts/ci/build-unica-tools.py
+++ b/scripts/ci/build-unica-tools.py
@@ -29,6 +29,26 @@ def run(args: list[str], *, cwd: Path | None = None) -> None:
     subprocess.run(args, cwd=cwd, check=True)
 
 
+def load_cargo_workspace_binary_owners(repo_root: Path) -> dict[str, set[str]]:
+    command = ["cargo", "metadata", "--locked", "--no-deps", "--format-version", "1"]
+    print("+", " ".join(command), flush=True)
+    completed = subprocess.run(
+        command,
+        cwd=repo_root,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    metadata = json.loads(completed.stdout)
+    owners: dict[str, set[str]] = {}
+    for package in metadata.get("packages", []):
+        package_name = package["name"]
+        for target in package.get("targets", []):
+            if "bin" in target.get("kind", []):
+                owners.setdefault(target["name"], set()).add(package_name)
+    return owners
+
+
 def sha256(path: Path) -> str:
     h = hashlib.sha256()
     with path.open("rb") as stream:
@@ -82,14 +102,29 @@ def build_cargo_workspace_binaries(
     bundle_root: Path,
     target: str,
     exe: str,
+    workspace_binary_owners: dict[str, set[str]],
 ) -> tuple[dict[str, Path], Path, float]:
     """Build runtime and package infrastructure in one locked Cargo invocation."""
-    packages = list(dict.fromkeys([tool["cargoPackage"] for tool in cargo_tools]))
-    packages.append("unica-bootstrap")
+    requested_pairs = [
+        (tool["cargoPackage"], tool.get("cargoBin", tool["binaryName"]))
+        for tool in cargo_tools
+    ]
+    requested_pairs.append(("unica-bootstrap", "unica-bootstrap"))
+    packages = list(dict.fromkeys(package for package, _ in requested_pairs))
+    selected_packages = set(packages)
+    for package, binary_name in requested_pairs:
+        owners = workspace_binary_owners.get(binary_name, set())
+        if package not in owners:
+            raise SystemExit(f"cargo package {package} does not own binary target {binary_name}")
+        selected_owners = owners & selected_packages
+        if selected_owners != {package}:
+            raise SystemExit(
+                f"cargo binary target {binary_name} is ambiguous across selected packages: "
+                f"{', '.join(sorted(selected_owners))}"
+            )
     binary_names = list(
-        dict.fromkeys([tool.get("cargoBin", tool["binaryName"]) for tool in cargo_tools])
+        dict.fromkeys(binary_name for _, binary_name in requested_pairs)
     )
-    binary_names.append("unica-bootstrap")
 
     command = ["cargo", "build", "--release", "--locked"]
     for package in packages:
@@ -232,6 +267,7 @@ def main() -> None:
         bundle_root=args.out_dir,
         target=args.target,
         exe=exe,
+        workspace_binary_owners=load_cargo_workspace_binary_owners(args.repo_root.resolve()),
     )
     built_paths.update(cargo_paths)
     if args.metrics_file is not None:

--- a/scripts/ci/evaluate-ci-gate.py
+++ b/scripts/ci/evaluate-ci-gate.py
@@ -26,7 +26,6 @@ ALWAYS_JOBS = (
 )
 PACKAGE_JOBS = (
     "build-tools",
-    "package-runtime",
     "package-thin",
     "release-assessment",
 )

--- a/scripts/ci/verify-release-assets.py
+++ b/scripts/ci/verify-release-assets.py
@@ -21,42 +21,45 @@ def sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def verify_runtime_asset_pair(asset_dir: Path, target: str) -> str:
+    metadata_path = asset_dir / f"unica-runtime-{target}.json"
+    archive_path = asset_dir / f"unica-runtime-{target}.tar.gz"
+    if not metadata_path.is_file() or not archive_path.is_file():
+        raise SystemExit(f"published runtime asset pair is missing for {target}")
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    if metadata.get("schemaVersion") != 1 or metadata.get("target") != target:
+        raise SystemExit(f"published runtime metadata identity mismatch for {target}")
+    if metadata.get("asset", {}).get("name") != archive_path.name:
+        raise SystemExit(f"published runtime archive name mismatch for {target}")
+    if metadata["asset"].get("sha256") != sha256(archive_path):
+        raise SystemExit(f"published runtime archive checksum mismatch for {target}")
+
+    expected = {item["path"]: item for item in metadata.get("files", [])}
+    with tarfile.open(archive_path, "r:gz") as archive:
+        members = [member for member in archive.getmembers() if member.isfile()]
+        actual_names = [member.name for member in members]
+        if actual_names != sorted(expected):
+            raise SystemExit(f"published runtime file set mismatch for {target}")
+        for member in members:
+            source = archive.extractfile(member)
+            if source is None:
+                raise SystemExit(f"cannot read published runtime member {member.name}")
+            digest = hashlib.sha256(source.read()).hexdigest()
+            if digest != expected[member.name]["sha256"]:
+                raise SystemExit(f"published runtime member checksum mismatch: {member.name}")
+            expected_mode = 0o755 if expected[member.name].get("executable") else 0o644
+            if member.mode != expected_mode or member.mtime != 0:
+                raise SystemExit(f"published runtime member metadata mismatch: {member.name}")
+
+    version = metadata.get("pluginVersion", "")
+    if not version:
+        raise SystemExit("published runtime target/version matrix is inconsistent")
+    return version
+
+
 def verify_release_assets(asset_dir: Path) -> str:
-    versions: set[str] = set()
-    found: set[str] = set()
-    for target in sorted(TARGETS):
-        metadata_path = asset_dir / f"unica-runtime-{target}.json"
-        archive_path = asset_dir / f"unica-runtime-{target}.tar.gz"
-        if not metadata_path.is_file() or not archive_path.is_file():
-            raise SystemExit(f"published runtime asset pair is missing for {target}")
-        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
-        if metadata.get("schemaVersion") != 1 or metadata.get("target") != target:
-            raise SystemExit(f"published runtime metadata identity mismatch for {target}")
-        if metadata.get("asset", {}).get("name") != archive_path.name:
-            raise SystemExit(f"published runtime archive name mismatch for {target}")
-        if metadata["asset"].get("sha256") != sha256(archive_path):
-            raise SystemExit(f"published runtime archive checksum mismatch for {target}")
-
-        expected = {item["path"]: item for item in metadata.get("files", [])}
-        with tarfile.open(archive_path, "r:gz") as archive:
-            members = [member for member in archive.getmembers() if member.isfile()]
-            actual_names = [member.name for member in members]
-            if actual_names != sorted(expected):
-                raise SystemExit(f"published runtime file set mismatch for {target}")
-            for member in members:
-                source = archive.extractfile(member)
-                if source is None:
-                    raise SystemExit(f"cannot read published runtime member {member.name}")
-                digest = hashlib.sha256(source.read()).hexdigest()
-                if digest != expected[member.name]["sha256"]:
-                    raise SystemExit(f"published runtime member checksum mismatch: {member.name}")
-                expected_mode = 0o755 if expected[member.name].get("executable") else 0o644
-                if member.mode != expected_mode or member.mtime != 0:
-                    raise SystemExit(f"published runtime member metadata mismatch: {member.name}")
-        versions.add(metadata.get("pluginVersion", ""))
-        found.add(target)
-
-    if found != TARGETS or len(versions) != 1 or "" in versions:
+    versions = {verify_runtime_asset_pair(asset_dir, target) for target in sorted(TARGETS)}
+    if len(versions) != 1:
         raise SystemExit("published runtime target/version matrix is inconsistent")
     return versions.pop()
 
@@ -64,8 +67,13 @@ def verify_release_assets(asset_dir: Path) -> str:
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--asset-dir", type=Path, required=True)
+    parser.add_argument("--target", choices=sorted(TARGETS))
     args = parser.parse_args()
-    version = verify_release_assets(args.asset_dir)
+    version = (
+        verify_runtime_asset_pair(args.asset_dir, args.target)
+        if args.target
+        else verify_release_assets(args.asset_dir)
+    )
     print(f"verified published Unica runtime assets: {version}")
 
 

--- a/spec/decisions/0010-ci-build-cache-and-artifact-flow.md
+++ b/spec/decisions/0010-ci-build-cache-and-artifact-flow.md
@@ -23,48 +23,66 @@ input required to create and verify its deterministic runtime archive.
 
 1. Each platform build uses one target-specific Cargo target directory for all
    workspace binaries built on that runner.
-2. `unica` and `unica-bootstrap` are selected in one mandatory `cargo build`
-   invocation. A restored cache accelerates this command but never replaces it.
+2. `unica` and `unica-bootstrap` are selected in one mandatory
+   `cargo build --locked` invocation. `--locked` keeps the dependency resolution
+   equal to the `Cargo.lock` content used in the cache key. A restored cache
+   accelerates this command but never replaces it.
 3. The Cargo target directory is cached with a key containing runner OS, Unica
-   target, the resolved Rust toolchain cache key, and the `Cargo.lock` hash.
+   target, the resolved Rust toolchain cache key, and the `Cargo.lock` hash. The
+   workflow does not use prefix `restore-keys`, so an exact hit and a miss remain
+   distinguishable.
 4. Cargo target directories and cache contents are never uploaded as workflow
    or release artifacts.
-5. Every platform build reports its target, cache hit or miss, and Cargo build
-   duration in the GitHub Actions job summary. Cold and warm runs therefore use
-   the same measurement rather than separate build paths.
+5. Every platform build reports its target, cache outcome (`exact-hit`, `miss`,
+   or `error`), and mandatory Cargo build duration in seconds in the GitHub
+   Actions job summary. Cold and warm runs therefore use the same build path and
+   measurement. Cache hit rate for a full run is the number of exact hits divided
+   by the three platform cache restores. A run with any cache error is reported
+   separately and is not valid cold or warm performance evidence.
 
 ### Runtime packaging
 
 The platform build job creates and verifies the complete tool bundle locally,
 smokes the packaged Unica MCP, and invokes `package-unica-runtime.py` before the
-runner is released. This preserves deterministic archive creation while
-removing the intermediate `package-runtime` job and the `unica-tools-*`
-artifact family.
+runner is released. It then reopens the target's generated archive and verifies
+the archive checksum, file set, member checksums, executable modes, and zeroed
+timestamps against its metadata. This single-target verification runs before
+the archive is uploaded or discarded. Tag publication retains the aggregate
+three-target verification after the published assets are downloaded again.
+This preserves deterministic archive creation while removing the intermediate
+`package-runtime` job and the `unica-tools-*` artifact family.
 
 The resulting data crosses job boundaries as three independently owned artifact
 classes:
 
-- `unica-runtime-metadata-<target>` contains only the runtime JSON metadata;
-- `unica-bootstrap-<target>` contains only the native bootstrap subtree;
-- `unica-runtime-<target>` contains only the publishable runtime archive.
+- `unica-runtime-metadata-<target>` contains only
+  `unica-runtime-<target>.json` at the artifact root;
+- `unica-bootstrap-<target>` contains exactly
+  `bootstrap/bin/<target>/unica-bootstrap[.exe]`, preserving the layout consumed
+  by thin packaging;
+- `unica-runtime-<target>` contains only the publishable
+  `unica-runtime-<target>.tar.gz` at the artifact root.
 
-Runtime metadata and bootstrap artifacts are uploaded for every full package
-contour and retained for one day. Runtime archives are uploaded on pull requests
-only when a downstream check consumes them; currently that is the Linux archive
-used by release assessment. Tag runs upload all three runtime archives for
-publication and byte-for-byte verification. These workflow artifacts are
-intermediate and use one-day retention because the release assets become the
-durable tag output.
+Runtime metadata and bootstrap artifacts are uploaded for every package
+pipeline and retained for one day. Pull-request and `workflow_dispatch` package
+pipelines upload only the Linux runtime archive consumed by release assessment.
+Tag pipelines upload all three runtime archives for publication and
+byte-for-byte verification. These workflow artifacts are intermediate and use
+one-day retention because the release assets become the durable tag output.
 
 `package-thin` downloads only the runtime metadata and bootstrap artifact
-families. `unica-thin-marketplace` keeps the existing longer retention because
-manual marketplace promotion retrieves it by `source_run_id`.
+families. `unica-thin-marketplace` uses an explicit `retention-days: 90` because
+manual marketplace staging and promotion retrieve it by `source_run_id` after
+the producing workflow has completed.
 
 ### Failure behavior
 
 - A cache miss is an observable cold build, not an error.
-- Cache restore or save failure must not bypass the mandatory Cargo build,
-  package validation, smoke test, or deterministic archive contract.
+- Cargo cache restore and save are best-effort. A restore failure is recorded as
+  `error` and does not stop the mandatory Cargo build; a save failure is visible
+  in the job log and does not invalidate an otherwise verified build. Neither
+  failure may bypass package validation, smoke, or deterministic archive
+  verification.
 - Missing metadata, bootstrap binaries, or a required runtime archive remains a
   hard artifact/download failure.
 - Tag publication still requires all macOS, Linux, and Windows archives and
@@ -75,22 +93,31 @@ manual marketplace promotion retrieves it by `source_run_id`.
 
 Contract tests must prove that:
 
-- the build helper issues one Cargo build for `unica` and `unica-bootstrap`
-  against one target directory;
+- the build helper issues one `cargo build --locked` for `unica` and
+  `unica-bootstrap` against one target directory;
 - the workflow cache key includes OS, target, toolchain, and `Cargo.lock`;
-- the workflow always executes the build after cache restoration;
+- the workflow uses no prefix restore key, distinguishes exact hit, miss, and
+  restore error, and always executes the build after cache restoration;
 - no `unica-tools-*` artifact or separate `package-runtime` job remains;
 - thin packaging consumes only runtime metadata and bootstrap artifacts;
+- bootstrap artifacts preserve the
+  `bootstrap/bin/<target>/unica-bootstrap[.exe]` payload layout;
 - intermediate artifacts use one-day retention while
-  `unica-thin-marketplace` does not;
-- pull requests upload only the runtime archive required by downstream
-  assessment, while tag runs upload and publish all targets;
+  `unica-thin-marketplace` uses 90-day retention;
+- pull requests and manual runs upload only the Linux runtime required by
+  downstream assessment, while tag runs upload and publish all targets;
+- each platform verifies its freshly packaged archive and metadata pair before
+  upload or disposal, while tags also verify the complete published matrix;
 - package, bootstrap smoke, release assessment, deterministic archive, and
   published-asset contracts remain connected to the stable `Unica CI` gate.
 
-The implementation PR records before/after wall time, aggregate runner time,
-cache results, artifact sizes, upload/download volume, and `package-thin`
-download volume from full workflow runs.
+The implementation PR identifies three full workflow runs: the pre-change
+baseline, an optimized cold run with no matching cache key, and a warm rerun of
+the same tree with the same key. For each optimized run it records per-target
+cache outcome and Cargo duration, exact hits out of three attempts, wall time,
+aggregate runner time, every artifact size, total upload/download volume, and
+the volume downloaded by `package-thin`. Runs with cache errors are diagnostic
+only and must be repeated before they can serve as cold or warm evidence.
 
 ## Consequences
 
@@ -103,4 +130,3 @@ download volume from full workflow runs.
   as a release artifact or proof of a valid bundle.
 - Release/tag behavior remains stricter than pull-request storage behavior: all
   targets are still packaged, published, downloaded again, and verified.
-

--- a/spec/decisions/0010-ci-build-cache-and-artifact-flow.md
+++ b/spec/decisions/0010-ci-build-cache-and-artifact-flow.md
@@ -1,0 +1,106 @@
+# ADR-0010: CI build cache and artifact flow
+
+- Status: `accepted`
+- Date: `2026-07-20`
+
+## Context
+
+The release workflow builds `unica` and `unica-bootstrap` in separate Cargo
+target directories on the same platform runner. It then uploads a complete
+`unica-tools-*` bundle, downloads that bundle in a separate Linux job to create
+the runtime archive, and downloads both complete runtime and tools artifacts in
+`package-thin` even though thin packaging needs only runtime metadata and the
+three bootstrap binaries.
+
+The reference PR run `29716722998` stored 464.4 MiB of artifacts: 233.3 MiB of
+tool bundles and 226.5 MiB of runtime bundles. The duplicate artifacts do not
+strengthen the release contract because the platform runner already has every
+input required to create and verify its deterministic runtime archive.
+
+## Decision
+
+### Cargo build
+
+1. Each platform build uses one target-specific Cargo target directory for all
+   workspace binaries built on that runner.
+2. `unica` and `unica-bootstrap` are selected in one mandatory `cargo build`
+   invocation. A restored cache accelerates this command but never replaces it.
+3. The Cargo target directory is cached with a key containing runner OS, Unica
+   target, the resolved Rust toolchain cache key, and the `Cargo.lock` hash.
+4. Cargo target directories and cache contents are never uploaded as workflow
+   or release artifacts.
+5. Every platform build reports its target, cache hit or miss, and Cargo build
+   duration in the GitHub Actions job summary. Cold and warm runs therefore use
+   the same measurement rather than separate build paths.
+
+### Runtime packaging
+
+The platform build job creates and verifies the complete tool bundle locally,
+smokes the packaged Unica MCP, and invokes `package-unica-runtime.py` before the
+runner is released. This preserves deterministic archive creation while
+removing the intermediate `package-runtime` job and the `unica-tools-*`
+artifact family.
+
+The resulting data crosses job boundaries as three independently owned artifact
+classes:
+
+- `unica-runtime-metadata-<target>` contains only the runtime JSON metadata;
+- `unica-bootstrap-<target>` contains only the native bootstrap subtree;
+- `unica-runtime-<target>` contains only the publishable runtime archive.
+
+Runtime metadata and bootstrap artifacts are uploaded for every full package
+contour and retained for one day. Runtime archives are uploaded on pull requests
+only when a downstream check consumes them; currently that is the Linux archive
+used by release assessment. Tag runs upload all three runtime archives for
+publication and byte-for-byte verification. These workflow artifacts are
+intermediate and use one-day retention because the release assets become the
+durable tag output.
+
+`package-thin` downloads only the runtime metadata and bootstrap artifact
+families. `unica-thin-marketplace` keeps the existing longer retention because
+manual marketplace promotion retrieves it by `source_run_id`.
+
+### Failure behavior
+
+- A cache miss is an observable cold build, not an error.
+- Cache restore or save failure must not bypass the mandatory Cargo build,
+  package validation, smoke test, or deterministic archive contract.
+- Missing metadata, bootstrap binaries, or a required runtime archive remains a
+  hard artifact/download failure.
+- Tag publication still requires all macOS, Linux, and Windows archives and
+  metadata, followed by published-byte verification and thin-plugin smoke on
+  all supported hosts.
+
+## Verification
+
+Contract tests must prove that:
+
+- the build helper issues one Cargo build for `unica` and `unica-bootstrap`
+  against one target directory;
+- the workflow cache key includes OS, target, toolchain, and `Cargo.lock`;
+- the workflow always executes the build after cache restoration;
+- no `unica-tools-*` artifact or separate `package-runtime` job remains;
+- thin packaging consumes only runtime metadata and bootstrap artifacts;
+- intermediate artifacts use one-day retention while
+  `unica-thin-marketplace` does not;
+- pull requests upload only the runtime archive required by downstream
+  assessment, while tag runs upload and publish all targets;
+- package, bootstrap smoke, release assessment, deterministic archive, and
+  published-asset contracts remain connected to the stable `Unica CI` gate.
+
+The implementation PR records before/after wall time, aggregate runner time,
+cache results, artifact sizes, upload/download volume, and `package-thin`
+download volume from full workflow runs.
+
+## Consequences
+
+- Platform runners do more packaging locally but avoid uploading and
+  re-downloading complete tool bundles.
+- Pull-request artifact storage drops from two complete three-platform copies
+  to metadata, bootstrap binaries, the thin marketplace payload, assessment
+  output, and the one Linux runtime required by assessment.
+- Warm builds reuse Cargo compilation products without treating cached output
+  as a release artifact or proof of a valid bundle.
+- Release/tag behavior remains stricter than pull-request storage behavior: all
+  targets are still packaged, published, downloaded again, and verified.
+

--- a/spec/decisions/README.md
+++ b/spec/decisions/README.md
@@ -12,6 +12,7 @@ This directory contains accepted architecture decisions for Unica.
 - [ADR-0006: Workspace-scoped internal services](0006-workspace-scoped-internal-services.md)
 - [ADR-0008: Public marketplace with a thin verified runtime](0008-public-marketplace-thin-runtime.md)
 - [ADR-0009: OS-specific code behind infrastructure platform facades](0009-os-specific-code-behind-platform-facade.md)
+- [ADR-0010: CI build cache and artifact flow](0010-ci-build-cache-and-artifact-flow.md)
 
 ## ADR Status Values
 

--- a/spec/plans/2026-07-20-issue-154-ci-artifacts.md
+++ b/spec/plans/2026-07-20-issue-154-ci-artifacts.md
@@ -255,4 +255,3 @@ claim the performance acceptance evidence locally: cold/warm cache outcomes,
 runner time, network volume, and real artifact sizes require GitHub Actions
 runs of the implementation commit. Record that evidence in the implementation
 PR after the branch is published and rerun unchanged for the warm sample.
-

--- a/spec/plans/2026-07-20-issue-154-ci-artifacts.md
+++ b/spec/plans/2026-07-20-issue-154-ci-artifacts.md
@@ -1,0 +1,258 @@
+# Issue #154 CI build and artifact optimization implementation plan
+
+> **For Codex:** Execute this plan task by task with red/green tests and run the
+> complete verification section before claiming completion.
+
+**Goal:** Remove duplicate Cargo work and oversized intermediate artifacts while
+preserving the existing package, release, deterministic archive, and stable CI
+gate contracts defined by ADR-0010.
+
+**Architecture:** The platform `build-tools` matrix owns the complete local
+build/package/verify lifecycle. It builds `unica` and `unica-bootstrap` once in a
+shared Cargo target directory, verifies the local runtime pair, and exports only
+the narrowly scoped runtime metadata, bootstrap, and conditionally required
+runtime archive artifacts. Downstream jobs consume those explicit artifact
+families; tag publication still verifies the complete published matrix.
+
+**Tech stack:** Python 3.12, `unittest`, Cargo, GitHub Actions YAML, existing
+package and release verification scripts.
+
+---
+
+## Task 1: Build workspace binaries once and emit build metrics
+
+**Files:**
+
+- Modify: `tests/ci/test_build_unica_tools.py`
+- Modify: `scripts/ci/build-unica-tools.py`
+
+### Step 1: Add failing unit tests
+
+Replace the independent Cargo-tool and bootstrap expectations with one test for
+a combined helper. The test must create fake `unica` and `unica-bootstrap`
+outputs in the same target directory and prove that:
+
+- exactly one `cargo build` command is issued;
+- the command includes `--locked`, both `--package` selections, both `--bin`
+  selections, and one `--target-dir`;
+- the Unica runtime binary and bootstrap binary are copied into their current
+  package layouts;
+- elapsed Cargo time is returned for workflow reporting.
+
+Add a separate test for the metrics writer. It must prove a stable JSON schema
+containing `schemaVersion`, `target`, and `cargoBuildSeconds` and a trailing
+newline.
+
+Run:
+
+```bash
+python3.12 -m unittest tests.ci.test_build_unica_tools
+```
+
+Expected: failure because the combined helper and metrics writer do not exist.
+
+### Step 2: Implement the combined build
+
+In `build-unica-tools.py`:
+
+- import `time`;
+- replace the per-tool Cargo helper and separate bootstrap helper with
+  `build_cargo_workspace_binaries(...)`;
+- gather all `cargo-workspace` tools and build their packages/binaries together
+  with `unica-bootstrap` using one `cargo build --release --locked` invocation;
+- use `.build/tool-work/<target>/cargo-target` as the only target directory for
+  both workspace binaries;
+- copy runtime binaries to `bin/<target>/` and bootstrap to
+  `bootstrap/bin/<target>/`, retaining executable-mode handling;
+- preserve direct release-asset download and checksum behavior;
+- add optional CLI argument `--metrics-file` and write the build metrics after a
+  successful Cargo invocation.
+
+Keep the existing CLI defaults compatible with local installation scripts.
+
+### Step 3: Run the focused test
+
+```bash
+python3.12 -m unittest tests.ci.test_build_unica_tools
+```
+
+Expected: pass.
+
+### Step 4: Commit
+
+```bash
+git add scripts/ci/build-unica-tools.py tests/ci/test_build_unica_tools.py
+git -c commit.gpgsign=false commit -m "ci: build Cargo package binaries once"
+```
+
+## Task 2: Verify one freshly packaged runtime pair
+
+**Files:**
+
+- Modify: `tests/ci/test_verify_release_assets.py`
+- Modify: `scripts/ci/verify-release-assets.py`
+
+### Step 1: Add a failing single-target contract test
+
+Build only the Linux runtime fixture and prove that the verifier can validate
+one `tar.gz` plus metadata pair without requiring the other targets. Retain an
+assertion that tampering with the archive fails verification.
+
+Run:
+
+```bash
+python3.12 -m unittest tests.ci.test_verify_release_assets
+```
+
+Expected: failure because the verifier currently always requires all targets.
+
+### Step 2: Extract target-level verification
+
+Refactor the existing verification body into
+`verify_runtime_asset_pair(asset_dir, target) -> str`. Keep every current check:
+archive checksum, member set, per-member checksum, executable mode, and zeroed
+mtime. Make `verify_release_assets(...)` aggregate the target-level function and
+still require one common version across all requested targets.
+
+Add `--target` with choices from the supported target set. With no option, the
+CLI must retain full-matrix release verification; with the option, it must
+validate just that target pair for the platform job.
+
+### Step 3: Run the focused test
+
+```bash
+python3.12 -m unittest tests.ci.test_verify_release_assets
+```
+
+Expected: pass.
+
+### Step 4: Commit
+
+```bash
+git add scripts/ci/verify-release-assets.py tests/ci/test_verify_release_assets.py
+git -c commit.gpgsign=false commit -m "ci: verify platform runtime assets locally"
+```
+
+## Task 3: Replace tool bundles and the packaging relay job
+
+**Files:**
+
+- Modify: `tests/ci/test_unica_workflow.py`
+- Modify: `.github/workflows/unica-plugin-release.yml`
+- Modify: `tests/ci/test_evaluate_ci_gate.py`
+- Modify: `scripts/ci/evaluate-ci-gate.py`
+
+### Step 1: Add failing workflow contract tests
+
+Update the workflow tests to require the ADR-0010 contract:
+
+- `build-tools` uses `actions/cache@v5` after the Rust toolchain step;
+- the cache key includes runner OS, matrix target, toolchain cache key, and
+  `hashFiles('Cargo.lock')`, with no `restore-keys`;
+- the build helper always runs and receives `--metrics-file`;
+- the job summary exposes `exact-hit`, `miss`, and `error` outcomes plus Cargo
+  duration;
+- platform jobs package and single-target verify their local runtime pair;
+- no `unica-tools-*` artifact or `package-runtime` job remains;
+- metadata and bootstrap are separate artifacts for every platform, with exact
+  documented paths and one-day retention;
+- pull requests and manual runs upload only the Linux runtime archive while tags
+  upload all three, also with one-day retention;
+- `package-thin` downloads only `unica-runtime-metadata-*` and
+  `unica-bootstrap-*`, while `unica-thin-marketplace` has 90-day retention;
+- release assessment and tag publishing depend directly on `build-tools`;
+- tag publishing still downloads all runtime artifacts and performs published
+  full-matrix verification;
+- the stable gate no longer expects `package-runtime`.
+
+Update the evaluator unit fixtures and failure case to match the reduced job
+graph.
+
+Run:
+
+```bash
+python3.12 -m unittest tests.ci.test_unica_workflow tests.ci.test_evaluate_ci_gate
+```
+
+Expected: failure against the old workflow/job graph.
+
+### Step 2: Implement build cache, local packaging, and narrow uploads
+
+In the `build-tools` matrix:
+
+- give `dtolnay/rust-toolchain@stable` an id;
+- restore/save `.build/tool-work/<target>/cargo-target` via
+  `actions/cache@v5`, best-effort, with the exact four-part key and no prefix
+  restore keys;
+- invoke the build helper with `.build/tool-work` and the target metrics file;
+- always write target, normalized cache outcome, and Cargo duration to the job
+  summary;
+- retain tool contract checks and packaged MCP smoke;
+- package the local runtime, then call `verify-release-assets.py --target`;
+- stage and upload one-file metadata and exact-layout bootstrap artifacts with
+  `retention-days: 1`;
+- upload the runtime archive only for Linux or a tag, with
+  `retention-days: 1` and no recompression.
+
+Delete `package-runtime`. Rewire downstream jobs as described in the failing
+tests and ADR. Add `actions/cache@v5` to the checked Node-action list.
+
+### Step 3: Update the stable gate evaluator
+
+Remove `package-runtime` from `PACKAGE_JOBS` and from all expected result
+fixtures. Preserve fail-closed behavior for missing, skipped, failed, and
+cancelled jobs that remain in the graph.
+
+### Step 4: Run focused tests
+
+```bash
+python3.12 -m unittest tests.ci.test_unica_workflow tests.ci.test_evaluate_ci_gate
+```
+
+Expected: pass.
+
+### Step 5: Commit
+
+```bash
+git add .github/workflows/unica-plugin-release.yml scripts/ci/evaluate-ci-gate.py tests/ci/test_unica_workflow.py tests/ci/test_evaluate_ci_gate.py
+git -c commit.gpgsign=false commit -m "ci: narrow runtime pipeline artifacts"
+```
+
+## Task 4: Verify the complete repository contract
+
+### Step 1: Run all CI contract tests
+
+```bash
+python3.12 -m unittest discover -s tests/ci
+```
+
+Expected: pass.
+
+### Step 2: Run Rust formatting, lint, and tests
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace -- --test-threads=1
+```
+
+Expected: all pass.
+
+### Step 3: Run repository hygiene checks
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors and only intentional changes before the final
+verification commit.
+
+### Step 4: Review against ADR-0010 and issue #154
+
+Inspect the final diff and explicitly check each ADR verification bullet. Do not
+claim the performance acceptance evidence locally: cold/warm cache outcomes,
+runner time, network volume, and real artifact sizes require GitHub Actions
+runs of the implementation commit. Record that evidence in the implementation
+PR after the branch is published and rerun unchanged for the warm sample.
+

--- a/spec/plans/2026-07-20-issue-154-ci-artifacts.md
+++ b/spec/plans/2026-07-20-issue-154-ci-artifacts.md
@@ -60,6 +60,9 @@ In `build-unica-tools.py`:
   `build_cargo_workspace_binaries(...)`;
 - gather all `cargo-workspace` tools and build their packages/binaries together
   with `unica-bootstrap` using one `cargo build --release --locked` invocation;
+- validate every requested `(cargoPackage, cargoBin)` pair and reject binary-name
+  collisions using locked Cargo workspace metadata before applying Cargo's
+  global package/bin filters;
 - use `.build/tool-work/<target>/cargo-target` as the only target directory for
   both workspace binaries;
 - copy runtime binaries to `bin/<target>/` and bootstrap to

--- a/tests/ci/test_build_unica_tools.py
+++ b/tests/ci/test_build_unica_tools.py
@@ -133,57 +133,7 @@ class BuildUnicaToolsTests(unittest.TestCase):
         self.assertNotIn("archive-release-asset", source)
         self.assertNotIn("archiveBinary", source)
 
-    def test_cargo_workspace_tool_builds_from_repo_root(self) -> None:
-        module = load_build_module()
-
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            repo_root = root / "repo"
-            repo_root.mkdir()
-            out_dir = root / "out"
-            out_dir.mkdir()
-            target_dir = root / "cargo-target"
-            produced = target_dir / "release" / "unica"
-            produced.parent.mkdir(parents=True)
-            produced.write_bytes(b"rust mcp")
-            calls = []
-
-            def fake_run(args, *, cwd=None):
-                calls.append((args, cwd))
-
-            with patch.object(module, "run", side_effect=fake_run):
-                dest = module.build_cargo_workspace_tool(
-                    {
-                        "name": "unica",
-                        "binaryName": "unica",
-                        "cargoPackage": "unica-coder",
-                        "cargoBin": "unica",
-                    },
-                    repo_root,
-                    target_dir,
-                    out_dir,
-                    "",
-                )
-
-            self.assertEqual(dest, out_dir / "unica")
-            self.assertEqual(dest.read_bytes(), b"rust mcp")
-            self.assertEqual(calls[0][1], repo_root)
-            self.assertEqual(
-                calls[0][0],
-                [
-                    "cargo",
-                    "build",
-                    "--release",
-                    "--package",
-                    "unica-coder",
-                    "--bin",
-                    "unica",
-                    "--target-dir",
-                    str(target_dir),
-                ],
-            )
-
-    def test_bootstrap_build_is_staged_outside_the_runtime_tool_manifest(self) -> None:
+    def test_workspace_binaries_share_one_locked_cargo_build(self) -> None:
         module = load_build_module()
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -191,28 +141,91 @@ class BuildUnicaToolsTests(unittest.TestCase):
             repo_root = root / "repo"
             repo_root.mkdir()
             bundle_root = root / "bundle"
+            target_bin_dir = bundle_root / "bin" / "win-x64"
+            target_bin_dir.mkdir(parents=True)
             target_dir = root / "cargo-target"
-            produced = target_dir / "release" / "unica-bootstrap.exe"
-            produced.parent.mkdir(parents=True)
-            produced.write_bytes(b"native bootstrap")
+            runtime_binary = target_dir / "release" / "unica.exe"
+            runtime_binary.parent.mkdir(parents=True)
+            runtime_binary.write_bytes(b"rust mcp")
+            bootstrap_binary = target_dir / "release" / "unica-bootstrap.exe"
+            bootstrap_binary.write_bytes(b"native bootstrap")
             calls = []
 
-            with patch.object(module, "run", side_effect=lambda args, cwd=None: calls.append((args, cwd))):
-                destination = module.build_bootstrap(
+            def fake_run(args, *, cwd=None):
+                calls.append((args, cwd))
+
+            with (
+                patch.object(module, "run", side_effect=fake_run),
+                patch.object(module.time, "monotonic", side_effect=[10.0, 12.5]),
+            ):
+                built_paths, bootstrap_path, duration = module.build_cargo_workspace_binaries(
+                    [
+                        {
+                            "name": "unica",
+                            "binaryName": "unica",
+                            "cargoPackage": "unica-coder",
+                            "cargoBin": "unica",
+                        }
+                    ],
                     repo_root=repo_root,
                     target_dir=target_dir,
+                    target_bin_dir=target_bin_dir,
                     bundle_root=bundle_root,
                     target="win-x64",
                     exe=".exe",
                 )
 
+            self.assertEqual(built_paths, {"unica": target_bin_dir / "unica.exe"})
+            self.assertEqual(built_paths["unica"].read_bytes(), b"rust mcp")
             self.assertEqual(
-                destination,
+                bootstrap_path,
                 bundle_root / "bootstrap" / "bin" / "win-x64" / "unica-bootstrap.exe",
             )
-            self.assertEqual(destination.read_bytes(), b"native bootstrap")
+            self.assertEqual(bootstrap_path.read_bytes(), b"native bootstrap")
+            self.assertEqual(duration, 2.5)
+            self.assertEqual(len(calls), 1)
             self.assertEqual(calls[0][1], repo_root)
-            self.assertIn("unica-bootstrap", calls[0][0])
+            self.assertEqual(
+                calls[0][0],
+                [
+                    "cargo",
+                    "build",
+                    "--release",
+                    "--locked",
+                    "--package",
+                    "unica-coder",
+                    "--package",
+                    "unica-bootstrap",
+                    "--bin",
+                    "unica",
+                    "--bin",
+                    "unica-bootstrap",
+                    "--target-dir",
+                    str(target_dir),
+                ],
+            )
+
+    def test_build_metrics_have_stable_schema_and_trailing_newline(self) -> None:
+        module = load_build_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            metrics_file = Path(tmp) / "nested" / "cargo.json"
+
+            module.write_build_metrics(
+                metrics_file,
+                target="linux-x64",
+                cargo_build_seconds=12.34567,
+            )
+
+            self.assertEqual(
+                json.loads(metrics_file.read_text(encoding="utf-8")),
+                {
+                    "schemaVersion": 1,
+                    "target": "linux-x64",
+                    "cargoBuildSeconds": 12.346,
+                },
+            )
+            self.assertTrue(metrics_file.read_bytes().endswith(b"\n"))
 
 
 if __name__ == "__main__":

--- a/tests/ci/test_build_unica_tools.py
+++ b/tests/ci/test_build_unica_tools.py
@@ -5,7 +5,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 
 def load_build_module():
@@ -173,6 +173,10 @@ class BuildUnicaToolsTests(unittest.TestCase):
                     bundle_root=bundle_root,
                     target="win-x64",
                     exe=".exe",
+                    workspace_binary_owners={
+                        "unica": {"unica-coder"},
+                        "unica-bootstrap": {"unica-bootstrap"},
+                    },
                 )
 
             self.assertEqual(built_paths, {"unica": target_bin_dir / "unica.exe"})
@@ -204,6 +208,115 @@ class BuildUnicaToolsTests(unittest.TestCase):
                     str(target_dir),
                 ],
             )
+
+    def test_workspace_binary_pairs_are_rejected_before_build_when_lock_is_malformed(self) -> None:
+        module = load_build_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(module, "run") as cargo_run:
+                with self.assertRaisesRegex(
+                    SystemExit,
+                    "unica-coder does not own binary target unica-bootstrap",
+                ):
+                    module.build_cargo_workspace_binaries(
+                        [
+                            {
+                                "name": "unica",
+                                "binaryName": "unica",
+                                "cargoPackage": "unica-coder",
+                                "cargoBin": "unica-bootstrap",
+                            }
+                        ],
+                        repo_root=root,
+                        target_dir=root / "cargo-target",
+                        target_bin_dir=root / "bundle" / "bin" / "linux-x64",
+                        bundle_root=root / "bundle",
+                        target="linux-x64",
+                        exe="",
+                        workspace_binary_owners={
+                            "unica": {"unica-coder"},
+                            "unica-bootstrap": {"unica-bootstrap"},
+                        },
+                    )
+
+            cargo_run.assert_not_called()
+
+    def test_workspace_binary_owners_come_from_locked_cargo_metadata(self) -> None:
+        module = load_build_module()
+        metadata = {
+            "packages": [
+                {
+                    "name": "unica-coder",
+                    "targets": [
+                        {"name": "unica", "kind": ["bin"]},
+                        {"name": "unica_coder", "kind": ["lib"]},
+                    ],
+                },
+                {
+                    "name": "unica-bootstrap",
+                    "targets": [{"name": "unica-bootstrap", "kind": ["bin"]}],
+                },
+            ]
+        }
+        completed = Mock(stdout=json.dumps(metadata))
+
+        with patch.object(module.subprocess, "run", return_value=completed) as cargo_metadata:
+            owners = module.load_cargo_workspace_binary_owners(Path("/repo"))
+
+        self.assertEqual(
+            owners,
+            {
+                "unica": {"unica-coder"},
+                "unica-bootstrap": {"unica-bootstrap"},
+            },
+        )
+        cargo_metadata.assert_called_once_with(
+            ["cargo", "metadata", "--locked", "--no-deps", "--format-version", "1"],
+            cwd=Path("/repo"),
+            check=True,
+            text=True,
+            stdout=module.subprocess.PIPE,
+        )
+
+    def test_workspace_binary_name_collision_is_rejected_before_build(self) -> None:
+        module = load_build_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with patch.object(module, "run") as cargo_run:
+                with self.assertRaisesRegex(
+                    SystemExit,
+                    "shared-bin is ambiguous across selected packages: package-a, package-b",
+                ):
+                    module.build_cargo_workspace_binaries(
+                        [
+                            {
+                                "name": "tool-a",
+                                "binaryName": "tool-a",
+                                "cargoPackage": "package-a",
+                                "cargoBin": "shared-bin",
+                            },
+                            {
+                                "name": "tool-b",
+                                "binaryName": "tool-b",
+                                "cargoPackage": "package-b",
+                                "cargoBin": "shared-bin",
+                            },
+                        ],
+                        repo_root=root,
+                        target_dir=root / "cargo-target",
+                        target_bin_dir=root / "bundle" / "bin" / "linux-x64",
+                        bundle_root=root / "bundle",
+                        target="linux-x64",
+                        exe="",
+                        workspace_binary_owners={
+                            "shared-bin": {"package-a", "package-b"},
+                            "unica-bootstrap": {"unica-bootstrap"},
+                        },
+                    )
+
+            cargo_run.assert_not_called()
 
     def test_build_metrics_have_stable_schema_and_trailing_newline(self) -> None:
         module = load_build_module()

--- a/tests/ci/test_evaluate_ci_gate.py
+++ b/tests/ci/test_evaluate_ci_gate.py
@@ -29,7 +29,6 @@ OUTPUT_NAMES = (
 ALWAYS_SUCCESS = {"classify-changes": "success", "verify-source": "success"}
 PACKAGE_SUCCESS = {
     "build-tools": "success",
-    "package-runtime": "success",
     "package-thin": "success",
     "release-assessment": "success",
 }
@@ -50,7 +49,6 @@ def source_results() -> dict[str, str]:
         "test-rust-primary": "skipped",
         "test-rust-platforms": "skipped",
         "build-tools": "skipped",
-        "package-runtime": "skipped",
         "package-thin": "skipped",
         "probe-thin-bootstrap": "skipped",
         "release-assessment": "skipped",
@@ -143,6 +141,28 @@ class EvaluateCiGateTests(unittest.TestCase):
         self.assertTrue(tag_evaluation.ok)
         self.assertEqual("release", tag_evaluation.contour)
 
+    def test_manual_dispatch_on_tag_ref_remains_non_publishing_full_contour(self) -> None:
+        module = load_gate_module()
+        outputs = classification(**{name: True for name in OUTPUT_NAMES})
+        results = {
+            **source_results(),
+            "test-rust-platforms": "success",
+            **PACKAGE_SUCCESS,
+            "probe-thin-bootstrap": "success",
+        }
+
+        evaluation = module.evaluate_gate(
+            "workflow_dispatch",
+            "refs/tags/v0.8.1",
+            outputs,
+            results,
+        )
+
+        self.assertTrue(evaluation.ok)
+        self.assertEqual("full", evaluation.contour)
+        for job in PUBLISH_SKIPPED:
+            self.assertEqual("skipped", evaluation.expected[job])
+
     def test_missing_invalid_or_inconsistent_classification_fails_closed(self) -> None:
         module = load_gate_module()
         invalid_cases = (
@@ -167,7 +187,7 @@ class EvaluateCiGateTests(unittest.TestCase):
             "verify-source": "cancelled",
             "test-rust-platforms": "failure",
             **PACKAGE_SUCCESS,
-            "package-runtime": "skipped",
+            "package-thin": "skipped",
             "probe-thin-bootstrap": "success",
         }
 
@@ -178,7 +198,7 @@ class EvaluateCiGateTests(unittest.TestCase):
             {
                 "verify-source": ("cancelled", "success"),
                 "test-rust-platforms": ("failure", "success"),
-                "package-runtime": ("skipped", "success"),
+                "package-thin": ("skipped", "success"),
             },
             {key: value for key, value in evaluation.unexpected.items() if key != "classification"},
         )

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -57,7 +57,6 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
             "test-rust-primary",
             "test-rust-platforms",
             "build-tools",
-            "package-runtime",
             "package-thin",
             "probe-thin-bootstrap",
             "release-assessment",
@@ -115,14 +114,32 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         self.assertIn("github.event_name == 'workflow_dispatch'", probe)
         self.assertIn("startsWith(github.ref, 'refs/tags/')", publish)
 
+    def test_only_tag_pushes_enable_release_behavior(self) -> None:
+        text = self.release_text()
+        build = job_block(text, "build-tools")
+        thin = job_block(text, "package-thin")
+
+        self.assertIn(
+            "github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')",
+            build,
+        )
+        self.assertIn(
+            "github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')",
+            thin,
+        )
+        for job_id in ("publish-release-assets", "smoke-thin-plugin", "verify-published-assets"):
+            with self.subTest(job_id=job_id):
+                job = job_block(text, job_id)
+                self.assertIn("github.event_name == 'push'", job)
+                self.assertIn("startsWith(github.ref, 'refs/tags/')", job)
+
     def test_conditional_pipeline_breaks_transitive_skip_propagation(self) -> None:
         text = self.release_text()
         dependencies = {
-            "package-runtime": ("needs.build-tools.result == 'success'",),
-            "package-thin": ("needs.package-runtime.result == 'success'",),
+            "package-thin": ("needs.build-tools.result == 'success'",),
             "probe-thin-bootstrap": ("needs.package-thin.result == 'success'",),
-            "release-assessment": ("needs.package-runtime.result == 'success'",),
-            "publish-release-assets": ("needs.package-runtime.result == 'success'",),
+            "release-assessment": ("needs.build-tools.result == 'success'",),
+            "publish-release-assets": ("needs.build-tools.result == 'success'",),
             "smoke-thin-plugin": (
                 "needs.package-thin.result == 'success'",
                 "needs.publish-release-assets.result == 'success'",
@@ -147,12 +164,14 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
 
         self.assertIn("actions/checkout@v7", combined)
         self.assertIn("actions/setup-python@v7", release)
+        self.assertIn("actions/cache@v5", release)
         self.assertIn("actions/upload-artifact@v7", release)
         self.assertIn("actions/download-artifact@v8", release)
         self.assertIn("softprops/action-gh-release@v3", release)
         for stale in (
             "actions/checkout@v4",
             "actions/setup-python@v5",
+            "actions/cache@v4",
             "actions/upload-artifact@v4",
             "actions/download-artifact@v4",
             "softprops/action-gh-release@v2",
@@ -170,7 +189,6 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
             "test-rust-primary": 60,
             "test-rust-platforms": 60,
             "build-tools": 90,
-            "package-runtime": 30,
             "package-thin": 30,
             "probe-thin-bootstrap": 30,
             "release-assessment": 60,
@@ -187,23 +205,86 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
             with self.subTest(job_id=job_id):
                 self.assertIn("timeout-minutes: 20", job_block(publish, job_id))
 
-    def test_runtime_matrix_builds_deterministic_assets_and_thin_payload(self) -> None:
+    def test_platform_build_uses_exact_cargo_cache_and_reports_outcome(self) -> None:
         text = self.release_text()
+        build = job_block(text, "build-tools")
+
+        self.assertIn("id: rust-toolchain", build)
+        self.assertIn("id: cargo-cache", build)
+        self.assertIn("continue-on-error: true", build)
+        self.assertIn("uses: actions/cache@v5", build)
+        self.assertIn("path: .build/tool-work/${{ matrix.target }}/cargo-target", build)
+        self.assertIn(
+            "key: cargo-${{ runner.os }}-${{ matrix.target }}-${{ "
+            "steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('Cargo.lock') }}",
+            build,
+        )
+        self.assertNotIn("restore-keys:", build)
+        self.assertLess(build.index("id: cargo-cache"), build.index("scripts/ci/build-unica-tools.py"))
+        self.assertIn("--metrics-file", build)
+        self.assertIn("if: always()", build)
+        self.assertIn("steps.cargo-cache.outcome", build)
+        self.assertIn("steps.cargo-cache.outputs.cache-hit", build)
+        for outcome in ("exact-hit", "miss", "error"):
+            with self.subTest(outcome=outcome):
+                self.assertIn(outcome, build)
+        self.assertIn("cargoBuildSeconds", build)
+        self.assertIn("GITHUB_STEP_SUMMARY", build)
+
+    def test_runtime_matrix_builds_verifies_and_exports_narrow_artifacts(self) -> None:
+        text = self.release_text()
+        build = job_block(text, "build-tools")
 
         for target in ("darwin-arm64", "linux-x64", "win-x64"):
             self.assertIn(f"target: {target}", text)
+        self.assertNotIn("  package-runtime:\n", text)
+        self.assertNotIn("unica-tools-", text)
+        self.assertIn("scripts/ci/build-unica-tools.py", build)
+        self.assertIn("scripts/ci/package-unica-runtime.py", build)
+        self.assertIn("scripts/ci/verify-release-assets.py", build)
+        self.assertIn('--target "${{ matrix.target }}"', build)
+        self.assertIn("name: unica-runtime-metadata-${{ matrix.target }}", build)
+        self.assertIn("name: unica-bootstrap-${{ matrix.target }}", build)
         self.assertIn("name: unica-runtime-${{ matrix.target }}", text)
-        self.assertIn("dist/unica-runtime-${{ matrix.target }}.tar.gz", text)
-        self.assertIn("scripts/ci/build-unica-tools.py", text)
-        self.assertIn("scripts/ci/package-unica-runtime.py", text)
+        self.assertIn(
+            ".build/runtime-assets/${{ matrix.target }}/unica-runtime-${{ matrix.target }}.json",
+            build,
+        )
+        self.assertIn(
+            ".build/runtime-assets/${{ matrix.target }}/unica-runtime-${{ matrix.target }}.tar.gz",
+            build,
+        )
+        self.assertIn(
+            ".build/bootstrap-artifacts/${{ matrix.target }}/bootstrap/bin/${{ matrix.target }}",
+            build,
+        )
+        self.assertIn("matrix.target == 'linux-x64'", build)
+        self.assertIn("startsWith(github.ref, 'refs/tags/')", build)
+        self.assertGreaterEqual(build.count("retention-days: 1"), 3)
+
+    def test_thin_payload_downloads_only_metadata_and_bootstrap(self) -> None:
+        text = self.release_text()
+        thin = job_block(text, "package-thin")
+
+        self.assertIn("needs: build-tools", thin)
+        self.assertIn("pattern: unica-runtime-metadata-*", thin)
+        self.assertIn("pattern: unica-bootstrap-*", thin)
+        self.assertNotIn("pattern: unica-tools-*", thin)
+        self.assertNotIn("pattern: unica-runtime-*\n", thin)
         self.assertIn("scripts/ci/package-unica-plugin.py", text)
-        self.assertIn("scripts/ci/smoke-unica-mcp.py", text)
-        self.assertIn("--runtime-metadata-root", text)
-        self.assertIn("--bootstrap-root", text)
-        self.assertIn("name: unica-thin-marketplace", text)
-        thin_upload = text[text.index("name: unica-thin-marketplace") :]
-        self.assertIn("include-hidden-files: true", thin_upload)
+        self.assertIn("--runtime-metadata-root", thin)
+        self.assertIn("--bootstrap-root", thin)
+        self.assertIn("name: unica-thin-marketplace", thin)
+        self.assertIn("include-hidden-files: true", thin)
+        self.assertIn("retention-days: 90", thin)
         self.assertNotIn("unica-codex-marketplace-${{ matrix.target }}", text)
+
+    def test_intermediate_non_marketplace_artifacts_expire_after_one_day(self) -> None:
+        text = self.release_text()
+        assessment = job_block(text, "release-assessment")
+
+        self.assertIn("name: unica-release-assessment", assessment)
+        self.assertIn("retention-days: 1", assessment)
 
     def test_packaged_bootstrap_is_smoked_on_every_supported_host(self) -> None:
         text = self.release_text()
@@ -260,7 +341,7 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         verify = text[text.index("  verify-published-assets:") :]
 
         self.assertNotIn("publish-assessment-pages", publish)
-        self.assertIn("needs: package-runtime", publish)
+        self.assertIn("needs: build-tools", publish)
         self.assertIn("softprops/action-gh-release@v3", publish)
         self.assertIn("unica-runtime-*.tar.gz", publish)
         self.assertIn("unica-runtime-*.json", publish)

--- a/tests/ci/test_verify_release_assets.py
+++ b/tests/ci/test_verify_release_assets.py
@@ -20,6 +20,43 @@ def load_module(path: Path, name: str):
 
 
 class VerifyReleaseAssetsTests(unittest.TestCase):
+    def test_verifies_one_packaged_runtime_pair_and_detects_tampering(self) -> None:
+        packager = load_module(REPO_ROOT / "scripts/ci/package-unica-runtime.py", "runtime_packager")
+        verifier = load_module(REPO_ROOT / "scripts/ci/verify-release-assets.py", "asset_verifier")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bundle = root / "linux-x64"
+            binary = bundle / "bin" / "linux-x64" / "unica"
+            binary.parent.mkdir(parents=True)
+            binary.write_bytes(b"linux-x64")
+            (bundle / "tools.json").write_text(
+                json.dumps(
+                    {
+                        "target": "linux-x64",
+                        "targetTriple": "x86_64-unknown-linux-gnu",
+                        "tools": [
+                            {
+                                "name": "unica",
+                                "version": "0.7.0",
+                                "targetTriple": "x86_64-unknown-linux-gnu",
+                                "binaryPath": "bin/linux-x64/unica",
+                                "sha256": packager.sha256(binary),
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            assets = root / "assets"
+            packager.package_runtime(bundle, assets)
+
+            self.assertEqual(verifier.verify_runtime_asset_pair(assets, "linux-x64"), "0.7.0")
+            with (assets / "unica-runtime-linux-x64.tar.gz").open("ab") as stream:
+                stream.write(b"tampered")
+            with self.assertRaisesRegex(SystemExit, "archive checksum mismatch"):
+                verifier.verify_runtime_asset_pair(assets, "linux-x64")
+
     def test_verifies_three_packaged_runtime_pairs_and_detects_tampering(self) -> None:
         packager = load_module(REPO_ROOT / "scripts/ci/package-unica-runtime.py", "runtime_packager")
         verifier = load_module(REPO_ROOT / "scripts/ci/verify-release-assets.py", "asset_verifier")


### PR DESCRIPTION
Closes #154

## What changed

- build `unica` and `unica-bootstrap` in one mandatory `cargo build --release --locked` invocation against one platform target directory
- validate Cargo package/bin ownership and output-name collisions before the combined build
- cache the Cargo target directory with an exact OS/target/toolchain/`Cargo.lock` key and report cache outcome plus Cargo duration
- package and fully verify each deterministic runtime archive on its platform runner
- remove the `unica-tools-*` artifact family and the `package-runtime` relay job
- split cross-job data into runtime metadata, exact-layout bootstrap payloads, and conditionally uploaded runtime archives
- retain intermediate artifacts for one day and the promotable thin marketplace payload for 90 days
- keep tag publication, cross-platform thin smoke, published-byte verification, and the stable `Unica CI` gate intact

The accepted contract is documented in `spec/decisions/0010-ci-build-cache-and-artifact-flow.md`; the TDD execution record is in `spec/plans/2026-07-20-issue-154-ci-artifacts.md`.

## Root cause

The previous workflow built workspace binaries in separate Cargo target directories, uploaded complete tool bundles, downloaded them into a separate Linux packaging job, and then downloaded oversized tool/runtime families again for thin packaging. The artifact graph duplicated Cargo work and transferred data that downstream consumers did not need.

## Validation

- `python3.12 -m unittest discover -s tests/ci`: 222 tests passed, 3 skipped
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace -- --test-threads=1`
- `actionlint .github/workflows/unica-plugin-release.yml`
- `git diff --check origin/main...HEAD`
- actual combined local release build for both workspace binaries completed successfully
- two independent final reviews completed with no remaining findings
- optimized cold and warm GitHub Actions attempts both passed the stable `Unica CI` gate

## Performance evidence

All optimized measurements use commit `83a16b71c7080a86140c5ca8a042bb7075a6ca94` and the same exact cache keys.

| Sample | Run | Cargo cache | Wall time | Aggregate runner time | Artifact upload | Derived artifact download | Upload + download | `package-thin` download |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| Issue baseline | [29716722998](https://github.com/IngvarConsulting/unica/actions/runs/29716722998) | no Cargo cache | 8:27 | 18:37 | 464.39 MiB | 801.82 MiB | 1,266.21 MiB | 459.84 MiB |
| Optimized cold | [29751193195 attempt 1](https://github.com/IngvarConsulting/unica/actions/runs/29751193195/attempts/1) | miss 3/3; save 3/3; error 0 | 7:42 | 17:18 | 103.81 MiB | 112.90 MiB | 216.70 MiB | 4.10 MiB |
| Optimized warm | [29751193195 attempt 2](https://github.com/IngvarConsulting/unica/actions/runs/29751193195/attempts/2) | exact-hit 3/3; error 0 | 6:50 | 15:16 | 103.81 MiB | 112.90 MiB | 216.70 MiB | 4.10 MiB |

Compared with the issue baseline, the warm sample reduces wall time by 19.13%, aggregate runner time by 17.99%, uploaded artifact bytes by 77.65%, derived artifact download bytes by 85.92%, and combined artifact transfer by 82.89%. The thin packager downloads 99.11% fewer bytes (112.12x smaller).

### Per-target Cargo and build-job time

| Target | Cold cache | Cold Cargo | Cold build job | Warm cache | Warm Cargo | Warm build job |
| --- | --- | ---: | ---: | --- | ---: | ---: |
| `linux-x64` | miss | 1m 21s | 2m 08s | exact-hit | 35.45s | 1m 28s |
| `darwin-arm64` | miss | 1m 27s | 2m 06s | exact-hit | 58.23s | 1m 39s |
| `win-x64` | miss | 2m 24s | 3m 59s | exact-hit | 1m 11s | 2m 40s |

The cache accelerates but does not replace the mandatory Cargo command: all six optimized platform jobs executed `cargo build --release --locked`, then package verification and smoke.

### Artifact sizes

Issue baseline:

| Artifact | Bytes | MiB |
| --- | ---: | ---: |
| `unica-release-assessment` | 6,973 | 0.01 |
| `unica-thin-marketplace` | 4,768,727 | 4.55 |
| `unica-runtime-linux-x64` | 99,649,325 | 95.03 |
| `unica-runtime-win-x64` | 71,037,155 | 67.75 |
| `unica-runtime-darwin-arm64` | 66,848,741 | 63.75 |
| `unica-tools-win-x64` | 73,271,836 | 69.88 |
| `unica-tools-linux-x64` | 102,180,022 | 97.45 |
| `unica-tools-darwin-arm64` | 69,187,436 | 65.98 |
| **Total** | **486,950,215** | **464.39** |

Optimized attempts:

| Artifact | Cold bytes | Warm bytes |
| --- | ---: | ---: |
| `unica-bootstrap-darwin-arm64` | 1,421,643 | 1,421,643 |
| `unica-bootstrap-linux-x64` | 1,571,573 | 1,571,573 |
| `unica-bootstrap-win-x64` | 1,304,973 | 1,304,973 |
| `unica-release-assessment` | 6,952 | 6,946 |
| `unica-runtime-linux-x64` | 99,771,592 | 99,771,592 |
| `unica-runtime-metadata-darwin-arm64` | 771 | 771 |
| `unica-runtime-metadata-linux-x64` | 774 | 774 |
| `unica-runtime-metadata-win-x64` | 772 | 772 |
| `unica-thin-marketplace` | 4,769,948 | 4,769,954 |
| **Total** | **108,848,998** | **108,848,998** |

### Transfer accounting

GitHub exposes compressed artifact sizes but not per-job transferred-byte counters. Download volume is therefore derived from those API sizes and the actual successful `download-artifact` consumers in each workflow graph:

- baseline: tool bundles into `package-runtime` (244,639,294 bytes), all tool/runtime bundles into `package-thin` (482,174,515), Linux runtime into assessment (99,649,325), and thin payload into three probes (14,306,181), totaling 840,769,315 bytes
- optimized cold: metadata/bootstrap into `package-thin` (4,300,506 bytes), Linux runtime into assessment (99,771,592), and thin payload into three probes (14,309,844), totaling 118,381,942 bytes
- optimized warm: the same consumers total 118,381,960 bytes; the 18-byte difference is the thin ZIP metadata

The prescribed baseline is a different historical PR head, so artifact and transfer comparisons are exact for the two workflow graphs while runner-time comparisons remain directional because unrelated CI routing also changed before this branch.
