### PR TITLE
fix(outline): report unavailable index states

### DIFF
--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -6172,6 +6172,45 @@ mod tests {
     }
 
     #[test]
+    fn code_outline_adapter_reports_building_index_as_retryable_failure() {
+        let context = temp_context("outline-building-index");
+        let lock_path = context.cache_root.join("locks/bsl_index.lock");
+        fs::create_dir_all(lock_path.parent().unwrap()).unwrap();
+        fs::write(&lock_path, "{").unwrap();
+        let index = FakeIndexRunner::default();
+        let grep = FakeProcessRunner {
+            output: ProcessOutput {
+                status_success: true,
+                status: "exit status: 0".to_string(),
+                stdout: String::new(),
+                stderr: String::new(),
+                timed_out: false,
+                cancelled: false,
+                stdout_truncated: false,
+            },
+        };
+        let args = Map::from_iter([(
+            "path".to_string(),
+            json!("CommonModules/SmokeModule/Ext/Module.bsl"),
+        )]);
+
+        let outcome = CodeNavigationAdapter::with_runners(&index, &grep)
+            .invoke("unica.code.outline", &args, &context, false)
+            .unwrap();
+
+        assert!(!outcome.ok);
+        assert_eq!(
+            outcome.summary,
+            "unica.code.outline pending RLM index build"
+        );
+        assert!(outcome.warnings.is_empty());
+        assert_eq!(outcome.errors, vec!["index_pending: rlm index building"]);
+        assert!(outcome.stdout.is_none());
+        assert!(index.commands.borrow().is_empty());
+        cleanup_context(&context);
+    }
+
+    #[test]
     fn code_outline_adapter_reports_invalid_source_dir_as_stable_failure() {
         let context = temp_context("outline-invalid-source-dir");
         let index = FakeIndexRunner::default();

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -1931,12 +1931,12 @@ impl<'a> CodeNavigationAdapter<'a> {
         context: &WorkspaceContext,
         cancellation: &CancellationToken,
     ) -> Result<AdapterOutcome, String> {
-        let candidates = index_path_candidates(context, args, "path")?;
         let readiness = self.rlm_readiness(context, args, cancellation);
         let db_path = match readiness {
             IndexReadiness::Ready { db_path } => db_path,
             other => return Ok(outline_index_unavailable_outcome(tool_name, other)),
         };
+        let candidates = index_path_candidates(context, args, "path")?;
         let include_methods = args
             .get("includeMethods")
             .and_then(Value::as_bool)
@@ -6168,6 +6168,74 @@ mod tests {
         assert!(!outcome.ok);
         assert!(outcome.stdout.is_none());
         assert!(outcome.errors[0].starts_with("index_unavailable:"));
+        cleanup_context(&context);
+    }
+
+    #[test]
+    fn code_outline_adapter_reports_invalid_source_dir_as_stable_failure() {
+        let context = temp_context("outline-invalid-source-dir");
+        let index = FakeIndexRunner::default();
+        let grep = FakeProcessRunner {
+            output: ProcessOutput {
+                status_success: true,
+                status: "exit status: 0".to_string(),
+                stdout: String::new(),
+                stderr: String::new(),
+                timed_out: false,
+                cancelled: false,
+                stdout_truncated: false,
+            },
+        };
+        let mut args = Map::new();
+        args.insert(
+            "path".to_string(),
+            json!("CommonModules/SmokeModule/Ext/Module.bsl"),
+        );
+        args.insert("sourceDir".to_string(), json!("../outside"));
+
+        let outcome = CodeNavigationAdapter::with_runners(&index, &grep)
+            .invoke("unica.code.outline", &args, &context, false)
+            .unwrap();
+
+        assert!(!outcome.ok);
+        assert!(outcome.warnings.is_empty());
+        assert_eq!(outcome.errors.len(), 1);
+        assert!(outcome.errors[0].starts_with("invalid_source_root:"));
+        assert!(outcome.stdout.is_none());
+        assert!(index.commands.borrow().is_empty());
+        cleanup_context(&context);
+    }
+
+    #[test]
+    fn code_outline_adapter_reports_cancellation_before_index_work() {
+        let context = temp_context("outline-cancelled");
+        let index = FakeIndexRunner::default();
+        let grep = FakeProcessRunner {
+            output: ProcessOutput {
+                status_success: true,
+                status: "exit status: 0".to_string(),
+                stdout: String::new(),
+                stderr: String::new(),
+                timed_out: false,
+                cancelled: false,
+                stdout_truncated: false,
+            },
+        };
+        let mut args = Map::new();
+        args.insert(
+            "path".to_string(),
+            json!("CommonModules/SmokeModule/Ext/Module.bsl"),
+        );
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+
+        let outcome = CodeNavigationAdapter::with_runners(&index, &grep)
+            .invoke_cancellable("unica.code.outline", &args, &context, false, &cancellation)
+            .unwrap();
+
+        assert!(!outcome.ok);
+        assert!(outcome.errors[0].starts_with(CANCELLED_PREFIX));
+        assert!(index.commands.borrow().is_empty());
         cleanup_context(&context);
     }
 

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -18,6 +18,7 @@ use crate::infrastructure::runtime_jobs::{
 };
 use crate::infrastructure::source_roots::normalize_path_identity;
 use crate::infrastructure::source_roots::resolve_source_root;
+use crate::infrastructure::source_roots::INVALID_SOURCE_ROOT_PREFIX;
 use crate::infrastructure::workspace::discover_workspace;
 use crate::infrastructure::workspace_index::{
     IndexReadiness, IndexRunner, WorkspaceIndexService, SYSTEM_INDEX_RUNNER,
@@ -1931,12 +1932,18 @@ impl<'a> CodeNavigationAdapter<'a> {
         context: &WorkspaceContext,
         cancellation: &CancellationToken,
     ) -> Result<AdapterOutcome, String> {
+        // Validate the caller-supplied `path` before readiness so an argument
+        // error is never masked by a not-ready index. `sourceDir` stays behind
+        // readiness: it is resolved there under the stable `invalid_source_root:`
+        // contract.
+        let raw_path = required_string(args, "path")?;
+        let path_rel = safe_workspace_rel(context, raw_path)?;
         let readiness = self.rlm_readiness(context, args, cancellation);
         let db_path = match readiness {
             IndexReadiness::Ready { db_path } => db_path,
             other => return Ok(outline_index_unavailable_outcome(tool_name, other)),
         };
-        let candidates = index_path_candidates(context, args, "path")?;
+        let candidates = index_path_candidates_for(context, args, raw_path, path_rel)?;
         let include_methods = args
             .get("includeMethods")
             .and_then(Value::as_bool)
@@ -2920,48 +2927,45 @@ fn index_unavailable_outcome(tool_name: &str, readiness: IndexReadiness) -> Adap
     }
 }
 
+fn index_failure_outcome(tool_name: &str, summary: &str, error: String) -> AdapterOutcome {
+    AdapterOutcome {
+        ok: false,
+        summary: format!("{tool_name} {summary}"),
+        changes: Vec::new(),
+        warnings: Vec::new(),
+        errors: vec![error],
+        artifacts: Vec::new(),
+        stdout: None,
+        stderr: None,
+        command: None,
+    }
+}
+
 fn outline_index_unavailable_outcome(tool_name: &str, readiness: IndexReadiness) -> AdapterOutcome {
     match readiness {
-        IndexReadiness::Building => AdapterOutcome {
-            ok: false,
-            summary: format!("{tool_name} pending RLM index build"),
-            changes: Vec::new(),
-            warnings: Vec::new(),
-            errors: vec!["index_pending: rlm index building".to_string()],
-            artifacts: Vec::new(),
-            stdout: None,
-            stderr: None,
-            command: None,
-        },
-        IndexReadiness::Unavailable(error) if error.starts_with("invalid_source_root:") => {
-            AdapterOutcome {
-                ok: false,
-                summary: format!("{tool_name} rejected invalid source root"),
-                changes: Vec::new(),
-                warnings: Vec::new(),
-                errors: vec![error],
-                artifacts: Vec::new(),
-                stdout: None,
-                stderr: None,
-                command: None,
-            }
+        IndexReadiness::Building => index_failure_outcome(
+            tool_name,
+            "pending RLM index build",
+            "index_pending: rlm index building".to_string(),
+        ),
+        IndexReadiness::Failed(error) | IndexReadiness::Unavailable(error)
+            if error.starts_with(INVALID_SOURCE_ROOT_PREFIX) =>
+        {
+            index_failure_outcome(tool_name, "rejected invalid source root", error)
         }
         other => {
             let warning = readiness_warning(other);
             if let Some(reason) = warning.strip_prefix(CANCELLED_PREFIX) {
                 return AdapterOutcome::cancelled(reason.trim());
             }
-            AdapterOutcome {
-                ok: false,
-                summary: format!("{tool_name} could not read RLM index"),
-                changes: Vec::new(),
-                warnings: Vec::new(),
-                errors: vec![format!("index_unavailable: {warning}")],
-                artifacts: Vec::new(),
-                stdout: None,
-                stderr: None,
-                command: None,
-            }
+            let detail = warning
+                .strip_prefix("rlm index unavailable: ")
+                .unwrap_or(&warning);
+            index_failure_outcome(
+                tool_name,
+                "could not read RLM index",
+                format!("index_unavailable: {detail}"),
+            )
         }
     }
 }
@@ -2999,14 +3003,16 @@ fn read_limit(args: &Map<String, Value>, default: usize) -> usize {
         .unwrap_or(default)
 }
 
-fn index_path_candidates(
+/// Expands an already-validated request path into index lookup candidates.
+/// The caller resolves `raw`/`rel` first so a bad path is reported as a path
+/// error rather than being masked by index readiness.
+fn index_path_candidates_for(
     context: &WorkspaceContext,
     args: &Map<String, Value>,
-    key: &str,
+    raw: &str,
+    rel: String,
 ) -> Result<Vec<String>, String> {
-    let raw = required_string(args, key)?;
     let mut candidates = BTreeSet::new();
-    let rel = safe_workspace_rel(context, raw)?;
     if !rel.is_empty() {
         candidates.insert(rel.clone());
     }
@@ -6133,7 +6139,40 @@ mod tests {
 
         assert!(!outcome.ok);
         assert!(outcome.stdout.is_none());
+        assert_eq!(outcome.errors.len(), 1);
         assert!(outcome.errors[0].starts_with("index_unavailable:"));
+        cleanup_context(&context);
+    }
+
+    #[test]
+    fn code_outline_adapter_rejects_escaping_path_before_reading_index_state() {
+        let context = temp_context("outline-escaping-path");
+        let lock_path = context.cache_root.join("locks/bsl_index.lock");
+        fs::create_dir_all(lock_path.parent().unwrap()).unwrap();
+        fs::write(&lock_path, "{").unwrap();
+        let index = FakeIndexRunner::default();
+        let grep = FakeProcessRunner {
+            output: ProcessOutput {
+                status_success: true,
+                status: "exit status: 0".to_string(),
+                stdout: String::new(),
+                stderr: String::new(),
+                timed_out: false,
+                cancelled: false,
+                stdout_truncated: false,
+            },
+        };
+        let args = Map::from_iter([("path".to_string(), json!("../outside/Module.bsl"))]);
+
+        let error = CodeNavigationAdapter::with_runners(&index, &grep)
+            .invoke("unica.code.outline", &args, &context, false)
+            .expect_err("an escaping path must be rejected on its own merits");
+
+        assert!(
+            error.contains("resolves outside workspace root"),
+            "a building index must not mask the path rejection: {error}"
+        );
+        assert!(index.commands.borrow().is_empty());
         cleanup_context(&context);
     }
 

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -1935,7 +1935,7 @@ impl<'a> CodeNavigationAdapter<'a> {
         let readiness = self.rlm_readiness(context, args, cancellation);
         let db_path = match readiness {
             IndexReadiness::Ready { db_path } => db_path,
-            other => return Ok(index_unavailable_outcome(tool_name, other)),
+            other => return Ok(outline_index_unavailable_outcome(tool_name, other)),
         };
         let include_methods = args
             .get("includeMethods")
@@ -2917,6 +2917,36 @@ fn index_unavailable_outcome(tool_name: &str, readiness: IndexReadiness) -> Adap
         stdout: None,
         stderr: None,
         command: None,
+    }
+}
+
+fn outline_index_unavailable_outcome(tool_name: &str, readiness: IndexReadiness) -> AdapterOutcome {
+    match readiness {
+        IndexReadiness::Building => AdapterOutcome {
+            ok: false,
+            summary: format!("{tool_name} pending RLM index build"),
+            changes: Vec::new(),
+            warnings: Vec::new(),
+            errors: vec!["index_pending: rlm index building".to_string()],
+            artifacts: Vec::new(),
+            stdout: None,
+            stderr: None,
+            command: None,
+        },
+        IndexReadiness::Unavailable(error) if error.starts_with("invalid_source_root:") => {
+            AdapterOutcome {
+                ok: false,
+                summary: format!("{tool_name} rejected invalid source root"),
+                changes: Vec::new(),
+                warnings: Vec::new(),
+                errors: vec![error],
+                artifacts: Vec::new(),
+                stdout: None,
+                stderr: None,
+                command: None,
+            }
+        }
+        other => index_unavailable_outcome(tool_name, other),
     }
 }
 
@@ -4294,6 +4324,40 @@ mod tests {
         assert!(outcome.errors[0].starts_with("cancelled:"));
         assert!(outcome.errors[0].contains("stale (content)"));
         assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn outline_reports_building_index_as_retryable_pending_failure() {
+        let outcome =
+            outline_index_unavailable_outcome("unica.code.outline", IndexReadiness::Building);
+
+        assert!(!outcome.ok);
+        assert!(outcome.warnings.is_empty());
+        assert_eq!(
+            outcome.summary,
+            "unica.code.outline pending RLM index build"
+        );
+        assert_eq!(outcome.errors, vec!["index_pending: rlm index building"]);
+        assert!(outcome.stdout.is_none());
+    }
+
+    #[test]
+    fn outline_reports_invalid_source_root_as_failure_with_stable_code() {
+        let outcome = outline_index_unavailable_outcome(
+            "unica.code.outline",
+            IndexReadiness::Unavailable(
+                "invalid_source_root: sourceDir must stay within workspace".to_string(),
+            ),
+        );
+
+        assert!(!outcome.ok);
+        assert!(outcome.warnings.is_empty());
+        assert_eq!(
+            outcome.errors,
+            vec!["invalid_source_root: sourceDir must stay within workspace"]
+        );
+        assert!(outcome.summary.contains("invalid source root"));
+        assert!(outcome.stdout.is_none());
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -2946,7 +2946,23 @@ fn outline_index_unavailable_outcome(tool_name: &str, readiness: IndexReadiness)
                 command: None,
             }
         }
-        other => index_unavailable_outcome(tool_name, other),
+        other => {
+            let warning = readiness_warning(other);
+            if let Some(reason) = warning.strip_prefix(CANCELLED_PREFIX) {
+                return AdapterOutcome::cancelled(reason.trim());
+            }
+            AdapterOutcome {
+                ok: false,
+                summary: format!("{tool_name} could not read RLM index"),
+                changes: Vec::new(),
+                warnings: Vec::new(),
+                errors: vec![format!("index_unavailable: {warning}")],
+                artifacts: Vec::new(),
+                stdout: None,
+                stderr: None,
+                command: None,
+            }
+        }
     }
 }
 
@@ -6118,6 +6134,40 @@ mod tests {
         assert!(stdout.contains("header: Smoke module header"));
         assert!(stdout.contains("region PublicApi: 1-5"));
         assert!(stdout.contains("Procedure SmokeProcedure() export"));
+        cleanup_context(&context);
+    }
+
+    #[test]
+    fn code_outline_adapter_reports_missing_index_as_failure() {
+        let context = temp_context("outline-missing-index");
+        let index = FakeIndexRunner {
+            outputs: RefCell::new(vec![index_success("Index not found: /tmp/bsl_index.db")]),
+            ..Default::default()
+        };
+        let grep = FakeProcessRunner {
+            output: ProcessOutput {
+                status_success: true,
+                status: "exit status: 0".to_string(),
+                stdout: String::new(),
+                stderr: String::new(),
+                timed_out: false,
+                cancelled: false,
+                stdout_truncated: false,
+            },
+        };
+        let mut args = Map::new();
+        args.insert(
+            "path".to_string(),
+            json!("CommonModules/SmokeModule/Ext/Module.bsl"),
+        );
+
+        let outcome = CodeNavigationAdapter::with_runners(&index, &grep)
+            .invoke("unica.code.outline", &args, &context, false)
+            .unwrap();
+
+        assert!(!outcome.ok);
+        assert!(outcome.stdout.is_none());
+        assert!(outcome.errors[0].starts_with("index_unavailable:"));
         cleanup_context(&context);
     }
 

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -4343,40 +4343,6 @@ mod tests {
     }
 
     #[test]
-    fn outline_reports_building_index_as_retryable_pending_failure() {
-        let outcome =
-            outline_index_unavailable_outcome("unica.code.outline", IndexReadiness::Building);
-
-        assert!(!outcome.ok);
-        assert!(outcome.warnings.is_empty());
-        assert_eq!(
-            outcome.summary,
-            "unica.code.outline pending RLM index build"
-        );
-        assert_eq!(outcome.errors, vec!["index_pending: rlm index building"]);
-        assert!(outcome.stdout.is_none());
-    }
-
-    #[test]
-    fn outline_reports_invalid_source_root_as_failure_with_stable_code() {
-        let outcome = outline_index_unavailable_outcome(
-            "unica.code.outline",
-            IndexReadiness::Unavailable(
-                "invalid_source_root: sourceDir must stay within workspace".to_string(),
-            ),
-        );
-
-        assert!(!outcome.ok);
-        assert!(outcome.warnings.is_empty());
-        assert_eq!(
-            outcome.errors,
-            vec!["invalid_source_root: sourceDir must stay within workspace"]
-        );
-        assert!(outcome.summary.contains("invalid source root"));
-        assert!(outcome.stdout.is_none());
-    }
-
-    #[test]
     fn code_grep_does_not_start_rlm_index_side_effect() {
         let root = std::env::temp_dir().join(format!("unica-code-grep-{}", std::process::id()));
         let workspace = root.join("workspace");
@@ -6240,6 +6206,10 @@ mod tests {
         assert!(outcome.warnings.is_empty());
         assert_eq!(outcome.errors.len(), 1);
         assert!(outcome.errors[0].starts_with("invalid_source_root:"));
+        assert_eq!(
+            outcome.summary,
+            "unica.code.outline rejected invalid source root"
+        );
         assert!(outcome.stdout.is_none());
         assert!(index.commands.borrow().is_empty());
         cleanup_context(&context);
@@ -6274,6 +6244,8 @@ mod tests {
 
         assert!(!outcome.ok);
         assert!(outcome.errors[0].starts_with(CANCELLED_PREFIX));
+        assert!(outcome.warnings.is_empty());
+        assert!(outcome.stdout.is_none());
         assert!(index.commands.borrow().is_empty());
         cleanup_context(&context);
     }

--- a/crates/unica-coder/src/infrastructure/source_roots.rs
+++ b/crates/unica-coder/src/infrastructure/source_roots.rs
@@ -166,8 +166,12 @@ fn ensure_inside_workspace(path: &Path, workspace_root: &Path) -> Result<(), Str
     ))
 }
 
+/// Stable prefix every source-root rejection carries. Consumers that classify a
+/// readiness failure as caller-fixable match on this instead of a literal.
+pub(crate) const INVALID_SOURCE_ROOT_PREFIX: &str = "invalid_source_root:";
+
 fn invalid_source_root(error: String) -> String {
-    format!("invalid_source_root: {error}")
+    format!("{INVALID_SOURCE_ROOT_PREFIX} {error}")
 }
 
 fn normalize_lexically(path: &Path) -> PathBuf {


### PR DESCRIPTION
Closes #201. unica.code.outline now returns a non-OK pending outcome while the RLM index is building and a non-OK stable invalid_source_root error for an invalid source root. Other navigation tools preserve their existing outcomes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code outline reliability by validating requested paths before any index-state checks, ensuring argument/path errors aren’t hidden by index readiness issues.
  * When the navigation index isn’t ready, outline now returns consistent, state-aware outcomes (retryable while building, non-retryable when unavailable).
  * Invalid source roots now produce a standardized “rejected invalid source root” failure.
* **Tests**
  * Added/updated coverage for escaping paths, missing/unavailable index behavior, retryable pending-index builds, stable invalid-source-root handling, and cancellation-before-index flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->