### PR TITLE
fix(ci): unblock the probe and make the release process self-advancing

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: release
+description: Publish a Unica version to the public marketplace, or resume a release that stalled part-way. Use when asked to cut, ship, promote, or finish a release, or when consumers still see an older version than the latest tag.
+argument-hint: [version, for example v0.9.2]
+---
+
+# Release Unica
+
+Follow [docs/release-runbook.md](../../../docs/release-runbook.md). It is the
+authoritative procedure; do not improvise an order.
+
+## Before anything
+
+Establish where the release already is, because most requests are to *resume*
+one rather than start one. Check in this order and enter the runbook at the
+first unfinished step:
+
+```bash
+gh release list --repo IngvarConsulting/unica --limit 3
+gh api repos/IngvarConsulting/unica-marketplace/tags --jq '.[0].name'
+gh pr list --repo IngvarConsulting/unica-marketplace --state open
+gh api repos/IngvarConsulting/unica-marketplace/contents/.agents/plugins/marketplace.json \
+  --jq '.content' | base64 -d | grep '"ref"'
+```
+
+A source release whose tag is newer than the catalog `ref` means the release is
+live for nobody. That is the common stall, and it is silent.
+
+## Rules
+
+- Never move or delete a published tag, and never force-push the marketplace
+  default branch.
+- Tag the staging merge commit, not the promotion commit. The promotion pull
+  request cannot go green before that tag exists.
+- Stop and ask before merging anything in `unica-marketplace` or creating a tag.
+  Those are the publishing steps and they are the user's call.
+- Signing is the user's: the key is theirs and the passphrase must not be handled
+  for them. If `gpg` fails with `Operation cancelled`, tell them to unlock it and
+  give them the exact tag command to run.
+- Report each step's verification output rather than asserting success.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -9,6 +9,18 @@ argument-hint: [version, for example v0.9.2]
 Follow [docs/release-runbook.md](../../../docs/release-runbook.md). It is the
 authoritative procedure; do not improvise an order.
 
+## Most of it is automated
+
+Release Warden merges the staging pull request, requests the promotion, and
+merges the promotion, each once its checks are green. The user's part is two
+tags: the source release tag and the marketplace tag. Before doing any of those
+steps by hand, check whether the warden is simply about to do it:
+
+```bash
+gh workflow run release-warden.yml --repo IngvarConsulting/unica -f dry_run=true
+gh run list --workflow "Release Warden" --repo IngvarConsulting/unica --limit 3
+```
+
 ## Before anything
 
 Establish where the release already is, because most requests are to *resume*

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -26,10 +26,19 @@ gh api repos/IngvarConsulting/unica-marketplace/contents/.agents/plugins/marketp
 A source release whose tag is newer than the catalog `ref` means the release is
 live for nobody. That is the common stall, and it is silent.
 
+## When something goes wrong
+
+Only the promotion merge is visible to consumers, so before it aborting just
+means closing a pull request. After step 1 a version is burnt: never re-cut it
+with different bytes, take the next patch instead. Rolling back a live release is
+a revert of the promotion commit, which is safe because published bytes never
+move. See the runbook's abort and rollback tables.
+
 ## Rules
 
 - Never move or delete a published tag, and never force-push the marketplace
-  default branch.
+  default branch. A catalog naming a missing tag breaks every install, and it is
+  the only genuinely corrupt state this process can reach.
 - Tag the staging merge commit, not the promotion commit. The promotion pull
   request cannot go green before that tag exists.
 - Stop and ask before merging anything in `unica-marketplace` or creating a tag.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -28,23 +28,33 @@ one rather than start one. Check in this order and enter the runbook at the
 first unfinished step:
 
 ```bash
-gh release list --repo IngvarConsulting/unica --limit 3
-gh api repos/IngvarConsulting/unica-marketplace/tags --jq '.[0].name'
+version=vX.Y.Z   # the version the user named, if they named one
+gh release view "$version" --repo IngvarConsulting/unica --json tagName,isPrerelease
+gh api "repos/IngvarConsulting/unica-marketplace/git/ref/tags/$version" || echo "no marketplace tag yet"
 gh pr list --repo IngvarConsulting/unica-marketplace --state open
 gh api repos/IngvarConsulting/unica-marketplace/contents/.agents/plugins/marketplace.json \
   --jq '.content' | base64 -d | grep '"ref"'
 ```
+
+If the user named a version, act on that one and stop if the open pull requests
+belong to a different version — resuming the wrong release is worse than asking.
+Without a named version, take the newest release that is not a prerelease.
 
 A source release whose tag is newer than the catalog `ref` means the release is
 live for nobody. That is the common stall, and it is silent.
 
 ## When something goes wrong
 
-Only the promotion merge is visible to consumers, so before it aborting just
-means closing a pull request. After step 1 a version is burnt: never re-cut it
-with different bytes, take the next patch instead. Rolling back a live release is
-a revert of the promotion commit, which is safe because published bytes never
-move. See the runbook's abort and rollback tables.
+Only the promotion merge is visible to consumers, so nothing before it needs
+undoing on their behalf. What cleanup is required depends on how far the release
+got, and the runbook's abort table is per step: closing a pull request is enough
+only while one is open, whereas a merged staging commit may need reverting and a
+published tag is left alone.
+
+Once assets are published the version is burnt. Never re-cut it with different
+bytes; take the next patch, and mark the abandoned release a prerelease so the
+warden stops reporting it as stalled. Rolling back a live release is a revert of
+the promotion commit, which is safe because published bytes never move.
 
 ## Rules
 

--- a/.github/workflows/publish-unica-marketplace.yml
+++ b/.github/workflows/publish-unica-marketplace.yml
@@ -110,8 +110,11 @@ jobs:
           git -C marketplace add .agents/plugins/marketplace.json
           git -C marketplace -c user.name=unica-release-bot -c user.email=actions@users.noreply.github.com \
             commit -m "promote: Unica ${RELEASE_TAG}"
-          promotion_sha="$(git -C marketplace rev-parse HEAD)"
           git -C marketplace push -u origin "$branch"
+          # The tag has to carry the plugin bytes, and the staging merge already
+          # does. Naming the promotion commit instead would demand a tag on a
+          # commit that does not exist until this step has run, which left the
+          # consumer install checks failing on their first run every release.
           gh pr create --repo IngvarConsulting/unica-marketplace --head "$branch" --base main \
             --title "Promote Unica ${RELEASE_TAG}" \
-            --body "Points the stable catalog at ${RELEASE_TAG}. Create the signed ${RELEASE_TAG} tag at commit ${promotion_sha} before merging this PR."
+            --body "Points the stable catalog at ${RELEASE_TAG}. Publish the signed ${RELEASE_TAG} tag at the staging merge commit ${STAGING_MERGE_SHA} before merging this PR; until it exists the consumer install checks cannot resolve the catalog ref. See docs/release-runbook.md."

--- a/.github/workflows/release-warden.yml
+++ b/.github/workflows/release-warden.yml
@@ -1,0 +1,45 @@
+name: Release Warden
+
+# A release crosses two repositories and waits on a human tag in the middle, so
+# it cannot be driven by a single job without either timing out or burning
+# minutes. This advances it one step whenever it can, and turns a stalled
+# release into a failed run instead of silence.
+
+on:
+  schedule:
+    - cron: "*/20 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Report the next action without taking it
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-warden
+  cancel-in-progress: false
+
+jobs:
+  advance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ secrets.UNICA_MARKETPLACE_TOKEN }}
+    steps:
+      - name: Require explicit cross-repository credential
+        run: test -n "$GH_TOKEN"
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      # A scheduled run reports a stall as a failure so it cannot go unnoticed;
+      # a manual run just describes the next action.
+      - name: Advance the release
+        run: >
+          python scripts/ci/release-warden.py
+          ${{ inputs.dry_run && '--dry-run' || '' }}
+          ${{ github.event_name == 'schedule' && '--alert-is-failure' || '' }}

--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -276,12 +276,22 @@ jobs:
     needs: build-tools
     if: ${{ always() && needs.build-tools.result == 'success' }}
     env:
-      RELEASE_TAG: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.ref_name || 'v0.9.1' }}
+      RELEASE_TAG: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+      # Packaging requires release.tag == v{pluginVersion}, so a non-tag build
+      # has to name the version in the tree. Deriving it keeps the version out of
+      # this file: a literal here is one more place to bump, and the only one no
+      # contract check covers.
+      - name: Resolve the release tag for non-tag builds
+        if: ${{ env.RELEASE_TAG == '' }}
+        run: |
+          set -euo pipefail
+          version="$(python -c 'import json; print(json.load(open("plugins/unica/.codex-plugin/plugin.json"))["version"])')"
+          echo "RELEASE_TAG=v${version}" >> "$GITHUB_ENV"
       - uses: actions/download-artifact@v8
         with:
           pattern: unica-runtime-metadata-*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,14 @@ When changing Unica, resolve conflicts in this order:
 3. `spec/` is the active architecture layer unless it contradicts live code, tests, or package metadata.
 4. `README.md` and skill prose
 
+## Releasing
+
+Publishing a version to the public marketplace follows
+`docs/release-runbook.md`. Read it before acting on any request to cut, ship,
+promote, or finish a release; the step order carries the ADR-0008 guarantee that
+the catalog never points at bytes that are not final, and improvising it exposes
+consumers to an unverified package.
+
 ## Search Hygiene
 
 Do not scan local ignored corpora as part of normal repo understanding:

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -231,14 +231,26 @@ already resolved it.
 
 ## Aborting
 
+Rows are named by the last step that completed.
+
 | Abort after | What to do | Cost |
 | --- | --- | --- |
-| 0 | Close the version pull request | none |
-| 1–2 | Leave the tag and assets in place, abandon the version, bump to the next patch | a burnt version number |
-| 3 staging pull request open | Close it | none |
-| 4 staging merged | Nothing is served. Either continue, or revert the staging commit on the marketplace default branch and abandon the version | none |
-| 5 marketplace tag pushed | Leave the tag, abandon the version. An unused tag is harmless | a burnt version number |
-| 6 promotion pull request open | Close it. The catalog is untouched | none |
+| Step 0 | Close the version pull request | none |
+| Step 1 or 2 | Close the staging pull request. Leave the tag and assets alone, abandon the version | a burnt version number |
+| Step 3 | Nothing is served. Either continue, or revert the staging commit on the marketplace default branch and abandon the version | none |
+| Step 4 | Leave the tag, abandon the version. An unused tag is harmless | a burnt version number |
+| Step 5 | Close the promotion pull request. The catalog is untouched | none |
+| Step 6 | The release is live; see [rolling back](#rolling-back-a-live-release) | consumers saw it |
+
+Whenever you abandon a version whose assets are already published, mark that
+release so the warden stops treating it as a release waiting to be served:
+
+```bash
+gh release edit vX.Y.Z --repo IngvarConsulting/unica --prerelease
+```
+
+Otherwise the scheduled run keeps reporting a stalled release, correctly but
+uselessly, until the next version ships.
 
 Never delete a tag to "clean up" an abandoned version. An unused tag costs
 nothing; a deleted one that something already resolved costs every consumer.
@@ -281,7 +293,8 @@ Protecting tags in the marketplace repository removes the first cause outright.
 | Promotion checks fail with `pathspec 'vX.Y.Z' did not match any file(s)` | The marketplace tag is missing | Do step 4, then `gh run rerun <run-id> --failed` |
 | `regression-policy` reports `consumer-fresh-install is required but concluded failure` | Aggregate gate reflecting the row above | Same as above |
 | Packaging fails with `release tag ... != ...` | Step 0 missed the workflow `RELEASE_TAG` fallback | Bump it and re-run |
-| `probe-thin-bootstrap` fails with `unexpectedly downloaded` | Pre-2026-07 behaviour, fixed by neutralising the checksum in the probe | Rebase onto a branch that contains the fix |
+| Scheduled warden run fails with `release is stalled` | A published release nothing is serving, and nothing open to advance | Finish the release, or mark it a prerelease if it was abandoned |
+| Warden reports `promotion pull request changes more than the catalog` | The promotion diff reached past the catalog files | Inspect it by hand; do not merge until it is explained |
 | Consumers still report the old version | Promotion was never merged | Check for an open promotion pull request |
 
 ## Never

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -30,6 +30,31 @@ the promotion checks install exactly as a consumer would. Those checks cannot
 pass until the tag exists, which makes the tag the natural approval gate: it is
 the one step that needs a human signing key.
 
+## What you do, and what runs itself
+
+**Release Warden** (`.github/workflows/release-warden.yml`) advances the release
+whenever it can. It runs every 20 minutes, merges the staging pull request once
+its checks are green, asks for the promotion, and merges the promotion once its
+checks are green. It cannot skip the tag: the promotion checks install through
+the catalog ref, so they stay red until the tag is published, which keeps the tag
+as the approval rather than a formality.
+
+That leaves two actions, both tags:
+
+| You | Warden |
+| --- | --- |
+| Step 0 — set the version | |
+| Step 1 — tag the source release | Steps 2–3: build, stage, merge staging |
+| Step 4 — tag the marketplace | Steps 5–6: promote, merge, go live |
+
+A scheduled run **fails** when a release is stalled with nothing to advance, so
+an unfinished publication surfaces within twenty minutes instead of sitting
+unnoticed. To see what it would do without acting, run it manually with
+`dry_run`.
+
+The steps below are still the source of truth for what happens and why, and they
+are what you follow by hand if the warden is disabled or itself broken.
+
 ## Preconditions
 
 - Write access to both repositories, and `gh` authenticated.
@@ -100,8 +125,9 @@ Note the run id — it is also encoded in the staging branch name
 
 ## Step 3 — merge the staging pull request
 
-Review that it changes `plugins/unica` only and that the catalog is untouched,
-then merge.
+**The warden does this** once the staging checks are green. Do it by hand only if
+the warden is disabled or failing. Review that it changes `plugins/unica` only
+and that the catalog is untouched, then merge.
 
 ```bash
 gh pr merge <staging-pr> --repo IngvarConsulting/unica-marketplace --merge
@@ -140,6 +166,10 @@ gh api "repos/IngvarConsulting/unica-marketplace/contents/plugins/unica/.codex-p
 
 ## Step 5 — promote
 
+**The warden does this** immediately after it merges staging, deriving the run id
+and the release tag from the staging branch name and the merge commit from the
+merge itself. Run it by hand only if the warden is disabled or failing.
+
 ```bash
 gh workflow run publish-unica-marketplace.yml --repo IngvarConsulting/unica \
   -f mode=promote \
@@ -154,6 +184,10 @@ previous stable, on macOS, Linux, and Windows. With the tag already pushed they
 pass on the first run.
 
 ## Step 6 — merge and verify
+
+**The warden does this** once the promotion checks are green, which cannot happen
+before step 4. It refuses to merge a promotion that touches anything beyond the
+catalog files. Verify the result either way.
 
 ```bash
 gh pr merge <promotion-pr> --repo IngvarConsulting/unica-marketplace --merge

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -40,27 +40,30 @@ the one step that needs a human signing key.
 
 ## Step 0 — prepare the version
 
-One commit bumps every place the version appears. `check-version-contract.py`
-covers most of them, but not all, so bump all of these together:
-
-| File | What changes |
-| --- | --- |
-| `Cargo.toml` | `workspace.package.version` (then refresh `Cargo.lock`) |
-| `plugins/unica/.codex-plugin/plugin.json` | `version` |
-| `plugins/unica/.claude-plugin/plugin.json` | `version` |
-| `plugins/unica/third-party/tools.lock.json` | the `unica` tool entry `version` |
-| `.github/workflows/unica-plugin-release.yml` | the `RELEASE_TAG` fallback used by non-tag builds |
-
-The workflow fallback is **not** covered by the version contract. If it is left
-behind, packaging fails on every later pull request with
-`release tag vX.Y.Z != vA.B.C`, because the runtime manifest requires
-`release.tag == v{pluginVersion}`.
-
-Verify, then merge through a pull request as usual:
+One command writes the version everywhere the package contract declares it, then
+runs the contract check:
 
 ```bash
-python3.12 scripts/ci/check-version-contract.py
+python3.12 scripts/dev/bump-version.py X.Y.Z
+cargo update --workspace --offline
 ```
+
+The version lives in several files because each is read by a different consumer:
+Cargo compiles it into the binaries, the two host manifests ship it to Codex and
+Claude Code, and the tools lock pins it beside the third-party tools. They are
+separate artifacts, so it cannot live in one file — but it is written by one
+command and enforced by one check,
+`scripts/ci/check-version-contract.py`, which fails the build if any of them
+drift apart.
+
+Tests that assert the current version still need updating by hand; they fail with
+an explicit diff, so run the suite before opening the pull request:
+
+```bash
+python3.12 -m unittest discover -s tests/ci
+```
+
+Then merge through a pull request as usual.
 
 ## Step 1 — tag the source release
 
@@ -160,6 +163,82 @@ gh api repos/IngvarConsulting/unica-marketplace/contents/.agents/plugins/marketp
 
 The release is live once the catalog names the new tag. Claude Code consumers
 read `.claude-plugin/marketplace.json`; check that entry too once it exists.
+
+## What consumers see, and when
+
+Only one step changes anything for consumers. Everything before it is invisible
+to them, which is what makes aborting cheap.
+
+| After step | Visible to consumers |
+| --- | --- |
+| 0 version prepared | nothing |
+| 1 source tag pushed | nothing |
+| 2 assets published | nothing — no catalog names them |
+| 3 staging merged | nothing — the catalog still names the previous tag |
+| 4 marketplace tag pushed | nothing |
+| 5 promotion pull request open | nothing |
+| **6 promotion merged** | **the release is live** |
+
+So this is not a distributed transaction that needs compensating steps. There is
+a single commit point, and before it "abort" means "stop and clean up".
+
+## One-way doors
+
+Two things can never be taken back once published, because other artifacts
+reference them by identity:
+
+- **Release assets** in `unica`. Runtime manifests pin them by SHA-256.
+- **Tags** in either repository. Consumers resolve `git-subdir` against them.
+
+This gives the rule that replaces rollback: **never reuse a version number**. If
+anything is wrong after step 1, abandon that version and release the next patch
+instead. Re-cutting `vX.Y.Z` with different bytes breaks every consumer that
+already resolved it.
+
+## Aborting
+
+| Abort after | What to do | Cost |
+| --- | --- | --- |
+| 0 | Close the version pull request | none |
+| 1–2 | Leave the tag and assets in place, abandon the version, bump to the next patch | a burnt version number |
+| 3 staging pull request open | Close it | none |
+| 4 staging merged | Nothing is served. Either continue, or revert the staging commit on the marketplace default branch and abandon the version | none |
+| 5 marketplace tag pushed | Leave the tag, abandon the version. An unused tag is harmless | a burnt version number |
+| 6 promotion pull request open | Close it. The catalog is untouched | none |
+
+Never delete a tag to "clean up" an abandoned version. An unused tag costs
+nothing; a deleted one that something already resolved costs every consumer.
+
+## Rolling back a live release
+
+Reverting is a one-file change, and it works because published bytes never move,
+so the previous tag still resolves to exactly what it always did.
+
+```bash
+git clone https://github.com/IngvarConsulting/unica-marketplace.git /tmp/unica-marketplace
+cd /tmp/unica-marketplace
+git revert --no-edit <promotion-merge-sha>
+git push origin main   # or open a pull request if the branch is protected
+```
+
+Confirm the catalog names the previous tag again, then treat the bad version as
+burnt and fix forward in the next patch. Consumers move back on their next
+update; those who already installed the bad version keep it until then, so
+prefer fixing forward when the fault is not severe.
+
+## The one state to avoid
+
+A catalog that names a tag which does not exist. Every install then fails with
+`pathspec 'vX.Y.Z' did not match any file(s)`, including for consumers who had
+been working fine.
+
+It has only two causes, both preventable:
+
+- deleting or moving a published tag;
+- merging a promotion pull request whose checks are red, since the consumer
+  install checks are exactly what proves the ref resolves.
+
+Protecting tags in the marketplace repository removes the first cause outright.
 
 ## Failure modes
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,180 @@
+# Release runbook
+
+How to publish a Unica version to the public marketplace, and why each step
+exists. Follow it top to bottom; every step states what to verify before moving
+on.
+
+Two repositories are involved:
+
+- `IngvarConsulting/unica` — source, runtime assets, release automation.
+- `IngvarConsulting/unica-marketplace` — the public catalog consumers install
+  from.
+
+## Why publication has two phases
+
+The catalog must never point at bytes that are not final. If it moved in the
+same step that published them, a partial or unverified upload would be served to
+every consumer immediately.
+
+So publication is split, per
+[ADR-0008](../spec/decisions/0008-public-marketplace-thin-runtime.md):
+
+1. **Stage** — put the plugin bytes on the marketplace default branch. The
+   catalog still names the previous tag, so no consumer is affected yet.
+2. **Promote** — move the catalog to the new tag. This is the moment the release
+   goes live.
+
+Between the two sits an immutable tag. The catalog pins `git-subdir` to a semver
+tag, which `scripts/verify_marketplace.py` in the marketplace repo enforces, and
+the promotion checks install exactly as a consumer would. Those checks cannot
+pass until the tag exists, which makes the tag the natural approval gate: it is
+the one step that needs a human signing key.
+
+## Preconditions
+
+- Write access to both repositories, and `gh` authenticated.
+- A GPG key able to sign tags. If signing fails with `Operation cancelled` in a
+  non-interactive shell, run `gpg-connect-agent updatestartuptty /bye` first, then
+  `echo test | gpg --clearsign > /dev/null` to unlock the agent.
+- The version to release is already merged to `main` and green.
+
+## Step 0 — prepare the version
+
+One commit bumps every place the version appears. `check-version-contract.py`
+covers most of them, but not all, so bump all of these together:
+
+| File | What changes |
+| --- | --- |
+| `Cargo.toml` | `workspace.package.version` (then refresh `Cargo.lock`) |
+| `plugins/unica/.codex-plugin/plugin.json` | `version` |
+| `plugins/unica/.claude-plugin/plugin.json` | `version` |
+| `plugins/unica/third-party/tools.lock.json` | the `unica` tool entry `version` |
+| `.github/workflows/unica-plugin-release.yml` | the `RELEASE_TAG` fallback used by non-tag builds |
+
+The workflow fallback is **not** covered by the version contract. If it is left
+behind, packaging fails on every later pull request with
+`release tag vX.Y.Z != vA.B.C`, because the runtime manifest requires
+`release.tag == v{pluginVersion}`.
+
+Verify, then merge through a pull request as usual:
+
+```bash
+python3.12 scripts/ci/check-version-contract.py
+```
+
+## Step 1 — tag the source release
+
+Tag the merged release commit on `main` in `unica` and push. The tag is what
+triggers the release build.
+
+```bash
+git tag -s vX.Y.Z <release-commit-sha> -m "Unica vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+The version must be fixed before artifacts are built: the runtime manifest
+embeds `release.tag` and derives every asset URL from it, and the bootstrap
+rejects a manifest whose URL disagrees with its declared version.
+
+## Step 2 — wait for the release build
+
+The tag push runs **Build Unica Codex Plugin**. It builds the runtime for the
+three targets, publishes `unica-runtime-<target>.tar.gz` with SHA-256 metadata to
+the GitHub release, and emits the thin marketplace payload as the
+`unica-thin-marketplace` artifact.
+
+On success it automatically opens a staging pull request in the marketplace
+repository. No manual trigger is needed.
+
+```bash
+gh run list --workflow "Build Unica Codex Plugin" --limit 3 \
+  --json databaseId,headBranch,conclusion
+gh pr list --repo IngvarConsulting/unica-marketplace --state open
+```
+
+Note the run id — it is also encoded in the staging branch name
+(`codex/stage-vX.Y.Z-<run-id>`), and the promote step needs it.
+
+## Step 3 — merge the staging pull request
+
+Review that it changes `plugins/unica` only and that the catalog is untouched,
+then merge.
+
+```bash
+gh pr merge <staging-pr> --repo IngvarConsulting/unica-marketplace --merge
+```
+
+Merging publishes nothing: the catalog still names the previous tag. Record the
+merge commit, the next step tags it.
+
+```bash
+gh pr view <staging-pr> --repo IngvarConsulting/unica-marketplace \
+  --json mergeCommit --jq .mergeCommit.oid
+```
+
+## Step 4 — tag the marketplace
+
+Tag the **staging merge commit**, before running the promotion.
+
+```bash
+git clone https://github.com/IngvarConsulting/unica-marketplace.git /tmp/unica-marketplace
+cd /tmp/unica-marketplace
+git tag -s vX.Y.Z <staging-merge-sha> -m "Unica vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+Consumers read the catalog from `main` and fetch only `./plugins/unica` at the
+tag, so the tag only has to carry the plugin bytes — which the staging merge
+already does. Tagging here rather than after the promotion pull request is what
+keeps that pull request green from the start.
+
+Verify the tag resolves to the payload:
+
+```bash
+gh api "repos/IngvarConsulting/unica-marketplace/contents/plugins/unica/.codex-plugin/plugin.json?ref=vX.Y.Z" \
+  --jq '.content' | base64 -d | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])'
+```
+
+## Step 5 — promote
+
+```bash
+gh workflow run publish-unica-marketplace.yml --repo IngvarConsulting/unica \
+  -f mode=promote \
+  -f source_run_id=<run-id-from-step-2> \
+  -f release_tag=vX.Y.Z \
+  -f staging_merge_sha=<staging-merge-sha>
+```
+
+This opens a pull request that changes only the catalog `ref`. Its checks
+install the plugin the way a consumer does — fresh install and upgrade from the
+previous stable, on macOS, Linux, and Windows. With the tag already pushed they
+pass on the first run.
+
+## Step 6 — merge and verify
+
+```bash
+gh pr merge <promotion-pr> --repo IngvarConsulting/unica-marketplace --merge
+gh api repos/IngvarConsulting/unica-marketplace/contents/.agents/plugins/marketplace.json \
+  --jq '.content' | base64 -d | grep '"ref"'
+```
+
+The release is live once the catalog names the new tag. Claude Code consumers
+read `.claude-plugin/marketplace.json`; check that entry too once it exists.
+
+## Failure modes
+
+| Symptom | Cause | Action |
+| --- | --- | --- |
+| Promotion checks fail with `pathspec 'vX.Y.Z' did not match any file(s)` | The marketplace tag is missing | Do step 4, then `gh run rerun <run-id> --failed` |
+| `regression-policy` reports `consumer-fresh-install is required but concluded failure` | Aggregate gate reflecting the row above | Same as above |
+| Packaging fails with `release tag ... != ...` | Step 0 missed the workflow `RELEASE_TAG` fallback | Bump it and re-run |
+| `probe-thin-bootstrap` fails with `unexpectedly downloaded` | Pre-2026-07 behaviour, fixed by neutralising the checksum in the probe | Rebase onto a branch that contains the fix |
+| Consumers still report the old version | Promotion was never merged | Check for an open promotion pull request |
+
+## Never
+
+- Move or delete a published tag, or force-push the marketplace default branch.
+  Consumers resolve `git-subdir` against those refs; changed bytes require a new
+  version.
+- Merge the promotion pull request before its checks are green. Red here means
+  the consumer install path is broken, not that the checks are wrong.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -27,8 +27,12 @@ So publication is split, per
 Between the two sits an immutable tag. The catalog pins `git-subdir` to a semver
 tag, which `scripts/verify_marketplace.py` in the marketplace repo enforces, and
 the promotion checks install exactly as a consumer would. Those checks cannot
-pass until the tag exists, which makes the tag the natural approval gate: it is
-the one step that needs a human signing key.
+pass until the tag exists, which makes the tag the approval gate.
+
+A release signs two tags, and they do different jobs. The **source tag** in
+`unica` (step 1) starts the build and fixes the version the artifacts declare.
+The **marketplace tag** (step 4) is the one the catalog resolves, and it is the
+gate: nothing reaches consumers until it exists.
 
 ## What you do, and what runs itself
 
@@ -57,11 +61,12 @@ are what you follow by hand if the warden is disabled or itself broken.
 
 ## Preconditions
 
-- Write access to both repositories, and `gh` authenticated.
+- Write access to both repositories, and `gh` authenticated. The tag steps push
+  over HTTPS, so run `gh auth setup-git` once in a fresh checkout.
 - A GPG key able to sign tags. If signing fails with `Operation cancelled` in a
   non-interactive shell, run `gpg-connect-agent updatestartuptty /bye` first, then
   `echo test | gpg --clearsign > /dev/null` to unlock the agent.
-- The version to release is already merged to `main` and green.
+- `main` is green, and the version bump is ready to verify and merge.
 
 ## Step 0 — prepare the version
 
@@ -169,6 +174,11 @@ gh api "repos/IngvarConsulting/unica-marketplace/contents/plugins/unica/.codex-p
 **The warden does this** immediately after it merges staging, deriving the run id
 and the release tag from the staging branch name and the merge commit from the
 merge itself. Run it by hand only if the warden is disabled or failing.
+
+Order differs between the two paths, and both are fine. By hand, tagging first
+means the promotion pull request is green on its first run. The warden opens it
+as soon as staging lands, so it sits red until you publish the tag and then goes
+green on the next run. Either way nothing merges before the tag exists.
 
 ```bash
 gh workflow run publish-unica-marketplace.yml --repo IngvarConsulting/unica \

--- a/scripts/ci/release-warden.py
+++ b/scripts/ci/release-warden.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Advance or report a release that is part-way through publication.
+
+The release is a two-phase publication, and every phase boundary used to be a
+manual step. Those steps are mechanical, but the waiting between them is not
+bounded: the marketplace tag is a human decision that may arrive hours later. A
+job that waited would either time out or burn minutes, so this runs on a
+schedule instead and moves the release one step whenever it can.
+
+The state machine is deliberately small:
+
+    catalog ref == latest release      -> nothing in flight
+    staging pull request, all green    -> merge it, then ask for promotion
+    promotion pull request, all green  -> merge it, the release goes live
+    anything else                      -> report what is being waited on
+
+Green is the gate everywhere. A promotion pull request cannot be green until the
+marketplace tag exists, because its checks install through the catalog ref, so
+merging on green keeps the tag as the human approval rather than bypassing it.
+The marketplace default branch has no protection rules, so the greenness check
+here is the only gate and must never be relaxed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from typing import Sequence
+
+
+MARKETPLACE = "IngvarConsulting/unica-marketplace"
+SOURCE = "IngvarConsulting/unica"
+CATALOG_PATHS = {
+    ".agents/plugins/marketplace.json",
+    ".claude-plugin/marketplace.json",
+}
+STAGE_BRANCH = re.compile(r"^codex/stage-(v\d+\.\d+\.\d+)-(\d+)$")
+PROMOTE_BRANCH = re.compile(r"^codex/promote-(v\d+\.\d+\.\d+)-(\d+)$")
+PENDING_STATES = {"PENDING", "QUEUED", "IN_PROGRESS", "WAITING", "REQUESTED", None, ""}
+PASSING_CONCLUSIONS = {"SUCCESS", "NEUTRAL", "SKIPPED"}
+
+
+@dataclass(frozen=True)
+class PullRequest:
+    number: int
+    branch: str
+    files: tuple[str, ...]
+    checks: tuple[tuple[str, str | None, str | None], ...]  # name, status, conclusion
+
+    @property
+    def release_tag(self) -> str | None:
+        match = STAGE_BRANCH.match(self.branch) or PROMOTE_BRANCH.match(self.branch)
+        return match.group(1) if match else None
+
+    @property
+    def source_run_id(self) -> str | None:
+        match = STAGE_BRANCH.match(self.branch) or PROMOTE_BRANCH.match(self.branch)
+        return match.group(2) if match else None
+
+    def blocking_checks(self) -> list[str]:
+        blocking = []
+        for name, status, conclusion in self.checks:
+            if status is not None and status.upper() in PENDING_STATES and conclusion is None:
+                blocking.append(f"{name}: pending")
+            elif conclusion is not None and conclusion.upper() not in PASSING_CONCLUSIONS:
+                blocking.append(f"{name}: {conclusion.lower()}")
+        return blocking
+
+    def is_green(self) -> bool:
+        return bool(self.checks) and not self.blocking_checks()
+
+
+@dataclass(frozen=True)
+class ReleaseState:
+    latest_release: str | None
+    catalog_ref: str | None
+    stage_pr: PullRequest | None = None
+    promote_pr: PullRequest | None = None
+
+
+@dataclass(frozen=True)
+class Action:
+    kind: str  # noop | merge-stage | merge-promote | wait | alert
+    detail: str
+    pull_request: int | None = None
+    context: dict[str, str] = field(default_factory=dict)
+
+
+def decide(state: ReleaseState) -> Action:
+    if state.latest_release is None:
+        return Action("alert", "no published source release found")
+    if state.catalog_ref == state.latest_release:
+        return Action("noop", f"catalog already serves {state.latest_release}")
+
+    detail_suffix = f"catalog serves {state.catalog_ref}, latest release is {state.latest_release}"
+
+    stage = state.stage_pr
+    if stage is not None:
+        if not stage.is_green():
+            return Action(
+                "wait",
+                f"staging checks are not green: {', '.join(stage.blocking_checks())}",
+                stage.number,
+            )
+        return Action(
+            "merge-stage",
+            f"staging is green, merging so the payload lands; {detail_suffix}",
+            stage.number,
+            {"release_tag": stage.release_tag or "", "source_run_id": stage.source_run_id or ""},
+        )
+
+    promote = state.promote_pr
+    if promote is not None:
+        unexpected = sorted(set(promote.files) - CATALOG_PATHS)
+        if unexpected:
+            return Action(
+                "alert",
+                f"promotion pull request changes more than the catalog: {', '.join(unexpected)}",
+                promote.number,
+            )
+        blocking = promote.blocking_checks()
+        if blocking:
+            # The install checks resolve the catalog ref, so they cannot pass
+            # before the marketplace tag is published. That is the human gate.
+            return Action(
+                "wait",
+                f"promotion is waiting for the {promote.release_tag} tag or a green run: "
+                f"{', '.join(blocking)}",
+                promote.number,
+            )
+        return Action(
+            "merge-promote",
+            f"promotion is green, publishing {promote.release_tag}",
+            promote.number,
+        )
+
+    return Action("alert", f"release is stalled with no open pull request; {detail_suffix}")
+
+
+def gh_json(args: Sequence[str]) -> object:
+    result = subprocess.run(
+        ["gh", *args], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+    )
+    return json.loads(result.stdout or "null")
+
+
+def load_pull_request(entry: dict) -> PullRequest:
+    checks = tuple(
+        (
+            item.get("name") or item.get("context") or "check",
+            item.get("status"),
+            item.get("conclusion") or item.get("state"),
+        )
+        for item in entry.get("statusCheckRollup") or []
+    )
+    return PullRequest(
+        number=entry["number"],
+        branch=entry["headRefName"],
+        files=tuple(item["path"] for item in entry.get("files") or []),
+        checks=checks,
+    )
+
+
+def observe() -> ReleaseState:
+    releases = gh_json(["release", "list", "--repo", SOURCE, "--limit", "1", "--json", "tagName"])
+    latest = releases[0]["tagName"] if releases else None
+
+    catalog = subprocess.run(
+        [
+            "gh",
+            "api",
+            f"repos/{MARKETPLACE}/contents/.agents/plugins/marketplace.json",
+            "--jq",
+            ".content",
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout
+    import base64
+
+    entry = json.loads(base64.b64decode(catalog))["plugins"][0]
+    catalog_ref = entry.get("source", {}).get("ref")
+
+    open_prs = gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            MARKETPLACE,
+            "--state",
+            "open",
+            "--json",
+            "number,headRefName,files,statusCheckRollup",
+        ]
+    )
+    stage_pr = None
+    promote_pr = None
+    for item in open_prs or []:
+        pull = load_pull_request(item)
+        if STAGE_BRANCH.match(pull.branch):
+            stage_pr = pull
+        elif PROMOTE_BRANCH.match(pull.branch):
+            promote_pr = pull
+
+    return ReleaseState(latest, catalog_ref, stage_pr, promote_pr)
+
+
+def apply(action: Action, *, dry_run: bool) -> None:
+    if dry_run or action.pull_request is None:
+        return
+    if action.kind == "merge-stage":
+        subprocess.run(
+            ["gh", "pr", "merge", str(action.pull_request), "--repo", MARKETPLACE, "--merge"],
+            check=True,
+        )
+        merge_sha = gh_json(
+            [
+                "pr",
+                "view",
+                str(action.pull_request),
+                "--repo",
+                MARKETPLACE,
+                "--json",
+                "mergeCommit",
+            ]
+        )["mergeCommit"]["oid"]
+        subprocess.run(
+            [
+                "gh",
+                "workflow",
+                "run",
+                "publish-unica-marketplace.yml",
+                "--repo",
+                SOURCE,
+                "-f",
+                "mode=promote",
+                "-f",
+                f"source_run_id={action.context['source_run_id']}",
+                "-f",
+                f"release_tag={action.context['release_tag']}",
+                "-f",
+                f"staging_merge_sha={merge_sha}",
+            ],
+            check=True,
+        )
+    elif action.kind == "merge-promote":
+        subprocess.run(
+            ["gh", "pr", "merge", str(action.pull_request), "--repo", MARKETPLACE, "--merge"],
+            check=True,
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--alert-is-failure",
+        action="store_true",
+        help="exit non-zero on alert, so a stalled release surfaces as a failed run",
+    )
+    args = parser.parse_args()
+
+    action = decide(observe())
+    print(f"{action.kind}: {action.detail}")
+    apply(action, dry_run=args.dry_run)
+    if action.kind == "alert" and args.alert_is_failure:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/release-warden.py
+++ b/scripts/ci/release-warden.py
@@ -141,6 +141,22 @@ def decide(state: ReleaseState) -> Action:
     return Action("alert", f"release is stalled with no open pull request; {detail_suffix}")
 
 
+def latest_servable_release(releases: Sequence[dict]) -> str | None:
+    """The newest release that is meant to reach consumers.
+
+    Abandoning a version is a legitimate outcome: once its assets are published
+    the number is burnt and the next patch is cut instead. Without a way to say
+    so, the warden would compare the catalog against a version nobody intends to
+    serve and alert forever. Marking the release as a draft or prerelease is that
+    signal, and it uses a field GitHub already has rather than a marker file.
+    """
+    for release in releases:
+        if release.get("isDraft") or release.get("isPrerelease"):
+            continue
+        return release.get("tagName")
+    return None
+
+
 def gh_json(args: Sequence[str]) -> object:
     result = subprocess.run(
         ["gh", *args], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
@@ -166,8 +182,19 @@ def load_pull_request(entry: dict) -> PullRequest:
 
 
 def observe() -> ReleaseState:
-    releases = gh_json(["release", "list", "--repo", SOURCE, "--limit", "1", "--json", "tagName"])
-    latest = releases[0]["tagName"] if releases else None
+    releases = gh_json(
+        [
+            "release",
+            "list",
+            "--repo",
+            SOURCE,
+            "--limit",
+            "10",
+            "--json",
+            "tagName,isDraft,isPrerelease",
+        ]
+    )
+    latest = latest_servable_release(releases or [])
 
     catalog = subprocess.run(
         [

--- a/scripts/ci/smoke-unica-bootstrap.py
+++ b/scripts/ci/smoke-unica-bootstrap.py
@@ -4,11 +4,46 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+
+# Valid as a manifest value, but no archive can ever hash to it.
+UNMATCHABLE_SHA256 = "0" * 64
+
+
+def neutralise_published_checksums(manifest_path: Path) -> str:
+    """Make the manifest describe runtime bytes that cannot exist, and return the original text.
+
+    A pull-request package is built with the release tag of the version in the
+    tree, and the manifest is self-consistent by design: `release.tag` must equal
+    `v{pluginVersion}` and the asset URL must match that tag, so the probe cannot
+    simply point it at an unpublished tag.
+
+    Once that version is released, a pull request that does not change the
+    runtime rebuilds byte-identical archives, the checksums match the published
+    assets, and the download the probe expects to fail succeeds instead. Only
+    hosts whose builds are not byte-reproducible, currently win-x64, kept
+    failing by accident.
+
+    Replacing the archive checksum removes that dependency on release state: the
+    bootstrap either cannot fetch the asset or rejects the bytes it fetched, and
+    both are the controlled failure this probe asserts.
+    """
+    if not manifest_path.is_file():
+        raise SystemExit(f"packaged runtime manifest is missing: {manifest_path}")
+    original = manifest_path.read_text(encoding="utf-8")
+    manifest = json.loads(original)
+    for runtime in manifest.get("targets", {}).values():
+        runtime["asset"]["sha256"] = UNMATCHABLE_SHA256
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    return original
 
 
 def consumer_path(target: str) -> str:
@@ -39,6 +74,11 @@ def smoke(
     if target != "win-x64":
         bootstrap.chmod(bootstrap.stat().st_mode | 0o755)
 
+    manifest_path = plugin_root / "runtime-manifest.json"
+    original_manifest = (
+        neutralise_published_checksums(manifest_path) if expect_download_failure else None
+    )
+
     with tempfile.TemporaryDirectory(prefix="unica-bootstrap-smoke-") as directory:
         root = Path(directory)
         environment = os.environ.copy()
@@ -60,13 +100,20 @@ def smoke(
             raise SystemExit(
                 f"packaged bootstrap smoke timed out after {timeout_seconds:g}s"
             ) from error
+        finally:
+            # The payload is a shared CI artifact; later jobs must still see the
+            # manifest the packaging step produced.
+            if original_manifest is not None:
+                manifest_path.write_text(original_manifest, encoding="utf-8")
 
     detail = "\n".join(part.strip() for part in (result.stderr, result.stdout) if part.strip())
     if "overflowed its stack" in detail:
         raise SystemExit(f"packaged bootstrap overflowed its stack: {detail}")
     if expect_download_failure:
         if result.returncode == 0:
-            raise SystemExit("packaged bootstrap unexpectedly downloaded an unpublished runtime")
+            raise SystemExit(
+                "packaged bootstrap accepted a runtime archive whose checksum was neutralised"
+            )
         controlled_failure = any(
             marker in detail
             for marker in ("failed to download", "runtime archive sha256")

--- a/scripts/ci/smoke-unica-bootstrap.py
+++ b/scripts/ci/smoke-unica-bootstrap.py
@@ -79,32 +79,34 @@ def smoke(
         neutralise_published_checksums(manifest_path) if expect_download_failure else None
     )
 
-    with tempfile.TemporaryDirectory(prefix="unica-bootstrap-smoke-") as directory:
-        root = Path(directory)
-        environment = os.environ.copy()
-        environment["CODEX_HOME"] = str(root / "codex-home")
-        environment["UNICA_RUNTIME_CACHE_DIR"] = str(root / "runtime-cache")
-        environment["PATH"] = consumer_path(target)
-        if shutil.which("node", path=environment["PATH"]):
-            raise SystemExit("Node.js leaked into the bootstrap consumer PATH")
-        try:
-            result = subprocess.run(
-                [str(bootstrap), "verify", "--plugin-root", str(plugin_root)],
-                capture_output=True,
-                text=True,
-                timeout=timeout_seconds,
-                check=False,
-                env=environment,
-            )
-        except subprocess.TimeoutExpired as error:
-            raise SystemExit(
-                f"packaged bootstrap smoke timed out after {timeout_seconds:g}s"
-            ) from error
-        finally:
-            # The payload is a shared CI artifact; later jobs must still see the
-            # manifest the packaging step produced.
-            if original_manifest is not None:
-                manifest_path.write_text(original_manifest, encoding="utf-8")
+    # Every exit from here restores the manifest, including the consumer-PATH
+    # guard below, which raises before the probe ever starts. The payload is a
+    # build artifact other steps read, so it must not be left neutralised.
+    try:
+        with tempfile.TemporaryDirectory(prefix="unica-bootstrap-smoke-") as directory:
+            root = Path(directory)
+            environment = os.environ.copy()
+            environment["CODEX_HOME"] = str(root / "codex-home")
+            environment["UNICA_RUNTIME_CACHE_DIR"] = str(root / "runtime-cache")
+            environment["PATH"] = consumer_path(target)
+            if shutil.which("node", path=environment["PATH"]):
+                raise SystemExit("Node.js leaked into the bootstrap consumer PATH")
+            try:
+                result = subprocess.run(
+                    [str(bootstrap), "verify", "--plugin-root", str(plugin_root)],
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout_seconds,
+                    check=False,
+                    env=environment,
+                )
+            except subprocess.TimeoutExpired as error:
+                raise SystemExit(
+                    f"packaged bootstrap smoke timed out after {timeout_seconds:g}s"
+                ) from error
+    finally:
+        if original_manifest is not None:
+            manifest_path.write_text(original_manifest, encoding="utf-8")
 
     detail = "\n".join(part.strip() for part in (result.stderr, result.stdout) if part.strip())
     if "overflowed its stack" in detail:

--- a/scripts/dev/bump-version.py
+++ b/scripts/dev/bump-version.py
@@ -24,8 +24,7 @@ from pathlib import Path
 SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
 
 
-def set_cargo_version(path: Path, version: str) -> bool:
-    original = path.read_text(encoding="utf-8")
+def render_cargo_version(original: str, version: str, path: Path) -> str:
     # Only the workspace package version, never a dependency's version field.
     updated, count = re.subn(
         r'(?m)^(\[workspace\.package\](?:\n(?!\[).*)*?\nversion = ")[^"]+(")',
@@ -35,49 +34,53 @@ def set_cargo_version(path: Path, version: str) -> bool:
     )
     if count != 1:
         raise SystemExit(f"could not locate workspace.package.version in {path}")
-    return write_if_changed(path, original, updated)
+    return updated
 
 
-def set_json_version(path: Path, version: str) -> bool:
-    original = path.read_text(encoding="utf-8")
+def render_json_version(original: str, version: str, path: Path) -> str:
     data = json.loads(original)
     data["version"] = version
-    return write_if_changed(path, original, json.dumps(data, ensure_ascii=False, indent=2) + "\n")
+    return json.dumps(data, ensure_ascii=False, indent=2) + "\n"
 
 
-def set_tools_lock_version(path: Path, version: str) -> bool:
-    original = path.read_text(encoding="utf-8")
+def render_tools_lock_version(original: str, version: str, path: Path) -> str:
     data = json.loads(original)
     entries = [tool for tool in data.get("tools", []) if tool.get("name") == "unica"]
     if len(entries) != 1:
         raise SystemExit(f"expected exactly one unica entry in {path}, found {len(entries)}")
     entries[0]["version"] = version
-    return write_if_changed(path, original, json.dumps(data, ensure_ascii=False, indent=2) + "\n")
-
-
-def write_if_changed(path: Path, original: str, updated: str) -> bool:
-    if original == updated:
-        return False
-    path.write_text(updated, encoding="utf-8")
-    return True
+    return json.dumps(data, ensure_ascii=False, indent=2) + "\n"
 
 
 def bump(repo_root: Path, version: str) -> list[str]:
+    """Render every file first, then write.
+
+    A malformed file part-way through the list would otherwise leave the
+    repository straddling two versions, which is the exact state the version
+    contract exists to forbid. Rendering everything before touching disk keeps a
+    failure a no-op.
+    """
     plugin = repo_root / "plugins" / "unica"
     targets = [
-        (repo_root / "Cargo.toml", set_cargo_version),
-        (plugin / ".codex-plugin" / "plugin.json", set_json_version),
-        (plugin / ".claude-plugin" / "plugin.json", set_json_version),
-        (plugin / "third-party" / "tools.lock.json", set_tools_lock_version),
+        (repo_root / "Cargo.toml", render_cargo_version),
+        (plugin / ".codex-plugin" / "plugin.json", render_json_version),
+        (plugin / ".claude-plugin" / "plugin.json", render_json_version),
+        (plugin / "third-party" / "tools.lock.json", render_tools_lock_version),
     ]
-    changed = []
-    for path, setter in targets:
+
+    pending = []
+    for path, render in targets:
         if not path.is_file():
             # A host manifest may legitimately not exist yet on older branches.
             continue
-        if setter(path, version):
-            changed.append(path.relative_to(repo_root).as_posix())
-    return changed
+        original = path.read_text(encoding="utf-8")
+        updated = render(original, version, path)
+        if original != updated:
+            pending.append((path, updated))
+
+    for path, updated in pending:
+        path.write_text(updated, encoding="utf-8")
+    return [path.relative_to(repo_root).as_posix() for path, _ in pending]
 
 
 def main() -> int:

--- a/scripts/dev/bump-version.py
+++ b/scripts/dev/bump-version.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Set the Unica release version everywhere the package contract declares it.
+
+The version appears in several files because each one is read by a different
+consumer: Cargo compiles it into the binaries, the two host manifests ship it to
+Codex and Claude Code, and the tools lock pins it alongside the third-party
+tools. They are separate artifacts, so the version cannot live in one file, but
+it can be written by one command and verified by one check.
+
+`scripts/ci/check-version-contract.py` is the gate; this script is the way to
+satisfy it without editing files by hand.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def set_cargo_version(path: Path, version: str) -> bool:
+    original = path.read_text(encoding="utf-8")
+    # Only the workspace package version, never a dependency's version field.
+    updated, count = re.subn(
+        r'(?m)^(\[workspace\.package\](?:\n(?!\[).*)*?\nversion = ")[^"]+(")',
+        rf"\g<1>{version}\g<2>",
+        original,
+        count=1,
+    )
+    if count != 1:
+        raise SystemExit(f"could not locate workspace.package.version in {path}")
+    return write_if_changed(path, original, updated)
+
+
+def set_json_version(path: Path, version: str) -> bool:
+    original = path.read_text(encoding="utf-8")
+    data = json.loads(original)
+    data["version"] = version
+    return write_if_changed(path, original, json.dumps(data, ensure_ascii=False, indent=2) + "\n")
+
+
+def set_tools_lock_version(path: Path, version: str) -> bool:
+    original = path.read_text(encoding="utf-8")
+    data = json.loads(original)
+    entries = [tool for tool in data.get("tools", []) if tool.get("name") == "unica"]
+    if len(entries) != 1:
+        raise SystemExit(f"expected exactly one unica entry in {path}, found {len(entries)}")
+    entries[0]["version"] = version
+    return write_if_changed(path, original, json.dumps(data, ensure_ascii=False, indent=2) + "\n")
+
+
+def write_if_changed(path: Path, original: str, updated: str) -> bool:
+    if original == updated:
+        return False
+    path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def bump(repo_root: Path, version: str) -> list[str]:
+    plugin = repo_root / "plugins" / "unica"
+    targets = [
+        (repo_root / "Cargo.toml", set_cargo_version),
+        (plugin / ".codex-plugin" / "plugin.json", set_json_version),
+        (plugin / ".claude-plugin" / "plugin.json", set_json_version),
+        (plugin / "third-party" / "tools.lock.json", set_tools_lock_version),
+    ]
+    changed = []
+    for path, setter in targets:
+        if not path.is_file():
+            # A host manifest may legitimately not exist yet on older branches.
+            continue
+        if setter(path, version):
+            changed.append(path.relative_to(repo_root).as_posix())
+    return changed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version", help="release version without the leading v, for example 0.9.2")
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    args = parser.parse_args()
+
+    version = args.version.removeprefix("v")
+    if not SEMVER.fullmatch(version):
+        raise SystemExit(f"version must be MAJOR.MINOR.PATCH, got {args.version}")
+
+    repo_root = args.repo_root.resolve()
+    changed = bump(repo_root, version)
+    for path in changed:
+        print(f"updated {path}")
+    if not changed:
+        print(f"already at {version}")
+
+    print("refresh Cargo.lock with: cargo update --workspace --offline")
+    contract = subprocess.run(
+        [sys.executable, "scripts/ci/check-version-contract.py", "--expected", version],
+        cwd=repo_root,
+        check=False,
+    )
+    return contract.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/test_product_contracts.py
+++ b/tests/ci/test_product_contracts.py
@@ -289,6 +289,40 @@ class ProductContractTests(unittest.TestCase):
             "https://ingvar.pro/products/unica/terms/en",
         )
 
+    def test_release_runbook_is_discoverable_and_names_the_tag_target(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        runbook = repo_root / "docs/release-runbook.md"
+        agents = (repo_root / "AGENTS.md").read_text(encoding="utf-8")
+        skill = (repo_root / ".claude/skills/release/SKILL.md").read_text(encoding="utf-8")
+
+        self.assertTrue(runbook.is_file())
+        # An agent asked to release has to reach the runbook from the entry point
+        # rather than reconstruct the order from the workflows.
+        self.assertIn("docs/release-runbook.md", agents)
+        self.assertIn("docs/release-runbook.md", skill)
+
+        text = runbook.read_text(encoding="utf-8")
+        for value in (
+            "staging merge commit",
+            "RELEASE_TAG",
+            "check-version-contract.py",
+            "publish-unica-marketplace.yml",
+        ):
+            with self.subTest(value=value):
+                self.assertIn(value, text)
+
+    def test_promotion_pr_points_the_tag_at_the_staging_merge(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        publish = (repo_root / ".github/workflows/publish-unica-marketplace.yml").read_text(
+            encoding="utf-8"
+        )
+
+        # Naming the promotion commit would require tagging a commit that does
+        # not exist until the promotion step has already run, which leaves the
+        # consumer install checks red on their first run every release.
+        self.assertIn("staging merge commit ${STAGING_MERGE_SHA}", publish)
+        self.assertNotIn("tag at commit ${promotion_sha}", publish)
+
     def test_readme_documents_public_marketplace_lifecycle(self) -> None:
         repo_root = Path(__file__).resolve().parents[2]
         readme = (repo_root / "README.md").read_text(encoding="utf-8")

--- a/tests/ci/test_product_contracts.py
+++ b/tests/ci/test_product_contracts.py
@@ -338,13 +338,11 @@ class ProductContractTests(unittest.TestCase):
         release = (repo_root / ".github/workflows/unica-plugin-release.yml").read_text(
             encoding="utf-8"
         )
-        version = json.loads(
-            (repo_root / "plugins/unica/.codex-plugin/plugin.json").read_text(encoding="utf-8")
-        )["version"]
+        # Any concrete version, however quoted, is a location no contract check
+        # covers, and packaging fails on every later pull request once it drifts.
+        literals = sorted(set(re.findall(r"v\d+\.\d+\.\d+", release)))
 
-        # A literal here would be a version location no contract check covers,
-        # and packaging fails on every later pull request when it drifts.
-        self.assertNotIn(f"'v{version}'", release)
+        self.assertEqual(literals, [])
         self.assertIn("Resolve the release tag for non-tag builds", release)
 
     def test_bump_version_writes_every_contract_location(self) -> None:
@@ -374,11 +372,51 @@ class ProductContractTests(unittest.TestCase):
                 target.write_text(
                     (repo_root / relative).read_text(encoding="utf-8"), encoding="utf-8"
                 )
+            # Synthesised rather than copied so the Claude manifest is covered on
+            # branches that do not carry it yet.
+            claude = work / "plugins/unica/.claude-plugin/plugin.json"
+            claude.parent.mkdir(parents=True, exist_ok=True)
+            claude.write_text(
+                json.dumps({"name": "unica", "version": "0.0.0"}) + "\n", encoding="utf-8"
+            )
 
-            module.bump(work, "9.8.7")
+            changed = module.bump(work, "9.8.7")
             values = contract_module.read_version_contract(work)
+            claude_version = json.loads(claude.read_text(encoding="utf-8"))["version"]
 
         self.assertEqual(set(values.values()), {"9.8.7"}, values)
+        self.assertEqual(claude_version, "9.8.7")
+        self.assertIn("plugins/unica/.claude-plugin/plugin.json", changed)
+
+    def test_bump_version_writes_nothing_when_a_later_file_is_malformed(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        module_path = repo_root / "scripts" / "dev" / "bump-version.py"
+        spec = importlib.util.spec_from_file_location("bump_version", module_path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            work = Path(tmp) / "repo"
+            cargo = work / "Cargo.toml"
+            cargo.parent.mkdir(parents=True, exist_ok=True)
+            cargo.write_text(
+                (repo_root / "Cargo.toml").read_text(encoding="utf-8"), encoding="utf-8"
+            )
+            lock = work / "plugins/unica/third-party/tools.lock.json"
+            lock.parent.mkdir(parents=True, exist_ok=True)
+            # Two unica entries: valid JSON, but no single version to set.
+            lock.write_text(
+                json.dumps({"tools": [{"name": "unica"}, {"name": "unica"}]}), encoding="utf-8"
+            )
+            before = cargo.read_text(encoding="utf-8")
+
+            with self.assertRaises(SystemExit):
+                module.bump(work, "9.8.7")
+
+            # Straddling two versions is the exact state the contract forbids, so
+            # a failure part-way through has to leave everything untouched.
+            self.assertEqual(cargo.read_text(encoding="utf-8"), before)
 
     def test_promotion_pr_points_the_tag_at_the_staging_merge(self) -> None:
         repo_root = Path(__file__).resolve().parents[2]

--- a/tests/ci/test_product_contracts.py
+++ b/tests/ci/test_product_contracts.py
@@ -304,12 +304,63 @@ class ProductContractTests(unittest.TestCase):
         text = runbook.read_text(encoding="utf-8")
         for value in (
             "staging merge commit",
-            "RELEASE_TAG",
+            "bump-version.py",
             "check-version-contract.py",
             "publish-unica-marketplace.yml",
+            # A release that fails part-way has to have a documented way out.
+            "One-way doors",
+            "never reuse a version number",
+            "Rolling back a live release",
         ):
             with self.subTest(value=value):
                 self.assertIn(value, text)
+
+    def test_release_tag_is_not_hardcoded_in_the_build_workflow(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        release = (repo_root / ".github/workflows/unica-plugin-release.yml").read_text(
+            encoding="utf-8"
+        )
+        version = json.loads(
+            (repo_root / "plugins/unica/.codex-plugin/plugin.json").read_text(encoding="utf-8")
+        )["version"]
+
+        # A literal here would be a version location no contract check covers,
+        # and packaging fails on every later pull request when it drifts.
+        self.assertNotIn(f"'v{version}'", release)
+        self.assertIn("Resolve the release tag for non-tag builds", release)
+
+    def test_bump_version_writes_every_contract_location(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        module_path = repo_root / "scripts" / "dev" / "bump-version.py"
+        spec = importlib.util.spec_from_file_location("bump_version", module_path)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        contract = importlib.util.spec_from_file_location(
+            "check_version_contract", repo_root / "scripts" / "ci" / "check-version-contract.py"
+        )
+        assert contract is not None and contract.loader is not None
+        contract_module = importlib.util.module_from_spec(contract)
+        contract.loader.exec_module(contract_module)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            work = Path(tmp) / "repo"
+            for relative in (
+                "Cargo.toml",
+                "plugins/unica/.codex-plugin/plugin.json",
+                "plugins/unica/third-party/tools.lock.json",
+            ):
+                target = work / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text(
+                    (repo_root / relative).read_text(encoding="utf-8"), encoding="utf-8"
+                )
+
+            module.bump(work, "9.8.7")
+            values = contract_module.read_version_contract(work)
+
+        self.assertEqual(set(values.values()), {"9.8.7"}, values)
 
     def test_promotion_pr_points_the_tag_at_the_staging_merge(self) -> None:
         repo_root = Path(__file__).resolve().parents[2]

--- a/tests/ci/test_product_contracts.py
+++ b/tests/ci/test_product_contracts.py
@@ -311,9 +311,27 @@ class ProductContractTests(unittest.TestCase):
             "One-way doors",
             "never reuse a version number",
             "Rolling back a live release",
+            "Release Warden",
         ):
             with self.subTest(value=value):
                 self.assertIn(value, text)
+
+    def test_warden_cannot_publish_without_the_human_tag(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        warden = (repo_root / "scripts/ci/release-warden.py").read_text(encoding="utf-8")
+        workflow = (repo_root / ".github/workflows/release-warden.yml").read_text(
+            encoding="utf-8"
+        )
+
+        # The marketplace default branch has no protection rules, so the
+        # greenness check in the warden is the only thing standing between a red
+        # promotion and every consumer.
+        self.assertIn("def is_green", warden)
+        self.assertIn("PASSING_CONCLUSIONS", warden)
+        # A stalled release has to surface rather than sit quietly, which is the
+        # failure this whole workflow exists to prevent.
+        self.assertIn("--alert-is-failure", workflow)
+        self.assertIn("schedule:", workflow)
 
     def test_release_tag_is_not_hardcoded_in_the_build_workflow(self) -> None:
         repo_root = Path(__file__).resolve().parents[2]

--- a/tests/ci/test_release_warden.py
+++ b/tests/ci/test_release_warden.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "ci" / "release-warden.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("release_warden", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    # Dataclasses resolve their deferred annotations through sys.modules, so the
+    # module has to be registered before it is executed.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class ReleaseWardenTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module = load_module()
+
+    def pull(self, branch: str, *, checks, files=(".agents/plugins/marketplace.json",)):
+        return self.module.PullRequest(number=7, branch=branch, files=tuple(files), checks=checks)
+
+    def green(self):
+        return (("consumer-fresh-install", "COMPLETED", "SUCCESS"),)
+
+    def test_nothing_to_do_when_the_catalog_already_serves_the_release(self) -> None:
+        action = self.module.decide(
+            self.module.ReleaseState(latest_release="v0.9.1", catalog_ref="v0.9.1")
+        )
+
+        self.assertEqual(action.kind, "noop")
+
+    def test_a_green_staging_pull_request_is_merged_and_carries_promotion_inputs(self) -> None:
+        stage = self.pull("codex/stage-v0.9.2-30117190305", checks=self.green())
+
+        action = self.module.decide(
+            self.module.ReleaseState("v0.9.2", "v0.9.1", stage_pr=stage)
+        )
+
+        self.assertEqual(action.kind, "merge-stage")
+        self.assertEqual(action.pull_request, 7)
+        # Both promotion inputs are derived from the branch name, so no value is
+        # transcribed by hand.
+        self.assertEqual(action.context["release_tag"], "v0.9.2")
+        self.assertEqual(action.context["source_run_id"], "30117190305")
+
+    def test_staging_is_not_merged_while_a_check_is_pending(self) -> None:
+        stage = self.pull(
+            "codex/stage-v0.9.2-1",
+            checks=(("staged-package-smoke", "IN_PROGRESS", None),),
+        )
+
+        action = self.module.decide(
+            self.module.ReleaseState("v0.9.2", "v0.9.1", stage_pr=stage)
+        )
+
+        self.assertEqual(action.kind, "wait")
+
+    def test_staging_is_not_merged_when_a_check_failed(self) -> None:
+        stage = self.pull(
+            "codex/stage-v0.9.2-1",
+            checks=(("contract", "COMPLETED", "FAILURE"),),
+        )
+
+        action = self.module.decide(
+            self.module.ReleaseState("v0.9.2", "v0.9.1", stage_pr=stage)
+        )
+
+        self.assertEqual(action.kind, "wait")
+        self.assertIn("contract: failure", action.detail)
+
+    def test_promotion_waits_until_the_tag_makes_the_install_checks_pass(self) -> None:
+        promote = self.pull(
+            "codex/promote-v0.9.2-1",
+            checks=(("consumer-fresh-install", "COMPLETED", "FAILURE"),),
+        )
+
+        action = self.module.decide(
+            self.module.ReleaseState("v0.9.2", "v0.9.1", promote_pr=promote)
+        )
+
+        # Red here means the catalog ref does not resolve yet, which is exactly
+        # the state before the human publishes the tag.
+        self.assertEqual(action.kind, "wait")
+        self.assertIn("v0.9.2", action.detail)
+
+    def test_a_green_promotion_publishes_the_release(self) -> None:
+        promote = self.pull("codex/promote-v0.9.2-1", checks=self.green())
+
+        action = self.module.decide(
+            self.module.ReleaseState("v0.9.2", "v0.9.1", promote_pr=promote)
+        )
+
+        self.assertEqual(action.kind, "merge-promote")
+        self.assertEqual(action.pull_request, 7)
+
+    def test_a_promotion_touching_more_than_the_catalog_is_never_merged(self) -> None:
+        promote = self.pull(
+            "codex/promote-v0.9.2-1",
+            checks=self.green(),
+            files=(".agents/plugins/marketplace.json", "plugins/unica/.mcp.json"),
+        )
+
+        action = self.module.decide(
+            self.module.ReleaseState("v0.9.2", "v0.9.1", promote_pr=promote)
+        )
+
+        self.assertEqual(action.kind, "alert")
+        self.assertIn("plugins/unica/.mcp.json", action.detail)
+
+    def test_both_host_catalogs_are_an_acceptable_promotion_diff(self) -> None:
+        promote = self.pull(
+            "codex/promote-v0.9.2-1",
+            checks=self.green(),
+            files=(".agents/plugins/marketplace.json", ".claude-plugin/marketplace.json"),
+        )
+
+        action = self.module.decide(
+            self.module.ReleaseState("v0.9.2", "v0.9.1", promote_pr=promote)
+        )
+
+        self.assertEqual(action.kind, "merge-promote")
+
+    def test_a_release_with_no_open_pull_request_is_reported_as_stalled(self) -> None:
+        action = self.module.decide(self.module.ReleaseState("v0.9.2", "v0.9.1"))
+
+        # This is the failure that went unnoticed for a day: the release exists,
+        # nobody is serving it, and nothing was open to merge.
+        self.assertEqual(action.kind, "alert")
+        self.assertIn("stalled", action.detail)
+
+    def test_a_pull_request_without_any_check_is_never_treated_as_green(self) -> None:
+        stage = self.pull("codex/stage-v0.9.2-1", checks=())
+
+        action = self.module.decide(
+            self.module.ReleaseState("v0.9.2", "v0.9.1", stage_pr=stage)
+        )
+
+        self.assertEqual(action.kind, "wait")
+
+    def test_staging_is_advanced_before_promotion_when_both_are_open(self) -> None:
+        stage = self.pull("codex/stage-v0.9.2-1", checks=self.green())
+        promote = self.pull("codex/promote-v0.9.2-1", checks=self.green())
+
+        action = self.module.decide(
+            self.module.ReleaseState("v0.9.2", "v0.9.1", stage_pr=stage, promote_pr=promote)
+        )
+
+        # Promotion must never overtake the payload it points at.
+        self.assertEqual(action.kind, "merge-stage")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci/test_release_warden.py
+++ b/tests/ci/test_release_warden.py
@@ -130,6 +130,22 @@ class ReleaseWardenTests(unittest.TestCase):
 
         self.assertEqual(action.kind, "merge-promote")
 
+    def test_an_abandoned_release_stops_being_treated_as_pending(self) -> None:
+        releases = [
+            {"tagName": "v0.9.2", "isDraft": False, "isPrerelease": True},
+            {"tagName": "v0.9.1", "isDraft": False, "isPrerelease": False},
+        ]
+
+        # Burning a version is a legitimate outcome. Without this the warden
+        # would compare the catalog against a version nobody intends to serve
+        # and alert on every scheduled run until the next release.
+        self.assertEqual(self.module.latest_servable_release(releases), "v0.9.1")
+
+    def test_a_draft_release_is_not_served_either(self) -> None:
+        releases = [{"tagName": "v0.9.2", "isDraft": True, "isPrerelease": False}]
+
+        self.assertIsNone(self.module.latest_servable_release(releases))
+
     def test_a_release_with_no_open_pull_request_is_reported_as_stalled(self) -> None:
         action = self.module.decide(self.module.ReleaseState("v0.9.2", "v0.9.1"))
 

--- a/tests/ci/test_smoke_unica_bootstrap.py
+++ b/tests/ci/test_smoke_unica_bootstrap.py
@@ -134,6 +134,19 @@ class SmokeUnicaBootstrapTests(unittest.TestCase):
 
             self.assertEqual(self.manifest_sha(plugin), self.PUBLISHED_SHA)
 
+    def test_the_manifest_is_restored_even_when_the_probe_never_starts(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            plugin = self.plugin(Path(directory))
+
+            # The consumer-PATH guard raises before the probe runs, and it must
+            # not leave the packaged artifact holding a neutralised checksum.
+            with patch.object(module.shutil, "which", return_value="/usr/bin/node"):
+                with self.assertRaisesRegex(SystemExit, "Node.js leaked"):
+                    module.smoke(plugin, "linux-x64", 2, expect_download_failure=True)
+
+            self.assertEqual(self.manifest_sha(plugin), self.PUBLISHED_SHA)
+
     def test_probe_requires_a_packaged_runtime_manifest(self) -> None:
         module = load_module()
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/ci/test_smoke_unica_bootstrap.py
+++ b/tests/ci/test_smoke_unica_bootstrap.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import subprocess
 import tempfile
 import unittest
@@ -22,12 +23,38 @@ def load_module():
 
 
 class SmokeUnicaBootstrapTests(unittest.TestCase):
+    PUBLISHED_SHA = "a" * 64
+
     def plugin(self, root: Path) -> Path:
         plugin = root / "plugin"
         bootstrap = plugin / "bootstrap" / "bin" / "linux-x64" / "unica-bootstrap"
         bootstrap.parent.mkdir(parents=True)
         bootstrap.write_bytes(b"bootstrap")
+        (plugin / "runtime-manifest.json").write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "pluginVersion": "0.9.1",
+                    "release": {"tag": "v0.9.1"},
+                    "targets": {
+                        "linux-x64": {
+                            "asset": {
+                                "name": "unica-runtime-linux-x64.tar.gz",
+                                "sha256": self.PUBLISHED_SHA,
+                            }
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
         return plugin
+
+    def manifest_sha(self, plugin: Path) -> str:
+        manifest = json.loads(
+            (plugin / "runtime-manifest.json").read_text(encoding="utf-8")
+        )
+        return manifest["targets"]["linux-x64"]["asset"]["sha256"]
 
     def test_probe_accepts_controlled_download_failure(self) -> None:
         module = load_module()
@@ -69,6 +96,75 @@ class SmokeUnicaBootstrapTests(unittest.TestCase):
                     2,
                     expect_download_failure=True,
                 )
+
+    def test_probe_neutralises_the_checksum_before_running_and_restores_it(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            plugin = self.plugin(Path(directory))
+            observed = {}
+
+            def fake_run(*args, **kwargs):
+                observed["sha"] = self.manifest_sha(plugin)
+                return subprocess.CompletedProcess(
+                    args=[],
+                    returncode=1,
+                    stdout="",
+                    stderr="unica-bootstrap: runtime archive sha256 actual != expected",
+                )
+
+            with patch.object(module.subprocess, "run", side_effect=fake_run):
+                module.smoke(plugin, "linux-x64", 2, expect_download_failure=True)
+
+            # The bootstrap must never see a checksum that published bytes can
+            # match, otherwise the probe's outcome depends on whether this version
+            # is already released and whether the host builds reproducibly.
+            self.assertEqual(observed["sha"], module.UNMATCHABLE_SHA256)
+            # Later jobs consume the same artifact and need the manifest back.
+            self.assertEqual(self.manifest_sha(plugin), self.PUBLISHED_SHA)
+
+    def test_probe_rejects_a_runtime_accepted_despite_the_neutralised_checksum(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            plugin = self.plugin(Path(directory))
+            result = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+            with patch.object(module.subprocess, "run", return_value=result):
+                with self.assertRaisesRegex(SystemExit, "neutralised"):
+                    module.smoke(plugin, "linux-x64", 2, expect_download_failure=True)
+
+            self.assertEqual(self.manifest_sha(plugin), self.PUBLISHED_SHA)
+
+    def test_probe_requires_a_packaged_runtime_manifest(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            plugin = self.plugin(Path(directory))
+            (plugin / "runtime-manifest.json").unlink()
+
+            with self.assertRaisesRegex(SystemExit, "runtime manifest is missing"):
+                module.smoke(plugin, "linux-x64", 2, expect_download_failure=True)
+
+    def test_release_smoke_leaves_the_packaged_checksum_untouched(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as directory:
+            plugin = self.plugin(Path(directory))
+            observed = {}
+
+            def fake_run(*args, **kwargs):
+                observed["sha"] = self.manifest_sha(plugin)
+                return subprocess.CompletedProcess(
+                    args=[],
+                    returncode=0,
+                    stdout="",
+                    stderr=(
+                        "verified Unica 0.9.1 package, runtime, and MCP tools at /cache"
+                    ),
+                )
+
+            with patch.object(module.subprocess, "run", side_effect=fake_run):
+                module.smoke(plugin, "linux-x64", 2, expect_download_failure=False)
+
+        # The tag build verifies the real published bytes end to end.
+        self.assertEqual(observed["sha"], self.PUBLISHED_SHA)
 
     def test_probe_rejects_stack_overflow_before_download_error(self) -> None:
         module = load_module()

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -405,8 +405,14 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         self.assertIn("codex/stage-", text)
         self.assertIn("codex/promote-", text)
         self.assertIn('git -C marketplace merge-base --is-ancestor "$STAGING_MERGE_SHA" "origin/main"', text)
-        self.assertIn('promotion_sha="$(git -C marketplace rev-parse HEAD)"', text)
-        self.assertIn("Create the signed ${RELEASE_TAG} tag at commit ${promotion_sha}", text)
+        # The tag names the staging merge, which already carries the plugin bytes
+        # and exists before this job runs. The promotion commit does not, so
+        # naming it kept the consumer install checks red on their first run.
+        self.assertIn(
+            "tag at the staging merge commit ${STAGING_MERGE_SHA} before merging this PR",
+            text,
+        )
+        self.assertNotIn("${promotion_sha}", text)
         self.assertNotIn("git ls-remote", text)
         self.assertNotIn('"refs/tags/${RELEASE_TAG}^{}"', text)
         self.assertIn("payload/plugins/unica/.codex-plugin/plugin.json", text)


### PR DESCRIPTION
Started as a fix for `probe-thin-bootstrap`, which blocks
[#212](https://github.com/IngvarConsulting/unica/pull/212). Publishing v0.9.1 by
hand while investigating exposed three more problems in the release process, all
fixed here.

## 1. The probe depended on release state

It runs with `--expect-download-failure` and asserts a non-zero exit, assuming
the packaged runtime is not published yet. A pull-request package is built with
the release tag of the version in the tree, and the manifest is self-consistent
by construction, so once that version ships a pull request that does not touch
the runtime rebuilds byte-identical archives and the download succeeds.

| Target | PR build | Published v0.9.1 | Probe |
| --- | --- | --- | --- |
| darwin-arm64 | `0fa1248eb055…` | `0fa1248eb055…` | failed |
| linux-x64 | `931bea8ed974…` | `931bea8ed974…` | failed |
| win-x64 | `3b2d7fc2a6cb…` | `babab10617e0…` | passed |

Only non-reproducible hosts kept failing by accident. The probe now neutralises
the archive checksum before running and restores the manifest afterwards, so the
bootstrap either cannot fetch the asset or rejects the bytes it fetched — both
the controlled failure the probe exists to assert. Pointing the manifest at an
unpublished tag was not an option: manifest validation rejects a URL that
disagrees with the declared version.

## 2. The promotion pull request was red by construction

The workflow asked for the tag at the promotion commit, which does not exist
until the promotion job has pushed it, so the consumer install checks failed on
their first run every release. The staging merge already carries the plugin
bytes and consumers fetch only `./plugins/unica` at the tag, so the tag belongs
there. Verified on v0.9.1: identical `plugins` trees at both commits, and
tagging the staging merge made the checks pass first time.

## 3. Releasing meant reconstructing the procedure

`docs/release-runbook.md` records the steps with the reason for each, what
consumers see at every point, an abort table, the rollback procedure, and the
one genuinely corrupt state — a catalog naming a missing tag. `AGENTS.md` points
at it, and a project skill lets Claude Code resume a release from wherever it
stalled.

The version no longer has to be set by hand in five places. The `RELEASE_TAG`
fallback is derived from the packaged manifest, so it is not a version location
at all — it was also the only one no contract check covered — and the rest are
written by `scripts/dev/bump-version.py`.

## 4. A stalled release was silent

v0.9.1 sat staged but unserved for a day and nothing reported it. Release Warden
runs every twenty minutes and advances the release when it can: merge staging
once green, request promotion with inputs derived from the branch name, merge
promotion once green. A scheduled run fails when a release is stalled with
nothing to advance.

Merging on green keeps the tag meaningful rather than bypassing it: promotion
checks install through the catalog ref, so they cannot pass before the tag is
published. **The marketplace default branch has no protection rules**, so this
greenness check is the only gate, and the warden also refuses a promotion that
touches anything beyond the catalog files. Enabling branch and tag protection
there is worth doing independently.

Abandoning a version is the documented response to a late failure, so the warden
skips drafts and prereleases; otherwise a burnt version would make every
scheduled run cry stall until the next release, training everyone to ignore the
alarm.

## Verification

- `339 passed, 3 skipped, 4639 subtests` under Python 3.12.
- The probe fix exercised against the real manifest from the failing run.
- The warden's decision function tested across every branch, and run against live
  state: `noop: catalog already serves v0.9.1`.
- `bump-version.py` run end to end on the working tree and reverted.
- Every path referenced in the runbook checked for existence.

Not covered: the warden has never driven a release end to end. The first real
run is worth shadowing with `dry_run=true` between steps.