### PR TITLE
release: prepare Unica v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,7 +1394,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unica-bootstrap"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "flate2",
  "fs2",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "unica-coder"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "diffy",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/unica-bootstrap", "crates/unica-coder"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.1"
+version = "0.10.0"
 edition = "2021"
 license = "LGPL-3.0-or-later"
 repository = "https://github.com/IngvarConsulting/unica"

--- a/plugins/unica/.claude-plugin/plugin.json
+++ b/plugins/unica/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unica",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Practical 1C:Enterprise development workflows for Claude Code.",
   "author": {
     "name": "Ingvar Consulting, LLC",

--- a/plugins/unica/.codex-plugin/plugin.json
+++ b/plugins/unica/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unica",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Practical 1C:Enterprise development workflows for Codex.",
   "author": {
     "name": "Ingvar Consulting, LLC",

--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -136,7 +136,7 @@
     },
     {
       "name": "unica",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "repository": "https://github.com/IngvarConsulting/unica",
       "sourceTag": "workspace",
       "sourceCommit": "workspace",

--- a/tests/ci/test_package_unica_plugin.py
+++ b/tests/ci/test_package_unica_plugin.py
@@ -875,6 +875,11 @@ class PackageUnicaPluginTests(unittest.TestCase):
     def test_generated_marketplace_is_thin_pinned_and_target_neutral(self) -> None:
         module = load_package_module()
         repo_root = Path(__file__).resolve().parents[2]
+        # Packaging requires the release tag to match the packaged version, so
+        # the fixture reads it rather than pinning a literal that every release
+        # would have to come back and edit.
+        version = module.read_release_version(repo_root / "plugins" / "unica")
+        release_tag = f"v{version}"
         target_triples = {
             "darwin-arm64": "aarch64-apple-darwin",
             "linux-x64": "x86_64-unknown-linux-gnu",
@@ -903,7 +908,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
                             "schemaVersion": 1,
                             "target": target,
                             "targetTriple": target_triple,
-                            "pluginVersion": "0.9.1",
+                            "pluginVersion": version,
                             "asset": {
                                 "name": f"unica-runtime-{target}.tar.gz",
                                 "mediaType": "application/gzip",
@@ -932,7 +937,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
                 "--bootstrap-root",
                 str(bootstrap_root),
                 "--release-tag",
-                "v0.9.1",
+                release_tag,
                 "--source-commit",
                 "a" * 40,
                 "--out-dir",
@@ -987,13 +992,13 @@ class PackageUnicaPluginTests(unittest.TestCase):
             )
             self.assertFalse(runtime_manifest["development"])
             self.assertEqual(runtime_manifest["source"]["commit"], "a" * 40)
-            self.assertEqual(runtime_manifest["release"]["tag"], "v0.9.1")
+            self.assertEqual(runtime_manifest["release"]["tag"], release_tag)
             self.assertEqual(sorted(runtime_manifest["targets"]), sorted(target_triples))
             for target, target_data in runtime_manifest["targets"].items():
                 self.assertEqual(
                     target_data["asset"]["url"],
                     "https://github.com/IngvarConsulting/unica/releases/download/"
-                    f"v0.9.1/unica-runtime-{target}.tar.gz",
+                    f"{release_tag}/unica-runtime-{target}.tar.gz",
                 )
 
             catalog = json.loads(
@@ -1003,7 +1008,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
             )
             source = catalog["plugins"][0]["source"]
             self.assertEqual(source["source"], "git-subdir")
-            self.assertEqual(source["ref"], "v0.9.1")
+            self.assertEqual(source["ref"], release_tag)
             self.assertEqual(source["path"], "./plugins/unica")
             self.assertNotIn("source\": \"local", json.dumps(catalog))
             self.assertEqual(list(out_dir.glob("*.tar.gz")), [])

--- a/tests/ci/test_version_contract.py
+++ b/tests/ci/test_version_contract.py
@@ -19,20 +19,20 @@ def load_module():
 
 
 class VersionContractTests(unittest.TestCase):
-    def test_repository_versions_are_exactly_0_9_1(self) -> None:
+    def test_every_contract_location_declares_the_same_version(self) -> None:
         module = load_module()
 
         values = module.read_version_contract(REPO_ROOT)
 
+        # Named rather than pinned to a literal: the contract is that the four
+        # locations agree, and asserting the number here only added a file every
+        # release had to come back and edit.
         self.assertEqual(
-            values,
-            {
-                "workspace": "0.9.1",
-                "plugin": "0.9.1",
-                "claude-plugin": "0.9.1",
-                "tools-lock-unica": "0.9.1",
-            },
+            sorted(values),
+            ["claude-plugin", "plugin", "tools-lock-unica", "workspace"],
         )
+        self.assertEqual(len(set(values.values())), 1, values)
+        self.assertRegex(next(iter(values.values())), r"^\d+\.\d+\.\d+$")
 
     def test_mismatch_names_the_contract_field(self) -> None:
         module = load_module()


### PR DESCRIPTION
Version bump for the first release carrying Claude Code support.

Minor rather than patch: a new supported host is a feature.

`scripts/dev/bump-version.py` wrote all four contract locations. The two tests
that pinned the version are rewritten to derive it, so the next release does not
have to come back and edit them:

- the version contract test now asserts what the contract actually says — the
  four locations agree and the value is a semver — instead of naming a number;
- the packaging fixture reads the release tag from the manifest, since packaging
  requires the tag to match the packaged version.

## Verification

- `352 passed, 3 skipped, 4652 subtests` under Python 3.12.
- `cargo test -p unica-bootstrap`, `cargo fmt --check`.
- `check-version-contract.py` reports 0.10.0.

Next steps follow `docs/release-runbook.md`: tag the source release, then the
marketplace tag once staging lands. Release Warden handles the merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the Unica plugin and package version to **0.10.0**.
  * Improved release validation to ensure version information remains consistent across published artifacts and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->