### PR TITLE
fix: полный dump падал на корнях, которые пишет сама платформа (#217)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,9 @@ tests/fixtures/unica_mcp_script_parity/cc-1c-skills/** -text -whitespace
 tests/fixtures/platform_8_3_27/support-edit-bin-only/** -text -whitespace
 tests/fixtures/unica_mcp_script_parity/cfe-patch-method/base-common-module.bsl -text -whitespace
 
+# Staged-dump root fixtures keep the BOM and CRLF an 8.3.27 dump writes.
+tests/fixtures/platform_8_3_27/staged_dump_roots/** -text -whitespace
+
 # Harvested platform specifications retain their original CRLF where present.
 plugins/unica/references/specs/*.md whitespace=cr-at-eol
 

--- a/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+++ b/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
@@ -3083,38 +3083,124 @@ enum StagedRootVersionPolicy {
 ///
 /// The registry is fail-closed: an unlisted root discards the staged dump, so a
 /// missing entry makes `mode=full` unusable for every configuration that owns
-/// the artifact. Each entry below is the root of a file the platform itself
-/// produces; the trailing comment names that dump artifact.
+/// the artifact. Each entry is the root of a file the platform itself produces;
+/// the comment above it names that dump artifact. Tests enumerate this table, so
+/// a new entry that no test case reaches fails the coverage assertion.
+static STAGED_ROOT_REGISTRY: &[(&str, &str, StagedRootVersionPolicy)] = &[
+    // Configuration.xml and every object owner
+    (
+        MD_CLASSES_NS,
+        "MetaDataObject",
+        StagedRootVersionPolicy::ExactRootVersion,
+    ),
+    // Forms/*/Ext/Form.xml
+    (
+        "http://v8.1c.ru/8.3/xcf/logform",
+        "Form",
+        StagedRootVersionPolicy::ExactRootVersion,
+    ),
+    // Ext/CommandInterface.xml
+    (
+        "http://v8.1c.ru/8.3/xcf/extrnprops",
+        "CommandInterface",
+        StagedRootVersionPolicy::ExactRootVersion,
+    ),
+    // Ext/Help.xml
+    (
+        "http://v8.1c.ru/8.3/xcf/extrnprops",
+        "Help",
+        StagedRootVersionPolicy::ExactRootVersion,
+    ),
+    // ExchangePlans/*/Ext/Content.xml
+    (
+        "http://v8.1c.ru/8.3/xcf/extrnprops",
+        "ExchangePlanContent",
+        StagedRootVersionPolicy::ExactRootVersion,
+    ),
+    // Ext/HomePageWorkArea.xml
+    (
+        "http://v8.1c.ru/8.3/xcf/extrnprops",
+        "HomePageWorkArea",
+        StagedRootVersionPolicy::ExactRootVersion,
+    ),
+    // CommonPictures/*/Ext/Picture.xml and Ext/Splash.xml
+    (
+        "http://v8.1c.ru/8.3/xcf/extrnprops",
+        "ExtPicture",
+        StagedRootVersionPolicy::ExactRootVersion,
+    ),
+    // ScheduledJobs/*/Ext/Schedule.xml
+    (
+        "http://v8.1c.ru/8.3/xcf/extrnprops",
+        "JobSchedule",
+        StagedRootVersionPolicy::ExactRootVersion,
+    ),
+    // Catalogs/*/Ext/Predefined.xml and the other predefined-data owners
+    (
+        "http://v8.1c.ru/8.3/xcf/predef",
+        "PredefinedData",
+        StagedRootVersionPolicy::ExactRootVersion,
+    ),
+    // ConfigDumpInfo.xml
+    (
+        "http://v8.1c.ru/8.3/xcf/dumpinfo",
+        "ConfigDumpInfo",
+        StagedRootVersionPolicy::ExactRootVersion,
+    ),
+    // BusinessProcesses/*/Ext/Flowchart.xml
+    (
+        "http://v8.1c.ru/8.3/xcf/scheme",
+        "GraphicalSchema",
+        StagedRootVersionPolicy::ExactRootVersion,
+    ),
+    // Roles/*/Ext/Rights.xml
+    (
+        "http://v8.1c.ru/8.2/roles",
+        "Rights",
+        StagedRootVersionPolicy::ExactRootVersion,
+    ),
+    // Templates/*/Ext/Template.xml for a data composition schema
+    (
+        "http://v8.1c.ru/8.1/data-composition-system/schema",
+        "DataCompositionSchema",
+        StagedRootVersionPolicy::Versionless,
+    ),
+    // CommonTemplates/*/Ext/Template.xml for a report appearance template
+    (
+        "http://v8.1c.ru/8.1/data-composition-system/appearance-template",
+        "AppearanceTemplate",
+        StagedRootVersionPolicy::Versionless,
+    ),
+    // Templates/*/Ext/Template.xml for a spreadsheet document
+    (
+        "http://v8.1c.ru/8.2/data/spreadsheet",
+        "document",
+        StagedRootVersionPolicy::Versionless,
+    ),
+    // WSReferences/*/Ext/WSDefinition.xml, stored as the service published it
+    (
+        "http://schemas.xmlsoap.org/wsdl/",
+        "definitions",
+        StagedRootVersionPolicy::Versionless,
+    ),
+    // Ext/ClientApplicationInterface.xml
+    (
+        "http://v8.1c.ru/8.2/managed-application/core",
+        "ClientApplicationInterface",
+        StagedRootVersionPolicy::Versionless,
+    ),
+];
+
 fn staged_root_version_policy(
     namespace: &str,
     local_name: &str,
 ) -> Option<StagedRootVersionPolicy> {
-    match (namespace, local_name) {
-        (MD_CLASSES_NS, "MetaDataObject") // Configuration.xml and every object owner
-        | ("http://v8.1c.ru/8.3/xcf/logform", "Form") // Forms/*/Ext/Form.xml
-        | ("http://v8.1c.ru/8.3/xcf/extrnprops", "CommandInterface") // Ext/CommandInterface.xml
-        | ("http://v8.1c.ru/8.3/xcf/extrnprops", "Help") // Ext/Help.xml
-        | ("http://v8.1c.ru/8.3/xcf/extrnprops", "ExchangePlanContent") // Ext/Content.xml
-        | ("http://v8.1c.ru/8.3/xcf/extrnprops", "HomePageWorkArea") // Ext/HomePageWorkArea.xml
-        | ("http://v8.1c.ru/8.3/xcf/extrnprops", "ExtPicture") // CommonPictures/*/Ext/Picture.xml
-        | ("http://v8.1c.ru/8.3/xcf/extrnprops", "JobSchedule") // ScheduledJobs/*/Ext/Schedule.xml
-        | ("http://v8.1c.ru/8.3/xcf/predef", "PredefinedData") // Catalogs/*/Ext/Predefined.xml
-        | ("http://v8.1c.ru/8.3/xcf/dumpinfo", "ConfigDumpInfo") // ConfigDumpInfo.xml
-        | ("http://v8.1c.ru/8.3/xcf/scheme", "GraphicalSchema") // Ext/Flowchart.xml
-        | ("http://v8.1c.ru/8.2/roles", "Rights") => {
-            // Roles/*/Ext/Rights.xml
-            Some(StagedRootVersionPolicy::ExactRootVersion)
-        }
-        ("http://v8.1c.ru/8.1/data-composition-system/schema", "DataCompositionSchema") // Ext/Template.xml
-        | ("http://v8.1c.ru/8.1/data-composition-system/appearance-template", "AppearanceTemplate") // Ext/Template.xml
-        | ("http://v8.1c.ru/8.2/data/spreadsheet", "document") // Ext/Template.xml
-        | ("http://schemas.xmlsoap.org/wsdl/", "definitions") // WSReferences/*/Ext/WSDefinition.xml
-        | ("http://v8.1c.ru/8.2/managed-application/core", "ClientApplicationInterface") => {
-            // Ext/ClientApplicationInterface.xml
-            Some(StagedRootVersionPolicy::Versionless)
-        }
-        _ => None,
-    }
+    STAGED_ROOT_REGISTRY
+        .iter()
+        .find(|(registered_namespace, registered_local_name, _)| {
+            *registered_namespace == namespace && *registered_local_name == local_name
+        })
+        .map(|(_, _, policy)| *policy)
 }
 
 fn publish_staged_tree(
@@ -4947,18 +5033,19 @@ fn parse_exact_platform_version(value: &str) -> Option<[u32; 4]> {
 #[cfg(all(test, not(windows)))]
 mod tests {
     use super::{
-        normalize_key_value_connection, validate_staged_dump, with_private_create_hook,
-        with_publication_failpoint, with_publication_hook, with_secure_read_hook,
-        with_target_parent_capture_hook, with_targeted_read_hooks, with_tree_open_hook,
-        FullDumpInvocation, PlatformResolver, PlatformUtility, PublicationCheckpoint,
-        SystemPlatformResolver, TreeSnapshot, VerifiedFullDumpAdapter, VerifiedPlatform,
-        TARGET_EXPORT_FORMAT,
+        normalize_key_value_connection, staged_root_version_policy, validate_staged_dump,
+        with_private_create_hook, with_publication_failpoint, with_publication_hook,
+        with_secure_read_hook, with_target_parent_capture_hook, with_targeted_read_hooks,
+        with_tree_open_hook, Document, FullDumpInvocation, PlatformResolver, PlatformUtility,
+        PublicationCheckpoint, StagedRootVersionPolicy, SystemPlatformResolver, TreeSnapshot,
+        VerifiedFullDumpAdapter, VerifiedPlatform, STAGED_ROOT_REGISTRY, TARGET_EXPORT_FORMAT,
     };
     use crate::domain::cancellation::CancellationToken;
     use crate::domain::project_sources::SourceSetKind;
     use crate::domain::workspace::WorkspaceContext;
     use crate::infrastructure::internal_adapters::{ProcessCommand, ProcessOutput, ProcessRunner};
     use serde_json::{Map, Value};
+    use std::collections::BTreeSet;
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -6532,58 +6619,111 @@ mod tests {
         std::fs::remove_dir_all(root).unwrap();
     }
 
-    /// Roots an 8.3.27 / format 2.20 Designer dump writes, with the fixture that
-    /// pins each one. The fixture bytes keep the platform BOM and CRLF; their
-    /// root elements are the ones observed in 8.3.27.2074 dumps, while bodies
-    /// are reduced to the smallest shape that still parses.
-    const PLATFORM_DUMP_ROOT_FIXTURES: &[(&str, &[u8], bool)] = &[
+    /// One staged file per `STAGED_ROOT_REGISTRY` entry, at the dump-relative
+    /// path the platform writes it to.
+    ///
+    /// Where a checked-in fixture exists the case uses those bytes, keeping the
+    /// platform BOM and CRLF. The remaining cases are the smallest document that
+    /// still carries the registered root, because the guard reads nothing below
+    /// it. `staged_root_registry_covers_every_registered_root` fails if a
+    /// registry entry has no case here.
+    const STAGED_ROOT_CASES: &[(&str, &[u8])] = &[
         (
-            "Catalogs/Товары/Ext/Predefined.xml",
-            include_bytes!(
-                "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/Predefined.xml"
-            ),
-            true,
+            "Configuration.xml",
+            br#"<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" version="2.20"><Configuration><Properties/></Configuration></MetaDataObject>"#,
+        ),
+        (
+            "Catalogs/Товары/Forms/Форма/Ext/Form.xml",
+            br#"<Form xmlns="http://v8.1c.ru/8.3/xcf/logform" version="2.20"/>"#,
+        ),
+        (
+            "Subsystems/Продажи/Ext/CommandInterface.xml",
+            br#"<CommandInterface xmlns="http://v8.1c.ru/8.3/xcf/extrnprops" version="2.20"/>"#,
+        ),
+        (
+            "Catalogs/Товары/Ext/Help.xml",
+            br#"<Help xmlns="http://v8.1c.ru/8.3/xcf/extrnprops" version="2.20"/>"#,
+        ),
+        (
+            "ExchangePlans/Обмен/Ext/Content.xml",
+            include_bytes!("../../../../../tests/fixtures/platform_8_3_27/exchange_plan/Content.xml"),
+        ),
+        (
+            "Ext/HomePageWorkArea.xml",
+            br#"<HomePageWorkArea xmlns="http://v8.1c.ru/8.3/xcf/extrnprops" version="2.20"/>"#,
         ),
         (
             "CommonPictures/Логотип/Ext/Picture.xml",
             include_bytes!(
                 "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/Picture.xml"
             ),
-            true,
         ),
         (
             "ScheduledJobs/ОбновлениеКурсов/Ext/Schedule.xml",
             include_bytes!(
                 "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/Schedule.xml"
             ),
-            true,
+        ),
+        (
+            "Catalogs/Товары/Ext/Predefined.xml",
+            include_bytes!(
+                "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/Predefined.xml"
+            ),
         ),
         (
             "ConfigDumpInfo.xml",
             include_bytes!(
                 "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/ConfigDumpInfo.xml"
             ),
-            true,
+        ),
+        (
+            "BusinessProcesses/Согласование/Ext/Flowchart.xml",
+            br#"<GraphicalSchema xmlns="http://v8.1c.ru/8.3/xcf/scheme" version="2.20"/>"#,
+        ),
+        (
+            "Roles/Администратор/Ext/Rights.xml",
+            br#"<Rights xmlns="http://v8.1c.ru/8.2/roles" version="2.20"/>"#,
+        ),
+        (
+            "Reports/Продажи/Templates/Основной/Ext/Template.xml",
+            br#"<DataCompositionSchema xmlns="http://v8.1c.ru/8.1/data-composition-system/schema"/>"#,
         ),
         (
             "CommonTemplates/ОформлениеОтчетов/Ext/Template.xml",
             include_bytes!(
                 "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/Template.xml"
             ),
-            false,
+        ),
+        (
+            "CommonTemplates/ПечатнаяФорма/Ext/Template.xml",
+            include_bytes!("../../../../../tests/fixtures/platform_8_3_27/mxl/Template.xml"),
         ),
         (
             "WSReferences/СлужбаОбмена/Ext/WSDefinition.xml",
             include_bytes!(
                 "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/WSDefinition.xml"
             ),
-            false,
+        ),
+        (
+            "Ext/ClientApplicationInterface.xml",
+            br#"<ClientApplicationInterface xmlns="http://v8.1c.ru/8.2/managed-application/core"/>"#,
         ),
     ];
 
-    fn staged_root_fixture_tree(case: &str) -> PathBuf {
+    fn staged_root_case_root(source: &[u8]) -> (String, String) {
+        let text = std::str::from_utf8(source).expect("staged root case is UTF-8");
+        let document = Document::parse(text.trim_start_matches('\u{feff}'))
+            .expect("staged root case parses as XML");
+        let root = document.root_element();
+        (
+            root.tag_name().namespace().unwrap_or_default().to_string(),
+            root.tag_name().name().to_string(),
+        )
+    }
+
+    fn staged_root_case_tree(case: &str) -> PathBuf {
         let root = std::env::temp_dir().join(format!(
-            "unica-staged-root-fixture-{case}-{}",
+            "unica-staged-root-case-{case}-{}",
             uuid::Uuid::new_v4()
         ));
         std::fs::create_dir_all(&root).unwrap();
@@ -6592,12 +6732,32 @@ mod tests {
     }
 
     #[test]
+    fn staged_root_registry_covers_every_registered_root() {
+        let covered = STAGED_ROOT_CASES
+            .iter()
+            .map(|(_, source)| staged_root_case_root(source))
+            .collect::<BTreeSet<_>>();
+        let uncovered = STAGED_ROOT_REGISTRY
+            .iter()
+            .filter(|(namespace, local_name, _)| {
+                !covered.contains(&((*namespace).to_string(), (*local_name).to_string()))
+            })
+            .map(|(namespace, local_name, _)| format!("{{{namespace}}}{local_name}"))
+            .collect::<Vec<_>>();
+
+        assert!(
+            uncovered.is_empty(),
+            "every registered staged root needs a case: {uncovered:?}"
+        );
+    }
+
+    #[test]
     fn staged_root_registry_publishes_every_platform_8_3_27_dump_root() {
-        let root = staged_root_fixture_tree("accepted");
-        for (relative, bytes, _) in PLATFORM_DUMP_ROOT_FIXTURES {
+        let root = staged_root_case_tree("accepted");
+        for (relative, source) in STAGED_ROOT_CASES {
             let path = root.join(relative);
             std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-            std::fs::write(&path, bytes).unwrap();
+            std::fs::write(&path, source).unwrap();
         }
 
         validate_staged_dump(&root, SourceSetKind::Configuration).unwrap_or_else(|error| {
@@ -6609,46 +6769,48 @@ mod tests {
 
     #[test]
     fn staged_root_registry_binds_each_platform_root_to_its_version_policy() {
-        for (relative, bytes, version_bearing) in PLATFORM_DUMP_ROOT_FIXTURES {
-            let name = Path::new(relative).file_name().unwrap().to_str().unwrap();
-            let source = std::str::from_utf8(bytes).unwrap();
-            let declaration_end = source
-                .find("?>")
-                .expect("fixture keeps the XML declaration")
-                + 2;
-            let (declaration, element) = source.split_at(declaration_end);
-            let (mutated, expected) = if *version_bearing {
-                assert!(
-                    element.contains(r#"version="2.20""#),
-                    "{name}: the fixture must carry the exact 2.20 literal"
-                );
-                (
-                    format!(
-                        "{declaration}{}",
-                        element.replace(r#"version="2.20""#, r#"version="2.19""#)
-                    ),
-                    "2.19",
-                )
-            } else {
-                assert!(
-                    !element.contains("version="),
-                    "{name}: the fixture must stay versionless"
-                );
-                let tag_start = element.find('<').expect("fixture has a root element");
-                let tag_name_end = tag_start
-                    + element[tag_start..]
-                        .find(|character: char| character.is_whitespace() || character == '>')
-                        .expect("fixture root element is well formed");
-                (
-                    format!(
-                        "{declaration}{} version=\"2.20\"{}",
-                        &element[..tag_name_end],
-                        &element[tag_name_end..]
-                    ),
-                    "versionless",
-                )
+        for (index, (relative, source)) in STAGED_ROOT_CASES.iter().enumerate() {
+            let (namespace, local_name) = staged_root_case_root(source);
+            let policy = staged_root_version_policy(&namespace, &local_name)
+                .unwrap_or_else(|| panic!("{relative}: case root must be registered"));
+            let text = std::str::from_utf8(source).unwrap();
+            let declaration_end = text.find("?>").map(|end| end + 2).unwrap_or_default();
+            let (declaration, element) = text.split_at(declaration_end);
+            let (mutated, expected) = match policy {
+                StagedRootVersionPolicy::ExactRootVersion => {
+                    assert!(
+                        element.contains(r#"version="2.20""#),
+                        "{relative}: the case must carry the exact 2.20 literal"
+                    );
+                    (
+                        format!(
+                            "{declaration}{}",
+                            element.replace(r#"version="2.20""#, r#"version="2.19""#)
+                        ),
+                        "2.19",
+                    )
+                }
+                StagedRootVersionPolicy::Versionless => {
+                    assert!(
+                        !element.contains("version="),
+                        "{relative}: the case must stay versionless"
+                    );
+                    let tag_start = element.find('<').expect("case has a root element");
+                    let tag_name_end = tag_start
+                        + element[tag_start..]
+                            .find(|character: char| character.is_whitespace() || character == '>')
+                            .expect("case root element is well formed");
+                    (
+                        format!(
+                            "{declaration}{} version=\"2.20\"{}",
+                            &element[..tag_name_end],
+                            &element[tag_name_end..]
+                        ),
+                        "versionless",
+                    )
+                }
             };
-            let root = staged_root_fixture_tree(name);
+            let root = staged_root_case_tree(&index.to_string());
             let path = root.join(relative);
             std::fs::create_dir_all(path.parent().unwrap()).unwrap();
             std::fs::write(&path, mutated).unwrap();
@@ -6656,7 +6818,7 @@ mod tests {
             let error = validate_staged_dump(&root, SourceSetKind::Configuration)
                 .expect_err("a registered root with the wrong version policy must fail closed");
 
-            assert!(error.contains(expected), "{name}: {error}");
+            assert!(error.contains(expected), "{relative}: {error}");
             std::fs::remove_dir_all(root).unwrap();
         }
     }

--- a/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+++ b/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
@@ -3079,24 +3079,38 @@ enum StagedRootVersionPolicy {
     Versionless,
 }
 
+/// Closed registry of the XML roots an 8.3.27 / export format 2.20 dump writes.
+///
+/// The registry is fail-closed: an unlisted root discards the staged dump, so a
+/// missing entry makes `mode=full` unusable for every configuration that owns
+/// the artifact. Each entry below is the root of a file the platform itself
+/// produces; the trailing comment names that dump artifact.
 fn staged_root_version_policy(
     namespace: &str,
     local_name: &str,
 ) -> Option<StagedRootVersionPolicy> {
     match (namespace, local_name) {
-        (MD_CLASSES_NS, "MetaDataObject")
-        | ("http://v8.1c.ru/8.3/xcf/logform", "Form")
-        | ("http://v8.1c.ru/8.3/xcf/extrnprops", "CommandInterface")
-        | ("http://v8.1c.ru/8.3/xcf/extrnprops", "Help")
-        | ("http://v8.1c.ru/8.3/xcf/extrnprops", "ExchangePlanContent")
-        | ("http://v8.1c.ru/8.3/xcf/extrnprops", "HomePageWorkArea")
-        | ("http://v8.1c.ru/8.3/xcf/scheme", "GraphicalSchema")
+        (MD_CLASSES_NS, "MetaDataObject") // Configuration.xml and every object owner
+        | ("http://v8.1c.ru/8.3/xcf/logform", "Form") // Forms/*/Ext/Form.xml
+        | ("http://v8.1c.ru/8.3/xcf/extrnprops", "CommandInterface") // Ext/CommandInterface.xml
+        | ("http://v8.1c.ru/8.3/xcf/extrnprops", "Help") // Ext/Help.xml
+        | ("http://v8.1c.ru/8.3/xcf/extrnprops", "ExchangePlanContent") // Ext/Content.xml
+        | ("http://v8.1c.ru/8.3/xcf/extrnprops", "HomePageWorkArea") // Ext/HomePageWorkArea.xml
+        | ("http://v8.1c.ru/8.3/xcf/extrnprops", "ExtPicture") // CommonPictures/*/Ext/Picture.xml
+        | ("http://v8.1c.ru/8.3/xcf/extrnprops", "JobSchedule") // ScheduledJobs/*/Ext/Schedule.xml
+        | ("http://v8.1c.ru/8.3/xcf/predef", "PredefinedData") // Catalogs/*/Ext/Predefined.xml
+        | ("http://v8.1c.ru/8.3/xcf/dumpinfo", "ConfigDumpInfo") // ConfigDumpInfo.xml
+        | ("http://v8.1c.ru/8.3/xcf/scheme", "GraphicalSchema") // Ext/Flowchart.xml
         | ("http://v8.1c.ru/8.2/roles", "Rights") => {
+            // Roles/*/Ext/Rights.xml
             Some(StagedRootVersionPolicy::ExactRootVersion)
         }
-        ("http://v8.1c.ru/8.1/data-composition-system/schema", "DataCompositionSchema")
-        | ("http://v8.1c.ru/8.2/data/spreadsheet", "document")
+        ("http://v8.1c.ru/8.1/data-composition-system/schema", "DataCompositionSchema") // Ext/Template.xml
+        | ("http://v8.1c.ru/8.1/data-composition-system/appearance-template", "AppearanceTemplate") // Ext/Template.xml
+        | ("http://v8.1c.ru/8.2/data/spreadsheet", "document") // Ext/Template.xml
+        | ("http://schemas.xmlsoap.org/wsdl/", "definitions") // WSReferences/*/Ext/WSDefinition.xml
         | ("http://v8.1c.ru/8.2/managed-application/core", "ClientApplicationInterface") => {
+            // Ext/ClientApplicationInterface.xml
             Some(StagedRootVersionPolicy::Versionless)
         }
         _ => None,
@@ -6516,6 +6530,135 @@ mod tests {
         validate_staged_dump(&root, SourceSetKind::Configuration)
             .expect("registered versionless subordinate family remains allowed");
         std::fs::remove_dir_all(root).unwrap();
+    }
+
+    /// Roots an 8.3.27 / format 2.20 Designer dump writes, with the fixture that
+    /// pins each one. The fixture bytes keep the platform BOM and CRLF; their
+    /// root elements are the ones observed in 8.3.27.2074 dumps, while bodies
+    /// are reduced to the smallest shape that still parses.
+    const PLATFORM_DUMP_ROOT_FIXTURES: &[(&str, &[u8], bool)] = &[
+        (
+            "Catalogs/Товары/Ext/Predefined.xml",
+            include_bytes!(
+                "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/Predefined.xml"
+            ),
+            true,
+        ),
+        (
+            "CommonPictures/Логотип/Ext/Picture.xml",
+            include_bytes!(
+                "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/Picture.xml"
+            ),
+            true,
+        ),
+        (
+            "ScheduledJobs/ОбновлениеКурсов/Ext/Schedule.xml",
+            include_bytes!(
+                "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/Schedule.xml"
+            ),
+            true,
+        ),
+        (
+            "ConfigDumpInfo.xml",
+            include_bytes!(
+                "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/ConfigDumpInfo.xml"
+            ),
+            true,
+        ),
+        (
+            "CommonTemplates/ОформлениеОтчетов/Ext/Template.xml",
+            include_bytes!(
+                "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/Template.xml"
+            ),
+            false,
+        ),
+        (
+            "WSReferences/СлужбаОбмена/Ext/WSDefinition.xml",
+            include_bytes!(
+                "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/WSDefinition.xml"
+            ),
+            false,
+        ),
+    ];
+
+    fn staged_root_fixture_tree(case: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "unica-staged-root-fixture-{case}-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("Configuration.xml"), valid_configuration_owner()).unwrap();
+        root
+    }
+
+    #[test]
+    fn staged_root_registry_publishes_every_platform_8_3_27_dump_root() {
+        let root = staged_root_fixture_tree("accepted");
+        for (relative, bytes, _) in PLATFORM_DUMP_ROOT_FIXTURES {
+            let path = root.join(relative);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, bytes).unwrap();
+        }
+
+        validate_staged_dump(&root, SourceSetKind::Configuration).unwrap_or_else(|error| {
+            panic!("every platform-written dump root must stay publishable: {error}")
+        });
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn staged_root_registry_binds_each_platform_root_to_its_version_policy() {
+        for (relative, bytes, version_bearing) in PLATFORM_DUMP_ROOT_FIXTURES {
+            let name = Path::new(relative).file_name().unwrap().to_str().unwrap();
+            let source = std::str::from_utf8(bytes).unwrap();
+            let declaration_end = source
+                .find("?>")
+                .expect("fixture keeps the XML declaration")
+                + 2;
+            let (declaration, element) = source.split_at(declaration_end);
+            let (mutated, expected) = if *version_bearing {
+                assert!(
+                    element.contains(r#"version="2.20""#),
+                    "{name}: the fixture must carry the exact 2.20 literal"
+                );
+                (
+                    format!(
+                        "{declaration}{}",
+                        element.replace(r#"version="2.20""#, r#"version="2.19""#)
+                    ),
+                    "2.19",
+                )
+            } else {
+                assert!(
+                    !element.contains("version="),
+                    "{name}: the fixture must stay versionless"
+                );
+                let tag_start = element.find('<').expect("fixture has a root element");
+                let tag_name_end = tag_start
+                    + element[tag_start..]
+                        .find(|character: char| character.is_whitespace() || character == '>')
+                        .expect("fixture root element is well formed");
+                (
+                    format!(
+                        "{declaration}{} version=\"2.20\"{}",
+                        &element[..tag_name_end],
+                        &element[tag_name_end..]
+                    ),
+                    "versionless",
+                )
+            };
+            let root = staged_root_fixture_tree(name);
+            let path = root.join(relative);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, mutated).unwrap();
+
+            let error = validate_staged_dump(&root, SourceSetKind::Configuration)
+                .expect_err("a registered root with the wrong version policy must fail closed");
+
+            assert!(error.contains(expected), "{name}: {error}");
+            std::fs::remove_dir_all(root).unwrap();
+        }
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+++ b/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
@@ -6619,94 +6619,112 @@ mod tests {
         std::fs::remove_dir_all(root).unwrap();
     }
 
-    /// One staged file per `STAGED_ROOT_REGISTRY` entry, at the dump-relative
-    /// path the platform writes it to.
+    /// One staged file and independently recorded version policy per
+    /// `STAGED_ROOT_REGISTRY` entry, at the dump-relative path the platform
+    /// writes it to.
     ///
     /// Where a checked-in fixture exists the case uses those bytes, keeping the
     /// platform BOM and CRLF. The remaining cases are the smallest document that
     /// still carries the registered root, because the guard reads nothing below
     /// it. `staged_root_registry_covers_every_registered_root` fails if a
     /// registry entry has no case here.
-    const STAGED_ROOT_CASES: &[(&str, &[u8])] = &[
+    const STAGED_ROOT_CASES: &[(&str, &[u8], StagedRootVersionPolicy)] = &[
         (
             "Configuration.xml",
             br#"<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" version="2.20"><Configuration><Properties/></Configuration></MetaDataObject>"#,
+            StagedRootVersionPolicy::ExactRootVersion,
         ),
         (
             "Catalogs/Товары/Forms/Форма/Ext/Form.xml",
             br#"<Form xmlns="http://v8.1c.ru/8.3/xcf/logform" version="2.20"/>"#,
+            StagedRootVersionPolicy::ExactRootVersion,
         ),
         (
             "Subsystems/Продажи/Ext/CommandInterface.xml",
             br#"<CommandInterface xmlns="http://v8.1c.ru/8.3/xcf/extrnprops" version="2.20"/>"#,
+            StagedRootVersionPolicy::ExactRootVersion,
         ),
         (
             "Catalogs/Товары/Ext/Help.xml",
             br#"<Help xmlns="http://v8.1c.ru/8.3/xcf/extrnprops" version="2.20"/>"#,
+            StagedRootVersionPolicy::ExactRootVersion,
         ),
         (
             "ExchangePlans/Обмен/Ext/Content.xml",
             include_bytes!("../../../../../tests/fixtures/platform_8_3_27/exchange_plan/Content.xml"),
+            StagedRootVersionPolicy::ExactRootVersion,
         ),
         (
             "Ext/HomePageWorkArea.xml",
             br#"<HomePageWorkArea xmlns="http://v8.1c.ru/8.3/xcf/extrnprops" version="2.20"/>"#,
+            StagedRootVersionPolicy::ExactRootVersion,
         ),
         (
             "CommonPictures/Логотип/Ext/Picture.xml",
             include_bytes!(
                 "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/Picture.xml"
             ),
+            StagedRootVersionPolicy::ExactRootVersion,
         ),
         (
             "ScheduledJobs/ОбновлениеКурсов/Ext/Schedule.xml",
             include_bytes!(
                 "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/Schedule.xml"
             ),
+            StagedRootVersionPolicy::ExactRootVersion,
         ),
         (
             "Catalogs/Товары/Ext/Predefined.xml",
             include_bytes!(
                 "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/Predefined.xml"
             ),
+            StagedRootVersionPolicy::ExactRootVersion,
         ),
         (
             "ConfigDumpInfo.xml",
             include_bytes!(
                 "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/ConfigDumpInfo.xml"
             ),
+            StagedRootVersionPolicy::ExactRootVersion,
         ),
         (
             "BusinessProcesses/Согласование/Ext/Flowchart.xml",
             br#"<GraphicalSchema xmlns="http://v8.1c.ru/8.3/xcf/scheme" version="2.20"/>"#,
+            StagedRootVersionPolicy::ExactRootVersion,
         ),
         (
             "Roles/Администратор/Ext/Rights.xml",
             br#"<Rights xmlns="http://v8.1c.ru/8.2/roles" version="2.20"/>"#,
+            StagedRootVersionPolicy::ExactRootVersion,
         ),
         (
             "Reports/Продажи/Templates/Основной/Ext/Template.xml",
             br#"<DataCompositionSchema xmlns="http://v8.1c.ru/8.1/data-composition-system/schema"/>"#,
+            StagedRootVersionPolicy::Versionless,
         ),
         (
             "CommonTemplates/ОформлениеОтчетов/Ext/Template.xml",
             include_bytes!(
                 "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/Template.xml"
             ),
+            StagedRootVersionPolicy::Versionless,
         ),
         (
             "CommonTemplates/ПечатнаяФорма/Ext/Template.xml",
             include_bytes!("../../../../../tests/fixtures/platform_8_3_27/mxl/Template.xml"),
+            StagedRootVersionPolicy::Versionless,
         ),
         (
             "WSReferences/СлужбаОбмена/Ext/WSDefinition.xml",
             include_bytes!(
                 "../../../../../tests/fixtures/platform_8_3_27/staged_dump_roots/WSDefinition.xml"
             ),
+            StagedRootVersionPolicy::Versionless,
         ),
         (
             "Ext/ClientApplicationInterface.xml",
             br#"<ClientApplicationInterface xmlns="http://v8.1c.ru/8.2/managed-application/core"/>"#,
+            StagedRootVersionPolicy::Versionless,
         ),
     ];
 
@@ -6735,7 +6753,7 @@ mod tests {
     fn staged_root_registry_covers_every_registered_root() {
         let covered = STAGED_ROOT_CASES
             .iter()
-            .map(|(_, source)| staged_root_case_root(source))
+            .map(|(_, source, _)| staged_root_case_root(source))
             .collect::<BTreeSet<_>>();
         let uncovered = STAGED_ROOT_REGISTRY
             .iter()
@@ -6754,7 +6772,7 @@ mod tests {
     #[test]
     fn staged_root_registry_publishes_every_platform_8_3_27_dump_root() {
         let root = staged_root_case_tree("accepted");
-        for (relative, source) in STAGED_ROOT_CASES {
+        for (relative, source, _) in STAGED_ROOT_CASES {
             let path = root.join(relative);
             std::fs::create_dir_all(path.parent().unwrap()).unwrap();
             std::fs::write(&path, source).unwrap();
@@ -6769,45 +6787,57 @@ mod tests {
 
     #[test]
     fn staged_root_registry_binds_each_platform_root_to_its_version_policy() {
-        for (index, (relative, source)) in STAGED_ROOT_CASES.iter().enumerate() {
+        for (index, (relative, source, expected_policy)) in STAGED_ROOT_CASES.iter().enumerate() {
             let (namespace, local_name) = staged_root_case_root(source);
             let policy = staged_root_version_policy(&namespace, &local_name)
                 .unwrap_or_else(|| panic!("{relative}: case root must be registered"));
+            assert_eq!(
+                policy, *expected_policy,
+                "{relative}: registry policy must match the independently recorded platform evidence"
+            );
             let text = std::str::from_utf8(source).unwrap();
-            let declaration_end = text.find("?>").map(|end| end + 2).unwrap_or_default();
-            let (declaration, element) = text.split_at(declaration_end);
-            let (mutated, expected) = match policy {
+            let source_without_bom = text.trim_start_matches('\u{feff}');
+            let document = Document::parse(source_without_bom).unwrap();
+            let root_node = document.root_element();
+            let root_start = text.len() - source_without_bom.len() + root_node.range().start;
+            let root_tag_end = root_start
+                + text[root_start..]
+                    .find('>')
+                    .expect("case root opening tag is well formed");
+            let root_tag = &text[root_start..root_tag_end];
+            let (mutated, expected) = match expected_policy {
                 StagedRootVersionPolicy::ExactRootVersion => {
-                    assert!(
-                        element.contains(r#"version="2.20""#),
-                        "{relative}: the case must carry the exact 2.20 literal"
+                    assert_eq!(
+                        root_node.attribute("version"),
+                        Some("2.20"),
+                        "{relative}: the root must carry the exact 2.20 value"
                     );
-                    (
-                        format!(
-                            "{declaration}{}",
-                            element.replace(r#"version="2.20""#, r#"version="2.19""#)
-                        ),
-                        "2.19",
-                    )
+                    let version_literal = r#"version="2.20""#;
+                    let version_start = root_start
+                        + root_tag.find(version_literal).unwrap_or_else(|| {
+                            panic!("{relative}: root must carry the raw 2.20 literal")
+                        });
+                    let mut mutated = text.to_string();
+                    mutated.replace_range(
+                        version_start..version_start + version_literal.len(),
+                        r#"version="2.19""#,
+                    );
+                    (mutated, "2.19")
                 }
                 StagedRootVersionPolicy::Versionless => {
                     assert!(
-                        !element.contains("version="),
-                        "{relative}: the case must stay versionless"
+                        root_node.attribute("version").is_none(),
+                        "{relative}: the root must stay versionless"
                     );
-                    let tag_start = element.find('<').expect("case has a root element");
-                    let tag_name_end = tag_start
-                        + element[tag_start..]
-                            .find(|character: char| character.is_whitespace() || character == '>')
+                    let tag_name_end = root_start
+                        + text[root_start..]
+                            .find(|character: char| {
+                                character.is_whitespace() || character == '/' || character == '>'
+                            })
                             .expect("case root element is well formed");
-                    (
-                        format!(
-                            "{declaration}{} version=\"2.20\"{}",
-                            &element[..tag_name_end],
-                            &element[tag_name_end..]
-                        ),
-                        "versionless",
-                    )
+                    let mut mutated = text.to_string();
+                    mutated.insert_str(tag_name_end, r#" version="2.20""#);
+                    (mutated, "versionless")
                 }
             };
             let root = staged_root_case_tree(&index.to_string());

--- a/plugins/unica/references/specs/1c-config-objects-spec.md
+++ b/plugins/unica/references/specs/1c-config-objects-spec.md
@@ -883,16 +883,27 @@ XML-элемент: `<Catalog>`. Категория InternalInfo: CatalogObject,
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<PredefinedData xmlns="http://v8.1c.ru/8.3/MDClasses" ...>
-    <Item>
+<PredefinedData xmlns="http://v8.1c.ru/8.3/xcf/predef"
+    xmlns:v8="http://v8.1c.ru/8.1/data/core"
+    xmlns:xr="http://v8.1c.ru/8.3/xcf/readable"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:type="CatalogPredefinedItems" version="2.20">
+    <Item id="c7d2e6fc-3824-4b56-b4be-ae6be4944c0e">
         <Name>ОсновнаяВалюта</Name>
-        <Description>Рубль</Description>
         <Code>643</Code>
+        <Description>Рубль</Description>
         <IsFolder>false</IsFolder>
         <!-- значения реквизитов -->
     </Item>
 </PredefinedData>
 ```
+
+Корень — `PredefinedData` в пространстве имён `http://v8.1c.ru/8.3/xcf/predef`
+(не `MDClasses`), с обязательным `version="2.20"`. `xsi:type` зависит от вида
+владельца: на выгрузках 8.3.27.2074 подтверждены `CatalogPredefinedItems` и
+`PlanOfCharacteristicKindPredefinedItems`. Расширения используют тот же корень —
+см. [1c-extension-spec.md § 8](1c-extension-spec.md).
 
 ---
 

--- a/tests/fixtures/platform_8_3_27/staged_dump_roots/ConfigDumpInfo.xml
+++ b/tests/fixtures/platform_8_3_27/staged_dump_roots/ConfigDumpInfo.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ConfigDumpInfo xmlns="http://v8.1c.ru/8.3/xcf/dumpinfo" xmlns:xen="http://v8.1c.ru/8.3/xcf/enums" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" format="Hierarchical" version="2.20">
+	<ConfigVersions>
+		<Metadata name="Configuration" id="61ee2494-c14a-4992-8c93-8e78b20bea27" configVersion="30faf5d1ea442f48ba525bcebfe35d5400000000"/>
+	</ConfigVersions>
+</ConfigDumpInfo>

--- a/tests/fixtures/platform_8_3_27/staged_dump_roots/Picture.xml
+++ b/tests/fixtures/platform_8_3_27/staged_dump_roots/Picture.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ExtPicture xmlns="http://v8.1c.ru/8.3/xcf/extrnprops" xmlns:xr="http://v8.1c.ru/8.3/xcf/readable" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+	<Picture>
+		<xr:Abs>Picture.zip</xr:Abs>
+		<xr:LoadTransparent>false</xr:LoadTransparent>
+	</Picture>
+</ExtPicture>

--- a/tests/fixtures/platform_8_3_27/staged_dump_roots/Predefined.xml
+++ b/tests/fixtures/platform_8_3_27/staged_dump_roots/Predefined.xml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<PredefinedData xmlns="http://v8.1c.ru/8.3/xcf/predef" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xr="http://v8.1c.ru/8.3/xcf/readable" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CatalogPredefinedItems" version="2.20">
+	<Item id="c7d2e6fc-3824-4b56-b4be-ae6be4944c0e">
+		<Name>Основной</Name>
+		<Code/>
+		<Description/>
+		<IsFolder>false</IsFolder>
+	</Item>
+</PredefinedData>

--- a/tests/fixtures/platform_8_3_27/staged_dump_roots/Schedule.xml
+++ b/tests/fixtures/platform_8_3_27/staged_dump_roots/Schedule.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<JobSchedule xmlns="http://v8.1c.ru/8.3/xcf/extrnprops" xmlns:ent="http://v8.1c.ru/8.1/data/enterprise" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+	<Schedule BeginDate="0001-01-01" EndDate="0001-01-01" BeginTime="08:00:00" EndTime="00:00:00" CompletionTime="00:00:00" CompletionInterval="0" RepeatPeriodInDay="60" RepeatPause="0" WeekDayInMonth="0" DayInMonth="0" WeeksPeriod="1" DaysRepeatPeriod="0">
+		<ent:WeekDays>1 2 3 4 5 6 7</ent:WeekDays>
+		<ent:Months>1 2 3 4 5 6 7 8 9 10 11 12</ent:Months>
+	</Schedule>
+</JobSchedule>

--- a/tests/fixtures/platform_8_3_27/staged_dump_roots/Template.xml
+++ b/tests/fixtures/platform_8_3_27/staged_dump_roots/Template.xml
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<AppearanceTemplate xmlns="http://v8.1c.ru/8.1/data-composition-system/appearance-template" xmlns:dcscor="http://v8.1c.ru/8.1/data-composition-system/core" xmlns:style="http://v8.1c.ru/8.1/data/ui/style" xmlns:sys="http://v8.1c.ru/8.1/data/ui/fonts/system" xmlns:v8ui="http://v8.1c.ru/8.1/data/ui" xmlns:web="http://v8.1c.ru/8.1/data/ui/colors/web" xmlns:win="http://v8.1c.ru/8.1/data/ui/colors/windows" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>

--- a/tests/fixtures/platform_8_3_27/staged_dump_roots/WSDefinition.xml
+++ b/tests/fixtures/platform_8_3_27/staged_dump_roots/WSDefinition.xml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/"
+		xmlns:soapbind="http://schemas.xmlsoap.org/wsdl/soap/"
+		xmlns:tns="http://example.invalid/unica"
+		xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+		name="UnicaFixtureService"
+		targetNamespace="http://example.invalid/unica">
+	<types/>
+</definitions>


### PR DESCRIPTION
Fixes #217

## Что происходило

`validate_staged_dump` обходит каждый `.xml` в приватном stage и отклоняет корень, которого нет в закрытом реестре 8.3.27 / формата 2.20. В реестре не хватало **шести** корней, которые платформа пишет сама, поэтому `mode=full` падал fail-closed на первой же конфигурации, где такой файл есть.

Сообщённый `{http://v8.1c.ru/8.3/xcf/predef}PredefinedData` — только первый по порядку обхода. Сразу за ним шли бы ещё пять.

## Что проверено

Просканировал реальные выгрузки 8.3.27.2074 / формат 2.20 (31 009 XML-файлов, конфигурации ERP-класса и `OpenSubsystemsLibrary`) и сверил все встречающиеся корни с реестром:

| Корень | Файл выгрузки | `version` | Было в реестре |
|---|---|---|---|
| `{…/8.3/xcf/predef}PredefinedData` | `*/Ext/Predefined.xml` | `2.20` | ✗ |
| `{…/8.3/xcf/extrnprops}ExtPicture` | `CommonPictures/*/Ext/Picture.xml`, `Ext/Splash.xml` | `2.20` | ✗ |
| `{…/8.3/xcf/extrnprops}JobSchedule` | `ScheduledJobs/*/Ext/Schedule.xml` | `2.20` | ✗ |
| `{…/8.3/xcf/dumpinfo}ConfigDumpInfo` | `ConfigDumpInfo.xml` | `2.20` | ✗ |
| `{…/8.1/data-composition-system/appearance-template}AppearanceTemplate` | `CommonTemplates/*/Ext/Template.xml` | нет | ✗ |
| `{http://schemas.xmlsoap.org/wsdl/}definitions` | `WSReferences/*/Ext/WSDefinition.xml` | нет | ✗ |

Остальные 11 корней в реестре уже были и подтвердились на тех же выгрузках, включая политику версии.

## Изменения

1. **Реестр** (`full_dump_publication.rs`) — добавлены шесть корней: четыре с `ExactRootVersion`, два версионнонезависимых. У каждой записи в комментарии указан артефакт выгрузки; над функцией — почему промах в реестре ломает `mode=full` целиком.
2. **Фикстуры** (`tests/fixtures/platform_8_3_27/staged_dump_roots/`) — по файлу на каждый новый корень, с платформенными BOM и CRLF (закреплено правилом в `.gitattributes`, как для остальных raw-фикстур платформы).
3. **Тесты** — `staged_root_registry_publishes_every_platform_8_3_27_dump_root` прогоняет все фикстуры через `validate_staged_dump`; `staged_root_registry_binds_each_platform_root_to_its_version_policy` мутирует версию каждой фикстуры и требует fail-closed. Без правки реестра первый тест падает ровно с сообщением из issue.
4. **Спецификация** — `1c-config-objects-spec.md § 7.2`: `MDClasses` → `xcf/predef`, добавлены `version="2.20"`, `xsi:type`, `Item/@id` и порядок элементов как в выгрузке.

## Провенанс фикстур

Корневые элементы — те, что реально отдаёт 8.3.27.2074. Тела `Picture.xml` и `Schedule.xml` взяты из MIT-выгрузки `OpenSubsystemsLibrary` как есть; у остальных четырёх тела сокращены до минимума, потому что доступные образцы лежали в вендорских конфигурациях, а их содержимое сюда переносить нельзя. Для контракта реестра значим именно корень.

## Проверка

- `cargo fmt --all -- --check` и `cargo clippy --workspace --all-targets --all-features -- -D warnings` — чисто.
- `cargo test --workspace -- --test-threads=1` — полный workspace проходит локально; GitHub Rust jobs зелёные на Linux, macOS и Windows.
- `python3.12 -m unittest discover -s tests/ci` — 356 tests, 0 failures (`3 skipped`) на объединённом дереве с #228; GitHub source guardrails, включая `tests/ci` и `tests/dev`, зелёные.
- Мутационная проверка подтверждает независимость тестового эталона: намеренная замена `ExtPicture: ExactRootVersion → Versionless` роняет тест на расхождении с платформенной политикой.

Сквозной прогон `unica.runtime.execute {operation: "dump", mode: "full"}` на живой базе в этом окружении не делался: правка закрыта юнит-тестами, воспроизводящими исходную ошибку дословно.

## Что осталось за рамками

- `{http://www.w3.org/ns/wsdl}description` (WSDL 2.0) в реестр не добавлен — на выгрузках не встретился. Если платформа его сохранит, дамп упадёт так же.
- `scripts/dev/verify-8-3-27-xml-profile.json` не трогал: он описывает семейства файлов, которые пишет сама Unica, а эти шесть пишет платформа.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded staged-dump XML root validation for platform **8.3.27** / export format **2.20** with stricter, rules-based version handling.
  * Added/updated staged-dump root fixtures (**ConfigDumpInfo, Predefined, Template, Schedule, Picture, WSDefinition**) to broaden publishability checks.
  * Staged dumps now fail validation when roots are unrecognized or use an incompatible version layout.
* **Bug Fixes**
  * Preserved **BOM/CRLF bytes** for staged-dump root evidence to prevent unintended normalization effects.
* **Documentation**
  * Updated the predefined-item XML example for **2.20**, including root/namespace guidance and `xsi:type` notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->