### PR TITLE
build: update v8-runner to nightly master

### DIFF
--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -60,25 +60,25 @@
       "name": "v8-runner",
       "version": "0.5.1",
       "repository": "https://github.com/alkoleft/v8-runner-rust",
-      "sourceTag": "v0.5.1",
-      "sourceCommit": "ad72f64222ab0a7e6dfd391adb437a956c0a2428",
+      "sourceTag": "master",
+      "sourceCommit": "72d346c0a8fcf8373d9388257d11e6bef0ad70b2",
       "assetRepository": "https://github.com/IngvarConsulting/unica-toolchain",
-      "assetTag": "v8-runner-v0.5.1-build.1",
+      "assetTag": "v8-runner-nightly-master-build.1",
       "license": "AGPL-3.0-only",
       "assetStrategy": "direct-release-asset",
       "binaryName": "v8-runner",
       "assets": {
         "darwin-arm64": {
           "assetName": "v8-runner-darwin-arm64",
-          "sha256": "31e7735ee3c7680ae597c61c3f00e4ce780f486c2d9875aeaacf00984a1a1a21"
+          "sha256": "603255722eadf9a5214f40a310b320fccc1b38eed2200d0420cca79299c5f573"
         },
         "linux-x64": {
           "assetName": "v8-runner-linux-x64",
-          "sha256": "17e6d96e42cf89d59f880b83cc335486ed85944c70d177292ea4ab4336822151"
+          "sha256": "9fac3c06129d922388baabb966bfb2b41621cb32c5f6fa70b312edb1e6d44d86"
         },
         "win-x64": {
           "assetName": "v8-runner-win-x64.exe",
-          "sha256": "67251d36f9e1babbf4fadfee16be0490b0205a7a2bd279795d7e5fc8012a02e1"
+          "sha256": "dada998f8b365e81ed5adda27f032898e375f025b6c90cd08d62066bc3c6e7e0"
         }
       }
     },

--- a/scripts/ci/check-tool-contracts.py
+++ b/scripts/ci/check-tool-contracts.py
@@ -4,10 +4,12 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sqlite3
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -69,6 +71,175 @@ RLM_SCHEMA_COLUMNS = {
 RLM_REQUIRED_META = {
     "builder_version": "14",
 }
+
+
+def validate_v8_runner_partial_load_list(payload: bytes, expected_path: str) -> list[str]:
+    errors: list[str] = []
+    bom = b"\xef\xbb\xbf"
+    if not payload.startswith(bom):
+        errors.append("v8-runner partial-load list is missing UTF-8 BOM")
+        text_payload = payload
+    else:
+        text_payload = payload[len(bom) :]
+    if b"\n" in text_payload and b"\r\n" not in text_payload:
+        errors.append("v8-runner partial-load list does not use CRLF line endings")
+    try:
+        contents = text_payload.decode("utf-8")
+    except UnicodeDecodeError as error:
+        errors.append(f"v8-runner partial-load list is not valid UTF-8: {error}")
+        return errors
+    if expected_path not in contents:
+        errors.append(
+            f"v8-runner partial-load list is missing expected Cyrillic path: {expected_path}"
+        )
+    return errors
+
+
+def check_v8_runner_partial_load_contract(runner: Path, target: str) -> list[str]:
+    label = "v8-runner partial-load contract"
+    if not runner.is_file():
+        return [f"{label}: binary not found: {runner}"]
+
+    with tempfile.TemporaryDirectory(prefix="unica-v8-runner-179-") as directory:
+        root = Path(directory)
+        source_root = root / "project" / "main"
+        object_root = source_root / "Catalogs.Товары"
+        work_path = root / "work"
+        infobase_path = root / "ib"
+        captured_list = root / "partial-load.lst"
+        object_root.mkdir(parents=True)
+        work_path.mkdir()
+        infobase_path.mkdir()
+        (object_root / "ObjectModule.bsl").write_text(
+            "Procedure Проверка()\nEndProcedure\n",
+            encoding="utf-8",
+        )
+        (object_root / "ObjectModule.xml").write_text(
+            "<MetaDataObject />\n",
+            encoding="utf-8",
+        )
+
+        stub_source = root / "platform-stub.rs"
+        stub_source.write_text(
+            """
+use std::{env, ffi::OsString, fs, path::PathBuf};
+
+fn main() {
+    let mut previous: Option<OsString> = None;
+    for argument in env::args_os().skip(1) {
+        if previous.as_deref() == Some(std::ffi::OsStr::new("-listFile")) {
+            let destination = PathBuf::from(
+                env::var_os("UNICA_V8_RUNNER_CAPTURE_LIST")
+                    .expect("UNICA_V8_RUNNER_CAPTURE_LIST"),
+            );
+            fs::copy(&argument, destination).expect("copy partial-load list");
+        }
+        if previous.as_deref() == Some(std::ffi::OsStr::new("/Out")) {
+            fs::write(&argument, b"platform stub completed\\n").expect("write /Out log");
+        }
+        previous = Some(argument);
+    }
+}
+""".lstrip(),
+            encoding="utf-8",
+        )
+        platform = root / ("1cv8.exe" if target == "win-x64" else "1cv8")
+        compiled = subprocess.run(
+            ["rustc", "--edition=2021", str(stub_source), "-o", str(platform)],
+            cwd=root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if compiled.returncode != 0:
+            return [f"{label}: failed to compile platform stub: {compiled.stderr.strip()}"]
+
+        def yaml_path(path: Path) -> str:
+            return str(path).replace("'", "''")
+
+        config = root / "v8project.yaml"
+        config.write_text(
+            "\n".join(
+                [
+                    f"workPath: '{yaml_path(work_path)}'",
+                    "format: DESIGNER",
+                    "builder: DESIGNER",
+                    "infobase:",
+                    f"  connection: 'File={yaml_path(infobase_path)}'",
+                    "build:",
+                    "  partialLoadThreshold: 20",
+                    "source-set:",
+                    "  - name: main",
+                    "    type: CONFIGURATION",
+                    "    path: project/main",
+                    "tools:",
+                    "  platform:",
+                    f"    path: '{yaml_path(platform)}'",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        environment = os.environ.copy()
+        environment["UNICA_V8_RUNNER_CAPTURE_LIST"] = str(captured_list)
+        command = [
+            str(runner),
+            "--config",
+            str(config),
+            "--json-message",
+            "build",
+        ]
+        initial = subprocess.run(
+            command,
+            cwd=root,
+            env=environment,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if initial.returncode != 0:
+            detail = (initial.stderr or initial.stdout).strip()
+            return [f"{label}: baseline build exited with {initial.returncode}: {detail}"]
+        captured_list.unlink(missing_ok=True)
+        (object_root / "ObjectModule.bsl").write_text(
+            "Procedure Проверка()\n    // Изменено после baseline\nEndProcedure\n",
+            encoding="utf-8",
+        )
+        result = subprocess.run(
+            command,
+            cwd=root,
+            env=environment,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout).strip()
+            return [f"{label}: runner exited with {result.returncode}: {detail}"]
+        if not captured_list.is_file():
+            return [f"{label}: platform stub did not receive a partial-load list"]
+        try:
+            envelope = json.loads(result.stdout)
+        except json.JSONDecodeError as error:
+            return [f"{label}: runner returned invalid JSON: {error}"]
+        steps = envelope.get("data", {}).get("steps", [])
+        if not steps or "partial" not in json.dumps(steps[0].get("mode", "")).lower():
+            return [
+                f"{label}: runner did not select partial build mode: "
+                f"{json.dumps(steps, ensure_ascii=False)}"
+            ]
+
+        expected_path = str(Path("Catalogs.Товары") / "ObjectModule.bsl")
+        return [
+            f"{label}: {error}"
+            for error in validate_v8_runner_partial_load_list(
+                captured_list.read_bytes(),
+                expected_path,
+            )
+        ]
 
 
 def run_command(command: list[str], cwd: Path) -> tuple[int, str]:
@@ -133,6 +304,13 @@ def check_tool_contracts(tools_dir: Path, target: str | None = None) -> list[str
         for token in expected_tokens:
             if token not in output:
                 errors.append(f"{label}: expected token not found in output: {token}")
+    if target is not None:
+        errors.extend(
+            check_v8_runner_partial_load_contract(
+                tool_executable(tools_dir, "v8-runner", target),
+                target,
+            )
+        )
     return errors
 
 

--- a/tests/ci/test_build_unica_tools.py
+++ b/tests/ci/test_build_unica_tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -39,7 +40,13 @@ class BuildUnicaToolsTests(unittest.TestCase):
             self.assertEqual(separator, "-build.")
             self.assertRegex(build_revision, r"^[1-9][0-9]*$")
 
-            source_suffix = f"-{tool['sourceTag']}"
+            source_tag = tool["sourceTag"]
+            source_label = (
+                source_tag
+                if source_tag.startswith("v")
+                else f"nightly-{re.sub(r'[^a-z0-9]+', '-', source_tag.lower()).strip('-')}"
+            )
+            source_suffix = f"-{source_label}"
             self.assertTrue(release_tag.endswith(source_suffix))
             release_name = release_tag[: -len(source_suffix)]
             self.assertTrue(
@@ -100,12 +107,27 @@ class BuildUnicaToolsTests(unittest.TestCase):
 
         updated_tools = json.loads(json.dumps(external_tools))
         for tool in updated_tools:
-            version = tool["sourceTag"].removeprefix("v").split(".")
-            version[-1] = str(int(version[-1]) + 1)
-            tool["sourceTag"] = f"v{'.'.join(version)}"
-            release_name = tool["assetTag"].rsplit("-v", 1)[0]
-            build_revision = int(tool["assetTag"].rsplit("-build.", 1)[1]) + 1
-            tool["assetTag"] = f"{release_name}-{tool['sourceTag']}-build.{build_revision}"
+            source_tag = tool["sourceTag"]
+            current_source_label = (
+                source_tag
+                if source_tag.startswith("v")
+                else f"nightly-{re.sub(r'[^a-z0-9]+', '-', source_tag.lower()).strip('-')}"
+            )
+            current_revision = tool["assetTag"].rsplit("-build.", 1)[1]
+            release_name = tool["assetTag"].removesuffix(
+                f"-{current_source_label}-build.{current_revision}"
+            )
+            if source_tag.startswith("v"):
+                version = source_tag.removeprefix("v").split(".")
+                version[-1] = str(int(version[-1]) + 1)
+                tool["sourceTag"] = f"v{'.'.join(version)}"
+                source_label = tool["sourceTag"]
+            else:
+                source_label = (
+                    f"nightly-{re.sub(r'[^a-z0-9]+', '-', source_tag.lower()).strip('-')}"
+                )
+            build_revision = int(current_revision) + 1
+            tool["assetTag"] = f"{release_name}-{source_label}-build.{build_revision}"
         self.assert_external_toolchain_contract(updated_tools)
 
     def test_release_asset_checksum_mismatch_fails_before_use(self) -> None:

--- a/tests/ci/test_product_contracts.py
+++ b/tests/ci/test_product_contracts.py
@@ -8,6 +8,7 @@ import tempfile
 import unittest
 from contextlib import closing
 from pathlib import Path
+from unittest.mock import patch
 
 
 def load_contract_module():
@@ -21,6 +22,69 @@ def load_contract_module():
 
 
 class ProductContractTests(unittest.TestCase):
+    def test_v8_runner_partial_load_list_requires_bom_crlf_and_cyrillic_path(self) -> None:
+        module = load_contract_module()
+        expected_path = str(
+            Path("Catalogs.Товары") / "Ext" / "ObjectModule.bsl"
+        )
+        payload = b"\xef\xbb\xbf" + expected_path.encode("utf-8") + b"\r\n"
+
+        self.assertEqual(
+            module.validate_v8_runner_partial_load_list(payload, expected_path),
+            [],
+        )
+        self.assertIn(
+            "UTF-8 BOM",
+            "\n".join(
+                module.validate_v8_runner_partial_load_list(
+                    payload.removeprefix(b"\xef\xbb\xbf"),
+                    expected_path,
+                )
+            ),
+        )
+        self.assertIn(
+            "CRLF",
+            "\n".join(
+                module.validate_v8_runner_partial_load_list(
+                    b"\xef\xbb\xbf" + expected_path.encode("utf-8") + b"\n",
+                    expected_path,
+                )
+            ),
+        )
+
+    def test_v8_runner_partial_load_smoke_rejects_missing_binary(self) -> None:
+        module = load_contract_module()
+
+        errors = module.check_v8_runner_partial_load_contract(
+            Path("/missing/v8-runner"),
+            "linux-x64",
+        )
+
+        self.assertEqual(
+            errors,
+            ["v8-runner partial-load contract: binary not found: /missing/v8-runner"],
+        )
+
+    def test_targeted_tool_contracts_run_v8_runner_partial_load_smoke(self) -> None:
+        module = load_contract_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tools_dir = Path(tmp)
+            runner = tools_dir / "v8-runner"
+            runner.write_bytes(b"runner")
+            with (
+                patch.object(module, "TOOL_HELP_CHECKS", []),
+                patch.object(
+                    module,
+                    "check_v8_runner_partial_load_contract",
+                    return_value=["behavioral failure"],
+                ) as behavioral_check,
+            ):
+                errors = module.check_tool_contracts(tools_dir, "linux-x64")
+
+        self.assertEqual(errors, ["behavioral failure"])
+        behavioral_check.assert_called_once_with(runner.resolve(), "linux-x64")
+
     BSL_ANALYZER_HELP = (
         "#!/usr/bin/env sh\n"
         "case \"$*\" in\n"

--- a/tests/ci/test_skill_provenance.py
+++ b/tests/ci/test_skill_provenance.py
@@ -198,8 +198,11 @@ class SkillProvenanceTests(unittest.TestCase):
 
         self.assertEqual(runtime_source["toolLockRef"], "v8-runner")
         self.assertIn(runtime_source["toolLockRef"], locked_tools)
-        self.assertEqual(locked_tools["v8-runner"]["sourceTag"], "v0.5.1")
-        self.assertEqual(locked_tools["v8-runner"]["sourceCommit"], "ad72f64222ab0a7e6dfd391adb437a956c0a2428")
+        self.assertEqual(locked_tools["v8-runner"]["sourceTag"], "master")
+        self.assertEqual(
+            locked_tools["v8-runner"]["sourceCommit"],
+            "72d346c0a8fcf8373d9388257d11e6bef0ad70b2",
+        )
 
     def test_rlm_tools_are_locked_to_reviewed_1_26_0_pair(self) -> None:
         tool_lock = json.loads(


### PR DESCRIPTION
## Что изменено

- v8-runner закреплён на commit `72d346c0a8fcf8373d9388257d11e6bef0ad70b2` из `master` и immutable asset tag `v8-runner-nightly-master-build.1`
- обновлены SHA-256 артефактов для Darwin, Linux и Windows
- проверки toolchain теперь различают официальные release-версии и nightly-сборки из веток/коммитов
- provenance-тест синхронизирован с новым источником

## Зачем

В master v8-runner накоплены исправления runtime-сценариев, которых нет в последнем официальном релизе. Toolchain должен уметь воспроизводимо использовать как release-теги, так и nightly-сборки из исходников.

## Проверки

- 10 unit/integration tests
- attribution contract
- skill upstream validation
- packaged tool contract для darwin-arm64
- полная локальная сборка и упаковка Unica с новым runner

## Границы PR

Новые runtime-возможности runner (`bootstrap`, readiness/wait controls и bounded EPF wait) здесь ещё не выводятся в публичную схему Unica: это отдельное изменение API после фиксации бинарного baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Updated the included V8 Runner tool to the latest nightly build from the master branch.
  - Refreshed the macOS, Linux, and Windows binaries and checksums to match the updated nightly artifacts.

- **Bug Fixes**
  - Improved CI contract validation for the V8 Runner “partial-load” output, including stricter format checks and expected path handling.

- **Tests**
  - Updated and expanded CI tests to cover the new nightly labeling and the V8 Runner partial-load contract behavior, including missing-binary scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->