### PR TITLE
Исправить публикацию аргументов worktree для unica.code.diagnostics

### DIFF
--- a/crates/unica-coder/src/application/tool_contracts.rs
+++ b/crates/unica-coder/src/application/tool_contracts.rs
@@ -575,22 +575,6 @@ pub fn input_schema_for_tool(tool: &ToolSpec) -> Value {
             {"required": ["definition"]}
         ]);
     }
-    if tool.name == "unica.code.diagnostics" {
-        schema["oneOf"] = json!([
-            {
-                "properties": {
-                    "mode": {"enum": ["analyze"]}
-                }
-            },
-            {
-                "required": ["mode"],
-                "properties": {
-                    "mode": {"enum": ["status", "catalog", "file", "workspace"]}
-                },
-                "not": {"required": ["timeoutSeconds"]}
-            }
-        ]);
-    }
     schema
 }
 
@@ -2323,13 +2307,15 @@ mod tests {
         assert_eq!(schema["additionalProperties"], false);
         assert!(schema["properties"].get("args").is_none());
         assert!(schema["properties"].get("argv").is_none());
+        assert!(schema["properties"].get("cwd").is_some());
+        assert!(schema["properties"].get("sourceDir").is_some());
         assert_eq!(schema["properties"]["codes"]["type"], "array");
         assert_eq!(schema["properties"]["rangeStart"]["type"], "integer");
         assert_eq!(schema["properties"]["maxFiles"]["type"], "integer");
         assert_eq!(schema["properties"]["timeoutSeconds"]["type"], "integer");
         assert_eq!(schema["properties"]["timeoutSeconds"]["minimum"], 30);
         assert_eq!(schema["properties"]["timeoutSeconds"]["maximum"], 3600);
-        assert_eq!(schema["oneOf"][1]["not"]["required"][0], "timeoutSeconds");
+        assert!(schema.get("oneOf").is_none());
         assert!(schema["properties"]["mode"]["enum"]
             .as_array()
             .unwrap()

--- a/crates/unica-coder/src/interfaces/mcp.rs
+++ b/crates/unica-coder/src/interfaces/mcp.rs
@@ -812,6 +812,32 @@ mod tests {
     }
 
     #[test]
+    fn tools_list_exposes_flat_diagnostics_worktree_contract() {
+        let app = UnicaApplication::new();
+        let request = json!({ "jsonrpc": "2.0", "id": 1, "method": "tools/list" });
+        let response = handle_message(&app, request).unwrap();
+        let listed = response["result"]["tools"].as_array().unwrap();
+        let diagnostics = listed
+            .iter()
+            .find(|tool| tool["name"] == "unica.code.diagnostics")
+            .expect("unica.code.diagnostics must be listed");
+
+        let schema = &diagnostics["inputSchema"];
+        let properties = schema["properties"].as_object().unwrap();
+        for name in [
+            "cwd",
+            "sourceDir",
+            "mode",
+            "path",
+            "codes",
+            "timeoutSeconds",
+        ] {
+            assert!(properties.contains_key(name), "missing {name}");
+        }
+        assert!(schema.get("oneOf").is_none());
+    }
+
+    #[test]
     fn native_tool_schema_is_contract_specific_and_does_not_expose_raw_args() {
         let app = UnicaApplication::new();
         let request = json!({ "jsonrpc": "2.0", "id": 1, "method": "tools/list" });


### PR DESCRIPTION
## Что изменено

- Удалён условный `oneOf` из публичной схемы `unica.code.diagnostics`.
- Сохранён плоский типизированный контракт со всеми аргументами, включая `cwd`, `sourceDir`, `mode`, `path`, `codes` и `timeoutSeconds`.
- Добавлены регрессионные проверки генератора схемы и публичного ответа `tools/list`.

## Причина

Codex интерпретировал ветви `oneOf` как полный union входных аргументов и публиковал для `unica.code.diagnostics` только поле `mode`. Поэтому к вызову нельзя было явно привязать активный Git worktree через `cwd` или выбрать каталог исходников через `sourceDir`, хотя маршрутизация Unica уже поддерживала оба аргумента.

## Влияние

Вызовы диагностики теперь можно однозначно привязать к выбранному worktree. Инструмент остаётся stateless и не сохраняет состояние `unica.project.map` между вызовами.

Ограничение `timeoutSeconds` не ослаблено: параметр по-прежнему принимается только для `mode=analyze` и проверяется runtime-валидатором в диапазоне 30–3600 секунд. Для `mode=file` по-прежнему обязателен `path`.

## Проверка

Успешно:

- `cargo fmt --all -- --check`;
- точечный тест контракта `bsl_diagnostics_contract_exposes_modes_and_keeps_analyze_default`;
- точечный тест публичного MCP `tools_list_exposes_flat_diagnostics_worktree_contract`.

Известные проблемы актуального `main`, не относящиеся к этому diff:

- `cargo clippy --package unica-coder --all-targets -- -D warnings` останавливается на `unused_import` и `dead_code` в `infrastructure/runtime_jobs.rs`;
- полный serial suite: 594 теста прошли, 5 Windows symlink-тестов требуют отсутствующую привилегию создания символических ссылок, 2 теста проигнорированы.

Закрывает #165.
