### PR TITLE
fix(diagnostics): contain file paths in source root

### DIFF
--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -2232,6 +2232,11 @@ impl<'a> BslAnalyzerMcpAdapter<'a> {
             "could not locate Unica plugin root for bsl-analyzer MCP adapter lookup".to_string()
         })?;
         let source_dir = resolve_source_dir(context, args)?;
+        if tool_name == "unica.code.diagnostics" {
+            if let Some(path) = args.get("path").and_then(Value::as_str) {
+                validate_diagnostics_path(&source_dir, path)?;
+            }
+        }
         let (remote_tool, tool_args) = bsl_mcp_tool_request(tool_name, args)?;
         let bundled_tool = resolve_bundled_tool(&plugin_root, "bsl-analyzer", !dry_run)?;
         let command = bsl_mcp_command(
@@ -3289,6 +3294,28 @@ fn resolve_source_dir(
 ) -> Result<PathBuf, String> {
     resolve_source_root(context, args.get("sourceDir").and_then(Value::as_str))
         .map(|resolved| resolved.path)
+}
+
+fn validate_diagnostics_path(source_dir: &Path, raw_path: &str) -> Result<(), String> {
+    let raw_path = Path::new(raw_path);
+    let candidate = if raw_path.is_absolute() {
+        raw_path.to_path_buf()
+    } else {
+        source_dir.join(raw_path)
+    };
+    let path = normalize_path_identity(&candidate)
+        .map_err(|error| format!("invalid_diagnostics_path: {error}"))?;
+    let source_dir = normalize_path_identity(source_dir)
+        .map_err(|error| format!("invalid_diagnostics_path: {error}"))?;
+    if path.starts_with(&source_dir) {
+        Ok(())
+    } else {
+        Err(format!(
+            "invalid_diagnostics_path: path {} is outside sourceDir {}",
+            path.display(),
+            source_dir.display()
+        ))
+    }
 }
 
 fn bsl_mcp_readiness_warnings(text: &str) -> Vec<String> {
@@ -6925,11 +6952,68 @@ source-set:
         assert_eq!(commands.len(), 1);
         assert_eq!(commands[0].tool_name, "diagnostics");
         assert_eq!(commands[0].tool_args["action"], "file");
+        assert_eq!(
+            commands[0].tool_args["path"],
+            "CommonModules/SmokeModule/Ext/Module.bsl"
+        );
         assert_eq!(commands[0].tool_args["min_severity"], "warning");
         assert_eq!(commands[0].tool_args["range_start"], 3);
         assert_eq!(commands[0].tool_args["range_end"], 7);
         assert_eq!(commands[0].tool_args["max_findings"], 5);
         cleanup_context(&context);
+    }
+
+    #[test]
+    fn diagnostics_mcp_adapter_rejects_paths_outside_source_dir() {
+        let context = temp_context("diagnostics-path-containment");
+        fs::create_dir_all(context.workspace_root.join("src")).unwrap();
+        let outside = context.workspace_root.with_file_name(format!(
+            "{}-outside",
+            context
+                .workspace_root
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+        ));
+        fs::create_dir_all(&outside).unwrap();
+        let absolute_outside_path = outside.join("Module.bsl");
+
+        let mut paths = vec![
+            "../outside/Module.bsl".to_string(),
+            absolute_outside_path.display().to_string(),
+        ];
+        if let Some(symlink_result) =
+            crate::infrastructure::platform::filesystem::create_dir_symlink_for_test(
+                &outside,
+                context.workspace_root.join("src").join("escape"),
+            )
+        {
+            symlink_result.unwrap();
+            paths.push("escape/Module.bsl".to_string());
+        }
+
+        for path in paths {
+            let runner = RecordingBslMcpRunner {
+                commands: RefCell::new(Vec::new()),
+                output: BslMcpOutput {
+                    result_text: "{\"action\":\"file\",\"findings\":[]}".to_string(),
+                    stderr: String::new(),
+                },
+            };
+            let mut args = Map::new();
+            args.insert("mode".to_string(), json!("file"));
+            args.insert("sourceDir".to_string(), json!("src"));
+            args.insert("path".to_string(), json!(path));
+
+            let error = BslAnalyzerMcpAdapter::with_runner(&runner)
+                .invoke("unica.code.diagnostics", &args, &context, false)
+                .unwrap_err();
+            assert!(error.starts_with("invalid_diagnostics_path:"), "{error}");
+            assert!(runner.commands.borrow().is_empty());
+        }
+
+        cleanup_context(&context);
+        let _ = fs::remove_dir_all(outside);
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -3301,6 +3301,7 @@ fn resolve_source_dir(
         .map(|resolved| resolved.path)
 }
 
+/// Rejects diagnostics paths whose normalized identity escapes the resolved source directory.
 fn validate_diagnostics_path(source_dir: &Path, raw_path: &str) -> Result<(), String> {
     let raw_path = Path::new(raw_path);
     let candidate = if raw_path.is_absolute() {

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -2208,6 +2208,13 @@ impl<'a> BslAnalyzerMcpAdapter<'a> {
                 "{tool_name} cancelled before adapter work"
             )));
         }
+        let diagnostics_path = match (tool_name, args.get("path")) {
+            ("unica.code.diagnostics", Some(Value::String(path))) => Some(path.as_str()),
+            ("unica.code.diagnostics", Some(_)) => {
+                return Err("invalid_diagnostics_path: argument `path` must be string".to_string());
+            }
+            _ => None,
+        };
         if tool_name == "unica.code.diagnostics" && diagnostics_mode(args) == "analyze" {
             let cli_args = diagnostics_analyze_args(args);
             let process_timeout = diagnostics_analyze_timeout(args)?;
@@ -2232,10 +2239,8 @@ impl<'a> BslAnalyzerMcpAdapter<'a> {
             "could not locate Unica plugin root for bsl-analyzer MCP adapter lookup".to_string()
         })?;
         let source_dir = resolve_source_dir(context, args)?;
-        if tool_name == "unica.code.diagnostics" {
-            if let Some(path) = args.get("path").and_then(Value::as_str) {
-                validate_diagnostics_path(&source_dir, path)?;
-            }
+        if let Some(path) = diagnostics_path {
+            validate_diagnostics_path(&source_dir, path)?;
         }
         let (remote_tool, tool_args) = bsl_mcp_tool_request(tool_name, args)?;
         let bundled_tool = resolve_bundled_tool(&plugin_root, "bsl-analyzer", !dry_run)?;
@@ -7014,6 +7019,35 @@ source-set:
 
         cleanup_context(&context);
         let _ = fs::remove_dir_all(outside);
+    }
+
+    #[test]
+    fn diagnostics_mcp_adapter_rejects_non_string_path_before_runner() {
+        let context = temp_context("diagnostics-non-string-path");
+
+        for path in [Value::Null, json!(true), json!(1), json!([]), json!({})] {
+            let runner = RecordingBslMcpRunner {
+                commands: RefCell::new(Vec::new()),
+                output: BslMcpOutput {
+                    result_text: "{\"action\":\"file\",\"findings\":[]}".to_string(),
+                    stderr: String::new(),
+                },
+            };
+            let mut args = Map::new();
+            args.insert("mode".to_string(), json!("file"));
+            args.insert("path".to_string(), path.clone());
+
+            let error = BslAnalyzerMcpAdapter::with_runner(&runner)
+                .invoke("unica.code.diagnostics", &args, &context, false)
+                .unwrap_err();
+            assert!(
+                error.starts_with("invalid_diagnostics_path:"),
+                "{path}: {error}"
+            );
+            assert!(runner.commands.borrow().is_empty(), "{path}");
+        }
+
+        cleanup_context(&context);
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -6969,6 +6969,36 @@ source-set:
     }
 
     #[test]
+    fn diagnostics_mcp_adapter_accepts_absolute_path_inside_source_dir() {
+        let context = temp_context("diagnostics-absolute-inside");
+        let path = context
+            .cwd
+            .join("CommonModules/SmokeModule/Ext/Module.bsl")
+            .display()
+            .to_string();
+        let runner = RecordingBslMcpRunner {
+            commands: RefCell::new(Vec::new()),
+            output: BslMcpOutput {
+                result_text: "{\"action\":\"file\",\"findings\":[]}".to_string(),
+                stderr: String::new(),
+            },
+        };
+        let mut args = Map::new();
+        args.insert("mode".to_string(), json!("file"));
+        args.insert("path".to_string(), json!(path));
+
+        let outcome = BslAnalyzerMcpAdapter::with_runner(&runner)
+            .invoke("unica.code.diagnostics", &args, &context, false)
+            .unwrap();
+
+        assert!(outcome.ok);
+        let commands = runner.commands.borrow();
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].tool_args["path"], path);
+        cleanup_context(&context);
+    }
+
+    #[test]
     fn diagnostics_mcp_adapter_rejects_paths_outside_source_dir() {
         let context = temp_context("diagnostics-path-containment");
         fs::create_dir_all(context.workspace_root.join("src")).unwrap();

--- a/docs/superpowers/plans/2026-07-26-diagnostics-path-containment.md
+++ b/docs/superpowers/plans/2026-07-26-diagnostics-path-containment.md
@@ -119,9 +119,12 @@ git commit -m "fix(diagnostics): contain file paths in source root"
 
 ### Task 2: Restrict `path` to file diagnostics
 
+> **Status:** landed on `main` separately via #216 (`fix(diagnostics): reject
+> ambiguous paths and loading success`); this branch carries only Task 1.
+
 **Files:**
-- Modify: `crates/unica-coder/src/application/tool_contracts.rs:1083-1118`
-- Test: `crates/unica-coder/src/application/tool_contracts.rs:3023-3090`
+- Modify: `crates/unica-coder/src/application/tool_contracts.rs:1090-1128`
+- Test: `crates/unica-coder/src/application/tool_contracts.rs:3954-4055`
 
 **Interfaces:**
 - Resolves: an omitted diagnostics `mode` as `analyze`.
@@ -132,8 +135,9 @@ git commit -m "fix(diagnostics): contain file paths in source root"
 
 Extend `bsl_diagnostics_contract_exposes_modes_and_keeps_analyze_default` with
 literal cases that supply `path` for explicit `analyze`, `status`, `catalog`,
-and `workspace` requests. Assert that every case reports that `path` is only
-supported for `file`; keep the existing omitted-mode `analyze` default.
+and `workspace` requests. Assert that every case reports that its mode does not
+support `path` and directs the caller to `file`; keep the existing omitted-mode
+`analyze` default.
 
 - [ ] **Step 2: Run the contract test and verify it fails**
 

--- a/docs/superpowers/plans/2026-07-26-diagnostics-path-containment.md
+++ b/docs/superpowers/plans/2026-07-26-diagnostics-path-containment.md
@@ -1,0 +1,111 @@
+# Diagnostics path containment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reject `unica.code.diagnostics` file paths outside the resolved source root before invoking `bsl-analyzer`.
+
+**Architecture:** Keep the boundary at the BSL MCP adapter, where both the resolved source root and typed diagnostics payload are available. Add a small path resolver that canonically identifies an existing path ancestor (including symlinks), checks containment in `sourceDir`, and returns the path only after that check. The adapter will use it only for diagnostics requests containing `path`.
+
+**Tech Stack:** Rust, `std::path`, existing `normalize_path_identity`, `BslAnalyzerMcpAdapter` unit tests.
+
+## Global Constraints
+
+- Preserve the existing source-root selection and graph-tool behavior.
+- `mode=analyze` continues to reject `path` at the contract layer.
+- Reject relative `..`, absolute external paths, and symlink escapes with `invalid_diagnostics_path:` before the BSL MCP runner is called.
+- Preserve the typed diagnostics payload for valid source-root-relative file paths.
+
+---
+
+### Task 1: Enforce diagnostics-file containment
+
+**Files:**
+- Modify: `crates/unica-coder/src/infrastructure/internal_adapters.rs:19, 2218-2225, 3214-3220, 6600-6640`
+- Test: `crates/unica-coder/src/infrastructure/internal_adapters.rs:6600-6640`
+
+**Interfaces:**
+- Consumes: `resolve_source_dir(context, args) -> Result<PathBuf, String>` and `normalize_path_identity(path) -> Result<PathBuf, String>`.
+- Produces: `validate_diagnostics_path(source_dir: &Path, raw_path: &str) -> Result<(), String>`, whose errors start with `invalid_diagnostics_path:`.
+- Preserves: `BslAnalyzerMcpAdapter::invoke("unica.code.diagnostics", ...)` builds its existing `diagnostics` MCP request only after validation.
+
+- [ ] **Step 1: Write the failing adapter tests**
+
+Add a table-driven test that invokes `unica.code.diagnostics` with `mode: "file"`, an explicit `sourceDir`, and each of these paths: `"../outside/Module.bsl"`, an absolute temporary file outside the source root, and `"escape/Module.bsl"` where `escape` is an in-root symlink to an outside temporary directory. For every supported symlink case, assert:
+
+```rust
+let error = BslAnalyzerMcpAdapter::with_runner(&runner)
+    .invoke("unica.code.diagnostics", &args, &context, false)
+    .unwrap_err();
+assert!(error.starts_with("invalid_diagnostics_path:"), "{error}");
+assert!(runner.commands.borrow().is_empty());
+```
+
+In the existing valid typed-diagnostics test, add an assertion that its relative `path` remains accepted and is copied as `tool_args["path"]`.
+
+- [ ] **Step 2: Run the new test and verify it fails**
+
+Run:
+
+```bash
+cargo test -p unica-coder --lib diagnostics_mcp_adapter_rejects_paths_outside_source_dir -- --nocapture
+```
+
+Expected: the test fails because the adapter currently forwards each path to the recording runner.
+
+- [ ] **Step 3: Add the minimal source-root containment helper**
+
+Import `Path` next to `PathBuf`. Implement `validate_diagnostics_path` beside `resolve_source_dir`:
+
+```rust
+fn validate_diagnostics_path(source_dir: &Path, raw_path: &str) -> Result<(), String> {
+    let raw_path = Path::new(raw_path);
+    let candidate = if raw_path.is_absolute() {
+        raw_path.to_path_buf()
+    } else {
+        source_dir.join(raw_path)
+    };
+    let path = normalize_path_identity(&candidate)
+        .map_err(|error| format!("invalid_diagnostics_path: {error}"))?;
+    let source_dir = normalize_path_identity(source_dir)
+        .map_err(|error| format!("invalid_diagnostics_path: {error}"))?;
+    if path.starts_with(&source_dir) {
+        Ok(())
+    } else {
+        Err(format!(
+            "invalid_diagnostics_path: path {} is outside sourceDir {}",
+            path.display(),
+            source_dir.display()
+        ))
+    }
+}
+```
+
+After resolving `source_dir` in `BslAnalyzerMcpAdapter::invoke_cancellable`, call the helper when `tool_name == "unica.code.diagnostics"` and the typed arguments contain a string `path`. Do this before `bsl_mcp_tool_request` and before constructing `BslMcpCommand`.
+
+- [ ] **Step 4: Run the focused tests**
+
+Run:
+
+```bash
+cargo test -p unica-coder --lib diagnostics_mcp_adapter_rejects_paths_outside_source_dir -- --nocapture
+cargo test -p unica-coder --lib diagnostics_mcp_adapter_builds_typed_request -- --nocapture
+```
+
+Expected: rejected cases return the stable prefix without a runner command; the valid file request retains its original typed payload.
+
+- [ ] **Step 5: Run full verification and commit**
+
+Run:
+
+```bash
+cargo fmt --all --check
+cargo test -p unica-coder --lib --quiet -- --test-threads=1
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Commit:
+
+```bash
+git add crates/unica-coder/src/infrastructure/internal_adapters.rs
+git commit -m "fix(diagnostics): contain file paths in source root"
+```

--- a/docs/superpowers/plans/2026-07-26-diagnostics-path-containment.md
+++ b/docs/superpowers/plans/2026-07-26-diagnostics-path-containment.md
@@ -2,16 +2,17 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Reject `unica.code.diagnostics` file paths outside the resolved source root before invoking `bsl-analyzer`.
+**Goal:** Accept `unica.code.diagnostics` `path` only for file mode and reject malformed or out-of-root file paths before invoking `bsl-analyzer`.
 
-**Architecture:** Keep the boundary at the BSL MCP adapter, where both the resolved source root and typed diagnostics payload are available. Add a small path resolver that canonically identifies an existing path ancestor (including symlinks), checks containment in `sourceDir`, and returns the path only after that check. The adapter will use it only for diagnostics requests containing `path`.
+**Architecture:** Enforce mode applicability in the application contract, where the diagnostics mode is resolved, and enforce type and source-root containment again at the BSL MCP adapter before runner selection. Add a small path resolver that canonically identifies an existing path ancestor (including symlinks), checks containment in `sourceDir`, and returns the path only after that check.
 
-**Tech Stack:** Rust, `std::path`, existing `normalize_path_identity`, `BslAnalyzerMcpAdapter` unit tests.
+**Tech Stack:** Rust, `std::path`, existing `normalize_path_identity`, `tool_contracts` tests, `BslAnalyzerMcpAdapter` unit tests.
 
 ## Global Constraints
 
 - Preserve the existing source-root selection and graph-tool behavior.
-- `mode=analyze` continues to reject `path` at the contract layer.
+- Permit `path` only for `mode=file`; omitted mode resolves to `analyze` and rejects `path`.
+- Reject every present non-string `path` before selecting or invoking a runner.
 - Reject relative `..`, absolute external paths, and symlink escapes with `invalid_diagnostics_path:` before the BSL MCP runner is called.
 - Preserve the typed diagnostics payload for valid source-root-relative file paths.
 
@@ -30,7 +31,7 @@
 
 - [ ] **Step 1: Write the failing adapter tests**
 
-Add a table-driven test that invokes `unica.code.diagnostics` with `mode: "file"`, an explicit `sourceDir`, and each of these paths: `"../outside/Module.bsl"`, an absolute temporary file outside the source root, and `"escape/Module.bsl"` where `escape` is an in-root symlink to an outside temporary directory. For every supported symlink case, assert:
+Add a table-driven test that invokes `unica.code.diagnostics` with `mode: "file"`, an explicit `sourceDir`, and each of these paths: `"../outside/Module.bsl"`, an absolute temporary file outside the source root, and `"escape/Module.bsl"` where `escape` is an in-root symlink to an outside temporary directory. Add a second test covering present non-string JSON values. For every rejected case, assert:
 
 ```rust
 let error = BslAnalyzerMcpAdapter::with_runner(&runner)
@@ -48,13 +49,16 @@ Run:
 
 ```bash
 cargo test -p unica-coder --lib diagnostics_mcp_adapter_rejects_paths_outside_source_dir -- --nocapture
+cargo test -p unica-coder --lib diagnostics_mcp_adapter_rejects_non_string_path_before_runner -- --nocapture
 ```
 
-Expected: the test fails because the adapter currently forwards each path to the recording runner.
+Expected: the tests fail because the adapter currently forwards each path to the recording runner.
 
 - [ ] **Step 3: Add the minimal source-root containment helper**
 
-Import `Path` next to `PathBuf`. Implement `validate_diagnostics_path` beside `resolve_source_dir`:
+Import `Path` next to `PathBuf`. Before selecting the diagnostics runner, reject
+every present non-string `path` with an `invalid_diagnostics_path:` error.
+Implement `validate_diagnostics_path` beside `resolve_source_dir`:
 
 ```rust
 fn validate_diagnostics_path(source_dir: &Path, raw_path: &str) -> Result<(), String> {
@@ -88,7 +92,8 @@ Run:
 
 ```bash
 cargo test -p unica-coder --lib diagnostics_mcp_adapter_rejects_paths_outside_source_dir -- --nocapture
-cargo test -p unica-coder --lib diagnostics_mcp_adapter_builds_typed_request -- --nocapture
+cargo test -p unica-coder --lib diagnostics_mcp_adapter_rejects_non_string_path_before_runner -- --nocapture
+cargo test -p unica-coder --lib bsl_diagnostics_adapter_maps_file_mode_to_allowlisted_mcp_call -- --nocapture
 ```
 
 Expected: rejected cases return the stable prefix without a runner command; the valid file request retains its original typed payload.
@@ -108,4 +113,68 @@ Commit:
 ```bash
 git add crates/unica-coder/src/infrastructure/internal_adapters.rs
 git commit -m "fix(diagnostics): contain file paths in source root"
+```
+
+---
+
+### Task 2: Restrict `path` to file diagnostics
+
+**Files:**
+- Modify: `crates/unica-coder/src/application/tool_contracts.rs:1083-1118`
+- Test: `crates/unica-coder/src/application/tool_contracts.rs:3023-3090`
+
+**Interfaces:**
+- Resolves: an omitted diagnostics `mode` as `analyze`.
+- Rejects: `path` for default or explicit `analyze`, `status`, `catalog`, and `workspace`.
+- Preserves: `mode=file` requires `path` for non-dry-run requests.
+
+- [ ] **Step 1: Write the failing contract tests**
+
+Extend `bsl_diagnostics_contract_exposes_modes_and_keeps_analyze_default` with
+literal cases that supply `path` for explicit `analyze`, `status`, `catalog`,
+and `workspace` requests. Assert that every case reports that `path` is only
+supported for `file`; keep the existing omitted-mode `analyze` default.
+
+- [ ] **Step 2: Run the contract test and verify it fails**
+
+Run:
+
+```bash
+cargo test -p unica-coder --lib bsl_diagnostics_contract_exposes_modes_and_keeps_analyze_default -- --nocapture
+```
+
+Expected: non-file modes other than `analyze` accept `path`.
+
+- [ ] **Step 3: Enforce the file-only contract**
+
+Resolve the diagnostics mode once, defaulting it to `analyze`. If `path` is
+present and the mode is not `file`, return the file-only contract error before
+the timeout and required-argument checks.
+
+- [ ] **Step 4: Run the focused contract test**
+
+Run:
+
+```bash
+cargo test -p unica-coder --lib bsl_diagnostics_contract_exposes_modes_and_keeps_analyze_default -- --nocapture
+```
+
+Expected: default and explicit non-file modes reject `path`, while file mode
+retains its required-path behavior.
+
+- [ ] **Step 5: Run full verification and commit**
+
+Run:
+
+```bash
+cargo fmt --all --check
+cargo test -p unica-coder --lib --quiet -- --test-threads=1
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Commit:
+
+```bash
+git add crates/unica-coder/src/application/tool_contracts.rs
+git commit -m "fix(diagnostics): reject path outside file mode"
 ```

--- a/docs/superpowers/specs/2026-07-26-diagnostics-path-containment-design.md
+++ b/docs/superpowers/specs/2026-07-26-diagnostics-path-containment-design.md
@@ -1,0 +1,38 @@
+# Diagnostics path containment design
+
+## Goal
+
+`unica.code.diagnostics` must reject a file path that does not belong to its
+resolved `sourceDir` before it invokes `bsl-analyzer`.
+
+## Scope
+
+The rule applies to diagnostics modes that accept `path` (`file` and any
+future typed diagnostics mode that forwards it). It does not change source-root
+selection, graph requests, or the full-source `analyze` mode, which already
+rejects `path` in #198.
+
+## Design
+
+The BSL MCP adapter resolves `sourceDir` through the existing
+`resolve_source_root` path. Before building the diagnostics MCP payload, it
+will resolve the supplied `path` relative to that root, normalize the identity
+through existing ancestors (therefore following symlinks), and require the
+result to start with the normalized source-root identity.
+
+On failure, the adapter returns one stable, actionable error prefixed
+`invalid_diagnostics_path:`. The diagnostic request is not sent to
+`bsl-analyzer`.
+
+## Rejected inputs
+
+- a relative path escaping the source root through `..`;
+- an absolute path outside that root;
+- a path that enters an in-root symlink whose target is outside that root.
+
+## Tests
+
+Adapter tests will use the recording BSL MCP runner. Each rejected case must
+assert the stable error prefix and that the runner received no command. A
+valid relative path must still produce the existing typed `diagnostics` MCP
+payload unchanged.

--- a/docs/superpowers/specs/2026-07-26-diagnostics-path-containment-design.md
+++ b/docs/superpowers/specs/2026-07-26-diagnostics-path-containment-design.md
@@ -13,7 +13,9 @@ The contract layer permits `path` only when the resolved diagnostics mode is
 every present `path` value to be a string and enforces file-path containment
 within the resolved `sourceDir`.
 
-The change does not alter source-root selection or graph requests.
+The change does not alter source-root selection or graph requests. The
+contract-layer rule shipped separately via #216; this change implements the
+adapter enforcement.
 
 ## Design
 

--- a/docs/superpowers/specs/2026-07-26-diagnostics-path-containment-design.md
+++ b/docs/superpowers/specs/2026-07-26-diagnostics-path-containment-design.md
@@ -2,23 +2,31 @@
 
 ## Goal
 
-`unica.code.diagnostics` must reject a file path that does not belong to its
-resolved `sourceDir` before it invokes `bsl-analyzer`.
+`unica.code.diagnostics` must accept `path` only for file diagnostics and must
+reject malformed or out-of-root file paths before it invokes `bsl-analyzer`.
 
 ## Scope
 
-The rule applies to diagnostics modes that accept `path` (`file` and any
-future typed diagnostics mode that forwards it). It does not change source-root
-selection, graph requests, or the full-source `analyze` mode, which already
-rejects `path` in #198.
+The contract layer permits `path` only when the resolved diagnostics mode is
+`file`; the default `analyze` mode and the explicit `analyze`, `status`,
+`catalog`, and `workspace` modes reject it. The adapter additionally requires
+every present `path` value to be a string and enforces file-path containment
+within the resolved `sourceDir`.
+
+The change does not alter source-root selection or graph requests.
 
 ## Design
 
+`tool_contracts.rs` resolves the omitted mode to `analyze`, rejects `path` for
+every non-file mode, and continues to require `path` for non-dry-run file
+requests.
+
 The BSL MCP adapter resolves `sourceDir` through the existing
-`resolve_source_root` path. Before building the diagnostics MCP payload, it
-will resolve the supplied `path` relative to that root, normalize the identity
-through existing ancestors (therefore following symlinks), and require the
-result to start with the normalized source-root identity.
+`resolve_source_root` path. Before selecting or invoking a runner, it rejects a
+present non-string `path`. Before building the diagnostics MCP payload, it
+resolves a string `path` relative to that root, normalizes the identity through
+existing ancestors (therefore following symlinks), and requires the result to
+start with the normalized source-root identity.
 
 On failure, the adapter returns one stable, actionable error prefixed
 `invalid_diagnostics_path:`. The diagnostic request is not sent to
@@ -26,13 +34,16 @@ On failure, the adapter returns one stable, actionable error prefixed
 
 ## Rejected inputs
 
+- a `path` supplied for a diagnostics mode other than `file`;
+- a present `path` whose JSON value is not a string;
 - a relative path escaping the source root through `..`;
 - an absolute path outside that root;
 - a path that enters an in-root symlink whose target is outside that root.
 
 ## Tests
 
-Adapter tests will use the recording BSL MCP runner. Each rejected case must
-assert the stable error prefix and that the runner received no command. A
-valid relative path must still produce the existing typed `diagnostics` MCP
-payload unchanged.
+Contract tests preserve the omitted-mode `analyze` default and cover explicit
+non-file modes. Adapter tests use the recording BSL MCP runner. Each malformed
+or out-of-root adapter case must assert the stable error prefix and that the
+runner received no command. A valid relative path must still produce the
+existing typed `diagnostics` MCP payload unchanged.


### PR DESCRIPTION
Закрывает #203.

Что меняется: до запуска `bsl-analyzer` адаптер BSL MCP проверяет, что `path` в `unica.code.diagnostics` — строка и находится внутри разрешённого `sourceDir`. Блокируются нестроковый `path`, путь через `..`, абсолютный внешний путь и симлинк за границу source root; абсолютный путь внутри source root принимается. Корректные file-запросы сохраняют typed MCP payload.

Контрактное правило «`path` только для `mode=file`» уехало в main отдельно через #216, поэтому здесь остаётся только адаптерный барьер. Ветка ребейзнута на актуальный main, история линейная, дублировавший контрактный коммит удалён.

Проверка локально: `cargo fmt --all --check`, 1492 теста unica-coder (2 ignored), строгий `cargo clippy --workspace --all-targets --all-features -- -D warnings`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened `unica.code.diagnostics` `path` validation to ensure it remains within the resolved `sourceDir`.
  * Rejects non-string values and attempts to escape via traversal, absolute paths outside the root, or symlink-based escapes, returning a stable `invalid_diagnostics_path:` error and avoiding any diagnostics runner invocation.
  * `path` is allowed only for `file` mode; other modes reject `path`.
* **Documentation**
  * Added a security plan and design spec for diagnostics path containment.
* **Tests**
  * Expanded contract and adapter tests, including stricter “file mode” tool-argument mapping (e.g., `path`, `min_severity`, `range_start`, `range_end`, `max_findings`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->