### PR TITLE
Fix diagnostics workspace arguments schema

### DIFF
--- a/crates/unica-coder/src/application/tool_contracts.rs
+++ b/crates/unica-coder/src/application/tool_contracts.rs
@@ -575,22 +575,6 @@ pub fn input_schema_for_tool(tool: &ToolSpec) -> Value {
             {"required": ["definition"]}
         ]);
     }
-    if tool.name == "unica.code.diagnostics" {
-        schema["oneOf"] = json!([
-            {
-                "properties": {
-                    "mode": {"enum": ["analyze"]}
-                }
-            },
-            {
-                "required": ["mode"],
-                "properties": {
-                    "mode": {"enum": ["status", "catalog", "file", "workspace"]}
-                },
-                "not": {"required": ["timeoutSeconds"]}
-            }
-        ]);
-    }
     schema
 }
 
@@ -2313,7 +2297,7 @@ mod tests {
     }
 
     #[test]
-    fn bsl_diagnostics_contract_exposes_modes_and_keeps_analyze_default() {
+    fn bsl_diagnostics_contract_stays_flat_and_keeps_analyze_default() {
         let diagnostics = tools()
             .into_iter()
             .find(|tool| tool.name == "unica.code.diagnostics")
@@ -2329,7 +2313,9 @@ mod tests {
         assert_eq!(schema["properties"]["timeoutSeconds"]["type"], "integer");
         assert_eq!(schema["properties"]["timeoutSeconds"]["minimum"], 30);
         assert_eq!(schema["properties"]["timeoutSeconds"]["maximum"], 3600);
-        assert_eq!(schema["oneOf"][1]["not"]["required"][0], "timeoutSeconds");
+        assert!(schema["properties"].get("cwd").is_some());
+        assert!(schema["properties"].get("sourceDir").is_some());
+        assert!(schema.get("oneOf").is_none());
         assert!(schema["properties"]["mode"]["enum"]
             .as_array()
             .unwrap()


### PR DESCRIPTION
## What changed

- remove the schema-level `oneOf` from `unica.code.diagnostics`
- keep the public diagnostics schema flat so MCP clients expose shared arguments such as `cwd` and `sourceDir`
- add a regression contract that requires the flat schema and both workspace-selection arguments

## Root cause

The raw schema already contained `cwd` and `sourceDir` in its top-level `properties`. The `oneOf` added for the analyze-only `timeoutSeconds` constraint caused Codex to project the two narrow branches as the callable union and omit those shared properties.

This fix does not introduce stateful coupling to `unica.project.map`. Workspace and source-set selection remain explicit per call. The existing server-side validation still restricts `timeoutSeconds` to `mode=analyze`, preserves the 30–3600 second bounds, and requires `path` for `mode=file`.

## Validation

- `cargo test --package unica-coder` (597 passed, 2 ignored)
- `cargo clippy --package unica-coder --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- real `tools/list` smoke assertion for a flat diagnostics schema with `cwd`, `sourceDir`, and `timeoutSeconds`
- `git diff --check origin/main...HEAD`
- independent code review: ready to merge, no findings

Closes #165
