### PR TITLE
fix(workspace): stop at git worktree boundary

### DIFF
--- a/crates/unica-coder/src/infrastructure/workspace.rs
+++ b/crates/unica-coder/src/infrastructure/workspace.rs
@@ -36,7 +36,7 @@ fn find_workspace_root(cwd: &Path) -> Option<PathBuf> {
         if base.join("v8project.yaml").is_file() {
             return Some(base.to_path_buf());
         }
-        if base.join(".git").exists() {
+        if base.join(".git").is_file() {
             return Some(base.to_path_buf());
         }
     }

--- a/crates/unica-coder/src/infrastructure/workspace.rs
+++ b/crates/unica-coder/src/infrastructure/workspace.rs
@@ -36,6 +36,9 @@ fn find_workspace_root(cwd: &Path) -> Option<PathBuf> {
         if base.join("v8project.yaml").is_file() {
             return Some(base.to_path_buf());
         }
+        if base.join(".git").exists() {
+            return Some(base.to_path_buf());
+        }
     }
     None
 }
@@ -89,6 +92,24 @@ mod tests {
 
         assert_eq!(context.workspace_root, nested);
         assert_ne!(context.workspace_root, root);
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn git_worktree_boundary_prevents_parent_workspace_discovery() {
+        let root = temp_root("unica-workspace-worktree-boundary");
+        let primary = root.join("primary");
+        let worktree = primary.join("worktrees/feature");
+        let nested = worktree.join("src/catalogs");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(primary.join("v8project.yaml"), "format: DESIGNER\n").unwrap();
+        std::fs::write(worktree.join(".git"), "gitdir: ../../.git/worktrees/feature\n").unwrap();
+
+        let context = discover_workspace(Some(nested)).unwrap();
+
+        assert_eq!(context.workspace_root, worktree);
+        assert_ne!(context.workspace_root, primary);
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/crates/unica-coder/src/infrastructure/workspace.rs
+++ b/crates/unica-coder/src/infrastructure/workspace.rs
@@ -104,7 +104,11 @@ mod tests {
         let nested = worktree.join("src/catalogs");
         std::fs::create_dir_all(&nested).unwrap();
         std::fs::write(primary.join("v8project.yaml"), "format: DESIGNER\n").unwrap();
-        std::fs::write(worktree.join(".git"), "gitdir: ../../.git/worktrees/feature\n").unwrap();
+        std::fs::write(
+            worktree.join(".git"),
+            "gitdir: ../../.git/worktrees/feature\n",
+        )
+        .unwrap();
 
         let context = discover_workspace(Some(nested)).unwrap();
 


### PR DESCRIPTION
Closes #199.

Workspace discovery now treats a linked-worktree `.git` file as a boundary, so a `cwd` inside that worktree cannot resolve `workspaceRoot` through a parent checkout. An ordinary `.git` directory remains intentionally ignored when there is no `v8project.yaml`; the existing fallback behavior is preserved.

Includes regression coverage for both the linked-worktree boundary and the ordinary parent-repository case.
