### PR TITLE
feat: publish Unica to Claude Code from one plugin directory

### DIFF
--- a/.github/workflows/publish-unica-marketplace.yml
+++ b/.github/workflows/publish-unica-marketplace.yml
@@ -50,9 +50,11 @@ jobs:
       - name: Require package contract files
         run: |
           test -f payload/plugins/unica/.codex-plugin/plugin.json
+          test -f payload/plugins/unica/.claude-plugin/plugin.json
           test -f payload/plugins/unica/.mcp.json
           test -f payload/plugins/unica/runtime-manifest.json
           test -f payload/.agents/plugins/marketplace.json
+          test -f payload/.claude-plugin/marketplace.json
       - name: Read the pinned release identity
         run: |
           release_tag="$(sed -n 's/.*"tag"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' payload/plugins/unica/runtime-manifest.json | head -n 1)"
@@ -93,8 +95,10 @@ jobs:
         run: gh auth setup-git
       - name: Download catalog candidate
         run: gh run download "$SOURCE_RUN_ID" --repo IngvarConsulting/unica --name unica-thin-marketplace --dir payload
-      - name: Require stable catalog candidate
-        run: test -f payload/.agents/plugins/marketplace.json
+      - name: Require stable catalog candidates
+        run: |
+          test -f payload/.agents/plugins/marketplace.json
+          test -f payload/.claude-plugin/marketplace.json
       - name: Open catalog-only promotion PR
         run: |
           set -euo pipefail
@@ -105,9 +109,10 @@ jobs:
             "$(git -C marketplace rev-parse "origin/main:plugins/unica")"
           branch="codex/promote-${RELEASE_TAG}-${SOURCE_RUN_ID}"
           git -C marketplace switch -c "$branch"
-          mkdir -p marketplace/.agents/plugins
+          mkdir -p marketplace/.agents/plugins marketplace/.claude-plugin
           cp payload/.agents/plugins/marketplace.json marketplace/.agents/plugins/marketplace.json
-          git -C marketplace add .agents/plugins/marketplace.json
+          cp payload/.claude-plugin/marketplace.json marketplace/.claude-plugin/marketplace.json
+          git -C marketplace add .agents/plugins/marketplace.json .claude-plugin/marketplace.json
           git -C marketplace -c user.name=unica-release-bot -c user.email=actions@users.noreply.github.com \
             commit -m "promote: Unica ${RELEASE_TAG}"
           git -C marketplace push -u origin "$branch"

--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -310,6 +310,21 @@ jobs:
           --release-tag "$RELEASE_TAG"
           --source-commit "${{ github.sha }}"
           --out-dir dist/thin
+      - name: Require both host contracts in the shared plugin directory
+        run: |
+          test -f dist/thin/marketplace/plugins/unica/.codex-plugin/plugin.json
+          test -f dist/thin/marketplace/plugins/unica/.claude-plugin/plugin.json
+          test -f dist/thin/marketplace/.agents/plugins/marketplace.json
+          test -f dist/thin/marketplace/.claude-plugin/marketplace.json
+      # Schema errors are caught here against a current client. The narrower
+      # question of which optional keys older clients still accept is pinned by
+      # tests/ci/test_package_unica_plugin.py, because a current client reports
+      # those as warnings rather than errors.
+      - name: Validate the Claude plugin and catalog
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude plugin validate dist/thin/marketplace/plugins/unica
+          claude plugin validate dist/thin/marketplace
       - uses: actions/upload-artifact@v7
         with:
           name: unica-thin-marketplace

--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -316,13 +316,16 @@ jobs:
           test -f dist/thin/marketplace/plugins/unica/.claude-plugin/plugin.json
           test -f dist/thin/marketplace/.agents/plugins/marketplace.json
           test -f dist/thin/marketplace/.claude-plugin/marketplace.json
-      # Schema errors are caught here against a current client. The narrower
-      # question of which optional keys older clients still accept is pinned by
-      # tests/ci/test_package_unica_plugin.py, because a current client reports
-      # those as warnings rather than errors.
+      # Pinned to the oldest supported client rather than the latest, so the gate
+      # tests the compatibility floor the README promises instead of a moving
+      # target. 2.1.67 and 2.1.68 reject the catalog's git-subdir source; 2.1.69
+      # is the first release that accepts it.
       - name: Validate the Claude plugin and catalog
+        env:
+          CLAUDE_CLI_VERSION: 2.1.69
         run: |
-          npm install -g @anthropic-ai/claude-code
+          npm install -g "@anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}"
+          test "$(claude --version | cut -d' ' -f1)" = "$CLAUDE_CLI_VERSION"
           claude plugin validate dist/thin/marketplace/plugins/unica
           claude plugin validate dist/thin/marketplace
       - uses: actions/upload-artifact@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 When changing Unica, resolve conflicts in this order:
 
 1. code and tests
-2. `plugins/unica/.mcp.json`, `plugins/unica/.codex-plugin/plugin.json`, and `plugins/unica/third-party/tools.lock.json` are package-contract sources, not background notes.
+2. `plugins/unica/.mcp.json`, `plugins/unica/.codex-plugin/plugin.json`, `plugins/unica/.claude-plugin/plugin.json`, and `plugins/unica/third-party/tools.lock.json` are package-contract sources, not background notes.
 3. `spec/` is the active architecture layer unless it contradicts live code, tests, or package metadata.
 4. `README.md` and skill prose
 
@@ -48,3 +48,4 @@ must not be generalized to other disallowed paths.
 - Surface contradictions in assumptions, docs, tests, and runtime behavior.
 - Keep the public MCP boundary as one server named `unica` with `unica.*` tools unless an ADR changes that contract.
 - Prompt-visible skills stay MCP-first. Direct packaged-script execution paths must not return once a native `unica.*` tool exists, except for documented utility exceptions.
+- One plugin directory serves Codex and Claude Code. Keep both manifests at the same version, keep `.mcp.json` host-neutral, and do not add optional manifest or catalog keys without checking that the oldest supported client accepts them; an unrecognized key is a load error there, not a warning.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+See [AGENTS.md](AGENTS.md) for entry points, source-of-truth ordering, search
+hygiene, and development rules. That file applies to Claude Code unchanged.
+
+## Claude-specific notes
+
+- Unica ships as one plugin directory for two hosts. Claude Code reads
+  `plugins/unica/.claude-plugin/plugin.json` and ignores `.codex-plugin/`.
+- Load the source tree directly with `claude --plugin-dir ./plugins/unica`; no
+  marketplace or install step is involved.
+- Skills are namespaced by the plugin, so `meta-validate` is invoked as
+  `/unica:meta-validate`.
+- MCP tools are exposed as `mcp__plugin_unica_unica__<tool>`, with every
+  character outside `A-Za-z0-9_-` replaced by `_`. The skill prose names tools in
+  their canonical dotted form, so `unica.meta.validate` is callable as
+  `mcp__plugin_unica_unica__unica_meta_validate`.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ claude plugin install unica@unica
 | Хост | Каталог кэша |
 | --- | --- |
 | Codex | `$CODEX_HOME/unica/runtimes/<version>/<target>`, при стандартном `CODEX_HOME` — `~/.codex/unica/runtimes/...` |
-| Claude Code | `~/.claude/plugins/data/unica-unica/runtimes/<version>/<target>` — этот каталог переживает обновление плагина |
+| Claude Code | `${CLAUDE_PLUGIN_DATA}/runtimes/<version>/<target>`, по умолчанию — `~/.claude/plugins/data/unica-unica/...`; этот каталог переживает обновление плагина |
 
 ## Обновление
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
 # Unica
 
-Unica (Ю&#x301;ника) — публичный плагин [Codex](https://openai.com/codex/) для разработки на 1С:Предприятии. Он добавляет
-навыки и один MCP-сервер `unica`, через который Codex создаёт и проверяет
-метаданные, формы, роли, СКД, внешние обработки и отчёты, запускает 1С и ищет BSL-код.
+Unica (Ю&#x301;ника) — публичный плагин [Codex](https://openai.com/codex/) и
+[Claude Code](https://code.claude.com/docs/en/overview) для разработки на
+1С:Предприятии. Он добавляет навыки и один MCP-сервер `unica`, через который
+агент создаёт и проверяет метаданные, формы, роли, СКД, внешние обработки и
+отчёты, запускает 1С и ищет BSL-код.
+
+Оба хоста получают один и тот же каталог плагина: манифесты лежат рядом, а
+`.mcp.json` определяет корень плагина по той переменной, которую подставляет
+конкретный хост.
 
 ## Требования
 
-- актуальный [Codex CLI](https://learn.chatgpt.com/docs/codex/cli) с командами `codex plugin`;
+- один из агентов:
+  - актуальный [Codex CLI](https://learn.chatgpt.com/docs/codex/cli) с командами `codex plugin`;
+  - [Claude Code](https://code.claude.com/docs/en/overview) **2.1.69 или новее** — более
+    ранние клиенты не разбирают тип источника `git-subdir` и не загрузят каталог;
 - стандартный Git, включая Git for Windows на Windows;
 - платформа 1С только для операций, которым реально требуется запуск 1С.
 
@@ -20,6 +29,8 @@ Unica (Ю&#x301;ника) — публичный плагин [Codex](https://op
 
 ## Установка
 
+### Codex
+
 ```sh
 codex plugin marketplace add IngvarConsulting/unica-marketplace --ref main
 codex plugin add unica@unica
@@ -28,14 +39,33 @@ codex plugin add unica@unica
 После установки откройте new Codex task: список навыков и MCP-конфигурация
 фиксируются на границе новой задачи, а не подменяются в уже работающей сессии.
 
+### Claude Code
+
+```sh
+claude plugin marketplace add IngvarConsulting/unica-marketplace
+claude plugin install unica@unica
+```
+
+Затем выполните `/reload-plugins` либо начните новую сессию. Навыки становятся
+доступны с префиксом плагина, например `/unica:meta-validate`.
+
+### Загрузка runtime
+
 При первом MCP-вызове `unica` скачивает из релиза `IngvarConsulting/unica`
 только исполнительные файлы для текущей ОС и архитектуры. Архив и каждый файл
-проверяются по SHA-256. Готовый runtime атомарно публикуется в
-`$CODEX_HOME/unica/runtimes/<version>/<target>`; при стандартном `CODEX_HOME`
-это `~/.codex/unica/runtimes/...`. Неполная или повреждённая загрузка не получает
-маркер готовности.
+проверяются по SHA-256. Неполная или повреждённая загрузка не получает маркер
+готовности.
+
+Готовый runtime атомарно публикуется в кэше хоста:
+
+| Хост | Каталог кэша |
+| --- | --- |
+| Codex | `$CODEX_HOME/unica/runtimes/<version>/<target>`, при стандартном `CODEX_HOME` — `~/.codex/unica/runtimes/...` |
+| Claude Code | `~/.claude/plugins/data/unica-unica/runtimes/<version>/<target>` — этот каталог переживает обновление плагина |
 
 ## Обновление
+
+### Codex
 
 ```sh
 codex plugin marketplace upgrade unica
@@ -48,6 +78,15 @@ codex plugin add unica@unica
 
 Отдельной команды `codex plugin upgrade` в поддерживаемом CLI нет, поэтому
 переустановка плагина после обновления каталога является намеренным шагом.
+
+### Claude Code
+
+```sh
+claude plugin marketplace update unica
+claude plugin update unica@unica
+```
+
+Затем выполните `/reload-plugins`.
 
 ## Переход со старых версий
 
@@ -93,9 +132,18 @@ codex plugin add unica@unica
 
 ## Удаление
 
+Codex:
+
 ```sh
 codex plugin remove unica@unica
 codex plugin marketplace remove unica
+```
+
+Claude Code:
+
+```sh
+claude plugin uninstall unica@unica
+claude plugin marketplace remove unica
 ```
 
 Проверенные исполняемые-кэши можно оставить для повторной установки. Их ручное
@@ -103,12 +151,18 @@ codex plugin marketplace remove unica
 
 ## Разработка
 
-Для разработки используется отдельный marketplace `unica-dev`:
+Для разработки под Codex используется отдельный marketplace `unica-dev`:
 
 ```sh
 git clone https://github.com/IngvarConsulting/unica.git
 cd unica
 scripts/dev/install-local-unica.sh
+```
+
+Под Claude Code каталог плагина подключается напрямую, без маркетплейса:
+
+```sh
+claude --plugin-dir ./plugins/unica
 ```
 
 На Windows x64 запускайте этот скрипт из **Git Bash**, входящего в 64-битный

--- a/crates/unica-bootstrap/src/main.rs
+++ b/crates/unica-bootstrap/src/main.rs
@@ -120,11 +120,14 @@ fn verify_installed_plugin_metadata(plugin_root: &Path) -> Result<()> {
         }
         hosts += 1;
         let metadata: serde_json::Value = serde_json::from_slice(&std::fs::read(&metadata_path)?)?;
-        let skills = metadata.get("skills").and_then(serde_json::Value::as_str);
+        // Absence is checked on the raw entry rather than the string projection,
+        // so a `skills` key of any type still counts as declared.
+        let declared_skills = metadata.get("skills");
+        let skills = declared_skills.and_then(serde_json::Value::as_str);
         if metadata.get("name").and_then(serde_json::Value::as_str) != Some("unica")
             || metadata.get("version").and_then(serde_json::Value::as_str) != Some(VERSION)
             || (expects_skills_pointer && skills != Some("./skills/"))
-            || (!expects_skills_pointer && skills.is_some())
+            || (!expects_skills_pointer && declared_skills.is_some())
         {
             return Err(unica_bootstrap::BootstrapError::new(format!(
                 "installed Unica plugin metadata does not expose version {VERSION} skills: {}",
@@ -212,5 +215,100 @@ mod tests {
     fn source_plugin_exposes_required_prompt_visible_skills() {
         let plugin_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../plugins/unica");
         verify_installed_skill_package(&plugin_root).unwrap();
+    }
+
+    struct ManifestFixture {
+        root: PathBuf,
+    }
+
+    impl ManifestFixture {
+        fn new(name: &str) -> Self {
+            let root =
+                env::temp_dir().join(format!("unica-manifest-{name}-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&root);
+            std::fs::create_dir_all(&root).unwrap();
+            Self { root }
+        }
+
+        fn write(&self, dir: &str, body: serde_json::Value) {
+            let manifest_dir = self.root.join(dir);
+            std::fs::create_dir_all(&manifest_dir).unwrap();
+            std::fs::write(
+                manifest_dir.join("plugin.json"),
+                serde_json::to_vec(&body).unwrap(),
+            )
+            .unwrap();
+        }
+    }
+
+    impl Drop for ManifestFixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn codex_manifest() -> serde_json::Value {
+        serde_json::json!({"name": "unica", "version": VERSION, "skills": "./skills/"})
+    }
+
+    fn claude_manifest() -> serde_json::Value {
+        serde_json::json!({"name": "unica", "version": VERSION})
+    }
+
+    #[test]
+    fn either_host_manifest_alone_satisfies_the_contract() {
+        let codex = ManifestFixture::new("codex-only");
+        codex.write(".codex-plugin", codex_manifest());
+        verify_installed_plugin_metadata(&codex.root).unwrap();
+
+        let claude = ManifestFixture::new("claude-only");
+        claude.write(".claude-plugin", claude_manifest());
+        verify_installed_plugin_metadata(&claude.root).unwrap();
+    }
+
+    #[test]
+    fn a_package_without_any_host_manifest_is_rejected() {
+        let fixture = ManifestFixture::new("no-host");
+        verify_installed_plugin_metadata(&fixture.root).unwrap_err();
+    }
+
+    #[test]
+    fn a_manifest_from_another_release_is_rejected() {
+        let fixture = ManifestFixture::new("stale-version");
+        fixture.write(".codex-plugin", codex_manifest());
+        fixture.write(
+            ".claude-plugin",
+            serde_json::json!({"name": "unica", "version": "0.0.0"}),
+        );
+        verify_installed_plugin_metadata(&fixture.root).unwrap_err();
+    }
+
+    #[test]
+    fn a_codex_manifest_without_the_skills_pointer_is_rejected() {
+        let fixture = ManifestFixture::new("codex-no-pointer");
+        fixture.write(
+            ".codex-plugin",
+            serde_json::json!({"name": "unica", "version": VERSION}),
+        );
+        verify_installed_plugin_metadata(&fixture.root).unwrap_err();
+    }
+
+    #[test]
+    fn a_claude_manifest_declaring_skills_is_rejected_whatever_its_type() {
+        // Claude Code always scans skills/, so any declaration would load the
+        // directory twice regardless of the value's JSON type.
+        for value in [
+            serde_json::json!("./skills/"),
+            serde_json::json!(["./skills/"]),
+            serde_json::json!({"path": "./skills/"}),
+            serde_json::Value::Null,
+        ] {
+            let fixture = ManifestFixture::new("claude-skills");
+            fixture.write(
+                ".claude-plugin",
+                serde_json::json!({"name": "unica", "version": VERSION, "skills": value}),
+            );
+            verify_installed_plugin_metadata(&fixture.root).unwrap_err();
+        }
     }
 }

--- a/crates/unica-bootstrap/src/main.rs
+++ b/crates/unica-bootstrap/src/main.rs
@@ -68,17 +68,7 @@ fn install_and_verify_runtime(plugin_root: &Path) -> Result<()> {
 }
 
 fn verify_installed_skill_package(plugin_root: &Path) -> Result<()> {
-    let metadata_path = plugin_root.join(".codex-plugin").join("plugin.json");
-    let metadata: serde_json::Value = serde_json::from_slice(&std::fs::read(&metadata_path)?)?;
-    if metadata.get("name").and_then(serde_json::Value::as_str) != Some("unica")
-        || metadata.get("version").and_then(serde_json::Value::as_str) != Some(VERSION)
-        || metadata.get("skills").and_then(serde_json::Value::as_str) != Some("./skills/")
-    {
-        return Err(unica_bootstrap::BootstrapError::new(format!(
-            "installed Unica plugin metadata does not expose version {VERSION} skills: {}",
-            metadata_path.display()
-        )));
-    }
+    verify_installed_plugin_metadata(plugin_root)?;
 
     let skills_root = plugin_root.join("skills");
     let mut visible = std::collections::BTreeSet::new();
@@ -116,6 +106,41 @@ fn verify_installed_skill_package(plugin_root: &Path) -> Result<()> {
     Ok(())
 }
 
+/// A package may carry the Codex manifest, the Claude manifest, or both. Every
+/// manifest that is present must agree on the plugin identity, and each host
+/// keeps its own skill-discovery contract: Codex needs the explicit `skills`
+/// pointer, while Claude Code always scans `skills/` and would load the
+/// directory twice if the manifest named it again.
+fn verify_installed_plugin_metadata(plugin_root: &Path) -> Result<()> {
+    let mut hosts = 0;
+    for (dir, expects_skills_pointer) in [(".codex-plugin", true), (".claude-plugin", false)] {
+        let metadata_path = plugin_root.join(dir).join("plugin.json");
+        if !metadata_path.is_file() {
+            continue;
+        }
+        hosts += 1;
+        let metadata: serde_json::Value = serde_json::from_slice(&std::fs::read(&metadata_path)?)?;
+        let skills = metadata.get("skills").and_then(serde_json::Value::as_str);
+        if metadata.get("name").and_then(serde_json::Value::as_str) != Some("unica")
+            || metadata.get("version").and_then(serde_json::Value::as_str) != Some(VERSION)
+            || (expects_skills_pointer && skills != Some("./skills/"))
+            || (!expects_skills_pointer && skills.is_some())
+        {
+            return Err(unica_bootstrap::BootstrapError::new(format!(
+                "installed Unica plugin metadata does not expose version {VERSION} skills: {}",
+                metadata_path.display()
+            )));
+        }
+    }
+    if hosts == 0 {
+        return Err(unica_bootstrap::BootstrapError::new(format!(
+            "installed Unica plugin has no host manifest: {}",
+            plugin_root.display()
+        )));
+    }
+    Ok(())
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Command {
     Run,
@@ -141,8 +166,18 @@ fn parse_command(args: &[String]) -> Result<(Command, PathBuf)> {
 }
 
 fn runtime_cache_root() -> Result<PathBuf> {
+    // The package points UNICA_RUNTIME_CACHE_DIR at ${CLAUDE_PLUGIN_DATA}, which
+    // only a host that understands the token expands. Hosts that pass it through
+    // literally would otherwise create a directory named after the token, so an
+    // unexpanded value is discarded in favour of the home-directory cache.
     if let Some(value) = env::var_os("UNICA_RUNTIME_CACHE_DIR") {
-        return Ok(PathBuf::from(value));
+        let value = PathBuf::from(value);
+        if !value.to_string_lossy().contains("${") {
+            return Ok(value);
+        }
+    }
+    if let Some(value) = env::var_os("CLAUDE_PLUGIN_DATA") {
+        return Ok(PathBuf::from(value).join("runtimes"));
     }
     Ok(codex_home_root()?.join("unica").join("runtimes"))
 }

--- a/plugins/unica/.claude-plugin/plugin.json
+++ b/plugins/unica/.claude-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "unica",
+  "version": "0.9.1",
+  "description": "Practical 1C:Enterprise development workflows for Claude Code.",
+  "author": {
+    "name": "Ingvar Consulting, LLC",
+    "url": "https://ingvar.pro"
+  },
+  "homepage": "https://ingvar.pro/products/unica/en",
+  "repository": "https://github.com/IngvarConsulting/unica",
+  "license": "LGPL-3.0-or-later",
+  "keywords": [
+    "1c",
+    "1c-enterprise",
+    "bsl",
+    "metadata",
+    "epf",
+    "erf",
+    "cfe",
+    "forms",
+    "database",
+    "mcp",
+    "v8-runner",
+    "rlm",
+    "code-analysis"
+  ]
+}

--- a/plugins/unica/README.md
+++ b/plugins/unica/README.md
@@ -36,8 +36,8 @@ claude plugin marketplace add IngvarConsulting/unica-marketplace
 claude plugin install unica@unica
 ```
 
-Claude Code 2.1.66 and earlier reject the catalog's `git-subdir` source type and
-cannot load it at all.
+Claude Code 2.1.68 and earlier reject the catalog's `git-subdir` source type and
+cannot load it at all; 2.1.69 is the first release that accepts it.
 
 ## Legacy transition boundary
 

--- a/plugins/unica/README.md
+++ b/plugins/unica/README.md
@@ -1,14 +1,19 @@
-# Unica Codex Plugin
+# Unica Plugin
 
 Unica models day-to-day 1C:Enterprise development workflows and exposes one
 public stdio MCP server named `unica`. Prompt-visible skills call native
 `unica.*` tools; bundled analyzers, runners, indexes, and the standards adapter
 remain private implementation details.
 
+One plugin directory serves both Codex and Claude Code. Each host reads its own
+manifest, `.codex-plugin/plugin.json` or `.claude-plugin/plugin.json`, and
+ignores the other.
+
 ## Public installation
 
-Prerequisites are Codex CLI and Git. Node.js, Python, download utilities, and
-archive utilities are not consumer dependencies.
+Prerequisites are Git and one host: Codex CLI, or Claude Code 2.1.69 or newer.
+Node.js, Python, download utilities, and archive utilities are not consumer
+dependencies.
 
 ```sh
 codex plugin marketplace add IngvarConsulting/unica-marketplace --ref main
@@ -22,6 +27,17 @@ codex plugin marketplace upgrade unica
 codex plugin remove unica@unica
 codex plugin add unica@unica
 ```
+
+On Claude Code the catalog is added without a ref, and skills appear under the
+plugin namespace as `/unica:<skill>`:
+
+```sh
+claude plugin marketplace add IngvarConsulting/unica-marketplace
+claude plugin install unica@unica
+```
+
+Claude Code 2.1.66 and earlier reject the catalog's `git-subdir` source type and
+cannot load it at all.
 
 ## Legacy transition boundary
 
@@ -71,11 +87,23 @@ runs `bootstrap/launch.sh`, which selects exactly one bootstrap:
 - `linux-x64`;
 - `win-x64` under Git for Windows.
 
+The alias resolves the plugin root from whichever host it runs under. Claude
+Code rewrites `${CLAUDE_PLUGIN_ROOT}` before the shell sees it; Codex leaves the
+token unset, and the shell falls back to Git's own `$PWD`/`$GIT_PREFIX` pair.
+One launcher therefore serves both hosts without a per-host package.
+
 The bootstrap reads the release-pinned `runtime-manifest.json`, downloads
 `unica-runtime-<target>.tar.gz`, verifies archive and file SHA-256 values, and
-publishes the runtime atomically under `$CODEX_HOME/unica/runtimes`. It then
-execs the single `unica` MCP process. Runtime stdout stays reserved for JSON-RPC;
-bootstrap diagnostics use stderr.
+publishes the runtime atomically in the host cache. It then execs the single
+`unica` MCP process. Runtime stdout stays reserved for JSON-RPC; bootstrap
+diagnostics use stderr.
+
+The cache is `$CODEX_HOME/unica/runtimes` under Codex and
+`${CLAUDE_PLUGIN_DATA}/runtimes` under Claude Code, which survives plugin
+updates. Packaged `.mcp.json` passes the Claude token through
+`UNICA_RUNTIME_CACHE_DIR`; a host that does not substitute it forwards the
+literal token, and the bootstrap discards any value that still contains `${`
+rather than creating a directory named after it.
 
 The runtime archive contains the target's `unica`, `bsl-analyzer`, `v8-runner`,
 `rlm-tools-bsl`, and `rlm-bsl-index` binaries plus the generated
@@ -116,14 +144,26 @@ scripts/dev/install-local-unica.sh --skip-install
 scripts/dev/install-local-unica.sh --marketplace-name unica-dev
 ```
 
+Claude Code loads a plugin directory directly, so the source tree needs no
+marketplace and no install step:
+
+```sh
+claude --plugin-dir ./plugins/unica
+```
+
+To package a current-host Claude debug build instead, pass
+`--local-debug-host claude` to `scripts/ci/package-unica-plugin.py`.
+
 ## Release pipeline
 
 The source workflow builds tools and `unica-bootstrap` natively on each runner,
 creates deterministic runtime archives and checksum metadata, re-downloads
 published release bytes for verification, and emits one thin marketplace
-payload. A separate workflow opens a plugin-only staging PR in
-`IngvarConsulting/unica-marketplace`. After that commit is tagged immutably, a
-catalog-only promotion PR points the stable `git-subdir` entry to the tag.
+payload carrying both host catalogs. A separate workflow opens a plugin-only
+staging PR in `IngvarConsulting/unica-marketplace`. After that commit is tagged
+immutably, a catalog-only promotion PR points both stable `git-subdir` entries,
+`.agents/plugins/marketplace.json` for Codex and `.claude-plugin/marketplace.json`
+for Claude Code, to the tag.
 
 The public catalog is never promoted before the source assets, staging commit,
 and immutable marketplace tag exist.

--- a/scripts/ci/check-version-contract.py
+++ b/scripts/ci/check-version-contract.py
@@ -17,6 +17,11 @@ def read_version_contract(repo_root: Path) -> dict[str, str]:
             encoding="utf-8"
         )
     )
+    claude_plugin = json.loads(
+        (repo_root / "plugins" / "unica" / ".claude-plugin" / "plugin.json").read_text(
+            encoding="utf-8"
+        )
+    )
     tools_lock = json.loads(
         (repo_root / "plugins" / "unica" / "third-party" / "tools.lock.json").read_text(
             encoding="utf-8"
@@ -29,6 +34,7 @@ def read_version_contract(repo_root: Path) -> dict[str, str]:
     return {
         "workspace": workspace["workspace"]["package"]["version"],
         "plugin": plugin["version"],
+        "claude-plugin": claude_plugin["version"],
         "tools-lock-unica": unica_tools[0]["version"],
     }
 

--- a/scripts/ci/classify-workflow-changes.py
+++ b/scripts/ci/classify-workflow-changes.py
@@ -28,6 +28,7 @@ TOOLCHAIN_PATHS = {
 }
 PACKAGE_PATHS = {
     ".agents/plugins/marketplace.json",
+    "plugins/unica/.claude-plugin/plugin.json",
     "plugins/unica/.codex-plugin/plugin.json",
     "plugins/unica/.mcp.json",
     "plugins/unica/bootstrap/launch.sh",

--- a/scripts/ci/package-unica-plugin.py
+++ b/scripts/ci/package-unica-plugin.py
@@ -313,6 +313,15 @@ def write_claude_marketplace(plugin_dir: Path, dest_path: Path, *, source: dict 
     author = manifest.get("author", {})
     if not author.get("name"):
         raise SystemExit("Claude plugin manifest must declare author.name")
+    # Named up front so a manifest missing one fails with the field rather than a
+    # KeyError from whichever line happened to reach it first.
+    missing = [
+        key
+        for key in ("description", "homepage", "repository", "license", "keywords", "version")
+        if not manifest.get(key)
+    ]
+    if missing:
+        raise SystemExit(f"Claude plugin manifest is missing: {', '.join(missing)}")
 
     # Only fields every supported Claude Code release accepts: newer optional
     # keys such as displayName are rejected outright by older clients rather

--- a/scripts/ci/package-unica-plugin.py
+++ b/scripts/ci/package-unica-plugin.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Assemble a Codex marketplace package from built Unica tool artifacts."""
+"""Assemble Codex and Claude marketplace packages from built Unica tool artifacts."""
 
 from __future__ import annotations
 
@@ -14,6 +14,12 @@ from pathlib import Path
 
 PLUGIN_ID = "unica"
 DISPLAY_NAME = "Unica"
+# One plugin directory serves both hosts. Each host reads its own manifest
+# directory and ignores the other, and the single `.mcp.json` launcher resolves
+# the plugin root from whichever host variable is present, so the package ships
+# one copy of the bootstrap matrix instead of one per host.
+HOST_MANIFEST_DIRS = {"codex": ".codex-plugin", "claude": ".claude-plugin"}
+CLAUDE_MARKETPLACE_PATH = Path(".claude-plugin") / "marketplace.json"
 SOURCE_PACKAGE_IGNORES = {"bin", ".DS_Store", "__pycache__", ".pytest_cache"}
 DISALLOWED_ARCHIVE_PARTS = {".build", "dist", "__pycache__", ".pytest_cache"}
 SUPPORTED_TARGETS = {
@@ -198,6 +204,21 @@ def load_tool_bundles(
     return grouped, bin_roots
 
 
+def read_release_version(plugin_src: Path) -> str:
+    """Return the release version both host manifests agree on."""
+    versions = {}
+    for host, manifest_dir in HOST_MANIFEST_DIRS.items():
+        manifest_path = plugin_src / manifest_dir / "plugin.json"
+        if not manifest_path.is_file():
+            raise SystemExit(f"plugin source is missing the {host} manifest: {manifest_path}")
+        versions[host] = json.loads(manifest_path.read_text(encoding="utf-8"))["version"]
+    distinct = set(versions.values())
+    if len(distinct) != 1:
+        detail = ", ".join(f"{host}={version}" for host, version in sorted(versions.items()))
+        raise SystemExit(f"host manifests disagree on the release version: {detail}")
+    return distinct.pop()
+
+
 def write_manifest(plugin_dir: Path, grouped_tools: dict[str, dict], lock_file: Path) -> None:
     lock_path = lock_file.resolve()
     manifest = {
@@ -219,6 +240,21 @@ def write_manifest(plugin_dir: Path, grouped_tools: dict[str, dict], lock_file: 
     path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
+# One launcher, both hosts. Claude Code rewrites `${CLAUDE_PLUGIN_ROOT}` in the
+# alias before the shell sees it, so `root` is already absolute there; Codex
+# leaves the token alone, the shell expands it to the empty string, and the
+# original `$PWD/${GIT_PREFIX:-}` resolution takes over unchanged.
+PACKAGED_MCP_ALIAS = (
+    'alias.unica-bootstrap=!f() { root="${CLAUDE_PLUGIN_ROOT}"; '
+    '[ -n "$root" ] || root="$PWD/${GIT_PREFIX:-}"; '
+    'exec sh "${root%/}/bootstrap/launch.sh" "${root%/}"; }; f'
+)
+# Claude Code keeps `${CLAUDE_PLUGIN_DATA}` across plugin updates, unlike the
+# plugin root. Hosts that do not substitute the token pass it through literally,
+# and the bootstrap discards any value that still contains `${`.
+PACKAGED_MCP_CACHE_DIR = "${CLAUDE_PLUGIN_DATA}/runtimes"
+
+
 def write_packaged_mcp_launcher(
     plugin_dir: Path, _grouped_tools: dict[str, dict] | None = None
 ) -> None:
@@ -226,33 +262,104 @@ def write_packaged_mcp_launcher(
     mcp = json.loads(mcp_path.read_text(encoding="utf-8"))
     server = mcp["mcpServers"]["unica"]
     server["command"] = "git"
-    server["args"] = [
-        "-c",
-        (
-            'alias.unica-bootstrap=!f() { root="$PWD/${GIT_PREFIX:-}"; '
-            'exec sh "${root}bootstrap/launch.sh" "$root"; }; f'
-        ),
-        "unica-bootstrap",
-    ]
+    server["args"] = ["-c", PACKAGED_MCP_ALIAS, "unica-bootstrap"]
     server["cwd"] = "."
+    server["env"] = {"UNICA_RUNTIME_CACHE_DIR": PACKAGED_MCP_CACHE_DIR}
     server["note"] = (
         "Single public Unica stdio MCP orchestrator. The public Git package enters "
-        "through a command-scoped Git shell alias, selects a native bootstrap for "
-        "the host, verifies the pinned runtime, and transparently launches unica."
+        "through a command-scoped Git shell alias, resolves the plugin root from the "
+        "host, selects a native bootstrap, verifies the pinned runtime, and "
+        "transparently launches unica."
     )
     mcp_path.write_text(json.dumps(mcp, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
-def write_local_debug_mcp_launcher(plugin_dir: Path, target: str) -> None:
+def assert_host_manifests_present(plugin_dir: Path) -> None:
+    """Both hosts must find their manifest in the shared plugin directory."""
+    for host, manifest_dir in sorted(HOST_MANIFEST_DIRS.items()):
+        manifest = plugin_dir / manifest_dir / "plugin.json"
+        if not manifest.is_file():
+            raise SystemExit(f"package is missing the {host} manifest: {manifest}")
+
+
+def claude_plugin_source(*, release_tag: str) -> dict:
+    """Pin the Claude catalog to the same immutable tag as the Codex catalog.
+
+    `git-subdir` is what keeps ADR-0008 intact for Claude: the catalog on the
+    marketplace default branch keeps naming the previous tag until a promotion
+    PR moves it, so staged bytes are never served. The trade-off is a floor on
+    the supported Claude Code version, because older clients reject the source
+    type; a relative `./plugins/unica` source would load everywhere but would
+    follow the marketplace branch instead of a tag.
+    """
+    return {
+        "source": "git-subdir",
+        "url": "https://github.com/IngvarConsulting/unica-marketplace.git",
+        "path": f"./plugins/{PLUGIN_ID}",
+        "ref": release_tag,
+    }
+
+
+def write_claude_marketplace(plugin_dir: Path, dest_path: Path, *, source: dict | str) -> None:
+    """Derive the Claude catalog from the packaged manifest.
+
+    Unlike the Codex catalog there is no hand-maintained source file: every field
+    Claude Code reads is already in `.claude-plugin/plugin.json`, so deriving it
+    here removes a contract that could drift from the manifest.
+    """
+    manifest = json.loads(
+        (plugin_dir / HOST_MANIFEST_DIRS["claude"] / "plugin.json").read_text(encoding="utf-8")
+    )
+    author = manifest.get("author", {})
+    if not author.get("name"):
+        raise SystemExit("Claude plugin manifest must declare author.name")
+
+    # Only fields every supported Claude Code release accepts: newer optional
+    # keys such as displayName are rejected outright by older clients rather
+    # than ignored, which would make the whole catalog unloadable for them.
+    entry = {
+        "name": PLUGIN_ID,
+        "source": source,
+        "description": manifest["description"],
+        "version": manifest["version"],
+        "author": author,
+        "homepage": manifest["homepage"],
+        "repository": manifest["repository"],
+        "license": manifest["license"],
+        "keywords": manifest["keywords"],
+        "category": "Coding",
+    }
+    catalog = {
+        "name": PLUGIN_ID,
+        "owner": {"name": author["name"]},
+        # Current releases read the description from either place; older ones
+        # only look under metadata, so that is where it goes.
+        "metadata": {"description": manifest["description"]},
+        "plugins": [entry],
+    }
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    dest_path.write_text(json.dumps(catalog, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def write_local_debug_mcp_launcher(plugin_dir: Path, target: str, *, host: str = "codex") -> None:
     if target not in SUPPORTED_TARGETS:
         raise SystemExit(f"unsupported local debug target: {target}")
+    if host not in HOST_MANIFEST_DIRS:
+        raise SystemExit(f"unknown package host: {host}")
     executable = "unica.exe" if target == "win-x64" else "unica"
     mcp_path = plugin_dir / ".mcp.json"
     mcp = json.loads(mcp_path.read_text(encoding="utf-8"))
     server = mcp["mcpServers"]["unica"]
-    server["command"] = f"./bin/{target}/{executable}"
-    server["args"] = []
-    server["cwd"] = "."
+    if host == "claude":
+        # Claude Code does not run plugin servers from the plugin root, so the
+        # binary is addressed absolutely instead of through cwd.
+        server["command"] = "${CLAUDE_PLUGIN_ROOT}/bin/" + f"{target}/{executable}"
+        server["args"] = []
+        server.pop("cwd", None)
+    else:
+        server["command"] = f"./bin/{target}/{executable}"
+        server["args"] = []
+        server["cwd"] = "."
     server["note"] = "Development-only current-host Unica MCP binary."
     mcp_path.write_text(json.dumps(mcp, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
@@ -448,21 +555,24 @@ def package_local_debug(
     out_dir: Path,
     marketplace_name: str,
     target: str,
+    host: str = "codex",
 ) -> None:
     plugin_src = repo_root / "plugins" / "unica"
     marketplace_src = repo_root / ".agents" / "plugins" / "marketplace.json"
     marketplace_dir = out_dir / "marketplace"
     shutil.rmtree(marketplace_dir, ignore_errors=True)
-    plugin_dst = marketplace_dir / "plugins" / "unica"
+    plugin_dst = marketplace_dir / "plugins" / PLUGIN_ID
     copy_tracked_plugin_source(repo_root, plugin_src, plugin_dst)
+    assert_host_manifests_present(plugin_dst)
 
-    marketplace_dst = marketplace_dir / ".agents" / "plugins"
-    marketplace_dst.mkdir(parents=True, exist_ok=True)
-    write_official_marketplace(
-        marketplace_src,
-        marketplace_dst / "marketplace.json",
-        marketplace_name=marketplace_name,
-    )
+    if host == "codex":
+        marketplace_dst = marketplace_dir / ".agents" / "plugins"
+        marketplace_dst.mkdir(parents=True, exist_ok=True)
+        write_official_marketplace(
+            marketplace_src,
+            marketplace_dst / "marketplace.json",
+            marketplace_name=marketplace_name,
+        )
 
     lock = load_lock(lock_file)
     grouped_tools, bin_roots = load_tool_bundles(
@@ -476,7 +586,13 @@ def package_local_debug(
         if source.is_dir():
             copy_binary_tree(source, plugin_dst / "bin" / target)
     write_manifest(plugin_dst, grouped_tools, lock_file)
-    write_local_debug_mcp_launcher(plugin_dst, target)
+    write_local_debug_mcp_launcher(plugin_dst, target, host=host)
+    if host == "claude":
+        write_claude_marketplace(
+            plugin_dst,
+            marketplace_dir / CLAUDE_MARKETPLACE_PATH,
+            source=f"./plugins/{PLUGIN_ID}",
+        )
     assert_archive_clean(marketplace_dir)
 
 
@@ -488,6 +604,7 @@ def main() -> None:
     parser.add_argument("--release-tag")
     parser.add_argument("--source-commit")
     parser.add_argument("--local-debug-target")
+    parser.add_argument("--local-debug-host", default="codex", choices=sorted(HOST_MANIFEST_DIRS))
     parser.add_argument("--tools-root", type=Path)
     parser.add_argument("--lock-file", type=Path, default=Path("plugins/unica/third-party/tools.lock.json"))
     parser.add_argument("--marketplace-name", default="unica-dev")
@@ -506,6 +623,7 @@ def main() -> None:
             out_dir=args.out_dir.resolve(),
             marketplace_name=args.marketplace_name,
             target=args.local_debug_target,
+            host=args.local_debug_host,
         )
         return
 
@@ -528,25 +646,18 @@ def main() -> None:
     if not marketplace_src.exists():
         raise SystemExit(f"marketplace source not found: {marketplace_src}")
 
-    plugin_json = json.loads((plugin_src / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8"))
-    version = plugin_json["version"]
+    version = read_release_version(plugin_src)
     metadata = load_runtime_metadata(args.runtime_metadata_root.resolve(), plugin_version=version)
+    bootstrap_root = args.bootstrap_root.resolve()
 
     marketplace_dir = args.out_dir / "marketplace"
     shutil.rmtree(marketplace_dir, ignore_errors=True)
     marketplace_dir.mkdir(parents=True, exist_ok=True)
-    plugin_dst = marketplace_dir / "plugins" / "unica"
+
+    plugin_dst = marketplace_dir / "plugins" / PLUGIN_ID
     copy_tracked_plugin_source(repo_root, plugin_src, plugin_dst)
-
-    marketplace_dst = marketplace_dir / ".agents" / "plugins"
-    marketplace_dst.mkdir(parents=True, exist_ok=True)
-    write_public_marketplace(
-        marketplace_src,
-        marketplace_dst / "marketplace.json",
-        release_tag=args.release_tag,
-    )
-
-    copy_bootstrap_matrix(args.bootstrap_root.resolve(), plugin_dst)
+    assert_host_manifests_present(plugin_dst)
+    copy_bootstrap_matrix(bootstrap_root, plugin_dst)
     write_release_runtime_manifest(
         plugin_dst,
         metadata,
@@ -556,10 +667,25 @@ def main() -> None:
     )
     write_packaged_mcp_launcher(plugin_dst)
 
+    marketplace_dst = marketplace_dir / ".agents" / "plugins"
+    marketplace_dst.mkdir(parents=True, exist_ok=True)
+    write_public_marketplace(
+        marketplace_src,
+        marketplace_dst / "marketplace.json",
+        release_tag=args.release_tag,
+    )
+    write_claude_marketplace(
+        plugin_dst,
+        marketplace_dir / CLAUDE_MARKETPLACE_PATH,
+        source=claude_plugin_source(release_tag=args.release_tag),
+    )
+
     json.loads((plugin_dst / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8"))
+    json.loads((plugin_dst / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"))
     json.loads((plugin_dst / ".mcp.json").read_text(encoding="utf-8"))
     json.loads((plugin_dst / "runtime-manifest.json").read_text(encoding="utf-8"))
     json.loads((marketplace_dst / "marketplace.json").read_text(encoding="utf-8"))
+    json.loads((marketplace_dir / CLAUDE_MARKETPLACE_PATH).read_text(encoding="utf-8"))
     assert_archive_clean(marketplace_dir)
 
     args.out_dir.mkdir(parents=True, exist_ok=True)

--- a/spec/decisions/0012-one-plugin-directory-for-two-hosts.md
+++ b/spec/decisions/0012-one-plugin-directory-for-two-hosts.md
@@ -1,0 +1,67 @@
+# ADR-0012: One plugin directory serves Codex and Claude Code
+
+- Status: accepted
+- Date: 2026-07-26
+
+## Context
+
+Unica is published to the Codex marketplace as a thin package under
+[ADR-0008](0008-public-marketplace-thin-runtime.md). Supporting Claude Code adds
+a second host with the same shape: a plugin directory holding `skills/`, a
+manifest directory, and a root `.mcp.json`.
+
+The two hosts agree on almost everything. Both scan `skills/<name>/SKILL.md`,
+both read `.mcp.json` from the plugin root, and Claude Code accepts the existing
+skill frontmatter unchanged. They disagree on two points. Each host reads its
+own manifest directory, `.codex-plugin/` or `.claude-plugin/`. And each resolves
+the plugin root differently: Codex launches the server with the plugin directory
+as the working directory, while Claude Code substitutes `${CLAUDE_PLUGIN_ROOT}`
+into the server configuration and does not guarantee a working directory.
+
+Measurements on Claude Code 2.1.49 settled three open questions:
+
+- A manifest-declared `mcpServers` path does not replace the root `.mcp.json`;
+  both are loaded. Two host-specific MCP files in one directory would therefore
+  start two servers under the same `unica` key.
+- `${CLAUDE_PLUGIN_ROOT}` is substituted inside an arbitrary `args` string, so a
+  Git alias can receive an absolute plugin root.
+- An unrecognized manifest or catalog key is a hard load error on older clients,
+  not a warning. `git-subdir` is likewise unparsable before 2.1.69.
+
+## Decision
+
+One plugin directory serves both hosts.
+
+Both manifests live side by side and are held at the same version by the version
+contract. Each host reads its own and ignores the other.
+
+`.mcp.json` stays single and host-neutral. The packaged Git alias resolves
+`root="${CLAUDE_PLUGIN_ROOT}"` first and falls back to `$PWD/${GIT_PREFIX:-}`
+when that is empty. Claude Code rewrites the token before the shell runs; Codex
+leaves it unset and the original resolution applies unchanged. The runtime cache
+travels the same way through `UNICA_RUNTIME_CACHE_DIR`, and the bootstrap
+discards a value still containing `${` so a host that does not substitute the
+token cannot create a directory named after it.
+
+The Claude catalog is generated from the Claude manifest rather than maintained
+by hand, and is pinned with `git-subdir` to the same immutable tag as the Codex
+catalog. Both manifests and both catalog entries are restricted to keys the
+oldest supported client accepts; a current client only warns about the rest, so
+this is enforced by test rather than by `claude plugin validate`.
+
+Claude Code 2.1.69 is the minimum supported version, because `git-subdir` is the
+only source type that both pins to a tag and addresses a subdirectory.
+
+## Consequences
+
+- The bootstrap matrix ships once, not once per host; a per-host directory would
+  have added roughly 9 MB to every marketplace release.
+- Staged plugin bytes stay unserved for both hosts. Each catalog keeps naming the
+  previous tag until its promotion PR moves it, preserving the ADR-0008
+  invariant.
+- Skills, references, and the MCP boundary have no host-specific variants, so
+  host support does not fan out into skill prose.
+- Adding an optional manifest or catalog key is a compatibility decision, not a
+  cosmetic one, and raises the minimum supported client when the key is newer.
+- Consumers below Claude Code 2.1.69 cannot load the catalog at all. Lowering the
+  floor would mean giving up either tag pinning or the shared directory.

--- a/spec/decisions/README.md
+++ b/spec/decisions/README.md
@@ -14,6 +14,7 @@ This directory contains accepted architecture decisions for Unica.
 - [ADR-0009: OS-specific code behind infrastructure platform facades](0009-os-specific-code-behind-platform-facade.md)
 - [ADR-0010: CI build cache and artifact flow](0010-ci-build-cache-and-artifact-flow.md)
 - [ADR-0011: DCS is the canonical data composition domain](0011-canonical-dcs-domain.md)
+- [ADR-0012: One plugin directory serves Codex and Claude Code](0012-one-plugin-directory-for-two-hosts.md)
 
 ## ADR Status Values
 

--- a/tests/ci/test_package_unica_plugin.py
+++ b/tests/ci/test_package_unica_plugin.py
@@ -283,7 +283,9 @@ class PackageUnicaPluginTests(unittest.TestCase):
         self.assertIn("bootstrap/launch.sh", server["args"][1])
         self.assertEqual(server["args"][2], "unica-bootstrap")
 
-    def resolve_packaged_alias(self, plugin_root: Path, *, claude_root: str | None) -> str:
+    def resolve_packaged_alias(
+        self, plugin_root: Path, *, claude_root: str | None, cwd: Path | None = None
+    ) -> str:
         """Run the packaged Git alias and return the plugin root it hands the launcher."""
         module = load_package_module()
         alias = module.PACKAGED_MCP_ALIAS
@@ -296,7 +298,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
 
         result = subprocess.run(
             ["git", "-c", alias, "unica-bootstrap"],
-            cwd=plugin_root,
+            cwd=cwd or plugin_root,
             env=env,
             text=True,
             stdout=subprocess.PIPE,
@@ -329,10 +331,13 @@ class PackageUnicaPluginTests(unittest.TestCase):
             # Codex launches with cwd at the plugin directory and no Claude token,
             # so Git's own PWD/GIT_PREFIX pair has to resolve the root.
             codex_resolved = self.resolve_packaged_alias(plugin_root, claude_root=None)
-            # Claude Code substitutes an absolute plugin root, which wins outright
-            # and stays correct regardless of the working directory.
+            # Run from the marketplace root, where the Codex fallback would resolve
+            # to the wrong directory and the launcher would not be found at all.
+            # Only the substituted token can produce the plugin root from here, so
+            # this distinguishes the two paths instead of letting them agree by
+            # sharing a working directory.
             claude_resolved = self.resolve_packaged_alias(
-                plugin_root, claude_root=str(plugin_root)
+                plugin_root, cwd=plugin_root.parent.parent, claude_root=str(plugin_root)
             )
 
         self.assertEqual(codex_resolved, f"resolved={plugin_root}")
@@ -466,10 +471,12 @@ class PackageUnicaPluginTests(unittest.TestCase):
                     source=module.claude_plugin_source(release_tag="v0.9.1"),
                 )
 
-        # The packaging failure has to name the field, not surface as a KeyError
-        # from whichever line reached it first.
-        self.assertIn("description", str(raised.exception))
-        self.assertIn("license", str(raised.exception))
+        # The packaging failure has to name every missing field, not surface as a
+        # KeyError from whichever line reached it first.
+        message = str(raised.exception)
+        for field in ("description", "homepage", "repository", "license", "keywords"):
+            with self.subTest(field=field):
+                self.assertIn(field, message)
 
     def test_claude_catalog_pins_the_release_tag(self) -> None:
         module = load_package_module()

--- a/tests/ci/test_package_unica_plugin.py
+++ b/tests/ci/test_package_unica_plugin.py
@@ -448,6 +448,29 @@ class PackageUnicaPluginTests(unittest.TestCase):
         # Older clients only read the description from metadata.
         self.assertIn("description", catalog["metadata"])
 
+    def test_claude_catalog_names_the_missing_manifest_field(self) -> None:
+        module = load_package_module()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "unica"
+            (plugin_dir / ".claude-plugin").mkdir(parents=True)
+            (plugin_dir / ".claude-plugin" / "plugin.json").write_text(
+                json.dumps({"name": "unica", "version": "0.9.1", "author": {"name": "n"}}),
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(SystemExit) as raised:
+                module.write_claude_marketplace(
+                    plugin_dir,
+                    Path(tmp) / "marketplace.json",
+                    source=module.claude_plugin_source(release_tag="v0.9.1"),
+                )
+
+        # The packaging failure has to name the field, not surface as a KeyError
+        # from whichever line reached it first.
+        self.assertIn("description", str(raised.exception))
+        self.assertIn("license", str(raised.exception))
+
     def test_claude_catalog_pins_the_release_tag(self) -> None:
         module = load_package_module()
 

--- a/tests/ci/test_package_unica_plugin.py
+++ b/tests/ci/test_package_unica_plugin.py
@@ -283,6 +283,194 @@ class PackageUnicaPluginTests(unittest.TestCase):
         self.assertIn("bootstrap/launch.sh", server["args"][1])
         self.assertEqual(server["args"][2], "unica-bootstrap")
 
+    def resolve_packaged_alias(self, plugin_root: Path, *, claude_root: str | None) -> str:
+        """Run the packaged Git alias and return the plugin root it hands the launcher."""
+        module = load_package_module()
+        alias = module.PACKAGED_MCP_ALIAS
+        env = os.environ.copy()
+        env.pop("CLAUDE_PLUGIN_ROOT", None)
+        env.pop("GIT_PREFIX", None)
+        if claude_root is not None:
+            # Claude Code rewrites the token in the config before the shell runs.
+            alias = alias.replace("${CLAUDE_PLUGIN_ROOT}", claude_root)
+
+        result = subprocess.run(
+            ["git", "-c", alias, "unica-bootstrap"],
+            cwd=plugin_root,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return result.stdout.strip()
+
+    @staticmethod
+    def make_alias_fixture(root: Path) -> Path:
+        """A marketplace clone holding the plugin, with a launcher that echoes its argument."""
+        # Resolved so the expectation matches the physical path Git reports on
+        # platforms where the temporary directory is reached through a symlink.
+        root.mkdir(parents=True)
+        root = root.resolve()
+        plugin_root = root / "plugins" / "unica"
+        launcher = plugin_root / "bootstrap" / "launch.sh"
+        launcher.parent.mkdir(parents=True)
+        launcher.write_text('#!/bin/sh\nprintf "resolved=%s\\n" "$1"\n', encoding="utf-8")
+        launcher.chmod(0o755)
+        subprocess.run(["git", "init", "-q", str(root)], check=True)
+        return plugin_root
+
+    @unittest.skipIf(os.name == "nt", "alias fixture uses POSIX test scripts")
+    def test_packaged_alias_resolves_the_plugin_root_for_both_hosts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_root = self.make_alias_fixture(Path(tmp) / "marketplace")
+
+            # Codex launches with cwd at the plugin directory and no Claude token,
+            # so Git's own PWD/GIT_PREFIX pair has to resolve the root.
+            codex_resolved = self.resolve_packaged_alias(plugin_root, claude_root=None)
+            # Claude Code substitutes an absolute plugin root, which wins outright
+            # and stays correct regardless of the working directory.
+            claude_resolved = self.resolve_packaged_alias(
+                plugin_root, claude_root=str(plugin_root)
+            )
+
+        self.assertEqual(codex_resolved, f"resolved={plugin_root}")
+        self.assertEqual(claude_resolved, f"resolved={plugin_root}")
+
+    @unittest.skipIf(os.name == "nt", "alias fixture uses POSIX test scripts")
+    def test_packaged_alias_keeps_the_codex_root_resolution_unchanged(self) -> None:
+        legacy_alias = (
+            'alias.unica-bootstrap=!f() { root="$PWD/${GIT_PREFIX:-}"; '
+            'exec sh "${root}bootstrap/launch.sh" "$root"; }; f'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_root = self.make_alias_fixture(Path(tmp) / "marketplace")
+            env = os.environ.copy()
+            env.pop("CLAUDE_PLUGIN_ROOT", None)
+            env.pop("GIT_PREFIX", None)
+            legacy = subprocess.run(
+                ["git", "-c", legacy_alias, "unica-bootstrap"],
+                cwd=plugin_root,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                check=True,
+            ).stdout.strip()
+            current = self.resolve_packaged_alias(plugin_root, claude_root=None)
+
+        # The launcher normalises the trailing separator, so the two forms must
+        # only agree once it is stripped.
+        self.assertEqual(legacy.rstrip("/"), current.rstrip("/"))
+
+    def test_packaged_plugin_serves_both_hosts_from_one_directory(self) -> None:
+        module = load_package_module()
+        repo_root = Path(__file__).resolve().parents[2]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "plugins" / "unica"
+            plugin_dir.mkdir(parents=True)
+            (plugin_dir / ".mcp.json").write_text(
+                (repo_root / "plugins" / "unica" / ".mcp.json").read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+            module.write_packaged_mcp_launcher(plugin_dir)
+            server = json.loads((plugin_dir / ".mcp.json").read_text(encoding="utf-8"))[
+                "mcpServers"
+            ]["unica"]
+
+        self.assertIn("${CLAUDE_PLUGIN_ROOT}", server["args"][1])
+        self.assertIn("$PWD/${GIT_PREFIX:-}", server["args"][1])
+        self.assertEqual(
+            server["env"]["UNICA_RUNTIME_CACHE_DIR"], "${CLAUDE_PLUGIN_DATA}/runtimes"
+        )
+
+    def test_source_plugin_carries_a_manifest_for_every_host(self) -> None:
+        module = load_package_module()
+        repo_root = Path(__file__).resolve().parents[2]
+
+        module.assert_host_manifests_present(repo_root / "plugins" / "unica")
+
+        versions = {
+            host: json.loads(
+                (repo_root / "plugins" / "unica" / manifest_dir / "plugin.json").read_text(
+                    encoding="utf-8"
+                )
+            )["version"]
+            for host, manifest_dir in module.HOST_MANIFEST_DIRS.items()
+        }
+
+        self.assertEqual(len(set(versions.values())), 1, versions)
+
+    def test_claude_contracts_avoid_keys_older_clients_reject(self) -> None:
+        """Pin the key sets that decide whether an older client loads Unica at all.
+
+        Claude Code rejects an unrecognized manifest or catalog key outright on
+        releases that predate it, so a key added for a newer client makes the
+        plugin unloadable for everyone below that version. A current client only
+        warns, which is why this is asserted here instead of via `validate`.
+        """
+        module = load_package_module()
+        repo_root = Path(__file__).resolve().parents[2]
+        allowed_manifest_keys = {
+            "name",
+            "version",
+            "description",
+            "author",
+            "homepage",
+            "repository",
+            "license",
+            "keywords",
+        }
+        allowed_entry_keys = allowed_manifest_keys | {"source", "category", "tags"}
+        allowed_catalog_keys = {"name", "owner", "metadata", "plugins"}
+
+        manifest = json.loads(
+            (repo_root / "plugins/unica/.claude-plugin/plugin.json").read_text(encoding="utf-8")
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "unica"
+            (plugin_dir / ".claude-plugin").mkdir(parents=True)
+            (plugin_dir / ".claude-plugin" / "plugin.json").write_text(
+                json.dumps(manifest), encoding="utf-8"
+            )
+            catalog_path = Path(tmp) / "marketplace.json"
+            module.write_claude_marketplace(
+                plugin_dir,
+                catalog_path,
+                source=module.claude_plugin_source(release_tag="v0.9.1"),
+            )
+            catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(set(manifest) - allowed_manifest_keys, set())
+        self.assertEqual(set(catalog) - allowed_catalog_keys, set())
+        self.assertEqual(set(catalog["plugins"][0]) - allowed_entry_keys, set())
+        # Older clients only read the description from metadata.
+        self.assertIn("description", catalog["metadata"])
+
+    def test_claude_catalog_pins_the_release_tag(self) -> None:
+        module = load_package_module()
+
+        source = module.claude_plugin_source(release_tag="v1.2.3")
+
+        # The catalog on the marketplace default branch must keep naming a tag,
+        # so staged plugin bytes are not served before a promotion moves it.
+        self.assertEqual(source["ref"], "v1.2.3")
+        self.assertEqual(source["path"], "./plugins/unica")
+        self.assertEqual(source["source"], "git-subdir")
+
+    def test_claude_manifest_leaves_skill_discovery_to_the_default_scan(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        manifest = json.loads(
+            (repo_root / "plugins/unica/.claude-plugin/plugin.json").read_text(encoding="utf-8")
+        )
+
+        # Claude Code always scans skills/, and a manifest pointer would add the
+        # same directory a second time.
+        self.assertNotIn("skills", manifest)
+        self.assertNotIn("mcpServers", manifest)
+        self.assertEqual(manifest["name"], "unica")
+
     @unittest.skipIf(os.name == "nt", "selector fixture uses POSIX test scripts")
     def test_launch_script_selects_git_for_windows_native_bootstrap(self) -> None:
         repo_root = Path(__file__).resolve().parents[2]

--- a/tests/ci/test_product_contracts.py
+++ b/tests/ci/test_product_contracts.py
@@ -499,6 +499,16 @@ class ProductContractTests(unittest.TestCase):
             "marketplace/.claude-plugin/marketplace.json",
             publish,
         )
+        # Copying is not enough: an unstaged catalog would leave the promotion
+        # PR without the Claude entry while the copy assertion still passed.
+        self.assertIn(
+            "git -C marketplace add .agents/plugins/marketplace.json "
+            ".claude-plugin/marketplace.json",
+            publish,
+        )
+        # The gate is pinned to the compatibility floor, not to the latest CLI.
+        self.assertIn("@anthropic-ai/claude-code@${CLAUDE_CLI_VERSION}", release)
+        self.assertIn("CLAUDE_CLI_VERSION: 2.1.69", release)
         self.assertIn("claude plugin validate", release)
 
     def test_readme_documents_the_frozen_v078_bridge(self) -> None:

--- a/tests/ci/test_product_contracts.py
+++ b/tests/ci/test_product_contracts.py
@@ -338,12 +338,23 @@ class ProductContractTests(unittest.TestCase):
         release = (repo_root / ".github/workflows/unica-plugin-release.yml").read_text(
             encoding="utf-8"
         )
-        # Any concrete version, however quoted, is a location no contract check
-        # covers, and packaging fails on every later pull request once it drifts.
-        literals = sorted(set(re.findall(r"v\d+\.\d+\.\d+", release)))
+        # A hardcoded release version is a location no contract check covers, and
+        # packaging fails on every later pull request once it drifts. A tag-shaped
+        # literal is wrong anywhere in the file, however quoted, and this also
+        # catches suffixed forms such as v1.2.3-rc1 by matching their prefix.
+        tag_literals = sorted(set(re.findall(r"v\d+\.\d+\.\d+", release)))
+        # An unprefixed literal is only wrong inside the step that derives the
+        # tag, including in an intermediate variable it reads. The file elsewhere
+        # pins other tools by bare version, so this cannot be a whole-file rule.
+        step_name = "Resolve the release tag for non-tag builds"
+        start = release.find(step_name)
+        self.assertNotEqual(start, -1, "the workflow no longer derives the release tag")
+        following = re.search(r"(?m)^      - (name|uses|run):", release[start:])
+        step = release[start : start + following.start()] if following else release[start:]
+        unprefixed = sorted(set(re.findall(r"\d+\.\d+\.\d+", step)))
 
-        self.assertEqual(literals, [])
-        self.assertIn("Resolve the release tag for non-tag builds", release)
+        self.assertEqual(tag_literals, [])
+        self.assertEqual(unprefixed, [])
 
     def test_bump_version_writes_every_contract_location(self) -> None:
         repo_root = Path(__file__).resolve().parents[2]

--- a/tests/ci/test_product_contracts.py
+++ b/tests/ci/test_product_contracts.py
@@ -449,6 +449,58 @@ class ProductContractTests(unittest.TestCase):
             with self.subTest(value=value):
                 self.assertIn(value, readme)
 
+    def test_readme_documents_the_claude_marketplace_lifecycle(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        readme = (repo_root / "README.md").read_text(encoding="utf-8")
+
+        required = (
+            "claude plugin marketplace add IngvarConsulting/unica-marketplace",
+            "claude plugin install unica@unica",
+            "claude plugin marketplace update unica",
+            "claude plugin update unica@unica",
+            "claude plugin uninstall unica@unica",
+            "claude plugin marketplace remove unica",
+            "claude --plugin-dir ./plugins/unica",
+            # The floor is load-bearing: older clients cannot parse git-subdir.
+            "2.1.69",
+        )
+        for value in required:
+            with self.subTest(value=value):
+                self.assertIn(value, readme)
+
+    def test_claude_host_contract_is_recorded_for_agents(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        agents = (repo_root / "AGENTS.md").read_text(encoding="utf-8")
+        claude_md = (repo_root / "CLAUDE.md").read_text(encoding="utf-8")
+        decisions = (repo_root / "spec/decisions/README.md").read_text(encoding="utf-8")
+
+        self.assertIn("plugins/unica/.claude-plugin/plugin.json", agents)
+        self.assertIn("AGENTS.md", claude_md)
+        self.assertIn("0012-one-plugin-directory-for-two-hosts.md", decisions)
+        self.assertTrue(
+            (repo_root / "spec/decisions/0012-one-plugin-directory-for-two-hosts.md").is_file()
+        )
+
+    def test_publish_workflow_promotes_both_host_catalogs(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        publish = (repo_root / ".github/workflows/publish-unica-marketplace.yml").read_text(
+            encoding="utf-8"
+        )
+        release = (repo_root / ".github/workflows/unica-plugin-release.yml").read_text(
+            encoding="utf-8"
+        )
+
+        # Staging must carry both manifests, and promotion must move both
+        # catalogs together, or one host would be left pointing at a stale tag.
+        self.assertIn("payload/plugins/unica/.claude-plugin/plugin.json", publish)
+        self.assertIn("payload/.claude-plugin/marketplace.json", publish)
+        self.assertIn(
+            "cp payload/.claude-plugin/marketplace.json "
+            "marketplace/.claude-plugin/marketplace.json",
+            publish,
+        )
+        self.assertIn("claude plugin validate", release)
+
     def test_readme_documents_the_frozen_v078_bridge(self) -> None:
         repo_root = Path(__file__).resolve().parents[2]
         readme = (repo_root / "README.md").read_text(encoding="utf-8")

--- a/tests/ci/test_version_contract.py
+++ b/tests/ci/test_version_contract.py
@@ -29,6 +29,7 @@ class VersionContractTests(unittest.TestCase):
             {
                 "workspace": "0.9.1",
                 "plugin": "0.9.1",
+                "claude-plugin": "0.9.1",
                 "tools-lock-unica": "0.9.1",
             },
         )


### PR DESCRIPTION
Adds Claude Code as a second supported host, published from the same
`plugins/unica` directory and the same `unica-marketplace` repository as the
Codex package.

## Approach

Both hosts already agree on nearly everything: `skills/<name>/SKILL.md` layout,
`.mcp.json` at the plugin root, and the existing skill frontmatter. They differ
on which manifest directory they read and on how the MCP server locates its own
plugin root.

So instead of a package per host, both manifests sit side by side and one
launcher resolves the root from whichever host variable is present:

```
root="${CLAUDE_PLUGIN_ROOT}"; [ -n "$root" ] || root="$PWD/${GIT_PREFIX:-}"
```

Claude Code rewrites the token before the shell runs; Codex leaves it unset and
the original resolution applies. The bootstrap matrix ships once rather than
once per host, saving roughly 9 MB per marketplace release.

## What measurement decided

Three findings against a real client shaped this, rather than reading the docs
alone:

- A manifest-declared `mcpServers` path **adds to** the root `.mcp.json` instead
  of replacing it. Two host-specific MCP files in one directory would have
  started two servers under the same `unica` key. This is why the launcher is
  shared rather than split.
- An unrecognized manifest or catalog key is a **hard load error** on older
  clients, not a warning. `$schema` and `displayName` were dropped for this
  reason. Because a current client only warns, the allowed key sets are pinned
  by test rather than by `claude plugin validate`.
- `git-subdir` is unparsable before **2.1.69**, which sets the documented
  minimum. It is kept because it is the only source type that both pins to an
  immutable tag and addresses a subdirectory, so the ADR-0008 invariant holds
  for Claude too: each catalog keeps naming the previous tag until its promotion
  PR moves it.

## Changes

- `plugins/unica/.claude-plugin/plugin.json`, held at the same version as the
  Codex manifest by the version contract.
- Host-neutral packaged `.mcp.json`; runtime cache travels through
  `UNICA_RUNTIME_CACHE_DIR` so Claude Code uses `${CLAUDE_PLUGIN_DATA}`, which
  survives plugin updates. The bootstrap discards a value still containing `${`
  so a host that does not substitute the token cannot create a directory named
  after it.
- `.claude-plugin/marketplace.json` generated from the manifest, so there is no
  second hand-maintained catalog to drift.
- Staging requires both manifests; promotion moves both catalogs together.
- Release packaging gained a `claude plugin validate` gate.
- ADR-0012, `CLAUDE.md`, and Claude install/update/uninstall paths in both
  READMEs.

## Verification

- `327 passed, 3 skipped, 4639 subtests` under Python 3.12.
- `cargo test -p unica-bootstrap`, `cargo fmt --check`, `cargo clippy -D warnings`.
- `claude plugin validate` passes clean on both the source and packaged plugin
  directory.
- A test compares the new alias against the previous Codex form in the real
  marketplace layout and asserts they resolve the same root, so the Codex path
  is unchanged.

Not included: submission to the `claude-community` marketplace, which is
deliberately deferred until the own marketplace is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Claude Code plugin manifest and end-to-end packaging/publish/promotion for both Codex and Claude Code using a shared directory layout.
  - Added Claude marketplace generation and promotion flow updates, including correct `.claude-plugin` marketplace staging.
- **Bug Fixes**
  - Strengthened CI validations for required host/catalog contracts and version consistency.
  - Improved runtime cache root handling by ignoring unresolved `${...}` values.
- **Documentation**
  - Expanded Claude Code setup/upgrade/reload/uninstall and runtime/development guidance; updated host/manifest rules.
- **Tests**
  - Added/extended CI and unit tests covering marketplace promotion, packaged artifact validation, and alias/runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->