### PR TITLE
build: update bsl-analyzer to v0.2.62

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,8 +678,8 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lexer"
-version = "0.2.55"
-source = "git+https://github.com/itrous/bsl-analyzer?rev=5a02bb44dedaf29e0e29af1f740279d279199854#5a02bb44dedaf29e0e29af1f740279d279199854"
+version = "0.2.62"
+source = "git+https://github.com/itrous/bsl-analyzer?rev=9a6cb15d60c0381dce6a3b5e536434adb12da89b#9a6cb15d60c0381dce6a3b5e536434adb12da89b"
 dependencies = [
  "logos",
  "smol_str",
@@ -893,8 +893,8 @@ dependencies = [
 
 [[package]]
 name = "parser"
-version = "0.2.55"
-source = "git+https://github.com/itrous/bsl-analyzer?rev=5a02bb44dedaf29e0e29af1f740279d279199854#5a02bb44dedaf29e0e29af1f740279d279199854"
+version = "0.2.62"
+source = "git+https://github.com/itrous/bsl-analyzer?rev=9a6cb15d60c0381dce6a3b5e536434adb12da89b#9a6cb15d60c0381dce6a3b5e536434adb12da89b"
 dependencies = [
  "lexer",
  "parser-error",
@@ -906,8 +906,8 @@ dependencies = [
 
 [[package]]
 name = "parser-error"
-version = "0.2.55"
-source = "git+https://github.com/itrous/bsl-analyzer?rev=5a02bb44dedaf29e0e29af1f740279d279199854#5a02bb44dedaf29e0e29af1f740279d279199854"
+version = "0.2.62"
+source = "git+https://github.com/itrous/bsl-analyzer?rev=9a6cb15d60c0381dce6a3b5e536434adb12da89b#9a6cb15d60c0381dce6a3b5e536434adb12da89b"
 dependencies = [
  "lexer",
  "smallvec",
@@ -1280,8 +1280,8 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stdx"
-version = "0.2.55"
-source = "git+https://github.com/itrous/bsl-analyzer?rev=5a02bb44dedaf29e0e29af1f740279d279199854#5a02bb44dedaf29e0e29af1f740279d279199854"
+version = "0.2.62"
+source = "git+https://github.com/itrous/bsl-analyzer?rev=9a6cb15d60c0381dce6a3b5e536434adb12da89b#9a6cb15d60c0381dce6a3b5e536434adb12da89b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
@@ -1332,14 +1332,12 @@ dependencies = [
 
 [[package]]
 name = "syntax"
-version = "0.2.55"
-source = "git+https://github.com/itrous/bsl-analyzer?rev=5a02bb44dedaf29e0e29af1f740279d279199854#5a02bb44dedaf29e0e29af1f740279d279199854"
+version = "0.2.62"
+source = "git+https://github.com/itrous/bsl-analyzer?rev=9a6cb15d60c0381dce6a3b5e536434adb12da89b#9a6cb15d60c0381dce6a3b5e536434adb12da89b"
 dependencies = [
  "parser-error",
  "rowan",
- "smol_str",
  "stdx",
- "text-size",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/IngvarConsulting/unica"
 [workspace.dependencies]
 # In-process parser semantics must match the bundled analyzer; a contract test
 # compares these resolved revisions with third-party/tools.lock.json.
-bsl-parser = { package = "parser", git = "https://github.com/itrous/bsl-analyzer", rev = "5a02bb44dedaf29e0e29af1f740279d279199854" }
-bsl-syntax = { package = "syntax", git = "https://github.com/itrous/bsl-analyzer", rev = "5a02bb44dedaf29e0e29af1f740279d279199854" }
+bsl-parser = { package = "parser", git = "https://github.com/itrous/bsl-analyzer", rev = "9a6cb15d60c0381dce6a3b5e536434adb12da89b" }
+bsl-syntax = { package = "syntax", git = "https://github.com/itrous/bsl-analyzer", rev = "9a6cb15d60c0381dce6a3b5e536434adb12da89b" }
 diffy = "0.5.0"
 fs2 = "0.4"
 jsonschema = { version = "0.30", default-features = false }

--- a/crates/unica-coder/src/infrastructure/native_operations/meta.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta.rs
@@ -2045,7 +2045,7 @@ mod edit_tests {
     }
 
     fn canonical_path(path: &Path) -> PathBuf {
-        path.canonicalize().unwrap()
+        crate::infrastructure::source_roots::normalize_path_identity(path).unwrap()
     }
 
     const TEST_MD_NS: &str = "http://v8.1c.ru/8.3/MDClasses";
@@ -5066,15 +5066,20 @@ mod edit_tests {
                 canonical_path(&src).join("Languages/Russian.xml")
             ]
         );
-        assert!(inspection
+        let error = inspection
             .context
-            .expect_err("missing registered language must fail")
-            .contains(
-                &canonical_path(&src)
-                    .join("Languages/Russian.xml")
-                    .display()
-                    .to_string()
-            ));
+            .expect_err("missing registered language must fail");
+        assert!(
+            error.starts_with("registered language file not found: "),
+            "{error}"
+        );
+        assert!(
+            error.ends_with(&format!(
+                "Languages{}Russian.xml",
+                std::path::MAIN_SEPARATOR
+            )),
+            "{error}"
+        );
         let _ = fs::remove_dir_all(&context.cwd);
     }
 

--- a/plugins/unica/ATTRIBUTIONS.md
+++ b/plugins/unica/ATTRIBUTIONS.md
@@ -26,7 +26,7 @@ skills — в [`provenance/skill-upstreams.json`](provenance/skill-upstreams.jso
 
 - Репозиторий: [itrous/bsl-analyzer](https://github.com/itrous/bsl-analyzer)
 - Автор: [BSL Analyzer Contributors](https://github.com/itrous/bsl-analyzer/graphs/contributors)
-- Закреплённая версия: `0.2.55`, commit `5a02bb44dedaf29e0e29af1f740279d279199854`
+- Закреплённая версия: `0.2.62`, commit `9a6cb15d60c0381dce6a3b5e536434adb12da89b`
 - Лицензия: [LGPL-3.0-or-later](third-party/licenses/bsl-analyzer/LICENSE-LGPL)
 - Дополнительные условия и происхождение: [NOTICE](third-party/licenses/bsl-analyzer/NOTICE)
 

--- a/plugins/unica/provenance/reviews/2026-06-18-product-update-backlog.json
+++ b/plugins/unica/provenance/reviews/2026-06-18-product-update-backlog.json
@@ -1,19 +1,19 @@
 {
   "schemaVersion": 1,
   "id": "2026-06-18-product-update-backlog",
-  "generatedAt": "2026-07-04",
+  "generatedAt": "2026-07-24",
   "purpose": "Product and dependency update backlog for Unica bundled tools, plugin package dependencies, and release-package inputs.",
   "products": [
     {
       "id": "bsl-analyzer",
       "kind": "bundled-tool",
-      "locked": "v0.2.55",
-      "latest": "v0.2.55",
+      "locked": "v0.2.62",
+      "latest": "v0.2.62",
       "risk": "high",
       "batch": "bsl-analyzer-contract",
       "status": "applied",
       "contractGate": true,
-      "notes": "Updated to v0.2.55 after reviewing v0.2.50, v0.2.53, v0.2.54, and v0.2.55 release assets. The refresh adds MCP startup/search responsiveness, typed metadata substrate and drift refresh work, deterministic diagnostics output, Salsa observability, and hot-path diagnostics/search improvements; Unica still consumes analyzer behavior only through typed unica.code.* graph/diagnostics gates."
+      "notes": "Updated to v0.2.62 after reviewing v0.2.56 through v0.2.62, including the issue #7 extension-analysis implementation. The refresh brings extension-topology and diagnostics fixes plus named-connection metadata work; Unica continues to consume only typed unica.code.* graph/diagnostics gates. It does not expose connection, event-log, execute, debug, rename, or fix-all capabilities. Dependency-aware CFE topology remains deferred until v8-runner #32 provides its shared configuration contract."
     },
     {
       "id": "rlm-tools-bsl",

--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -32,27 +32,27 @@
   "tools": [
     {
       "name": "bsl-analyzer",
-      "version": "0.2.55",
+      "version": "0.2.62",
       "repository": "https://github.com/itrous/bsl-analyzer",
-      "sourceTag": "v0.2.55",
-      "sourceCommit": "5a02bb44dedaf29e0e29af1f740279d279199854",
+      "sourceTag": "v0.2.62",
+      "sourceCommit": "9a6cb15d60c0381dce6a3b5e536434adb12da89b",
       "assetRepository": "https://github.com/IngvarConsulting/unica-toolchain",
-      "assetTag": "bsl-analyzer-v0.2.55-build.1",
+      "assetTag": "bsl-analyzer-v0.2.62-build.1",
       "license": "LGPL-3.0-or-later",
       "assetStrategy": "direct-release-asset",
       "binaryName": "bsl-analyzer",
       "assets": {
         "darwin-arm64": {
           "assetName": "bsl-analyzer-darwin-arm64",
-          "sha256": "c9ce4cf5281ae9599a99aac06818420252b26e8ad40fb522a954ab144d2aa6cc"
+          "sha256": "97c599b2be9e8c4e267d7a8567b21d01d5d6939060d28084ae1f598d15c084a4"
         },
         "linux-x64": {
           "assetName": "bsl-analyzer-linux-x64",
-          "sha256": "ca1f4177bfb11e9cb8e2550bb17a6d83f69b3d5496dc5c233996fc08bd7cb5e9"
+          "sha256": "070374453c933025c0750d59a658dfe9edd6415f7b5aa80d122268acc08ae8b9"
         },
         "win-x64": {
           "assetName": "bsl-analyzer-win-x64.exe",
-          "sha256": "f024f6d03ad58bfed18cefaf38e4a6e593a1c37b22bc6926d8d270e631bc8703"
+          "sha256": "9c42ef7d6b379b3f80afb525f9cbec757abd2ba1877bbdcfb5db49df9972fd22"
         }
       }
     },

--- a/tests/ci/test_skill_provenance.py
+++ b/tests/ci/test_skill_provenance.py
@@ -335,6 +335,15 @@ class SkillProvenanceTests(unittest.TestCase):
             analyzer["sourceCommit"],
             "9a6cb15d60c0381dce6a3b5e536434adb12da89b",
         )
+        self.assertEqual(analyzer["assetTag"], "bsl-analyzer-v0.2.62-build.1")
+        self.assertEqual(
+            {target: asset["sha256"] for target, asset in analyzer["assets"].items()},
+            {
+                "darwin-arm64": "97c599b2be9e8c4e267d7a8567b21d01d5d6939060d28084ae1f598d15c084a4",
+                "linux-x64": "070374453c933025c0750d59a658dfe9edd6415f7b5aa80d122268acc08ae8b9",
+                "win-x64": "9c42ef7d6b379b3f80afb525f9cbec757abd2ba1877bbdcfb5db49df9972fd22",
+            },
+        )
 
     def test_all_local_and_contract_paths_exist(self) -> None:
         data = self.load_provenance()

--- a/tests/ci/test_skill_provenance.py
+++ b/tests/ci/test_skill_provenance.py
@@ -320,7 +320,7 @@ class SkillProvenanceTests(unittest.TestCase):
                 "dcfff95ce678f49971b14d8acd82b042a6855470",
             )
 
-    def test_bsl_analyzer_review_metadata_follows_tools_lock(self) -> None:
+    def test_bsl_analyzer_contract_is_v0_2_62(self) -> None:
         tool_lock = json.loads(
             (self.repo_root() / "plugins" / "unica" / "third-party" / "tools.lock.json").read_text(
                 encoding="utf-8"
@@ -329,9 +329,12 @@ class SkillProvenanceTests(unittest.TestCase):
         locked_tools = {tool["name"]: tool for tool in tool_lock["tools"]}
 
         analyzer = locked_tools["bsl-analyzer"]
-        self.assertTrue(analyzer["version"])
-        self.assertEqual(analyzer["sourceTag"], f"v{analyzer['version']}")
-        self.assertRegex(analyzer["sourceCommit"], r"^[0-9a-f]{40}$")
+        self.assertEqual(analyzer["version"], "0.2.62")
+        self.assertEqual(analyzer["sourceTag"], "v0.2.62")
+        self.assertEqual(
+            analyzer["sourceCommit"],
+            "9a6cb15d60c0381dce6a3b5e536434adb12da89b",
+        )
 
     def test_all_local_and_contract_paths_exist(self) -> None:
         data = self.load_provenance()
@@ -463,7 +466,7 @@ class SkillProvenanceTests(unittest.TestCase):
         backlog = self.load_product_backlog()
         products = {item["id"]: item for item in backlog["products"]}
 
-        self.assertEqual(backlog["generatedAt"], "2026-07-04")
+        self.assertEqual(backlog["generatedAt"], "2026-07-24")
         tool_lock = json.loads(
             (self.repo_root() / "plugins" / "unica" / "third-party" / "tools.lock.json").read_text(
                 encoding="utf-8"


### PR DESCRIPTION
## What changed
- Pins in-process parser and bundled tool to `itrous/bsl-analyzer` `v0.2.62` (`9a6cb15d60c0381dce6a3b5e536434adb12da89b`).
- Pins three native assets and their SHA-256 values from the immutable [toolchain release](https://github.com/IngvarConsulting/unica-toolchain/releases/tag/bsl-analyzer-v0.2.62-build.1).
- Refreshes attribution, provenance review, and explicit lock-contract assertions.
- Repairs a current Windows-only meta-validation test expectation: it now uses the production path-identity normalizer, so `\\?\` is not compared as user-facing artifact text.

## Scope
- Includes the upstream issue #7 extension-analysis implementation through the current upstream default-branch release.
- Does not expose named-connection or runtime-mutating analyzer operations. Dependency-aware CFE topology remains deferred pending v8-runner #32.

## Verification
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p unica-coder infrastructure::native_operations::meta::edit_tests:: -- --test-threads=1`
- `python3.12 -m unittest tests.ci.test_build_unica_tools tests.ci.test_attributions tests.ci.test_skill_provenance tests.ci.test_product_contracts tests.ci.test_package_unica_plugin tests.ci.test_package_unica_runtime`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the bundled BSL Analyzer to version 0.2.62.
  - Added extension analysis capabilities to the analyzer.

- **Bug Fixes**
  - Refreshed the platform-specific bundled analyzer artifacts to keep releases consistent across supported systems.

- **Documentation**
  - Updated analyzer attribution metadata and the published product update notes to reflect BSL Analyzer v0.2.62 and the latest update date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->