### PR TITLE
docs: add packaged attribution and license page

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,4 +131,5 @@ WSL сохраняет Linux-семантику и собирает `linux-x64`.
 - `.github/workflows/publish-unica-marketplace.yml` — staging и promotion
   публичного каталога.
 
-Лицензия: LGPL-3.0-or-later.
+[Авторы, источники и лицензии](plugins/unica/ATTRIBUTIONS.md).
+Лицензия Unica: LGPL-3.0-or-later.

--- a/docs/superpowers/plans/2026-07-22-issue-115-attributions.md
+++ b/docs/superpowers/plans/2026-07-22-issue-115-attributions.md
@@ -1,0 +1,312 @@
+# Issue 115 Attribution Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a manually authored, source-backed `ATTRIBUTIONS.md` whose component coverage and packaged license references are enforced offline.
+
+**Architecture:** Keep versions, repositories, and component identity in the existing package manifests. Add a focused Python checker that extracts explicit attribution markers from the handwritten Markdown and compares them with tool, adapter, and provenance inventories; prose remains human-owned. Correct the two provenance/license contradictions before relying on those inventories.
+
+**Tech Stack:** Markdown, JSON package metadata, Python 3.12 standard library and `unittest`, existing plugin packager.
+
+## Global Constraints
+
+- Scope is the public Unica plugin artifact, not development, CI, test, or transitive dependencies.
+- `ATTRIBUTIONS.md` is manually written and must never be generated or rewritten from metadata.
+- CI is offline; it validates recorded identifiers, HTTPS URLs, and packaged paths, not live network availability or free-form prose accuracy.
+- Keep the public MCP boundary as one server named `unica` with `unica.*` tools.
+- `ai_rules_1c` contributed ideas only; no copied or adapted material and no redistribution license claim.
+- The pinned `v8-runner` source license is `AGPL-3.0-only`, not MIT.
+- Fix source metadata and tests together; do not preserve false assertions for compatibility.
+
+---
+
+### Task 1: Correct license and provenance contracts
+
+**Files:**
+- Modify: `plugins/unica/third-party/tools.lock.json`
+- Create: `plugins/unica/third-party/licenses/v8-runner/LICENSE`
+- Modify: `plugins/unica/third-party/NOTICE.md`
+- Modify: `plugins/unica/provenance/skill-upstreams.json`
+- Create: `plugins/unica/provenance/reviews/2026-07-22-ai-rules-idea-provenance-correction.json`
+- Modify: `scripts/ci/check-skill-upstreams.py`
+- Modify: `tests/ci/test_skill_provenance.py`
+- Modify: `tests/ci/test_package_unica_plugin.py`
+
+**Interfaces:**
+- Consumes: pinned commits already declared in `tools.lock.json` and `skill-upstreams.json`.
+- Produces: `v8-runner.license == "AGPL-3.0-only"`; `ai-rules-1c.usage == "inspiration-only"`; each `ai-rules-1c` entry has `status == "inspiration-only"`, `primarySource == "unica"`, and `decision == "ignored-with-reason"`.
+
+- [ ] **Step 1: Add failing contract tests**
+
+Add tests with these assertions:
+
+```python
+def test_v8_runner_license_matches_pinned_source_and_is_packaged(self) -> None:
+    lock = json.loads((self.repo_root() / "plugins/unica/third-party/tools.lock.json").read_text())
+    runner = next(tool for tool in lock["tools"] if tool["name"] == "v8-runner")
+    self.assertEqual(runner["license"], "AGPL-3.0-only")
+    license_path = self.repo_root() / "plugins/unica/third-party/licenses/v8-runner/LICENSE"
+    self.assertTrue(license_path.is_file())
+    self.assertIn("GNU AFFERO GENERAL PUBLIC LICENSE", license_path.read_text())
+
+def test_ai_rules_is_recorded_as_inspiration_not_adaptation(self) -> None:
+    upstream = next(item for item in self.load_provenance()["upstreams"] if item["id"] == "ai-rules-1c")
+    self.assertEqual(upstream["usage"], "inspiration-only")
+    for entry in upstream["entries"]:
+        self.assertEqual(entry["status"], "inspiration-only")
+        self.assertEqual(entry["primarySource"], "unica")
+        self.assertEqual(entry["decision"], "ignored-with-reason")
+        self.assertIn("ideas", entry["decisionReason"])
+```
+
+Extend the package-source copy test to expect
+`third-party/licenses/v8-runner/LICENSE` in the destination.
+
+- [ ] **Step 2: Run the focused tests and verify the intended failures**
+
+Run:
+
+```bash
+python3.12 -m unittest \
+  tests.ci.test_skill_provenance.SkillProvenanceTests.test_v8_runner_license_matches_pinned_source_and_is_packaged \
+  tests.ci.test_skill_provenance.SkillProvenanceTests.test_ai_rules_is_recorded_as_inspiration_not_adaptation -v
+```
+
+Expected: FAIL because the lock says MIT, the AGPL license file is absent, and provenance still says `adapted`/`ported`.
+
+- [ ] **Step 3: Correct the source contracts**
+
+Change the `v8-runner` lock license to `AGPL-3.0-only`. Copy the exact license text from the pinned source URL
+`https://github.com/alkoleft/v8-runner-rust/blob/ad72f64222ab0a7e6dfd391adb437a956c0a2428/LICENSE`
+into `third-party/licenses/v8-runner/LICENSE`, and reference it from `NOTICE.md`.
+
+Add `"inspiration-only"` to `ALLOWED_STATUSES`. Set `usage` on the `ai-rules-1c` upstream and mechanically correct every one of its entries to the interface above. Each note and decision reason must say that Unica used ideas only, that the local skill is Unica-owned, and that no donor expression was copied or adapted. Record the correction and its reason in the new review JSON without rewriting the dated historical review.
+
+- [ ] **Step 4: Run provenance and packaging contracts**
+
+Run:
+
+```bash
+python3.12 -m unittest tests.ci.test_skill_provenance tests.ci.test_package_unica_plugin -v
+python3.12 scripts/ci/check-skill-upstreams.py --validate-only
+```
+
+Expected: PASS; validation reports `errors: []`.
+
+- [ ] **Step 5: Commit the corrected contracts**
+
+```bash
+git add plugins/unica/third-party plugins/unica/provenance \
+  scripts/ci/check-skill-upstreams.py tests/ci/test_skill_provenance.py \
+  tests/ci/test_package_unica_plugin.py
+git commit -m "fix: correct attribution source contracts"
+```
+
+### Task 2: Add the offline attribution coverage checker
+
+**Files:**
+- Create: `scripts/ci/check-attributions.py`
+- Create: `tests/ci/test_attributions.py`
+
+**Interfaces:**
+- Consumes markers in the exact form `<!-- unica-attribution: KIND ID -->`, where `KIND` is `project`, `tool`, `adapter`, or `upstream`.
+- Produces: `expected_markers(repo_root: Path) -> set[tuple[str, str]]`, `parse_sections(markdown: str) -> dict[tuple[str, str], str]`, and `validate_attributions(repo_root: Path, attribution_file: Path | None = None) -> list[str]`. Consecutive markers inside one level-two Markdown section map to the same section body so related tools can share prose.
+- CLI exits 0 and prints `attributions: ok` when valid; otherwise prints one error per line to stderr and exits 1.
+
+- [ ] **Step 1: Write failing parser and inventory tests**
+
+Create `tests/ci/test_attributions.py` using `importlib.util` like `test_skill_provenance.py`. Cover:
+
+```python
+def test_expected_markers_follow_package_inventories(self):
+    self.assertEqual(module.expected_markers(self.repo_root()), {
+        ("project", "unica"),
+        ("tool", "bsl-analyzer"), ("tool", "v8-runner"),
+        ("tool", "rlm-tools-bsl"), ("tool", "rlm-bsl-index"),
+        ("adapter", "v8std"),
+        ("upstream", "cc-1c-skills"), ("upstream", "ai-rules-1c"),
+        ("upstream", "v8-runner-rust"),
+    })
+
+def test_parse_sections_rejects_duplicate_markers(self):
+    with self.assertRaisesRegex(ValueError, "duplicate attribution marker: tool demo"):
+        module.parse_sections("<!-- unica-attribution: tool demo -->\nA\n<!-- unica-attribution: tool demo -->\nB")
+
+def test_validation_reports_missing_unknown_and_invalid_links(self):
+    errors = module.validate_attributions(fixture_root, fixture_root / "ATTRIBUTIONS.md")
+    self.assertIn("missing attribution: tool demo", errors)
+    self.assertIn("unknown attribution: tool ghost", errors)
+    self.assertIn("tool other: repository link must be absolute HTTPS", errors)
+```
+
+Use temporary fixture roots with minimal JSON manifests; do not mutate repository files in tests.
+
+- [ ] **Step 2: Run tests and verify import/function failures**
+
+Run: `python3.12 -m unittest tests.ci.test_attributions -v`
+
+Expected: FAIL because `scripts/ci/check-attributions.py` does not exist.
+
+- [ ] **Step 3: Implement the minimal checker**
+
+Implement with the standard library only. Parse marker lines using:
+
+```python
+MARKER_RE = re.compile(r"^<!-- unica-attribution: (project|tool|adapter|upstream) ([a-z0-9][a-z0-9._-]*) -->$")
+LINK_RE = re.compile(r"\[[^]]+\]\(([^)]+)\)")
+```
+
+`expected_markers` reads the four authoritative files, excludes the `unica` tool from tool markers, and adds it as the project marker. `parse_sections` splits on level-two headings, collects all markers in each heading block, and maps every collected marker to that complete block; duplicate markers remain errors. `validate_attributions` compares exact sets. Project, tool, and upstream sections require labelled `Repository:` and `Author:` HTTPS links. Tool and non-inspiration upstream sections must also contain a labelled `License:` link; local license links must resolve inside `plugins/unica`, while external HTTPS license links are permitted for non-redistributed sources. Adapter sections instead require `Provider:` and `Service:` HTTPS links and the phrase `not redistributed`.
+
+- [ ] **Step 4: Run checker tests and the real CLI**
+
+Run:
+
+```bash
+python3.12 -m unittest tests.ci.test_attributions -v
+python3.12 scripts/ci/check-attributions.py
+```
+
+Expected: unit tests PASS; the real CLI FAILS only with `ATTRIBUTIONS.md not found` until Task 3.
+
+- [ ] **Step 5: Commit the checker**
+
+```bash
+git add scripts/ci/check-attributions.py tests/ci/test_attributions.py
+git commit -m "test: enforce attribution coverage"
+```
+
+### Task 3: Write and package the attribution page
+
+**Files:**
+- Create: `plugins/unica/ATTRIBUTIONS.md`
+- Modify: `README.md`
+- Modify: `plugins/unica/README.md`
+- Modify: `tests/ci/test_attributions.py`
+- Modify: `tests/ci/test_package_unica_plugin.py`
+
+**Interfaces:**
+- Consumes: marker/checker contract from Task 2 and corrected source metadata from Task 1.
+- Produces: a Russian-language editorial page covering every expected marker, plus discoverable README links and packaged-file proof.
+
+- [ ] **Step 1: Add failing repository and packaging assertions**
+
+Add tests that call `validate_attributions(repo_root)` and expect `[]`, assert both READMEs contain a relative link to `ATTRIBUTIONS.md`, and use `copy_tracked_plugin_source` to prove the staged plugin contains `ATTRIBUTIONS.md` plus all referenced local license files.
+
+- [ ] **Step 2: Run tests and verify missing-page/link failures**
+
+Run:
+
+```bash
+python3.12 -m unittest tests.ci.test_attributions tests.ci.test_package_unica_plugin -v
+```
+
+Expected: FAIL because the page and README links do not exist.
+
+- [ ] **Step 3: Verify upstream facts before writing**
+
+For every pinned repository, inspect the pinned commit rather than the current default branch. Use `gh api repos/OWNER/REPO/contents/PATH?ref=COMMIT` for LICENSE, package metadata, and author-bearing notices. Record project or contributor names only when a pinned primary file states them; otherwise thank the named project contributors and link its contributor history rather than inventing a personal author.
+
+Explicit facts already established by the approved design:
+
+- `v8-runner` at `ad72f64222ab0a7e6dfd391adb437a956c0a2428` is AGPL-3.0-only;
+- `ai_rules_1c` supplied ideas only and published no license at its baseline;
+- `rlm-tools-bsl`'s pinned LICENSE credits Stefan O'Shea and Roman Starchenko;
+- `cc-1c-skills`'s pinned LICENSE credits Nick Shirokov.
+
+- [ ] **Step 4: Write the page by hand**
+
+Write natural prose, not a manifest dump. Include these sections:
+
+```markdown
+# Авторы, источники и лицензии
+
+## Unica
+<!-- unica-attribution: project unica -->
+
+## Встроенные инструменты
+<!-- unica-attribution: tool bsl-analyzer -->
+<!-- unica-attribution: tool v8-runner -->
+<!-- unica-attribution: tool rlm-tools-bsl -->
+<!-- unica-attribution: tool rlm-bsl-index -->
+
+## Внешние сервисы
+<!-- unica-attribution: adapter v8std -->
+
+## Источники поведения и идей
+<!-- unica-attribution: upstream cc-1c-skills -->
+<!-- unica-attribution: upstream ai-rules-1c -->
+<!-- unica-attribution: upstream v8-runner-rust -->
+
+## Как читается цепочка лицензий
+## Благодарности
+```
+
+Group the two RLM tools in one narrative while retaining both markers. Explain aggregation versus adaptation, identify local license paths, state that v8std is not redistributed, and label `ai_rules_1c` as inspiration without a redistribution claim.
+
+- [ ] **Step 5: Add README links and pass focused tests**
+
+Add `Авторы, источники и лицензии` links near the existing license sections. Run:
+
+```bash
+python3.12 scripts/ci/check-attributions.py
+python3.12 -m unittest tests.ci.test_attributions tests.ci.test_package_unica_plugin -v
+```
+
+Expected: `attributions: ok`; all tests PASS.
+
+- [ ] **Step 6: Commit the manual page**
+
+```bash
+git add plugins/unica/ATTRIBUTIONS.md README.md plugins/unica/README.md \
+  tests/ci/test_attributions.py tests/ci/test_package_unica_plugin.py
+git commit -m "docs: add packaged attribution page"
+```
+
+### Task 4: Full validation and issue handoff
+
+**Files:**
+- Modify only files required by failures caused by Tasks 1-3.
+
+**Interfaces:**
+- Consumes: all preceding task deliverables.
+- Produces: a clean branch with repository, package, provenance, and Rust tests passing.
+
+- [ ] **Step 1: Run all Python CI tests**
+
+Run: `python3.12 -m unittest discover -s tests/ci -p 'test_*.py' -v`
+
+Expected: PASS with zero failures and errors.
+
+- [ ] **Step 2: Run provenance and attribution validators**
+
+Run:
+
+```bash
+python3.12 scripts/ci/check-skill-upstreams.py --validate-only
+python3.12 scripts/ci/check-attributions.py
+```
+
+Expected: no provenance errors and `attributions: ok`.
+
+- [ ] **Step 3: Run the Rust workspace suite**
+
+Run: `cargo test`
+
+Expected: PASS. If the known bootstrap JSON-RPC timeout appears once, rerun only the failing test and report both results; do not conceal the baseline flake.
+
+- [ ] **Step 4: Verify the final diff and package content**
+
+Run:
+
+```bash
+git diff --check origin/main...HEAD
+git status --short
+git log --oneline origin/main..HEAD
+```
+
+Expected: no whitespace errors, no uncommitted files, and focused commits for contracts, checker, page, and any test-only repair.
+
+- [ ] **Step 5: Request code review and prepare GitHub handoff**
+
+Use `superpowers:requesting-code-review`. Address only verified findings, then summarize the corrected license/provenance contradictions, tests, and the manual-maintenance limitation. Do not close issue #115 until the branch is published and CI/package verification succeeds.

--- a/docs/superpowers/specs/2026-07-22-issue-115-attributions-design.md
+++ b/docs/superpowers/specs/2026-07-22-issue-115-attributions-design.md
@@ -1,0 +1,130 @@
+# Issue 115: Packaged Attribution Page
+
+## Goal
+
+Give plugin users one packaged, readable page that identifies the authors and
+repositories behind Unica's shipped tools, external service adapters, and
+adapted skill behavior; thanks those authors; and explains the applicable
+license chain.
+
+The page must remain consistent with package-contract metadata. It must not
+become a second manually maintained inventory.
+
+## Scope
+
+The attribution page covers the public Unica plugin artifact:
+
+- Unica itself;
+- every bundled executable declared in `third-party/tools.lock.json`, excluding
+  duplicate presentation of the Unica executable itself;
+- every external service adapter declared in the packaged source manifest;
+- every distinct upstream repository represented in
+  `provenance/skill-upstreams.json` whose behavior or guidance was adapted into
+  packaged skills.
+
+Development-only dependencies, CI actions, test fixtures, build tools, and
+transitive Rust or Python dependencies are outside this issue. Their license
+obligations remain governed by their own dependency and distribution
+mechanisms.
+
+## Source-of-truth model
+
+Existing package metadata remains authoritative:
+
+- `third-party/tools.lock.json` owns bundled tool identity, version, repository,
+  pinned source revision, and license;
+- `provenance/skill-upstreams.json` owns adapted-skill donor repositories and
+  adaptation coverage;
+- the packaged source manifest owns external service adapter identity and URL;
+- `.codex-plugin/plugin.json` owns Unica author, homepage, and license identity.
+
+Those records will gain only the attribution fields that cannot be derived
+reliably, such as a human-readable project/author name, author URL,
+acknowledgement text, and an upstream license reference. The design does not
+introduce a new unified manifest or duplicate version and commit data.
+
+Authorship and license values must be verified against the upstream repository
+and then recorded explicitly. A repository owner inferred from its GitHub URL
+is not sufficient evidence of authorship.
+
+## Generated page
+
+A deterministic repository script will render
+`plugins/unica/ATTRIBUTIONS.md`. The generated page will contain:
+
+1. Unica copyright, homepage, and LGPL-3.0-or-later license;
+2. bundled tools grouped by upstream project, with authors, repository, pinned
+   version/revision, shipped role, upstream license, and included license or
+   notice path;
+3. external service adapters, with provider/project, endpoint or homepage,
+   integration role, and a clear statement that the remote service is not
+   redistributed as part of Unica;
+4. adapted skill sources grouped by donor repository, with author links,
+   affected packaged skills, upstream license, and an explanation that the
+   behavior was adapted behind Unica's typed `unica.*` MCP boundary;
+5. a concise license-chain explanation and acknowledgements.
+
+Repeated tools from one repository and repeated skill entries from one donor
+will be grouped. Lists and groups will use stable sorting so regeneration is
+reproducible. The page will label itself as generated and point maintainers to
+the authoritative metadata and generator.
+
+The plugin README and the repository root README will link to the page. The
+existing packaging process must copy it into the marketplace artifact without
+special release-time network access.
+
+## License-chain semantics
+
+The page will describe relationships rather than claim that one license
+automatically replaces another:
+
+- original third-party code remains subject to its upstream license;
+- Unica's own code and adaptations are distributed under
+  LGPL-3.0-or-later;
+- copied or modified material retains required upstream notices and license
+  terms;
+- separately invoked or aggregated binaries retain their declared licenses;
+- remote services are referenced integrations, not redistributed components.
+
+Full upstream license texts continue to live under `third-party/licenses/`
+when redistribution requires or warrants inclusion. The generated page links
+to those files; it does not duplicate complete license texts.
+
+## Validation and failure behavior
+
+The generator has a check mode that renders in memory and fails when the
+checked-in page differs. CI tests will also fail when:
+
+- a scoped tool, adapter, or donor lacks required attribution metadata;
+- an attribution URL is absent or is not an absolute HTTPS URL;
+- a declared bundled-license path does not exist in the packaged tree;
+- a tool or donor disappears from the generated page;
+- output ordering is nondeterministic.
+
+Checks are offline and deterministic. They validate recorded URLs and paths,
+not live network availability. Upstream facts are verified during metadata
+changes and reviewed in source control.
+
+## Testing strategy
+
+Implementation follows test-first development:
+
+1. add failing unit/contract tests for complete source coverage, grouping,
+   deterministic rendering, URL/path validation, and stale-output detection;
+2. add the smallest metadata extensions and generator needed to pass them;
+3. generate the page and add README links;
+4. run the focused attribution tests, provenance validation, packaging tests,
+   and the relevant repository test suite.
+
+The packaging test must inspect a produced plugin archive or staging directory
+and prove that `ATTRIBUTIONS.md` and referenced packaged license files are
+present.
+
+## Non-goals
+
+- replacing the existing provenance or tool-lock contracts;
+- producing an SBOM for every transitive dependency;
+- making CI query GitHub or other upstream hosts;
+- adding attribution prose to prompt-visible skills;
+- changing the public MCP server or `unica.*` tool boundary.
+

--- a/docs/superpowers/specs/2026-07-22-issue-115-attributions-design.md
+++ b/docs/superpowers/specs/2026-07-22-issue-115-attributions-design.md
@@ -20,7 +20,7 @@ The attribution page covers the public Unica plugin artifact:
   duplicate presentation of the Unica executable itself;
 - every external service adapter declared in the packaged source manifest;
 - every distinct upstream repository represented in
-  `provenance/skill-upstreams.json` whose behavior or guidance was adapted into
+  `provenance/skill-upstreams.json` whose behavior, guidance, or ideas informed
   packaged skills.
 
 Development-only dependencies, CI actions, test fixtures, build tools, and
@@ -48,6 +48,15 @@ Authorship and license values must be verified against the upstream repository
 and then recorded explicitly. A repository owner inferred from its GitHub URL
 is not sufficient evidence of authorship.
 
+`ai_rules_1c` is inspiration only: Unica used ideas from that repository, not
+copied or adapted material. Its baseline publishes no license, so the page must
+not imply that it grants redistribution rights or forms part of Unica's
+license chain. Provenance metadata must state this boundary explicitly.
+
+The pinned `v8-runner` source is AGPL-3.0. The incorrect MIT declaration in
+`third-party/tools.lock.json` must be corrected and the corresponding license
+text must be packaged.
+
 ## Attribution page
 
 Maintainers will write `plugins/unica/ATTRIBUTIONS.md` manually. It will
@@ -63,6 +72,8 @@ contain:
 4. adapted skill sources grouped by donor repository, with author links,
    affected packaged skills, upstream license, and an explanation that the
    behavior was adapted behind Unica's typed `unica.*` MCP boundary;
+   inspiration-only sources are labelled separately and make no redistribution
+   or adaptation claim;
 5. a concise license-chain explanation and acknowledgements.
 
 Repeated tools from one repository and repeated skill entries from one donor
@@ -85,6 +96,8 @@ automatically replaces another:
   terms;
 - separately invoked or aggregated binaries retain their declared licenses;
 - remote services are referenced integrations, not redistributed components.
+- inspiration-only sources contribute ideas rather than copied expression and
+  do not enter the redistribution license chain.
 
 Full upstream license texts continue to live under `third-party/licenses/`
 when redistribution requires or warrants inclusion. The attribution page links

--- a/docs/superpowers/specs/2026-07-22-issue-115-attributions-design.md
+++ b/docs/superpowers/specs/2026-07-22-issue-115-attributions-design.md
@@ -53,7 +53,7 @@ copied or adapted material. Its baseline publishes no license, so the page must
 not imply that it grants redistribution rights or forms part of Unica's
 license chain. Provenance metadata must state this boundary explicitly.
 
-The pinned `v8-runner` source is AGPL-3.0. The incorrect MIT declaration in
+The pinned `v8-runner` source is AGPL-3.0-only. The incorrect MIT declaration in
 `third-party/tools.lock.json` must be corrected and the corresponding license
 text must be packaged.
 

--- a/docs/superpowers/specs/2026-07-22-issue-115-attributions-design.md
+++ b/docs/superpowers/specs/2026-07-22-issue-115-attributions-design.md
@@ -1,4 +1,4 @@
-# Issue 115: Packaged Attribution Page
+# Issue 115: Manually Maintained Attribution Page
 
 ## Goal
 
@@ -7,8 +7,9 @@ repositories behind Unica's shipped tools, external service adapters, and
 adapted skill behavior; thanks those authors; and explains the applicable
 license chain.
 
-The page must remain consistent with package-contract metadata. It must not
-become a second manually maintained inventory.
+The page is a manually written editorial document. Automated checks protect
+its inventory coverage, while human review remains responsible for the
+accuracy and quality of its prose.
 
 ## Scope
 
@@ -27,7 +28,7 @@ transitive Rust or Python dependencies are outside this issue. Their license
 obligations remain governed by their own dependency and distribution
 mechanisms.
 
-## Source-of-truth model
+## Source and ownership model
 
 Existing package metadata remains authoritative:
 
@@ -38,19 +39,19 @@ Existing package metadata remains authoritative:
 - the packaged source manifest owns external service adapter identity and URL;
 - `.codex-plugin/plugin.json` owns Unica author, homepage, and license identity.
 
-Those records will gain only the attribution fields that cannot be derived
-reliably, such as a human-readable project/author name, author URL,
-acknowledgement text, and an upstream license reference. The design does not
-introduce a new unified manifest or duplicate version and commit data.
+`plugins/unica/ATTRIBUTIONS.md` owns the human-readable author names,
+acknowledgements, explanations, and license-chain narrative. The design does
+not introduce a new unified manifest or duplicate machine-readable version and
+commit data in another JSON file.
 
 Authorship and license values must be verified against the upstream repository
 and then recorded explicitly. A repository owner inferred from its GitHub URL
 is not sufficient evidence of authorship.
 
-## Generated page
+## Attribution page
 
-A deterministic repository script will render
-`plugins/unica/ATTRIBUTIONS.md`. The generated page will contain:
+Maintainers will write `plugins/unica/ATTRIBUTIONS.md` manually. It will
+contain:
 
 1. Unica copyright, homepage, and LGPL-3.0-or-later license;
 2. bundled tools grouped by upstream project, with authors, repository, pinned
@@ -65,9 +66,8 @@ A deterministic repository script will render
 5. a concise license-chain explanation and acknowledgements.
 
 Repeated tools from one repository and repeated skill entries from one donor
-will be grouped. Lists and groups will use stable sorting so regeneration is
-reproducible. The page will label itself as generated and point maintainers to
-the authoritative metadata and generator.
+will be grouped. The page will point maintainers to the authoritative package
+metadata that must be consulted when it is edited.
 
 The plugin README and the repository root README will link to the page. The
 existing packaging process must copy it into the marketplace artifact without
@@ -87,32 +87,40 @@ automatically replaces another:
 - remote services are referenced integrations, not redistributed components.
 
 Full upstream license texts continue to live under `third-party/licenses/`
-when redistribution requires or warrants inclusion. The generated page links
+when redistribution requires or warrants inclusion. The attribution page links
 to those files; it does not duplicate complete license texts.
 
 ## Validation and failure behavior
 
-The generator has a check mode that renders in memory and fails when the
-checked-in page differs. CI tests will also fail when:
+An offline CI checker will compare scoped component identifiers from the
+authoritative metadata with explicit machine-readable markers embedded in the
+manually written Markdown. It will fail when:
 
-- a scoped tool, adapter, or donor lacks required attribution metadata;
-- an attribution URL is absent or is not an absolute HTTPS URL;
+- a scoped tool, adapter, or donor has no matching attribution entry;
+- a required repository, author, or license URL is absent or is not an
+  absolute HTTPS URL;
 - a declared bundled-license path does not exist in the packaged tree;
-- a tool or donor disappears from the generated page;
-- output ordering is nondeterministic.
+- an attribution marker is duplicated or refers to a component outside the
+  authoritative inventories.
 
 Checks are offline and deterministic. They validate recorded URLs and paths,
 not live network availability. Upstream facts are verified during metadata
 changes and reviewed in source control.
 
+CI cannot prove that free-form prose remains factually current. This is an
+accepted consequence of choosing a manually authored page. Reviewers must
+compare author, acknowledgement, and license wording with upstream sources
+when components or their metadata change.
+
 ## Testing strategy
 
 Implementation follows test-first development:
 
-1. add failing unit/contract tests for complete source coverage, grouping,
-   deterministic rendering, URL/path validation, and stale-output detection;
-2. add the smallest metadata extensions and generator needed to pass them;
-3. generate the page and add README links;
+1. add failing unit/contract tests for complete source coverage, unique
+   markers, URL validation, and license-path validation;
+2. write the attribution page and add the smallest checker needed to pass the
+   tests;
+3. add README links;
 4. run the focused attribution tests, provenance validation, packaging tests,
    and the relevant repository test suite.
 
@@ -125,6 +133,6 @@ present.
 - replacing the existing provenance or tool-lock contracts;
 - producing an SBOM for every transitive dependency;
 - making CI query GitHub or other upstream hosts;
+- generating or rewriting the attribution page from metadata;
 - adding attribution prose to prompt-visible skills;
 - changing the public MCP server or `unica.*` tool boundary.
-

--- a/plugins/unica/ATTRIBUTIONS.md
+++ b/plugins/unica/ATTRIBUTIONS.md
@@ -1,0 +1,144 @@
+# Авторы, источники и лицензии
+
+Эта страница описывает компоненты публичного пакета Unica, источники идей и
+адаптированного поведения, а также границы применимых лицензий. Версии,
+репозитории и закреплённые коммиты инструментов задаются в
+[`third-party/tools.lock.json`](third-party/tools.lock.json), а происхождение
+skills — в [`provenance/skill-upstreams.json`](provenance/skill-upstreams.json).
+
+## Unica
+
+<!-- unica-attribution: project unica -->
+
+- Репозиторий: [IngvarConsulting/unica](https://github.com/IngvarConsulting/unica)
+- Автор: [Ingvar Consulting, LLC](https://ingvar.pro)
+- Лицензия: [LGPL-3.0-or-later](LICENSE)
+
+Команда Unica благодарит всех авторов перечисленных ниже проектов. Unica
+объединяет их через один типизированный MCP-сервер `unica`; это объединение не
+заменяет и не отменяет лицензии отдельных компонентов.
+
+## Встроенные инструменты
+
+### BSL Analyzer
+
+<!-- unica-attribution: tool bsl-analyzer -->
+
+- Репозиторий: [itrous/bsl-analyzer](https://github.com/itrous/bsl-analyzer)
+- Автор: [BSL Analyzer Contributors](https://github.com/itrous/bsl-analyzer/graphs/contributors)
+- Закреплённая версия: `0.2.55`, commit `5a02bb44dedaf29e0e29af1f740279d279199854`
+- Лицензия: [LGPL-3.0-or-later](third-party/licenses/bsl-analyzer/LICENSE-LGPL)
+- Дополнительные условия и происхождение: [NOTICE](third-party/licenses/bsl-analyzer/NOTICE)
+
+Unica поставляет LSP-бинарник `bsl-analyzer`. Его лицензионная заметка
+объясняет смешанную модель workspace: итоговый бинарник статически связывает
+компоненты уровня LGPL и поэтому распространяется как LGPL-3.0-or-later; там же
+перечислены архитектурные источники, тестовые данные и материалы платформы 1С
+с отдельными условиями.
+
+### v8-runner
+
+<!-- unica-attribution: tool v8-runner -->
+
+- Репозиторий: [alkoleft/v8-runner-rust](https://github.com/alkoleft/v8-runner-rust)
+- Автор: [v8-runner contributors](https://github.com/alkoleft/v8-runner-rust/graphs/contributors)
+- Закреплённая версия: `0.5.1`, commit `ad72f64222ab0a7e6dfd391adb437a956c0a2428`
+- Лицензия: [AGPL-3.0-only](third-party/licenses/v8-runner/LICENSE)
+
+`v8-runner` запускается Unica как отдельный внутренний процесс. На его
+распространяемый бинарник и исходный код действует AGPL-3.0-only; лицензия
+LGPL-3.0-or-later проекта Unica не заменяет эти условия.
+
+### rlm-tools-bsl и rlm-bsl-index
+
+<!-- unica-attribution: tool rlm-tools-bsl -->
+<!-- unica-attribution: tool rlm-bsl-index -->
+
+- Репозиторий: [Dach-Coin/rlm-tools-bsl](https://github.com/Dach-Coin/rlm-tools-bsl)
+- Автор: [Roman Starchenko](https://github.com/Dach-Coin); исходный проект
+  `rlm-tools` — [Stefan O'Shea](https://github.com/stefanoshea)
+- Закреплённая версия: `1.26.0`, commit `dcfff95ce678f49971b14d8acd82b042a6855470`
+- Лицензия: [MIT](third-party/licenses/rlm-tools-bsl/LICENSE)
+
+Оба бинарника собираются из одного репозитория. MIT notice сохраняет
+благодарность Stefan O'Shea за исходный `rlm-tools` и Roman Starchenko за
+адаптацию `rlm-tools-bsl`.
+
+## Внешние сервисы
+
+### v8std
+
+<!-- unica-attribution: adapter v8std -->
+
+- Поставщик: [проект v8std и его участники](https://github.com/zeegin/v8std)
+- Сервис: [ai.v8std.ru/mcp](https://ai.v8std.ru/mcp)
+
+Unica обращается к этому MCP-сервису как к удалённому адаптеру стандартов 1С.
+Сам сервис, его серверный код и содержимое сайта **не распространяется** в
+пакете Unica и не включается в цепочку лицензирования поставляемых бинарников.
+
+## Источники поведения и идей
+
+### cc-1c-skills
+
+<!-- unica-attribution: upstream cc-1c-skills -->
+
+- Репозиторий: [Nikolay-Shirokov/cc-1c-skills](https://github.com/Nikolay-Shirokov/cc-1c-skills)
+- Автор: [Nick Shirokov](https://github.com/Nikolay-Shirokov)
+- Проверенный baseline: `f3466e19fdc37954c030e48daabcc192f0098fe7`
+- Лицензия: [MIT](https://github.com/Nikolay-Shirokov/cc-1c-skills/blob/f3466e19fdc37954c030e48daabcc192f0098fe7/LICENSE)
+
+Unica благодарит Nick Shirokov за практические операции и описание форматов
+1С. Принятое поведение переработано в собственную реализацию Unica и доступно
+только через типизированные инструменты `unica.*`; исходные script-wrapper'ы
+донорского проекта в публичный workflow не входят.
+
+### ai_rules_1c
+
+<!-- unica-attribution: upstream ai-rules-1c -->
+
+- Репозиторий: [comol/ai_rules_1c](https://github.com/comol/ai_rules_1c)
+- Автор: [Oleg Philippov (comol)](https://github.com/comol)
+- Проверенный baseline: `484e550043a4cb749d59d0671329f3112e3ae668`
+
+Из `ai_rules_1c` использованы только общие идеи. Текст, код и иные формы
+выражения из репозитория не копировались и не адаптировались; соответствующие
+skills принадлежат Unica. На указанном baseline лицензия не опубликована,
+поэтому Unica не заявляет право на распространение материалов этого проекта и
+не включает его в цепочку лицензий поставки.
+
+### v8-runner-rust как источник runtime-контракта
+
+<!-- unica-attribution: upstream v8-runner-rust -->
+
+- Репозиторий: [alkoleft/v8-runner-rust](https://github.com/alkoleft/v8-runner-rust)
+- Автор: [v8-runner contributors](https://github.com/alkoleft/v8-runner-rust/graphs/contributors)
+- Проверенный baseline: версия и commit берутся из `third-party/tools.lock.json`
+- Лицензия: [AGPL-3.0-only](third-party/licenses/v8-runner/LICENSE)
+
+Контракт runtime-навыков Unica согласован с возможностями закреплённого
+`v8-runner`. Сам бинарник остаётся отдельным AGPL-компонентом; адаптер и
+публичная MCP-поверхность Unica распространяются по лицензии Unica.
+
+## Как читается цепочка лицензий
+
+- собственный код и документация Unica — LGPL-3.0-or-later;
+- адаптированное по MIT поведение `cc-1c-skills` сохраняет ссылку на автора и
+  исходную лицензию, а реализация Unica публикуется под LGPL-3.0-or-later;
+- отдельные встроенные бинарники сохраняют собственные лицензии:
+  LGPL-3.0-or-later, AGPL-3.0-only или MIT согласно разделам выше;
+- `ai_rules_1c` является источником идей, а не распространяемого или
+  адаптированного материала;
+- удалённый сервис v8std не поставляется вместе с Unica.
+
+Полные тексты и обязательные notices для поставляемых компонентов находятся в
+каталоге [`third-party/licenses/`](third-party/licenses/). При расхождении этой
+страницы с package metadata источником истины являются закреплённые manifests и
+тексты лицензий; страницу необходимо исправить вручную.
+
+## Благодарности
+
+Спасибо авторам и участникам BSL Analyzer, v8-runner, rlm-tools,
+rlm-tools-bsl, cc-1c-skills, ai_rules_1c и v8std, а также сообществу разработки
+1С за открытые инструменты, исследования форматов и практические знания, на
+которых строится Unica.

--- a/plugins/unica/README.md
+++ b/plugins/unica/README.md
@@ -139,4 +139,5 @@ cargo test --workspace -- --test-threads=1
 git diff --check
 ```
 
+[Авторы, источники и лицензии](ATTRIBUTIONS.md).
 License: LGPL-3.0-or-later.

--- a/plugins/unica/provenance/reviews/2026-07-22-ai-rules-idea-provenance-correction.json
+++ b/plugins/unica/provenance/reviews/2026-07-22-ai-rules-idea-provenance-correction.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "correctedAt": "2026-07-22",
+  "upstream": "ai-rules-1c",
+  "baselineCommit": "484e550043a4cb749d59d0671329f3112e3ae668",
+  "previousClassification": "adapted guidance",
+  "correctedClassification": "inspiration-only",
+  "reason": "Unica used general ideas from ai-rules-1c. No donor expression was copied or adapted; each local skill is Unica-owned.",
+  "licenseFinding": "No license was published at the recorded baseline, so Unica makes no redistribution or adaptation claim for this source.",
+  "historicalRecords": "Earlier dated review artifacts are retained as historical records and are superseded by this correction for current provenance classification."
+}

--- a/plugins/unica/provenance/skill-upstreams.json
+++ b/plugins/unica/provenance/skill-upstreams.json
@@ -1089,8 +1089,8 @@
       "entries": [
         {
           "skill": "api-design",
-          "status": "adapted",
-          "notes": "Unica-owned skill based on the Infostart \"База по API\" model; ai-rules-1c is tracked only as possible secondary guidance for architecture/MCP-routing ideas.",
+          "status": "inspiration-only",
+          "notes": "Unica-owned skill informed by general ideas from ai-rules-1c; no donor expression was copied or adapted.",
           "upstreamPaths": [
             "content/agents/architect.md",
             "content/agents/arch-reviewer.md",
@@ -1106,12 +1106,12 @@
           "baselineCommit": "a421cf44eb1f5859cf2a2b74884f8fbcaefc4826",
           "primarySource": "unica",
           "decision": "ignored-with-reason",
-          "decisionReason": "Unica-owned skill; ai-rules-1c changes are secondary guidance only and do not replace the Infostart-based API model."
+          "decisionReason": "Unica used ideas only; the local skill is Unica-owned, and no donor expression was copied or adapted."
         },
         {
           "skill": "background-jobs",
-          "status": "adapted",
-          "notes": "Guidance adapted from ai-rules-1c and rewritten for Unica skill routing through public unica.* MCP tools.",
+          "status": "inspiration-only",
+          "notes": "Unica-owned skill informed by general ideas from ai-rules-1c; no donor expression was copied or adapted.",
           "upstreamPaths": [
             "content/rules/async-methods.md",
             "content/rules/locks-and-transactions.md",
@@ -1125,12 +1125,14 @@
             "tests/ci/test_unica_skills.py"
           ],
           "baselineCommit": "a421cf44eb1f5859cf2a2b74884f8fbcaefc4826",
-          "decision": "ported"
+          "decision": "ignored-with-reason",
+          "primarySource": "unica",
+          "decisionReason": "Unica used ideas only; the local skill is Unica-owned, and no donor expression was copied or adapted."
         },
         {
           "skill": "bsp-patterns",
-          "status": "adapted",
-          "notes": "Guidance adapted from ai-rules-1c and rewritten for Unica skill routing through public unica.* MCP tools.",
+          "status": "inspiration-only",
+          "notes": "Unica-owned skill informed by general ideas from ai-rules-1c; no donor expression was copied or adapted.",
           "upstreamPaths": [
             "content/rules/platform-solutions.md",
             "content/rules/tooling-playbooks.md",
@@ -1144,12 +1146,14 @@
             "tests/ci/test_unica_skills.py"
           ],
           "baselineCommit": "a421cf44eb1f5859cf2a2b74884f8fbcaefc4826",
-          "decision": "ported"
+          "decision": "ignored-with-reason",
+          "primarySource": "unica",
+          "decisionReason": "Unica used ideas only; the local skill is Unica-owned, and no donor expression was copied or adapted."
         },
         {
           "skill": "code-diagnostics",
-          "status": "adapted",
-          "notes": "Guidance adapted from ai-rules-1c and rewritten for Unica skill routing through public unica.* MCP tools.",
+          "status": "inspiration-only",
+          "notes": "Unica-owned skill informed by general ideas from ai-rules-1c; no donor expression was copied or adapted.",
           "upstreamPaths": [
             "content/commands/doctor.md",
             "content/commands/checkmcp.md",
@@ -1163,12 +1167,14 @@
             "tests/ci/test_unica_skills.py"
           ],
           "baselineCommit": "a421cf44eb1f5859cf2a2b74884f8fbcaefc4826",
-          "decision": "ported"
+          "decision": "ignored-with-reason",
+          "primarySource": "unica",
+          "decisionReason": "Unica used ideas only; the local skill is Unica-owned, and no donor expression was copied or adapted."
         },
         {
           "skill": "code-review",
-          "status": "adapted",
-          "notes": "Guidance adapted from ai-rules-1c and rewritten for Unica skill routing through public unica.* MCP tools.",
+          "status": "inspiration-only",
+          "notes": "Unica-owned skill informed by general ideas from ai-rules-1c; no donor expression was copied or adapted.",
           "upstreamPaths": [
             "content/agents/code-reviewer.md",
             "content/rules/anti-patterns.md",
@@ -1182,12 +1188,14 @@
             "tests/ci/test_unica_skills.py"
           ],
           "baselineCommit": "a421cf44eb1f5859cf2a2b74884f8fbcaefc4826",
-          "decision": "ported"
+          "decision": "ignored-with-reason",
+          "primarySource": "unica",
+          "decisionReason": "Unica used ideas only; the local skill is Unica-owned, and no donor expression was copied or adapted."
         },
         {
           "skill": "code-search",
-          "status": "adapted",
-          "notes": "Guidance adapted from ai-rules-1c and rewritten for Unica skill routing through public unica.* MCP tools.",
+          "status": "inspiration-only",
+          "notes": "Unica-owned skill informed by general ideas from ai-rules-1c; no donor expression was copied or adapted.",
           "upstreamPaths": [
             "content/agents/explorer.md",
             "content/rules/mcp-first-search.md",
@@ -1200,12 +1208,14 @@
             "tests/ci/test_unica_skills.py"
           ],
           "baselineCommit": "a421cf44eb1f5859cf2a2b74884f8fbcaefc4826",
-          "decision": "ported"
+          "decision": "ignored-with-reason",
+          "primarySource": "unica",
+          "decisionReason": "Unica used ideas only; the local skill is Unica-owned, and no donor expression was copied or adapted."
         },
         {
           "skill": "data-exchange",
-          "status": "adapted",
-          "notes": "Guidance adapted from ai-rules-1c and rewritten for Unica skill routing through public unica.* MCP tools.",
+          "status": "inspiration-only",
+          "notes": "Unica-owned skill informed by general ideas from ai-rules-1c; no donor expression was copied or adapted.",
           "upstreamPaths": [
             "content/rules/integrations-add.md",
             "content/rules/registers-design.md",
@@ -1218,12 +1228,14 @@
             "tests/ci/test_unica_skills.py"
           ],
           "baselineCommit": "a421cf44eb1f5859cf2a2b74884f8fbcaefc4826",
-          "decision": "ported"
+          "decision": "ignored-with-reason",
+          "primarySource": "unica",
+          "decisionReason": "Unica used ideas only; the local skill is Unica-owned, and no donor expression was copied or adapted."
         },
         {
           "skill": "data-separation",
-          "status": "adapted",
-          "notes": "Guidance adapted from ai-rules-1c and rewritten for Unica skill routing through public unica.* MCP tools.",
+          "status": "inspiration-only",
+          "notes": "Unica-owned skill informed by general ideas from ai-rules-1c; no donor expression was copied or adapted.",
           "upstreamPaths": [
             "content/rules/dev-standards-architecture.md",
             "content/rules/dev-standards-core.md",
@@ -1237,12 +1249,14 @@
             "tests/ci/test_unica_skills.py"
           ],
           "baselineCommit": "a421cf44eb1f5859cf2a2b74884f8fbcaefc4826",
-          "decision": "ported"
+          "decision": "ignored-with-reason",
+          "primarySource": "unica",
+          "decisionReason": "Unica used ideas only; the local skill is Unica-owned, and no donor expression was copied or adapted."
         },
         {
           "skill": "db-performance",
-          "status": "adapted",
-          "notes": "Guidance adapted from ai-rules-1c and rewritten for Unica skill routing through public unica.* MCP tools.",
+          "status": "inspiration-only",
+          "notes": "Unica-owned skill informed by general ideas from ai-rules-1c; no donor expression was copied or adapted.",
           "upstreamPaths": [
             "content/agents/performance-optimizer.md",
             "content/rules/dcs-design.md",
@@ -1255,12 +1269,14 @@
             "tests/ci/test_unica_skills.py"
           ],
           "baselineCommit": "a421cf44eb1f5859cf2a2b74884f8fbcaefc4826",
-          "decision": "ported"
+          "decision": "ignored-with-reason",
+          "primarySource": "unica",
+          "decisionReason": "Unica used ideas only; the local skill is Unica-owned, and no donor expression was copied or adapted."
         },
         {
           "skill": "integration-implement",
-          "status": "adapted",
-          "notes": "Guidance adapted from ai-rules-1c and rewritten for Unica skill routing through public unica.* MCP tools.",
+          "status": "inspiration-only",
+          "notes": "Unica-owned skill informed by general ideas from ai-rules-1c; no donor expression was copied or adapted.",
           "upstreamPaths": [
             "content/rules/integrations-add.md",
             "content/rules/sdd-integrations.md",
@@ -1273,12 +1289,14 @@
             "tests/ci/test_unica_skills.py"
           ],
           "baselineCommit": "a421cf44eb1f5859cf2a2b74884f8fbcaefc4826",
-          "decision": "ported"
+          "decision": "ignored-with-reason",
+          "primarySource": "unica",
+          "decisionReason": "Unica used ideas only; the local skill is Unica-owned, and no donor expression was copied or adapted."
         },
         {
           "skill": "log-analysis",
-          "status": "adapted",
-          "notes": "Guidance adapted from ai-rules-1c and rewritten for Unica skill routing through public unica.* MCP tools.",
+          "status": "inspiration-only",
+          "notes": "Unica-owned skill informed by general ideas from ai-rules-1c; no donor expression was copied or adapted.",
           "upstreamPaths": [
             "content/rules/logging-strategy.md",
             "content/agents/performance-optimizer.md",
@@ -1291,12 +1309,14 @@
             "tests/ci/test_unica_skills.py"
           ],
           "baselineCommit": "a421cf44eb1f5859cf2a2b74884f8fbcaefc4826",
-          "decision": "ported"
+          "decision": "ignored-with-reason",
+          "primarySource": "unica",
+          "decisionReason": "Unica used ideas only; the local skill is Unica-owned, and no donor expression was copied or adapted."
         },
         {
           "skill": "platform-help",
-          "status": "adapted",
-          "notes": "Guidance adapted from ai-rules-1c and rewritten for Unica skill routing through public unica.* MCP tools.",
+          "status": "inspiration-only",
+          "notes": "Unica-owned skill informed by general ideas from ai-rules-1c; no donor expression was copied or adapted.",
           "upstreamPaths": [
             "content/rules/platform-solutions.md",
             "content/rules/dev-standards-core.md",
@@ -1309,12 +1329,14 @@
             "tests/ci/test_unica_skills.py"
           ],
           "baselineCommit": "a421cf44eb1f5859cf2a2b74884f8fbcaefc4826",
-          "decision": "ported"
+          "decision": "ignored-with-reason",
+          "primarySource": "unica",
+          "decisionReason": "Unica used ideas only; the local skill is Unica-owned, and no donor expression was copied or adapted."
         },
         {
           "skill": "query-optimize",
-          "status": "adapted",
-          "notes": "Guidance adapted from ai-rules-1c and rewritten for Unica skill routing through public unica.* MCP tools.",
+          "status": "inspiration-only",
+          "notes": "Unica-owned skill informed by general ideas from ai-rules-1c; no donor expression was copied or adapted.",
           "upstreamPaths": [
             "content/agents/performance-optimizer.md",
             "content/rules/dcs-design.md",
@@ -1327,12 +1349,14 @@
             "tests/ci/test_unica_skills.py"
           ],
           "baselineCommit": "a421cf44eb1f5859cf2a2b74884f8fbcaefc4826",
-          "decision": "ported"
+          "decision": "ignored-with-reason",
+          "primarySource": "unica",
+          "decisionReason": "Unica used ideas only; the local skill is Unica-owned, and no donor expression was copied or adapted."
         },
         {
           "skill": "release-support",
-          "status": "adapted",
-          "notes": "Guidance adapted from ai-rules-1c and rewritten for Unica skill routing through public unica.* MCP tools.",
+          "status": "inspiration-only",
+          "notes": "Unica-owned skill informed by general ideas from ai-rules-1c; no donor expression was copied or adapted.",
           "upstreamPaths": [
             "content/rules/extension-patterns.md",
             "content/rules/verification-checklist.md",
@@ -1345,12 +1369,14 @@
             "tests/ci/test_unica_skills.py"
           ],
           "baselineCommit": "a421cf44eb1f5859cf2a2b74884f8fbcaefc4826",
-          "decision": "ported"
+          "decision": "ignored-with-reason",
+          "primarySource": "unica",
+          "decisionReason": "Unica used ideas only; the local skill is Unica-owned, and no donor expression was copied or adapted."
         },
         {
           "skill": "security-auth-crypto",
-          "status": "adapted",
-          "notes": "Guidance adapted from ai-rules-1c and rewritten for Unica skill routing through public unica.* MCP tools.",
+          "status": "inspiration-only",
+          "notes": "Unica-owned skill informed by general ideas from ai-rules-1c; no donor expression was copied or adapted.",
           "upstreamPaths": [
             "content/rules/integrations-add.md",
             "content/rules/dev-standards-core.md",
@@ -1363,12 +1389,14 @@
             "tests/ci/test_unica_skills.py"
           ],
           "baselineCommit": "a421cf44eb1f5859cf2a2b74884f8fbcaefc4826",
-          "decision": "ported"
+          "decision": "ignored-with-reason",
+          "primarySource": "unica",
+          "decisionReason": "Unica used ideas only; the local skill is Unica-owned, and no donor expression was copied or adapted."
         },
         {
           "skill": "test-authoring",
-          "status": "adapted",
-          "notes": "Guidance adapted from ai-rules-1c and rewritten for Unica skill routing through public unica.* MCP tools.",
+          "status": "inspiration-only",
+          "notes": "Unica-owned skill informed by general ideas from ai-rules-1c; no donor expression was copied or adapted.",
           "upstreamPaths": [
             "content/agents/tester.md",
             "content/rules/verification-checklist.md",
@@ -1382,12 +1410,15 @@
             "tests/ci/test_unica_skills.py"
           ],
           "baselineCommit": "a421cf44eb1f5859cf2a2b74884f8fbcaefc4826",
-          "decision": "ported"
+          "decision": "ignored-with-reason",
+          "primarySource": "unica",
+          "decisionReason": "Unica used ideas only; the local skill is Unica-owned, and no donor expression was copied or adapted."
         }
       ],
-      "lastAdaptedLocalCommit": "e5b4eeab4dac92e0c9f60d3f886aa2bb7ef79f80",
-      "lastAdaptedAt": "2026-05-04T23:48:32+07:00",
-      "baselineSelection": "latest donor commit before the local v17/v18 guidance adaptation window"
+      "baselineSelection": "latest donor commit reviewed as an inspiration source",
+      "usage": "inspiration-only",
+      "lastReviewedLocalCommit": "e5b4eeab4dac92e0c9f60d3f886aa2bb7ef79f80",
+      "lastReviewedAt": "2026-05-04T23:48:32+07:00"
     },
     {
       "id": "v8-runner-rust",

--- a/plugins/unica/third-party/NOTICE.md
+++ b/plugins/unica/third-party/NOTICE.md
@@ -13,8 +13,9 @@ commit generated tool binaries.
 
 ## v8-runner
 
+- Included license: `third-party/licenses/v8-runner/LICENSE`
 - See `third-party/tools.lock.json` for the pinned repository, version, tag,
-  commit, license field, and target assets.
+  commit, AGPL-3.0-only license field, and target assets.
 
 ## rlm-tools-bsl
 

--- a/plugins/unica/third-party/licenses/v8-runner/LICENSE
+++ b/plugins/unica/third-party/licenses/v8-runner/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -64,7 +64,7 @@
       "sourceCommit": "ad72f64222ab0a7e6dfd391adb437a956c0a2428",
       "assetRepository": "https://github.com/IngvarConsulting/unica-toolchain",
       "assetTag": "v8-runner-v0.5.1-build.1",
-      "license": "MIT",
+      "license": "AGPL-3.0-only",
       "assetStrategy": "direct-release-asset",
       "binaryName": "v8-runner",
       "assets": {

--- a/scripts/ci/check-attributions.py
+++ b/scripts/ci/check-attributions.py
@@ -108,12 +108,20 @@ def is_https(url: str | None) -> bool:
     return parsed.scheme == "https" and bool(parsed.netloc)
 
 
-def validate_local_license(root: Path, marker: tuple[str, str], link: str | None) -> str | None:
+def validate_local_license(
+    root: Path,
+    marker: tuple[str, str],
+    link: str | None,
+    *,
+    allow_external: bool,
+) -> str | None:
     label = f"{marker[0]} {marker[1]}"
     if not link:
         return f"{label}: license link is required"
     if is_https(link):
-        return None
+        if allow_external:
+            return None
+        return f"{label}: license link must point to a packaged file"
     relative = Path(link.split("#", 1)[0])
     if relative.is_absolute() or ".." in relative.parts:
         return f"{label}: license link must stay inside plugins/unica"
@@ -173,7 +181,12 @@ def validate_attributions(
         if needs_license:
             if kind in {"project", "tool"} and record["license"] not in section:
                 errors.append(f"{label}: declared license {record['license']} must appear in the section")
-            license_error = validate_local_license(root, marker, labelled_link(section, "license"))
+            license_error = validate_local_license(
+                root,
+                marker,
+                labelled_link(section, "license"),
+                allow_external=kind == "upstream",
+            )
             if license_error:
                 errors.append(license_error)
 

--- a/scripts/ci/check-attributions.py
+++ b/scripts/ci/check-attributions.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Validate coverage and structural links in Unica's manual attribution page."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+MARKER_RE = re.compile(
+    r"^<!-- unica-attribution: (project|tool|adapter|upstream) "
+    r"([a-z0-9][a-z0-9._-]*) -->$"
+)
+LABELS = {
+    "repository": re.compile(r"(?:Repository|Репозиторий):\s*\[[^]]+\]\(([^)]+)\)"),
+    "author": re.compile(r"(?:Author|Автор):\s*\[[^]]+\]\(([^)]+)\)"),
+    "license": re.compile(r"(?:License|Лицензия):\s*\[[^]]+\]\(([^)]+)\)"),
+    "provider": re.compile(r"(?:Provider|Поставщик):\s*\[[^]]+\]\(([^)]+)\)"),
+    "service": re.compile(r"(?:Service|Сервис):\s*\[[^]]+\]\(([^)]+)\)"),
+}
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def plugin_root(repo_root: Path) -> Path:
+    return repo_root / "plugins" / "unica"
+
+
+def inventory(repo_root: Path) -> dict[tuple[str, str], dict]:
+    root = plugin_root(repo_root)
+    plugin = load_json(root / ".codex-plugin" / "plugin.json")
+    tools = load_json(root / "third-party" / "tools.lock.json").get("tools", [])
+    adapters = load_json(root / "third-party" / "manifest.json").get("internalAdapters", [])
+    upstreams = load_json(root / "provenance" / "skill-upstreams.json").get("upstreams", [])
+
+    result: dict[tuple[str, str], dict] = {
+        ("project", plugin["name"]): {
+            "repository": plugin["repository"],
+            "author": plugin["author"]["url"],
+            "license": plugin["license"],
+        }
+    }
+    result.update(
+        {
+            ("tool", tool["name"]): tool
+            for tool in tools
+            if tool["name"] != plugin["name"]
+        }
+    )
+    result.update({("adapter", adapter["name"]): adapter for adapter in adapters})
+    result.update({("upstream", upstream["id"]): upstream for upstream in upstreams})
+    return result
+
+
+def expected_markers(repo_root: Path) -> set[tuple[str, str]]:
+    return set(inventory(repo_root))
+
+
+def parse_sections(markdown: str) -> dict[tuple[str, str], str]:
+    sections: dict[tuple[str, str], str] = {}
+    pending: list[tuple[str, str]] = []
+    body: list[str] = []
+
+    def flush() -> None:
+        nonlocal pending, body
+        if not pending:
+            body = []
+            return
+        text = "\n".join(body).strip()
+        for marker in pending:
+            sections[marker] = text
+        pending = []
+        body = []
+
+    for line in markdown.splitlines():
+        match = MARKER_RE.fullmatch(line.strip())
+        if match:
+            marker = (match.group(1), match.group(2))
+            if marker in sections or marker in pending:
+                raise ValueError(f"duplicate attribution marker: {marker[0]} {marker[1]}")
+            if pending and any(item.strip() for item in body):
+                flush()
+            pending.append(marker)
+            continue
+        if line.startswith("## ") and pending:
+            flush()
+        if pending:
+            body.append(line)
+    flush()
+    return sections
+
+
+def labelled_link(section: str, label: str) -> str | None:
+    match = LABELS[label].search(section)
+    return match.group(1) if match else None
+
+
+def is_https(url: str | None) -> bool:
+    if not url:
+        return False
+    parsed = urlparse(url)
+    return parsed.scheme == "https" and bool(parsed.netloc)
+
+
+def validate_local_license(root: Path, marker: tuple[str, str], link: str | None) -> str | None:
+    label = f"{marker[0]} {marker[1]}"
+    if not link:
+        return f"{label}: license link is required"
+    if is_https(link):
+        return None
+    relative = Path(link.split("#", 1)[0])
+    if relative.is_absolute() or ".." in relative.parts:
+        return f"{label}: license link must stay inside plugins/unica"
+    target = root / relative
+    if not target.is_file():
+        return f"{label}: packaged license path does not exist: {link}"
+    return None
+
+
+def validate_attributions(
+    repo_root: Path, attribution_file: Path | None = None
+) -> list[str]:
+    root = plugin_root(repo_root)
+    attribution_file = attribution_file or root / "ATTRIBUTIONS.md"
+    if not attribution_file.is_file():
+        return [f"ATTRIBUTIONS.md not found: {attribution_file}"]
+
+    try:
+        sections = parse_sections(attribution_file.read_text(encoding="utf-8"))
+    except ValueError as exc:
+        return [str(exc)]
+
+    records = inventory(repo_root)
+    actual = set(sections)
+    expected = set(records)
+    errors = [f"missing attribution: {kind} {name}" for kind, name in sorted(expected - actual)]
+    errors.extend(f"unknown attribution: {kind} {name}" for kind, name in sorted(actual - expected))
+
+    for marker in sorted(expected & actual):
+        kind, name = marker
+        section = sections[marker]
+        record = records[marker]
+        label = f"{kind} {name}"
+
+        if kind == "adapter":
+            provider = labelled_link(section, "provider")
+            service = labelled_link(section, "service")
+            if not is_https(provider):
+                errors.append(f"{label}: provider link must be absolute HTTPS")
+            if service != record["url"] or not is_https(service):
+                errors.append(f"{label}: service link must match {record['url']}")
+            lowered = section.lower()
+            if "not redistributed" not in lowered and "не распространяется" not in lowered:
+                errors.append(f"{label}: section must state that the service is not redistributed")
+            continue
+
+        repository = labelled_link(section, "repository")
+        if repository != record["repository"] or not is_https(repository):
+            errors.append(f"{label}: repository link must match {record['repository']}")
+        author = labelled_link(section, "author")
+        if not is_https(author):
+            errors.append(f"{label}: author link must be absolute HTTPS")
+
+        needs_license = kind in {"project", "tool"} or (
+            kind == "upstream" and record.get("usage") != "inspiration-only"
+        )
+        if needs_license:
+            if kind in {"project", "tool"} and record["license"] not in section:
+                errors.append(f"{label}: declared license {record['license']} must appear in the section")
+            license_error = validate_local_license(root, marker, labelled_link(section, "license"))
+            if license_error:
+                errors.append(license_error)
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--attribution-file", type=Path)
+    args = parser.parse_args()
+
+    repo_root = args.repo_root.resolve()
+    attribution_file = args.attribution_file.resolve() if args.attribution_file else None
+    errors = validate_attributions(repo_root, attribution_file)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("attributions: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check-skill-upstreams.py
+++ b/scripts/ci/check-skill-upstreams.py
@@ -24,6 +24,7 @@ ALLOWED_ROLES = {
 }
 ALLOWED_STATUSES = {
     "adapted",
+    "inspiration-only",
     "ported-to-unica",
     "test-fixture-only",
     "still-local-script",

--- a/tests/ci/test_attributions.py
+++ b/tests/ci/test_attributions.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def load_attribution_module():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "check-attributions.py"
+    spec = importlib.util.spec_from_file_location("check_attributions", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class AttributionTests(unittest.TestCase):
+    def repo_root(self) -> Path:
+        return Path(__file__).resolve().parents[2]
+
+    def make_fixture_repo(self, root: Path) -> None:
+        plugin = root / "plugins" / "unica"
+        (plugin / ".codex-plugin").mkdir(parents=True)
+        (plugin / "third-party").mkdir()
+        (plugin / "provenance").mkdir()
+        (plugin / ".codex-plugin" / "plugin.json").write_text(
+            json.dumps(
+                {
+                    "name": "unica",
+                    "repository": "https://example.invalid/unica",
+                    "author": {"name": "Unica Author", "url": "https://example.invalid/author"},
+                    "license": "LGPL-3.0-or-later",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (plugin / "third-party" / "tools.lock.json").write_text(
+            json.dumps(
+                {
+                    "tools": [
+                        {
+                            "name": "unica",
+                            "repository": "https://example.invalid/unica",
+                            "license": "LGPL-3.0-or-later",
+                        },
+                        {
+                            "name": "demo",
+                            "repository": "https://example.invalid/demo",
+                            "license": "MIT",
+                        },
+                        {
+                            "name": "other",
+                            "repository": "https://example.invalid/other",
+                            "license": "MIT",
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        (plugin / "third-party" / "manifest.json").write_text(
+            json.dumps({"internalAdapters": []}), encoding="utf-8"
+        )
+        (plugin / "provenance" / "skill-upstreams.json").write_text(
+            json.dumps({"upstreams": []}), encoding="utf-8"
+        )
+        (plugin / "LICENSE").write_text("license", encoding="utf-8")
+
+    def test_expected_markers_follow_package_inventories(self) -> None:
+        module = load_attribution_module()
+
+        self.assertEqual(
+            module.expected_markers(self.repo_root()),
+            {
+                ("project", "unica"),
+                ("tool", "bsl-analyzer"),
+                ("tool", "v8-runner"),
+                ("tool", "rlm-tools-bsl"),
+                ("tool", "rlm-bsl-index"),
+                ("adapter", "v8std"),
+                ("upstream", "cc-1c-skills"),
+                ("upstream", "ai-rules-1c"),
+                ("upstream", "v8-runner-rust"),
+            },
+        )
+
+    def test_parse_sections_maps_grouped_markers_to_one_section(self) -> None:
+        module = load_attribution_module()
+
+        sections = module.parse_sections(
+            "## RLM\n"
+            "<!-- unica-attribution: tool rlm-tools-bsl -->\n"
+            "<!-- unica-attribution: tool rlm-bsl-index -->\n"
+            "Общий текст.\n"
+        )
+
+        self.assertEqual(sections[("tool", "rlm-tools-bsl")], sections[("tool", "rlm-bsl-index")])
+        self.assertIn("Общий текст", sections[("tool", "rlm-tools-bsl")])
+
+    def test_parse_sections_rejects_duplicate_markers(self) -> None:
+        module = load_attribution_module()
+
+        with self.assertRaisesRegex(ValueError, "duplicate attribution marker: tool demo"):
+            module.parse_sections(
+                "## One\n<!-- unica-attribution: tool demo -->\nA\n"
+                "## Two\n<!-- unica-attribution: tool demo -->\nB\n"
+            )
+
+    def test_validation_reports_missing_unknown_and_invalid_repository_links(self) -> None:
+        module = load_attribution_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.make_fixture_repo(root)
+            attribution = root / "plugins" / "unica" / "ATTRIBUTIONS.md"
+            attribution.write_text(
+                "## Unica\n"
+                "<!-- unica-attribution: project unica -->\n"
+                "- Репозиторий: [Unica](https://example.invalid/unica)\n"
+                "- Автор: [Author](https://example.invalid/author)\n"
+                "- Лицензия: [LGPL](LICENSE)\n\n"
+                "## Other\n"
+                "<!-- unica-attribution: tool other -->\n"
+                "- Репозиторий: [Other](http://example.invalid/other)\n"
+                "- Автор: [Author](https://example.invalid/author)\n"
+                "- Лицензия: [Apache](https://example.invalid/license)\n\n"
+                "## Ghost\n"
+                "<!-- unica-attribution: tool ghost -->\n",
+                encoding="utf-8",
+            )
+
+            errors = module.validate_attributions(root, attribution)
+
+        self.assertIn("missing attribution: tool demo", errors)
+        self.assertIn("unknown attribution: tool ghost", errors)
+        self.assertIn("tool other: repository link must match https://example.invalid/other", errors)
+        self.assertIn("tool other: declared license MIT must appear in the section", errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci/test_attributions.py
+++ b/tests/ci/test_attributions.py
@@ -138,6 +138,7 @@ class AttributionTests(unittest.TestCase):
         self.assertIn("unknown attribution: tool ghost", errors)
         self.assertIn("tool other: repository link must match https://example.invalid/other", errors)
         self.assertIn("tool other: declared license MIT must appear in the section", errors)
+        self.assertIn("tool other: license link must point to a packaged file", errors)
 
     def test_repository_attribution_page_is_complete_and_linked(self) -> None:
         module = load_attribution_module()

--- a/tests/ci/test_attributions.py
+++ b/tests/ci/test_attributions.py
@@ -139,6 +139,20 @@ class AttributionTests(unittest.TestCase):
         self.assertIn("tool other: repository link must match https://example.invalid/other", errors)
         self.assertIn("tool other: declared license MIT must appear in the section", errors)
 
+    def test_repository_attribution_page_is_complete_and_linked(self) -> None:
+        module = load_attribution_module()
+        repo_root = self.repo_root()
+
+        self.assertEqual(module.validate_attributions(repo_root), [])
+        self.assertIn(
+            "[Авторы, источники и лицензии](plugins/unica/ATTRIBUTIONS.md)",
+            (repo_root / "README.md").read_text(encoding="utf-8"),
+        )
+        self.assertIn(
+            "[Авторы, источники и лицензии](ATTRIBUTIONS.md)",
+            (repo_root / "plugins/unica/README.md").read_text(encoding="utf-8"),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ci/test_package_unica_plugin.py
+++ b/tests/ci/test_package_unica_plugin.py
@@ -4,6 +4,7 @@ import importlib.util
 import hashlib
 import json
 import os
+import re
 import stat
 import subprocess
 from unittest.mock import patch
@@ -415,6 +416,28 @@ class PackageUnicaPluginTests(unittest.TestCase):
             self.assertFalse((dest / "skills" / "web-test" / ".browser-session.json").exists())
             self.assertFalse((dest / "skills" / "web-test" / "screenshot.png").exists())
             self.assertFalse((dest / "skills" / "web-test" / "trace.mp4").exists())
+
+    def test_attribution_page_and_referenced_local_licenses_are_packaged(self) -> None:
+        module = load_package_module()
+        repo_root = Path(__file__).resolve().parents[2]
+        plugin_src = repo_root / "plugins" / "unica"
+        attribution = plugin_src / "ATTRIBUTIONS.md"
+
+        self.assertTrue(attribution.is_file())
+        local_license_links = {
+            link
+            for link in re.findall(r"\[[^]]+\]\(([^)]+)\)", attribution.read_text(encoding="utf-8"))
+            if not link.startswith("https://") and "LICENSE" in link
+        }
+        self.assertTrue(local_license_links)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            destination = Path(tmp) / "unica"
+            module.copy_tracked_plugin_source(repo_root, plugin_src, destination)
+
+            self.assertTrue((destination / "ATTRIBUTIONS.md").is_file())
+            for link in local_license_links:
+                self.assertTrue((destination / link).is_file(), link)
 
     def test_plugin_source_copy_rejects_tracked_source_bin(self) -> None:
         module = load_package_module()

--- a/tests/ci/test_skill_provenance.py
+++ b/tests/ci/test_skill_provenance.py
@@ -62,11 +62,21 @@ class SkillProvenanceTests(unittest.TestCase):
             marker = repo / "marker.txt"
             marker.write_text("stale\n", encoding="utf-8")
             subprocess.run(["git", "add", "marker.txt"], cwd=repo, check=True)
-            subprocess.run(["git", "commit", "-m", "stale"], cwd=repo, check=True, stdout=subprocess.PIPE)
+            subprocess.run(
+                ["git", "-c", "commit.gpgsign=false", "commit", "-m", "stale"],
+                cwd=repo,
+                check=True,
+                stdout=subprocess.PIPE,
+            )
             stale_commit = module.git_output(["rev-parse", "HEAD"], cwd=repo)
 
             marker.write_text("fresh\n", encoding="utf-8")
-            subprocess.run(["git", "commit", "-am", "fresh"], cwd=repo, check=True, stdout=subprocess.PIPE)
+            subprocess.run(
+                ["git", "-c", "commit.gpgsign=false", "commit", "-am", "fresh"],
+                cwd=repo,
+                check=True,
+                stdout=subprocess.PIPE,
+            )
             fresh_commit = module.git_output(["rev-parse", "HEAD"], cwd=repo)
             subprocess.run(["git", "update-ref", "refs/remotes/origin/main", fresh_commit], cwd=repo, check=True)
             subprocess.run(["git", "reset", "--hard", stale_commit], cwd=repo, check=True, stdout=subprocess.PIPE)
@@ -96,7 +106,7 @@ class SkillProvenanceTests(unittest.TestCase):
         self.assertEqual(upstreams["v8-runner-rust"]["toolLockRef"], "v8-runner")
         self.assertNotIn("baselineCommit", upstreams["v8-runner-rust"])
 
-    def test_historical_donor_baselines_track_last_local_adaptation_not_current_head(self) -> None:
+    def test_historical_donor_baselines_track_last_local_review_not_current_head(self) -> None:
         data = self.load_provenance()
         upstreams = {item["id"]: item for item in data["upstreams"]}
 
@@ -113,7 +123,7 @@ class SkillProvenanceTests(unittest.TestCase):
             "484e550043a4cb749d59d0671329f3112e3ae668",
         )
         self.assertEqual(
-            upstreams["ai-rules-1c"]["lastAdaptedLocalCommit"],
+            upstreams["ai-rules-1c"]["lastReviewedLocalCommit"],
             "e5b4eeab4dac92e0c9f60d3f886aa2bb7ef79f80",
         )
 
@@ -125,7 +135,36 @@ class SkillProvenanceTests(unittest.TestCase):
         self.assertEqual(api_design["primarySource"], "unica")
         self.assertEqual(api_design["decision"], "ignored-with-reason")
         self.assertIn("Unica-owned", api_design["decisionReason"])
-        self.assertIn("secondary guidance", api_design["notes"])
+        self.assertIn("general ideas", api_design["notes"])
+        self.assertIn("no donor expression", api_design["notes"])
+
+    def test_v8_runner_license_matches_pinned_source_and_is_packaged(self) -> None:
+        tool_lock = json.loads(
+            (self.repo_root() / "plugins/unica/third-party/tools.lock.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        runner = next(tool for tool in tool_lock["tools"] if tool["name"] == "v8-runner")
+
+        self.assertEqual(runner["license"], "AGPL-3.0-only")
+        license_path = self.repo_root() / "plugins/unica/third-party/licenses/v8-runner/LICENSE"
+        self.assertTrue(license_path.is_file())
+        self.assertIn("GNU AFFERO GENERAL PUBLIC LICENSE", license_path.read_text(encoding="utf-8"))
+
+    def test_ai_rules_is_recorded_as_inspiration_not_adaptation(self) -> None:
+        ai_rules = next(
+            item for item in self.load_provenance()["upstreams"] if item["id"] == "ai-rules-1c"
+        )
+
+        self.assertEqual(ai_rules.get("usage"), "inspiration-only")
+        self.assertNotIn("lastAdaptedLocalCommit", ai_rules)
+        self.assertNotIn("lastAdaptedAt", ai_rules)
+        self.assertIn("lastReviewedLocalCommit", ai_rules)
+        for entry in ai_rules["entries"]:
+            self.assertEqual(entry["status"], "inspiration-only")
+            self.assertEqual(entry["primarySource"], "unica")
+            self.assertEqual(entry["decision"], "ignored-with-reason")
+            self.assertIn("ideas", entry["decisionReason"])
 
     def test_tool_lock_ref_uses_tools_lock_as_single_binary_baseline(self) -> None:
         data = self.load_provenance()

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -566,7 +566,7 @@ class UnicaSkillRoutingTests(unittest.TestCase):
                 for token in SCENARIO_REQUIRED_TOKENS.get(skill, []):
                     self.assertIn(token, text)
 
-    def test_ai_rules_guidance_refresh_is_adapted_to_unica_surface(self) -> None:
+    def test_unica_owned_guidance_contains_required_operational_concepts(self) -> None:
         docs = {
             "code-search": self.skill_root() / "code-search" / "SKILL.md",
             "code-diagnostics": self.skill_root() / "code-diagnostics" / "SKILL.md",


### PR DESCRIPTION
## Что изменено

- добавлена вручную поддерживаемая страница `plugins/unica/ATTRIBUTIONS.md` с авторами, источниками, благодарностями и цепочками лицензий;
- добавлены ссылки на неё из корневого README и README плагина;
- добавлен offline-checker полноты tool, adapter и upstream-маркеров, ссылок и поставляемых license-файлов;
- packaging-тест доказывает, что страница и локальные лицензии попадают в plugin payload.

## Исправленные первопричины

- лицензия закреплённого `v8-runner` исправлена с MIT на `AGPL-3.0-only`; точный LICENSE закреплённого коммита включён в пакет;
- `ai_rules_1c` переклассифицирован как inspiration-only: использованы идеи, а не скопированный или адаптированный материал; добавлена отдельная provenance-коррекция.

## Проверка

- `python3.12 -m unittest discover -s tests/ci -p 'test_*.py'` — 247 passed, 3 skipped;
- `python3.12 -m py_compile scripts/ci/*.py tests/ci/*.py`;
- `python3.12 scripts/ci/check-skill-upstreams.py --validate-only`;
- `python3.12 scripts/ci/check-attributions.py`;
- `cargo fmt --all -- --check`;
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`;
- `cargo test --workspace -- --test-threads=1` — workspace tests passed, including 643 `unica-coder` tests.

Closes #115.
