### PR TITLE
release: prepare Unica v0.9.1

### DIFF
--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -276,7 +276,7 @@ jobs:
     needs: build-tools
     if: ${{ always() && needs.build-tools.result == 'success' }}
     env:
-      RELEASE_TAG: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.ref_name || 'v0.8.1' }}
+      RELEASE_TAG: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.ref_name || 'v0.9.1' }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,7 +1394,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unica-bootstrap"
-version = "0.8.1"
+version = "0.9.1"
 dependencies = [
  "flate2",
  "fs2",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "unica-coder"
-version = "0.8.1"
+version = "0.9.1"
 dependencies = [
  "diffy",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/unica-bootstrap", "crates/unica-coder"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.1"
+version = "0.9.1"
 edition = "2021"
 license = "LGPL-3.0-or-later"
 repository = "https://github.com/IngvarConsulting/unica"

--- a/plugins/unica/.codex-plugin/plugin.json
+++ b/plugins/unica/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unica",
-  "version": "0.8.1",
+  "version": "0.9.1",
   "description": "Practical 1C:Enterprise development workflows for Codex.",
   "author": {
     "name": "Ingvar Consulting, LLC",

--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -136,7 +136,7 @@
     },
     {
       "name": "unica",
-      "version": "0.8.1",
+      "version": "0.9.1",
       "repository": "https://github.com/IngvarConsulting/unica",
       "sourceTag": "workspace",
       "sourceCommit": "workspace",

--- a/tests/ci/test_evaluate_ci_gate.py
+++ b/tests/ci/test_evaluate_ci_gate.py
@@ -134,7 +134,7 @@ class EvaluateCiGateTests(unittest.TestCase):
         }
 
         manual_evaluation = module.evaluate_gate("workflow_dispatch", "refs/heads/main", outputs, manual)
-        tag_evaluation = module.evaluate_gate("push", "refs/tags/v0.8.1", outputs, tag)
+        tag_evaluation = module.evaluate_gate("push", "refs/tags/v0.9.1", outputs, tag)
 
         self.assertTrue(manual_evaluation.ok)
         self.assertEqual("full", manual_evaluation.contour)
@@ -153,7 +153,7 @@ class EvaluateCiGateTests(unittest.TestCase):
 
         evaluation = module.evaluate_gate(
             "workflow_dispatch",
-            "refs/tags/v0.8.1",
+            "refs/tags/v0.9.1",
             outputs,
             results,
         )

--- a/tests/ci/test_legacy_migration_boundary.py
+++ b/tests/ci/test_legacy_migration_boundary.py
@@ -70,7 +70,7 @@ class LegacyMigrationBoundaryTests(unittest.TestCase):
             with self.subTest(marker=marker):
                 self.assertNotIn(marker, release)
 
-    def test_v08x_metadata_and_guidance_keep_only_the_frozen_v078_bridge(self) -> None:
+    def test_post_v080_pre_v1_metadata_keeps_only_the_frozen_v078_bridge(self) -> None:
         metadata = json.loads(
             (REPO_ROOT / "plugins/unica/.codex-plugin/plugin.json").read_text(
                 encoding="utf-8"
@@ -86,7 +86,9 @@ class LegacyMigrationBoundaryTests(unittest.TestCase):
         marketplace_adr = (
             REPO_ROOT / "spec/decisions/0008-public-marketplace-thin-runtime.md"
         ).read_text(encoding="utf-8")
-        self.assertRegex(metadata["version"], r"^0\.8\.\d+$")
+        version = metadata["version"]
+        self.assertRegex(version, r"^0\.\d+\.\d+$")
+        self.assertGreaterEqual(tuple(map(int, version.split("."))), (0, 8, 0))
         for filename in ("install-unica.sh", "install-unica.ps1"):
             frozen_url = f"releases/download/v0.7.8/{filename}"
             obsolete_url = f"releases/download/v0.7.7/{filename}"

--- a/tests/ci/test_package_unica_plugin.py
+++ b/tests/ci/test_package_unica_plugin.py
@@ -685,7 +685,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
                             "schemaVersion": 1,
                             "target": target,
                             "targetTriple": target_triple,
-                            "pluginVersion": "0.8.1",
+                            "pluginVersion": "0.9.1",
                             "asset": {
                                 "name": f"unica-runtime-{target}.tar.gz",
                                 "mediaType": "application/gzip",
@@ -714,7 +714,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
                 "--bootstrap-root",
                 str(bootstrap_root),
                 "--release-tag",
-                "v0.8.1",
+                "v0.9.1",
                 "--source-commit",
                 "a" * 40,
                 "--out-dir",
@@ -769,13 +769,13 @@ class PackageUnicaPluginTests(unittest.TestCase):
             )
             self.assertFalse(runtime_manifest["development"])
             self.assertEqual(runtime_manifest["source"]["commit"], "a" * 40)
-            self.assertEqual(runtime_manifest["release"]["tag"], "v0.8.1")
+            self.assertEqual(runtime_manifest["release"]["tag"], "v0.9.1")
             self.assertEqual(sorted(runtime_manifest["targets"]), sorted(target_triples))
             for target, target_data in runtime_manifest["targets"].items():
                 self.assertEqual(
                     target_data["asset"]["url"],
                     "https://github.com/IngvarConsulting/unica/releases/download/"
-                    f"v0.8.1/unica-runtime-{target}.tar.gz",
+                    f"v0.9.1/unica-runtime-{target}.tar.gz",
                 )
 
             catalog = json.loads(
@@ -785,7 +785,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
             )
             source = catalog["plugins"][0]["source"]
             self.assertEqual(source["source"], "git-subdir")
-            self.assertEqual(source["ref"], "v0.8.1")
+            self.assertEqual(source["ref"], "v0.9.1")
             self.assertEqual(source["path"], "./plugins/unica")
             self.assertNotIn("source\": \"local", json.dumps(catalog))
             self.assertEqual(list(out_dir.glob("*.tar.gz")), [])

--- a/tests/ci/test_version_contract.py
+++ b/tests/ci/test_version_contract.py
@@ -19,7 +19,7 @@ def load_module():
 
 
 class VersionContractTests(unittest.TestCase):
-    def test_repository_versions_are_exactly_0_8_1(self) -> None:
+    def test_repository_versions_are_exactly_0_9_1(self) -> None:
         module = load_module()
 
         values = module.read_version_contract(REPO_ROOT)
@@ -27,9 +27,9 @@ class VersionContractTests(unittest.TestCase):
         self.assertEqual(
             values,
             {
-                "workspace": "0.8.1",
-                "plugin": "0.8.1",
-                "tools-lock-unica": "0.8.1",
+                "workspace": "0.9.1",
+                "plugin": "0.9.1",
+                "tools-lock-unica": "0.9.1",
             },
         )
 


### PR DESCRIPTION
## Что изменено

- версия Unica синхронизирована как `0.9.1` в Cargo workspace, plugin manifest,
  package lock и release workflow;
- package/gate tests обновлены для нового release tag;
- legacy-migration contract исправлен по реальному инварианту: любая pre-1.0
  версия начиная с `0.8.0` сохраняет только замороженный мост `v0.7.8`, без
  жёсткой привязки теста к серии `0.8.x`.

## Зачем

Текущий `main` содержит 32 merged PR после `v0.8.1`. Этот PR подготавливает
единый release commit для `v0.9.1`; русские GitHub Release notes с персональными
благодарностями всем контрибьюторам будут опубликованы после успешного tag
workflow.

## Проверка

- `python3.12 -m unittest discover -s tests/ci --durations 20` — 320 tests,
  3 skipped;
- `python3.12 -m unittest discover -s tests/dev --durations 20` — 187 tests;
- `python3.12 -m py_compile scripts/ci/*.py tests/ci/*.py scripts/dev/*.py
  tests/dev/*.py`;
- `cargo fmt --all -- --check`;
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`;
- `cargo test --workspace -- --test-threads=1` — 1468 unit tests, integration и
  doc suites;
- `python3.12 scripts/ci/check-version-contract.py --expected 0.9.1`;
- `cargo metadata --locked --no-deps --format-version 1`;
- `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Release**
  * Updated the Unica plugin release version to **0.9.1** across package metadata, marketplace assets, and release tooling.
  * Release packaging now defaults to tag **v0.9.1** when no release tag is provided.

* **Tests**
  * Updated release validation and packaging checks for version **0.9.1**.
  * Broadened version compatibility checks for post-0.8, pre-1.0 plugin versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->