### PR TITLE
fix(meta): подробный dry-run для meta.edit

### DIFF
--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -437,11 +437,14 @@ fn call_tool(
             job: None,
         });
     }
-    let mut support_guard_warning = if spec.mutating && !dry_run {
+    let support_guard_warning = if spec.mutating {
         match ports.evaluate_support_guard(spec, args, &context)? {
             SupportGuardCheck::Allow => None,
             SupportGuardCheck::Warn(warning) => Some(warning),
-            SupportGuardCheck::Block(outcome) => {
+            SupportGuardCheck::Block(mut outcome) => {
+                if dry_run {
+                    outcome.summary = format!("dry run: {}", outcome.summary);
+                }
                 let cache = ports.cache_report(&context, &[], dry_run, spec.cache_access)?;
                 return Ok(OperationResult {
                     ok: outcome.ok,
@@ -466,30 +469,6 @@ fn call_tool(
 
     let handler_outcome = ports.invoke_handler(spec, args, &context, dry_run, cancellation)?;
     let mut outcome = handler_outcome.adapter;
-    if is_successful_detailed_compile_preview(spec, dry_run, &outcome) {
-        match ports.evaluate_support_guard(spec, args, &context)? {
-            SupportGuardCheck::Allow => {}
-            SupportGuardCheck::Warn(warning) => support_guard_warning = Some(warning),
-            SupportGuardCheck::Block(blocked) => {
-                let cache = ports.cache_report(&context, &[], dry_run, spec.cache_access)?;
-                return Ok(OperationResult {
-                    ok: blocked.ok,
-                    summary: blocked.summary,
-                    changes: blocked.changes,
-                    warnings: blocked.warnings,
-                    errors: blocked.errors,
-                    artifacts: blocked.artifacts,
-                    cache,
-                    stdout: blocked.stdout,
-                    stderr: blocked.stderr,
-                    command: blocked.command,
-                    diagnostics: None,
-                    data: None,
-                    job: None,
-                });
-            }
-        }
-    }
     if let Some(warning) = support_guard_warning {
         outcome.warnings.insert(0, warning);
     }
@@ -715,23 +694,6 @@ fn should_emit_events(
             )
         });
     !is_semantic_form_edit_preview
-}
-
-fn is_successful_detailed_compile_preview(
-    spec: ToolSpec,
-    dry_run: bool,
-    outcome: &AdapterOutcome,
-) -> bool {
-    dry_run
-        && outcome.ok
-        && outcome.summary.contains("planned native")
-        && matches!(
-            spec.handler,
-            ToolHandler::NativeOperation {
-                operation: "meta-compile" | "role-compile" | "subsystem-compile",
-                ..
-            }
-        )
 }
 
 fn runtime_result_diagnostics(
@@ -9981,10 +9943,71 @@ mod tests {
             .unwrap();
 
         assert!(!result.ok, "{result:?}");
-        assert!(result.summary.contains("support guard"), "{result:?}");
+        assert_eq!(
+            result.summary,
+            "dry run: unica.meta.compile blocked by support guard"
+        );
         assert!(result.cache.events.is_empty(), "{result:?}");
         assert_eq!(std::fs::read(&config_path).unwrap(), config_before);
         assert!(!src.join("CommonModules/PreviewSupportGuard.xml").exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn support_guard_blocks_meta_edit_before_dry_run_planning_in_both_modes() {
+        let (root, workspace, _bin_path) = support_test_workspace(
+            "unica-meta-edit-preview-support-guard",
+            support_test_parent_configurations_bin(
+                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            ),
+        );
+        let object_path = workspace.join("src/Catalogs/Items.xml");
+        let before = std::fs::read(&object_path).unwrap();
+        let mut results = Vec::new();
+
+        for dry_run in [false, true] {
+            let mut args = Map::new();
+            args.insert(
+                "cwd".to_string(),
+                Value::String(workspace.display().to_string()),
+            );
+            args.insert("dryRun".to_string(), Value::Bool(dry_run));
+            args.insert(
+                "ObjectPath".to_string(),
+                Value::String("src/Catalogs/Items.xml".to_string()),
+            );
+            args.insert(
+                "Operation".to_string(),
+                Value::String("modify-property".to_string()),
+            );
+            args.insert(
+                "Value".to_string(),
+                Value::String("Name=Changed".to_string()),
+            );
+
+            results.push(
+                UnicaApplication::new()
+                    .call_tool("unica.meta.edit", &args)
+                    .unwrap(),
+            );
+        }
+
+        let applied = &results[0];
+        let preview = &results[1];
+        assert!(!applied.ok, "{applied:?}");
+        assert!(!preview.ok, "{preview:?}");
+        assert_eq!(applied.summary, "unica.meta.edit blocked by support guard");
+        assert_eq!(
+            preview.summary,
+            "dry run: unica.meta.edit blocked by support guard"
+        );
+        assert_eq!(preview.errors, applied.errors);
+        assert_eq!(preview.artifacts, applied.artifacts);
+        assert!(preview.stdout.is_none(), "{preview:?}");
+        assert!(preview.cache.events.is_empty(), "{preview:?}");
+        assert_eq!(std::fs::read(&object_path).unwrap(), before);
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -4674,6 +4674,108 @@ mod tests {
     }
 
     #[test]
+    fn mutating_native_support_guard_coverage_is_explicit() {
+        use operation_descriptors::{SupportGuardPolicy, SupportGuardRequirement};
+
+        let mut guarded = Vec::new();
+        let mut exempt = Vec::new();
+        for tool in tools().into_iter().filter(|tool| tool.mutating) {
+            let ToolHandler::NativeOperation { operation, .. } = tool.handler else {
+                continue;
+            };
+            let descriptor = operation_descriptors::native_operation_descriptor(operation).unwrap();
+            match descriptor.support_guard {
+                Some(policy) => {
+                    match policy {
+                        SupportGuardPolicy::PathArgs { names, requirement } => {
+                            assert!(!names.is_empty(), "{operation} guard target is empty");
+                            assert_eq!(
+                                requirement,
+                                SupportGuardRequirement::Editable,
+                                "{operation} path mutation must require an editable owner"
+                            );
+                            if operation == "subsystem-compile" {
+                                assert_eq!(
+                                    names,
+                                    &["Parent", "parent", "OutputDir", "outputDir"],
+                                    "subsystem compilation must guard Parent first and retain OutputDir as the root fallback"
+                                );
+                            }
+                        }
+                        SupportGuardPolicy::MetaRemove { requirement } => {
+                            assert_eq!(operation, "meta-remove");
+                            assert_eq!(requirement, SupportGuardRequirement::Removed);
+                        }
+                        SupportGuardPolicy::ObjectName { requirement } => {
+                            assert!(
+                                matches!(
+                                    operation,
+                                    "help-add" | "form-remove" | "template-add" | "template-remove"
+                                ),
+                                "{operation} unexpectedly uses object-name guard resolution"
+                            );
+                            assert_eq!(requirement, SupportGuardRequirement::Editable);
+                        }
+                    }
+                    guarded.push(operation);
+                }
+                None => exempt.push(operation),
+            }
+        }
+        guarded.sort_unstable();
+        exempt.sort_unstable();
+
+        assert_eq!(
+            guarded,
+            [
+                "cf-edit",
+                "code-patch",
+                "dcs-compile",
+                "dcs-edit",
+                "form-add",
+                "form-compile",
+                "form-edit",
+                "form-remove",
+                "help-add",
+                "interface-edit",
+                "meta-compile",
+                "meta-edit",
+                "meta-remove",
+                "mxl-compile",
+                "role-compile",
+                "subsystem-compile",
+                "subsystem-edit",
+                "template-add",
+                "template-remove",
+            ],
+            "guarded platform-XML mutations changed without updating the support contract"
+        );
+        let expected_exemptions = [
+            ("cf-init", "creates a new configuration tree"),
+            ("cfe-borrow", "writes only into an extension"),
+            ("cfe-init", "creates a new extension tree"),
+            ("cfe-patch-method", "writes only into an extension"),
+            ("epf-init", "creates a new external processor tree"),
+            ("erf-init", "creates a new external report tree"),
+            (
+                "support-edit",
+                "must remain available to change the support lock itself",
+            ),
+        ];
+        assert!(expected_exemptions
+            .iter()
+            .all(|(_, reason)| !reason.is_empty()));
+        assert_eq!(
+            exempt,
+            expected_exemptions
+                .iter()
+                .map(|(operation, _)| *operation)
+                .collect::<Vec<_>>(),
+            "every unguarded native mutation must remain an explicitly justified support-guard exception"
+        );
+    }
+
+    #[test]
     fn mutating_platform_xml_operations_declare_effective_format_paths() {
         use operation_descriptors::FormatGuardPolicy;
 
@@ -8591,21 +8693,33 @@ mod tests {
             "cwd".to_string(),
             Value::String(workspace.display().to_string()),
         );
-        args.insert("dryRun".to_string(), Value::Bool(false));
         args.insert(
             "ObjectName".to_string(),
             Value::String("Catalogs/Items".to_string()),
         );
         args.insert("SrcDir".to_string(), Value::String("src".to_string()));
 
-        let result = UnicaApplication::new()
-            .call_tool("unica.help.add", &args)
-            .unwrap();
+        let mut results = Vec::new();
+        for dry_run in [false, true] {
+            args.insert("dryRun".to_string(), Value::Bool(dry_run));
+            let result = UnicaApplication::new()
+                .call_tool("unica.help.add", &args)
+                .unwrap();
 
-        assert!(!result.ok);
-        assert!(result.summary.contains("support guard"));
-        assert!(!ext.join("Help.xml").exists());
-        assert!(result.cache.events.is_empty());
+            assert!(!result.ok, "dryRun={dry_run}: {result:?}");
+            assert_eq!(
+                result.summary,
+                if dry_run {
+                    "dry run: unica.help.add blocked by support guard"
+                } else {
+                    "unica.help.add blocked by support guard"
+                }
+            );
+            assert!(!ext.join("Help.xml").exists());
+            assert!(result.cache.events.is_empty(), "{result:?}");
+            results.push(result);
+        }
+        assert_support_guard_block_parity(&results[0], &results[1]);
 
         let _ = std::fs::remove_dir_all(root);
     }
@@ -9380,21 +9494,37 @@ mod tests {
             "cwd".to_string(),
             Value::String(workspace.display().to_string()),
         );
-        args.insert("dryRun".to_string(), Value::Bool(false));
         args.insert("ConfigDir".to_string(), Value::String("src".to_string()));
         args.insert(
             "Object".to_string(),
             Value::String("Catalog.Items".to_string()),
         );
 
-        let result = UnicaApplication::new()
-            .call_tool("unica.meta.remove", &args)
-            .unwrap();
+        let mut results = Vec::new();
+        for dry_run in [false, true] {
+            args.insert("dryRun".to_string(), Value::Bool(dry_run));
+            let result = UnicaApplication::new()
+                .call_tool("unica.meta.remove", &args)
+                .unwrap();
 
-        assert!(!result.ok);
-        assert!(result.summary.contains("support guard"));
-        assert!(result.errors.join("\n").contains("не снят с поддержки"));
-        assert!(object_path.exists());
+            assert!(!result.ok, "dryRun={dry_run}: {result:?}");
+            assert_eq!(
+                result.summary,
+                if dry_run {
+                    "dry run: unica.meta.remove blocked by support guard"
+                } else {
+                    "unica.meta.remove blocked by support guard"
+                }
+            );
+            assert!(
+                result.errors.join("\n").contains("не снят с поддержки"),
+                "{result:?}"
+            );
+            assert!(object_path.exists(), "dryRun={dry_run}");
+            assert!(result.cache.events.is_empty(), "{result:?}");
+            results.push(result);
+        }
+        assert_support_guard_block_parity(&results[0], &results[1]);
 
         let _ = std::fs::remove_dir_all(root);
     }
@@ -9469,6 +9599,52 @@ mod tests {
     </Properties>
   </Form>
 </MetaDataObject>"#
+    }
+
+    fn support_test_subsystem_xml(uuid: &str, name: &str) -> String {
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" version="2.20">
+  <Subsystem uuid="{uuid}">
+    <Properties>
+      <Name>{name}</Name>
+      <Synonym/>
+      <Comment/>
+      <IncludeHelpInContents>true</IncludeHelpInContents>
+      <IncludeInCommandInterface>true</IncludeInCommandInterface>
+      <UseOneCommand>false</UseOneCommand>
+      <Explanation/>
+      <Picture/>
+      <Content/>
+    </Properties>
+    <ChildObjects/>
+  </Subsystem>
+</MetaDataObject>"#
+        )
+    }
+
+    fn assert_support_guard_block_parity(applied: &OperationResult, preview: &OperationResult) {
+        assert_eq!(preview.summary, format!("dry run: {}", applied.summary));
+        assert_eq!(preview.ok, applied.ok);
+        assert_eq!(preview.changes, applied.changes);
+        assert_eq!(preview.warnings, applied.warnings);
+        assert_eq!(preview.errors, applied.errors);
+        assert_eq!(preview.artifacts, applied.artifacts);
+        assert_eq!(preview.stdout, applied.stdout);
+        assert_eq!(preview.stderr, applied.stderr);
+        assert_eq!(preview.command, applied.command);
+        assert_eq!(preview.diagnostics, applied.diagnostics);
+        assert_eq!(preview.data, applied.data);
+        assert_eq!(preview.job, applied.job);
+        assert_eq!(preview.cache.mode, applied.cache.mode);
+        assert_eq!(preview.cache.root, applied.cache.root);
+        assert_eq!(preview.cache.workspace_epoch, applied.cache.workspace_epoch);
+        assert_eq!(preview.cache.events, applied.cache.events);
+        assert_eq!(preview.cache.invalidated, applied.cache.invalidated);
+        assert_eq!(preview.cache.refreshed, applied.cache.refreshed);
+        assert_eq!(preview.cache.lazy_rebuilt, applied.cache.lazy_rebuilt);
+        assert_eq!(preview.cache.stale, applied.cache.stale);
+        assert_eq!(preview.cache.fresh, applied.cache.fresh);
     }
 
     fn support_test_workspace(
@@ -10009,6 +10185,128 @@ mod tests {
         assert!(preview.cache.events.is_empty(), "{preview:?}");
         assert_eq!(std::fs::read(&object_path).unwrap(), before);
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn subsystem_compile_guards_locked_parent_before_both_planners() {
+        for dry_run in [false, true] {
+            let root = test_workspace_root(if dry_run {
+                "unica-subsystem-parent-guard-preview"
+            } else {
+                "unica-subsystem-parent-guard-apply"
+            });
+            let workspace = root.join("workspace");
+            let src = workspace.join("src");
+            let ext = src.join("Ext");
+            let subsystems = src.join("Subsystems");
+            std::fs::create_dir_all(&ext).unwrap();
+            std::fs::create_dir_all(&subsystems).unwrap();
+            std::fs::write(
+                workspace.join("v8project.yaml"),
+                "format: DESIGNER\nsource-set:\n  - name: main\n    type: CONFIGURATION\n    path: src\n",
+            )
+            .unwrap();
+            std::fs::write(
+                src.join("Configuration.xml"),
+                support_test_configuration_xml("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            )
+            .unwrap();
+            let parent_path = subsystems.join("Parent.xml");
+            std::fs::write(
+                &parent_path,
+                support_test_subsystem_xml("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "Parent"),
+            )
+            .unwrap();
+            std::fs::write(
+                ext.join("ParentConfigurations.bin"),
+                support_test_parent_configurations_bin(
+                    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                    "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                    "cccccccc-cccc-cccc-cccc-cccccccccccc",
+                ),
+            )
+            .unwrap();
+            let before = std::fs::read(&parent_path).unwrap();
+            let args = json!({
+                "cwd": workspace,
+                "dryRun": dry_run,
+                "OutputDir": "src",
+                "Parent": "src/Subsystems/Parent.xml",
+                "Value": r#"{"name":"Child"}"#
+            })
+            .as_object()
+            .unwrap()
+            .clone();
+
+            let result = UnicaApplication::new()
+                .call_tool("unica.subsystem.compile", &args)
+                .unwrap();
+            let after = std::fs::read(&parent_path).unwrap();
+            let normalized_parent = normalized_path(&parent_path).display().to_string();
+            let child_exists = src.join("Subsystems/Parent/Subsystems/Child.xml").exists();
+            std::fs::remove_dir_all(root).unwrap();
+
+            assert!(!result.ok, "dryRun={dry_run}: {result:?}");
+            assert_eq!(
+                result.summary,
+                if dry_run {
+                    "dry run: unica.subsystem.compile blocked by support guard"
+                } else {
+                    "unica.subsystem.compile blocked by support guard"
+                }
+            );
+            assert!(result.errors.join("\n").contains("на замке"), "{result:?}");
+            assert_eq!(result.artifacts, [normalized_parent]);
+            assert!(result.cache.events.is_empty(), "{result:?}");
+            assert_eq!(after, before, "dryRun={dry_run}");
+            assert!(!child_exists, "dryRun={dry_run}");
+        }
+    }
+
+    #[test]
+    fn subsystem_compile_retains_locked_configuration_fallback_without_parent() {
+        let config_uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+        let (root, workspace, _bin_path) = support_test_workspace(
+            "unica-subsystem-root-guard",
+            support_test_parent_configurations_bin(
+                config_uuid,
+                config_uuid,
+                "cccccccc-cccc-cccc-cccc-cccccccccccc",
+            ),
+        );
+        let src = workspace.join("src");
+        let config_path = src.join("Configuration.xml");
+        let before = std::fs::read(&config_path).unwrap();
+        let mut args = json!({
+            "cwd": workspace,
+            "OutputDir": "src",
+            "Value": r#"{"name":"RootChild"}"#
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let mut results = Vec::new();
+
+        for dry_run in [false, true] {
+            args.insert("dryRun".to_string(), Value::Bool(dry_run));
+            let result = UnicaApplication::new()
+                .call_tool("unica.subsystem.compile", &args)
+                .unwrap();
+
+            assert!(!result.ok, "dryRun={dry_run}: {result:?}");
+            assert_eq!(
+                result.artifacts,
+                [normalized_path(&src).display().to_string()]
+            );
+            assert!(result.errors.join("\n").contains("на замке"), "{result:?}");
+            assert!(result.cache.events.is_empty(), "{result:?}");
+            assert_eq!(std::fs::read(&config_path).unwrap(), before);
+            assert!(!src.join("Subsystems/RootChild.xml").exists());
+            results.push(result);
+        }
+        assert_support_guard_block_parity(&results[0], &results[1]);
+
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/crates/unica-coder/src/application/operation_descriptors.rs
+++ b/crates/unica-coder/src/application/operation_descriptors.rs
@@ -69,6 +69,7 @@ const CI_PATH_REQUIRED: &[&str] = &["CIPath"];
 pub(crate) const SUBSYSTEM_PATH: &[&str] = &["SubsystemPath", "subsystemPath", "Path", "path"];
 const SUBSYSTEM_PATH_REQUIRED: &[&str] = &["SubsystemPath"];
 const SUBSYSTEM_COMPILE_WRITE: &[&str] = &["OutputDir", "outputDir", "Parent", "parent"];
+const SUBSYSTEM_COMPILE_GUARD: &[&str] = &["Parent", "parent", "OutputDir", "outputDir"];
 const OUTPUT_PATH: &[&str] = &["OutputPath", "outputPath"];
 pub(crate) const TEMPLATE_PATH: &[&str] = &["TemplatePath", "templatePath", "Path", "path"];
 const TEMPLATE_PATH_REQUIRED: &[&str] = &["TemplatePath"];
@@ -419,7 +420,10 @@ pub(super) const NATIVE_OPERATION_DESCRIPTORS: &[OperationDescriptor] = &[
         SUBSYSTEM_COMPILE_REQUIRED,
         SUBSYSTEM_COMPILE_WRITE,
         SUBSYSTEM_COMPILE_WRITE,
-        Some(path_guard(OUTPUT_DIR, SupportGuardRequirement::Editable)),
+        Some(path_guard(
+            SUBSYSTEM_COMPILE_GUARD,
+            SupportGuardRequirement::Editable,
+        )),
     ),
     descriptor_with_paths(
         "subsystem-edit",

--- a/crates/unica-coder/src/infrastructure/native_operations.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations.rs
@@ -48,6 +48,9 @@ impl NativeOperationAdapter {
             if let Some(outcome) = external::preview(operation, tool_name, args, context) {
                 return Ok(outcome);
             }
+            if operation == "meta-edit" {
+                return Ok(meta::preview_meta_edit(args, context));
+            }
             if operation == "form-edit" && form::has_edit_payload(args) {
                 return Ok(form::preview_form_edit(args, context));
             }

--- a/crates/unica-coder/src/infrastructure/native_operations/meta.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta.rs
@@ -16522,7 +16522,29 @@ pub(crate) fn preview_meta_edit(
     args: &Map<String, Value>,
     context: &WorkspaceContext,
 ) -> AdapterOutcome {
-    edit_meta_with_mode(args, context, true)
+    let outcome = edit_meta_with_mode(args, context, true);
+    let Some(error) = outcome.errors.first() else {
+        return outcome;
+    };
+    if !error.starts_with("Object file not found:") {
+        return outcome;
+    }
+
+    let object_path = string_arg(args, OBJECT_PATH).unwrap_or("<missing ObjectPath>");
+    let operation = string_arg(args, &["operation", "Operation"]).unwrap_or("definition file");
+    AdapterOutcome {
+        ok: true,
+        summary: "dry run: unica.meta.edit planned native metadata edit".to_string(),
+        changes: vec![format!("would update {object_path}")],
+        warnings: vec![format!("detailed validation unavailable: {error}")],
+        errors: Vec::new(),
+        artifacts: Vec::new(),
+        stdout: Some(format!(
+            "[INFO] Planned operation: {operation}\n[INFO] Planned update: {object_path}\n[WARN] {error}\n"
+        )),
+        stderr: None,
+        command: None,
+    }
 }
 
 fn edit_meta_with_mode(

--- a/crates/unica-coder/src/infrastructure/native_operations/meta.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta.rs
@@ -11,6 +11,7 @@ use crate::infrastructure::platform_xml_owner::{
     resolve_platform_xml_owners_with_provenance, root_version_literal, PlatformXmlOwnerKind,
     PlatformXmlOwnerProvenance,
 };
+use diffy::{apply, DiffOptions, Patch};
 use roxmltree::Document;
 use serde_json::{json, Map, Value};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -2628,7 +2629,7 @@ mod edit_tests {
     }
 
     #[test]
-    fn preview_meta_edit_validates_and_describes_inline_change_without_writing() {
+    fn preview_meta_edit_reports_projected_inline_diff_without_writing() {
         let context = temp_context("preview-inline-change");
         let object_path = context.cwd.join("Catalogs/Preview.xml");
         write_file(&object_path, &sample_catalog_xml());
@@ -2648,6 +2649,92 @@ mod edit_tests {
         let stdout = outcome.stdout.as_deref().unwrap_or_default();
         assert!(stdout.contains("Planned operation: modify-property: Comment=Previewed"));
         assert!(stdout.contains("Planned update:"));
+        assert!(stdout.contains("--- a/"), "{stdout}");
+        assert!(stdout.contains("+++ b/"), "{stdout}");
+        assert!(stdout.contains("-\t\t\t<Comment/>"), "{stdout}");
+        assert!(
+            stdout.contains("+\t\t\t<Comment>Previewed</Comment>"),
+            "{stdout}"
+        );
+        assert_eq!(fs::read(&object_path).unwrap(), before);
+
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
+    fn preview_meta_edit_rejects_missing_object() {
+        let context = temp_context("preview-missing-object");
+        let object_path = context.cwd.join("Catalogs/Missing.xml");
+
+        let outcome = preview_meta_edit(
+            &meta_edit_args(&object_path, "modify-property", "Comment=Previewed"),
+            &context,
+        );
+
+        assert!(!outcome.ok, "{outcome:?}");
+        assert!(outcome.summary.starts_with("dry run:"), "{outcome:?}");
+        assert!(outcome
+            .errors
+            .iter()
+            .any(|error| error.contains("Object file not found:")));
+        assert!(outcome.changes.is_empty());
+        assert!(outcome.artifacts.is_empty());
+
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
+    fn preview_meta_edit_reports_definition_file_diff_without_writing() {
+        let context = temp_context("preview-definition-file");
+        let object_path = context.cwd.join("Catalogs/Preview.xml");
+        let definition_path = context.cwd.join("meta-edit.json");
+        write_file(&object_path, &sample_catalog_xml());
+        write_file(
+            &definition_path,
+            &json!({"modify": {"properties": {"Comment": "Defined"}}}).to_string(),
+        );
+        let before = fs::read(&object_path).unwrap();
+
+        let outcome = preview_meta_edit(
+            &meta_edit_definition_args(&object_path, &definition_path),
+            &context,
+        );
+
+        assert!(outcome.ok, "{outcome:?}");
+        let stdout = outcome.stdout.as_deref().unwrap_or_default();
+        assert!(stdout.contains("--- a/"), "{stdout}");
+        assert!(stdout.contains("-\t\t\t<Comment/>"), "{stdout}");
+        assert!(
+            stdout.contains("+\t\t\t<Comment>Defined</Comment>"),
+            "{stdout}"
+        );
+        assert_eq!(fs::read(&object_path).unwrap(), before);
+
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
+    fn preview_meta_edit_reports_no_file_changes_without_diff() {
+        let context = temp_context("preview-no-op");
+        let object_path = context.cwd.join("Catalogs/Preview.xml");
+        let xml = sample_catalog_xml().replace("<Comment/>", "<Comment>Unchanged</Comment>");
+        write_file(&object_path, &xml);
+        let before = fs::read(&object_path).unwrap();
+
+        let outcome = preview_meta_edit(
+            &meta_edit_args(&object_path, "modify-property", "Comment=Unchanged"),
+            &context,
+        );
+
+        assert!(outcome.ok, "{outcome:?}");
+        assert!(
+            outcome.summary.contains("found no metadata changes"),
+            "{outcome:?}"
+        );
+        assert!(outcome.changes.is_empty());
+        let stdout = outcome.stdout.as_deref().unwrap_or_default();
+        assert!(stdout.contains("[INFO] No changes"), "{stdout}");
+        assert!(!stdout.contains("--- a/"), "{stdout}");
         assert_eq!(fs::read(&object_path).unwrap(), before);
 
         let _ = fs::remove_dir_all(&context.cwd);
@@ -16523,29 +16610,7 @@ pub(crate) fn preview_meta_edit(
     args: &Map<String, Value>,
     context: &WorkspaceContext,
 ) -> AdapterOutcome {
-    let outcome = edit_meta_with_mode(args, context, true);
-    let Some(error) = outcome.errors.first() else {
-        return outcome;
-    };
-    if !error.starts_with("Object file not found:") {
-        return outcome;
-    }
-
-    let object_path = string_arg(args, OBJECT_PATH).unwrap_or("<missing ObjectPath>");
-    let operation = string_arg(args, &["operation", "Operation"]).unwrap_or("definition file");
-    AdapterOutcome {
-        ok: true,
-        summary: "dry run: unica.meta.edit planned native metadata edit".to_string(),
-        changes: vec![format!("would update {object_path}")],
-        warnings: vec![format!("detailed validation unavailable: {error}")],
-        errors: Vec::new(),
-        artifacts: Vec::new(),
-        stdout: Some(format!(
-            "[INFO] Planned operation: {operation}\n[INFO] Planned update: {object_path}\n[WARN] {error}\n"
-        )),
-        stderr: None,
-        command: None,
-    }
+    edit_meta_with_mode(args, context, true)
 }
 
 /// Runs the shared metadata-edit workflow in either preview or apply mode.
@@ -16675,6 +16740,19 @@ fn edit_meta_with_mode(
             info_lines.push(format!("[INFO] Saved: {}", object_path.display()));
         } else if changed {
             info_lines.push(format!("[INFO] Planned update: {}", object_path.display()));
+            let diff_path = object_path
+                .strip_prefix(&context.cwd)
+                .unwrap_or(&object_path)
+                .display()
+                .to_string();
+            let before = String::from_utf8(original_bytes.clone())
+                .map_err(|err| format!("failed to preview {}: {err}", object_path.display()))?;
+            let after = String::from_utf8(serialized_bytes)
+                .map_err(|err| format!("failed to preview {}: {err}", object_path.display()))?;
+            info_lines.push(format!(
+                "\n=== projected diff ===\n{}",
+                meta_edit_unified_diff(&diff_path, &before, &after)?
+            ));
         } else {
             counts = MetaEditCounts::default();
             info_lines.push("[INFO] No changes".to_string());
@@ -16691,7 +16769,11 @@ fn edit_meta_with_mode(
         Ok((stdout, object_path, changed, warnings)) => AdapterOutcome {
             ok: true,
             summary: if dry_run {
-                "dry run: unica.meta.edit planned native metadata edit".to_string()
+                if changed {
+                    "dry run: unica.meta.edit planned native metadata edit".to_string()
+                } else {
+                    "dry run: unica.meta.edit found no metadata changes".to_string()
+                }
             } else {
                 "unica.meta.edit completed with native metadata editor".to_string()
             },
@@ -16713,7 +16795,11 @@ fn edit_meta_with_mode(
         },
         Err(error) => AdapterOutcome {
             ok: false,
-            summary: "unica.meta.edit failed in native metadata editor".to_string(),
+            summary: if dry_run {
+                "dry run: unica.meta.edit failed in native metadata editor".to_string()
+            } else {
+                "unica.meta.edit failed in native metadata editor".to_string()
+            },
             changes: Vec::new(),
             warnings: Vec::new(),
             errors: vec![error.clone()],
@@ -16723,6 +16809,25 @@ fn edit_meta_with_mode(
             command: None,
         },
     }
+}
+
+/// Renders and verifies an exact unified diff for the projected metadata bytes.
+fn meta_edit_unified_diff(path: &str, before: &str, after: &str) -> Result<String, String> {
+    let mut options = DiffOptions::new();
+    options
+        .set_original_filename(format!("a/{path}"))
+        .set_modified_filename(format!("b/{path}"));
+    let rendered = options.create_patch(before, after).to_string();
+    let reparsed = Patch::from_str(&rendered)
+        .map_err(|error| format!("generated meta-edit diff cannot be parsed: {error}"))?;
+    let rebuilt = apply(before, &reparsed)
+        .map_err(|error| format!("generated meta-edit diff cannot be applied: {error}"))?;
+    if rebuilt.as_bytes() != after.as_bytes() {
+        return Err(
+            "generated meta-edit diff does not reproduce the exact projected XML".to_string(),
+        );
+    }
+    Ok(rendered)
 }
 
 fn meta_edit_source_eol(text: &str) -> MetaEditEol {

--- a/crates/unica-coder/src/infrastructure/native_operations/meta.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta.rs
@@ -16667,7 +16667,7 @@ fn edit_meta_with_mode(
         Ok((stdout, object_path, changed, warnings)) => AdapterOutcome {
             ok: true,
             summary: if dry_run {
-                "unica.meta.edit planned native metadata edit".to_string()
+                "dry run: unica.meta.edit planned native metadata edit".to_string()
             } else {
                 "unica.meta.edit completed with native metadata editor".to_string()
             },

--- a/crates/unica-coder/src/infrastructure/native_operations/meta.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta.rs
@@ -2628,6 +2628,7 @@ mod edit_tests {
         let _ = fs::remove_dir_all(&context.cwd);
     }
 
+    /// Verifies inline previews expose the exact projected XML without writing it.
     #[test]
     fn preview_meta_edit_reports_projected_inline_diff_without_writing() {
         let context = temp_context("preview-inline-change");
@@ -2661,6 +2662,7 @@ mod edit_tests {
         let _ = fs::remove_dir_all(&context.cwd);
     }
 
+    /// Verifies a missing preview target remains a useful dry-run failure.
     #[test]
     fn preview_meta_edit_rejects_missing_object() {
         let context = temp_context("preview-missing-object");
@@ -2683,6 +2685,7 @@ mod edit_tests {
         let _ = fs::remove_dir_all(&context.cwd);
     }
 
+    /// Verifies DefinitionFile previews use the same exact diff contract.
     #[test]
     fn preview_meta_edit_reports_definition_file_diff_without_writing() {
         let context = temp_context("preview-definition-file");
@@ -2713,6 +2716,7 @@ mod edit_tests {
         let _ = fs::remove_dir_all(&context.cwd);
     }
 
+    /// Verifies byte-identical previews report a no-op and omit the diff.
     #[test]
     fn preview_meta_edit_reports_no_file_changes_without_diff() {
         let context = temp_context("preview-no-op");
@@ -2738,6 +2742,28 @@ mod edit_tests {
         assert_eq!(fs::read(&object_path).unwrap(), before);
 
         let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    /// Verifies a renderer fault does not turn a valid metadata edit into a failure.
+    #[test]
+    fn projected_diff_render_failure_becomes_warning() {
+        let mut info_lines = Vec::new();
+        let mut warnings = Vec::new();
+
+        meta_edit_record_projected_diff(
+            &mut info_lines,
+            &mut warnings,
+            Err("synthetic renderer failure".to_string()),
+        );
+
+        assert!(info_lines.is_empty());
+        assert_eq!(
+            warnings,
+            vec![
+                "projected diff could not be rendered safely: synthetic renderer failure"
+                    .to_string()
+            ]
+        );
     }
 
     #[test]
@@ -16749,10 +16775,11 @@ fn edit_meta_with_mode(
                 .map_err(|err| format!("failed to preview {}: {err}", object_path.display()))?;
             let after = String::from_utf8(serialized_bytes)
                 .map_err(|err| format!("failed to preview {}: {err}", object_path.display()))?;
-            info_lines.push(format!(
-                "\n=== projected diff ===\n{}",
-                meta_edit_unified_diff(&diff_path, &before, &after)?
-            ));
+            meta_edit_record_projected_diff(
+                &mut info_lines,
+                &mut warnings,
+                meta_edit_unified_diff(&diff_path, &before, &after),
+            );
         } else {
             counts = MetaEditCounts::default();
             info_lines.push("[INFO] No changes".to_string());
@@ -16808,6 +16835,20 @@ fn edit_meta_with_mode(
             stderr: Some(format!("{error}\n")),
             command: None,
         },
+    }
+}
+
+/// Adds a verified diff to stdout or records a non-fatal renderer diagnostic.
+fn meta_edit_record_projected_diff(
+    info_lines: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+    rendered: Result<String, String>,
+) {
+    match rendered {
+        Ok(diff) => info_lines.push(format!("\n=== projected diff ===\n{diff}")),
+        Err(error) => warnings.push(format!(
+            "projected diff could not be rendered safely: {error}"
+        )),
     }
 }
 

--- a/crates/unica-coder/src/infrastructure/native_operations/meta.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta.rs
@@ -16518,6 +16518,7 @@ pub(crate) fn edit_meta(args: &Map<String, Value>, context: &WorkspaceContext) -
     edit_meta_with_mode(args, context, false)
 }
 
+/// Validates a metadata edit and reports its planned effects without writing files.
 pub(crate) fn preview_meta_edit(
     args: &Map<String, Value>,
     context: &WorkspaceContext,
@@ -16547,6 +16548,7 @@ pub(crate) fn preview_meta_edit(
     }
 }
 
+/// Runs the shared metadata-edit workflow in either preview or apply mode.
 fn edit_meta_with_mode(
     args: &Map<String, Value>,
     context: &WorkspaceContext,

--- a/crates/unica-coder/src/infrastructure/native_operations/meta.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta.rs
@@ -2628,6 +2628,32 @@ mod edit_tests {
     }
 
     #[test]
+    fn preview_meta_edit_validates_and_describes_inline_change_without_writing() {
+        let context = temp_context("preview-inline-change");
+        let object_path = context.cwd.join("Catalogs/Preview.xml");
+        write_file(&object_path, &sample_catalog_xml());
+        let before = fs::read(&object_path).unwrap();
+
+        let outcome = preview_meta_edit(
+            &meta_edit_args(&object_path, "modify-property", "Comment=Previewed"),
+            &context,
+        );
+
+        assert!(outcome.ok, "{outcome:?}");
+        assert!(outcome.summary.contains("planned native metadata edit"));
+        assert_eq!(
+            outcome.changes,
+            vec![format!("would update {}", object_path.display())]
+        );
+        let stdout = outcome.stdout.as_deref().unwrap_or_default();
+        assert!(stdout.contains("Planned operation: modify-property: Comment=Previewed"));
+        assert!(stdout.contains("Planned update:"));
+        assert_eq!(fs::read(&object_path).unwrap(), before);
+
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
     fn edit_meta_rejects_invalid_boolean_definition_map_without_writing() {
         let context = temp_context("invalid-boolean-definition");
         let object_path = context.cwd.join("Catalogs/BooleanProbe.xml");
@@ -16489,6 +16515,21 @@ struct MetaEditLineNumberLengthAuthorization {
 }
 
 pub(crate) fn edit_meta(args: &Map<String, Value>, context: &WorkspaceContext) -> AdapterOutcome {
+    edit_meta_with_mode(args, context, false)
+}
+
+pub(crate) fn preview_meta_edit(
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> AdapterOutcome {
+    edit_meta_with_mode(args, context, true)
+}
+
+fn edit_meta_with_mode(
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+    dry_run: bool,
+) -> AdapterOutcome {
     let edit_result = (|| -> Result<(String, PathBuf, bool, Vec<String>), String> {
         let definition_file = path_arg(args, &["definitionFile", "DefinitionFile"]);
         let operation = string_arg(args, &["operation", "Operation"]);
@@ -16578,6 +16619,9 @@ pub(crate) fn edit_meta(args: &Map<String, Value>, context: &WorkspaceContext) -
                 authorization.policy,
                 &mut counts,
             )?;
+            if dry_run {
+                info_lines.push(format!("[INFO] Planned operation: {operation}: {value}"));
+            }
             authorization.provenance
         };
 
@@ -16590,7 +16634,7 @@ pub(crate) fn edit_meta(args: &Map<String, Value>, context: &WorkspaceContext) -
         let serialized_bytes = meta_edit_preserve_source_format(&xml_text, source_format);
         let changed = serialized_bytes != original_bytes;
         let mut warnings = Vec::new();
-        if changed {
+        if changed && !dry_run {
             transaction.replace_bytes(&object_path, &original_bytes, serialized_bytes)?;
             if let Some(provenance) = line_number_length_provenance {
                 provenance.bind_to(&mut transaction)?;
@@ -16605,6 +16649,8 @@ pub(crate) fn edit_meta(args: &Map<String, Value>, context: &WorkspaceContext) -
                 })?
                 .cleanup_warnings;
             info_lines.push(format!("[INFO] Saved: {}", object_path.display()));
+        } else if changed {
+            info_lines.push(format!("[INFO] Planned update: {}", object_path.display()));
         } else {
             counts = MetaEditCounts::default();
             info_lines.push("[INFO] No changes".to_string());
@@ -16620,9 +16666,17 @@ pub(crate) fn edit_meta(args: &Map<String, Value>, context: &WorkspaceContext) -
     match edit_result {
         Ok((stdout, object_path, changed, warnings)) => AdapterOutcome {
             ok: true,
-            summary: "unica.meta.edit completed with native metadata editor".to_string(),
+            summary: if dry_run {
+                "unica.meta.edit planned native metadata edit".to_string()
+            } else {
+                "unica.meta.edit completed with native metadata editor".to_string()
+            },
             changes: if changed {
-                vec![format!("updated {}", object_path.display())]
+                vec![if dry_run {
+                    format!("would update {}", object_path.display())
+                } else {
+                    format!("updated {}", object_path.display())
+                }]
             } else {
                 Vec::new()
             },

--- a/crates/unica-coder/src/infrastructure/native_operations/tests.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/tests.rs
@@ -76,6 +76,7 @@ fn compile_preview_without_payload_uses_the_safe_dry_run_placeholder() {
     fs::remove_dir_all(root).unwrap();
 }
 
+/// Verifies the facade routes meta-edit dry-runs to the detailed preview.
 #[test]
 fn meta_edit_dry_run_dispatches_to_projected_diff_preview() {
     let root = temp_root("meta-edit-dry-run-dispatch");

--- a/crates/unica-coder/src/infrastructure/native_operations/tests.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/tests.rs
@@ -77,6 +77,52 @@ fn compile_preview_without_payload_uses_the_safe_dry_run_placeholder() {
 }
 
 #[test]
+fn meta_edit_dry_run_dispatches_to_projected_diff_preview() {
+    let root = temp_root("meta-edit-dry-run-dispatch");
+    let object_path = root.join("Catalogs/Preview.xml");
+    fs::create_dir_all(object_path.parent().unwrap()).unwrap();
+    let original = br#"<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:cfg="http://v8.1c.ru/8.1/data/enterprise/current-config" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xr="http://v8.1c.ru/8.3/xcf/readable" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+	<Catalog uuid="11111111-1111-4111-8111-111111111111">
+		<Properties>
+			<Name>Preview</Name>
+			<Synonym/>
+			<Comment/>
+			<Owners/>
+			<InputByString/>
+			<BasedOn/>
+		</Properties>
+		<ChildObjects/>
+	</Catalog>
+</MetaDataObject>
+"#;
+    fs::write(&object_path, original).unwrap();
+    let context = discover_workspace(Some(root.clone())).unwrap();
+    let args = serde_json::from_value(json!({
+        "ObjectPath": object_path.display().to_string(),
+        "Operation": "modify-property",
+        "Value": "Comment=Dispatched"
+    }))
+    .unwrap();
+
+    let result =
+        NativeOperationAdapter::invoke("meta-edit", "unica.meta.edit", &args, &context, true, true)
+            .unwrap();
+
+    assert!(result.ok, "{result:?}");
+    let stdout = result.stdout.as_deref().unwrap_or_default();
+    assert!(stdout.contains("--- a/"), "{stdout}");
+    assert!(stdout.contains("-\t\t\t<Comment/>"), "{stdout}");
+    assert!(
+        stdout.contains("+\t\t\t<Comment>Dispatched</Comment>"),
+        "{stdout}"
+    );
+    assert_eq!(fs::read(&object_path).unwrap(), original);
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn subsystem_preview_with_unavailable_parent_uses_the_legacy_placeholder() {
     let root = temp_root("subsystem-preview-parent-fallback");
     let context = discover_workspace(Some(root.clone())).unwrap();

--- a/plugins/unica/skills/meta-edit/SKILL.md
+++ b/plugins/unica/skills/meta-edit/SKILL.md
@@ -253,7 +253,7 @@ Batch через `;;` во всех операциях. Подробный си�
     "name": "unica.meta.edit",
     "arguments": {
       "cwd": "<workspace>",
-      "ObjectPath": "src/Catalogs/ДоговорыКонтрагентов/ДоговорыКонтрагентов.xml",
+      "ObjectPath": "src/Catalogs/Контрагенты/Контрагенты.xml",
       "Operation": "set-owners",
       "Value": "Catalog.Контрагенты ;; Catalog.Организации",
       "dryRun": false

--- a/plugins/unica/skills/meta-edit/SKILL.md
+++ b/plugins/unica/skills/meta-edit/SKILL.md
@@ -253,7 +253,7 @@ Batch через `;;` во всех операциях. Подробный си�
     "name": "unica.meta.edit",
     "arguments": {
       "cwd": "<workspace>",
-      "ObjectPath": "src/Catalogs/Контрагенты/Контрагенты.xml",
+      "ObjectPath": "src/Catalogs/ДоговорыКонтрагентов/ДоговорыКонтрагентов.xml",
       "Operation": "set-owners",
       "Value": "Catalog.Контрагенты ;; Catalog.Организации",
       "dryRun": false

--- a/tests/ci/test_unica_mcp_script_parity.py
+++ b/tests/ci/test_unica_mcp_script_parity.py
@@ -4769,6 +4769,8 @@ class UnicaMcpScriptParityTests(unittest.TestCase):
                     descriptor_path.write_text(
                         "<MetaDataObject/>\n", encoding="utf-8"
                     )
+                elif example.skill == "meta-edit":
+                    prepare_meta_edit_skill_example(workspace, example, arguments)
             messages = [
                 dry_run_message_for_example(example, index + 1, workspace)
                 for index, example in enumerate(examples)
@@ -5605,6 +5607,98 @@ def dry_run_message_for_example(
     arguments["cwd"] = str(workspace)
     arguments["dryRun"] = True
     return message
+
+
+def prepare_meta_edit_skill_example(
+    workspace: Path,
+    example: SkillMcpExample,
+    arguments: dict[str, Any],
+) -> None:
+    """Create real metadata and definition fixtures for one documented example."""
+    raw_object_path = arguments["ObjectPath"]
+    if raw_object_path == "<path>":
+        raw_object_path = f"fixtures/meta-edit-{example.line}.xml"
+        arguments["ObjectPath"] = raw_object_path
+    object_path = workspace / raw_object_path
+    object_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not object_path.exists():
+        is_document = "Documents" in object_path.parts
+        source = FIXTURES_ROOT / (
+            BSP_META_DOCUMENT_FIXTURE if is_document else BSP_META_CATALOG_FIXTURE
+        )
+        xml = source.read_bytes().decode("utf-8-sig")
+        xml, replacements = re.subn(
+            r"(<Properties>\s*<Name>)[^<]+",
+            rf"\g<1>{object_path.stem}",
+            xml,
+            count=1,
+        )
+        if replacements != 1:
+            raise AssertionError(f"cannot rename metadata fixture for {object_path}")
+        object_path.write_bytes(xml.encode("utf-8"))
+
+    operation = arguments.get("Operation")
+    value = str(arguments.get("Value", ""))
+    if operation in {"add-owner", "set-owners"}:
+        self_reference = f"Catalog.{object_path.stem}"
+        owners = {item.strip() for item in value.split(";;")}
+        if self_reference in owners:
+            raise AssertionError(
+                f"metadata skill example makes {self_reference} its own owner"
+            )
+    if operation in {"remove-attribute", "modify-attribute"}:
+        attribute_name = value.split(";;", 1)[0].split(":", 1)[0].strip()
+        ensure_meta_edit_skill_attribute(object_path, attribute_name)
+
+    if arguments.get("DefinitionFile") == "<json>":
+        definition_path = workspace / "fixtures" / f"meta-edit-{example.line}.json"
+        definition_path.parent.mkdir(parents=True, exist_ok=True)
+        definition_path.write_text(
+            json.dumps(
+                {"modify": {"properties": {"Comment": "Skill preview"}}},
+                ensure_ascii=False,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        arguments["DefinitionFile"] = str(definition_path.relative_to(workspace))
+
+
+def ensure_meta_edit_skill_attribute(object_path: Path, attribute_name: str) -> None:
+    """Clone a valid attribute so remove/modify examples have a real target."""
+    xml = object_path.read_text(encoding="utf-8")
+    if f"<Name>{attribute_name}</Name>" in xml:
+        return
+    match = re.search(
+        r"(?ms)^\t\t\t<Attribute\b.*?^\t\t\t</Attribute>",
+        xml,
+    )
+    if match is None:
+        raise AssertionError(f"no reusable Attribute fixture in {object_path}")
+    attribute = match.group(0)
+    attribute = re.sub(
+        r"(<Name>)[^<]+(</Name>)",
+        rf"\g<1>{attribute_name}\g<2>",
+        attribute,
+        count=1,
+    )
+    digest = hashlib.sha256(attribute_name.encode("utf-8")).hexdigest()[:32]
+    fixture_uuid = (
+        f"{digest[:8]}-{digest[8:12]}-{digest[12:16]}-"
+        f"{digest[16:20]}-{digest[20:32]}"
+    )
+    attribute = re.sub(
+        r'uuid="[^"]+"',
+        f'uuid="{fixture_uuid}"',
+        attribute,
+        count=1,
+    )
+    root_close = re.search(r"(?m)^\t\t</ChildObjects>\s*$", xml)
+    if root_close is None:
+        raise AssertionError(f"no root ChildObjects closing tag in {object_path}")
+    xml = f"{xml[:root_close.start()]}{attribute}\n{xml[root_close.start():]}"
+    object_path.write_text(xml, encoding="utf-8")
 
 
 def script_args(arguments: dict[str, Any]) -> list[str]:


### PR DESCRIPTION
## Что исправлено

Closes #53.

- `unica.meta.edit` при `dryRun=true` проходит тот же разбор и валидацию, что и apply, но не коммитит транзакцию.
- Read-only support guard теперь выполняется перед любым mutating handler независимо от `dryRun`; заблокированный preview возвращает те же guard-данные, что apply, с префиксом `dry run:` в summary.
- Контрактный тест фиксирует полный охват support guard: 19 защищённых native-мутаций и 7 явно обоснованных исключений. Для вложенного subsystem.compile guard сначала проверяет Parent, затем сохраняет fallback на OutputDir.
- Для существующего объекта ответ показывает точный проверяемый unified diff; no-op возвращается без diff и без planned changes.
- Внутренний сбой рендера diff не превращает валидный preview в ошибку: результат остаётся успешным с явным warning.
- Отсутствующий `ObjectPath` больше не маскируется как успешный план: dry-run возвращает `ok=false` с явной ошибкой.
- MCP parity-тесты создают реальные фикстуры для всех примеров `meta-edit`, включая `DefinitionFile`, remove/modify и семантическую проверку владельцев.
- Пример `set-owners` снова использует подчинённый справочник `ДоговорыКонтрагентов`.

## Проверки

- `cargo test -p unica-coder --lib -- --test-threads=1` — 1520 passed, 2 ignored
- `python3.12 -m unittest tests.ci.test_unica_mcp_script_parity` — 26 passed, 3 skipped
- `python3.12 -m unittest tests.ci.test_unica_skills` — 40 passed
- `cargo clippy -p unica-coder --lib --all-features -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dry-run (preview) support for metadata edits, including an exact unified diff of projected XML changes while leaving files unchanged.
  * Preview outcomes now use “planned/would update” language, show “No changes” without diff when identical, and prefix blocked failures with “dry run: …”.

* **Bug Fixes**
  * Improved preview dispatch so `meta-edit` consistently uses the projected-diff preview path.
  * Support-guard blocking now applies consistently in both preview and apply modes, with updated preview messaging and warnings.

* **Tests / QA**
  * Added unit tests for preview diff-only updates, no-op handling, warning-only diff failures, and updated CI parity fixtures for metadata-edit examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


