### PR TITLE
fix(platform-help): distinguish platform help from standards

### DIFF
--- a/plugins/unica/references/platform/compatibility-modes.md
+++ b/plugins/unica/references/platform/compatibility-modes.md
@@ -62,9 +62,12 @@ methods behave as they did in an older release.
 6. When environments or candidate modes differ, present the result as a
    matrix.
 
-Use `unica.standards.search` and `unica.standards.explain` for the platform
-contract. Inspect project metadata and code through the relevant public
-`unica.*` tools.
+`unica.standards.search` and `unica.standards.explain` cover development
+standards, not the platform contract. An exact compatibility boundary requires
+a `platform-help` source for the target version. Until public MCP `unica`
+exposes that source, report a `platform-help contract gap` instead of
+substituting a standards result. Inspect project metadata and code through the
+relevant public `unica.*` tools.
 
 BSP code is corroborating implementation evidence: it can show how a carefully
 maintained library resolves platform and compatibility versions in practice.

--- a/plugins/unica/skills/bsp-patterns/SKILL.md
+++ b/plugins/unica/skills/bsp-patterns/SKILL.md
@@ -16,7 +16,7 @@ description: "Поиск и применение паттернов БСП. Ис
 1. Identify the BSP subsystem or library pattern by intent, not by guessed module name.
 2. Search existing project usage with `unica.code.search` before writing new code. Prefer local project conventions over generic snippets.
 3. Inspect affected metadata, forms, roles, and external processing registration with `unica.*.info` skills.
-4. Use `unica.standards.search` for platform/BSP guidance when the pattern affects security, rights, background jobs, files, or external calls.
+4. Use `unica.standards.search` only for a `development-standard` that constrains the pattern. Do not treat it as platform or BSP documentation. Exact platform mechanics require a `platform-help` source; if public MCP `unica` does not expose one, report the contract gap. Treat local BSP code as corroborating implementation evidence, not as the platform contract.
 5. Implement the smallest integration point and verify with `unica.runtime.execute` syntax/tests.
 
 ## References

--- a/plugins/unica/skills/code-diagnostics/SKILL.md
+++ b/plugins/unica/skills/code-diagnostics/SKILL.md
@@ -42,7 +42,7 @@ When comments disable diagnostics over a line or range, treat the exact marker a
 - Extract literal codes or ids from the comment: АПК, EDT, BSL LS, analyzer rule names, numeric or mnemonic ids.
 - Use `unica.standards.explain` with all extracted codes. If v8std does not resolve a code, search with `unica.standards.search` using the code plus nearby diagnostic text.
 - Explain why the отключение exists only when the code, surrounding range, and standard support the reason. If the reason is absent, say that the suppression is not justified in the source.
-- Prefer narrowing the disabled range or fixing the code. Keep suppression only when the standard or platform limitation makes the diagnostic intentionally false-positive.
+- Prefer narrowing the disabled range or fixing the code. Keep suppression only when `development-standard` evidence, a verified `platform-help` source, or a runtime reproduction proves the diagnostic intentionally false-positive. Do not infer a platform limitation from `unica.standards.*`.
 
 ## MCP examples
 

--- a/plugins/unica/skills/log-analysis/SKILL.md
+++ b/plugins/unica/skills/log-analysis/SKILL.md
@@ -26,7 +26,7 @@ Accept explicit journal registration exports, technological log files, copied lo
 2. Build a timeline. Keep clock source and timezone explicit when several files are involved.
 3. Extract module, procedure, metadata object, HTTP path, query text, user/session, and transaction identifiers.
 4. Map log entries back to source with `unica.code.search` and metadata with `unica.meta.info`.
-5. Use `unica.standards.search` or `unica.standards.explain` for diagnostic ids, platform messages, or standards-sensitive recommendations.
+5. Use `unica.standards.search` or `unica.standards.explain` for diagnostic ids and `development-standard` recommendations. The exact meaning of a platform message requires a `platform-help` source; if public MCP `unica` does not expose one, report the contract gap.
 6. Separate root cause from consequences: the first exception/lock/timeout usually matters more than later rollback noise.
 7. For DBMS evidence, preserve lock holder/waiter, SQL text, transaction boundary, process id, session id, wait event, table/index name, and elapsed time together.
 

--- a/plugins/unica/skills/platform-help/SKILL.md
+++ b/plugins/unica/skills/platform-help/SKILL.md
@@ -34,7 +34,7 @@ description: "Справка платформы 1С и объектной мод
 ## Stop rules
 
 - Do not present `unica.standards.*` output as proof of platform API behavior or exact method signatures.
-- If the requested platform-help source is not available through public MCP `unica`, report it as a Unica MCP contract gap instead of bypassing the public boundary.
+- If the requested platform-help source is not available through public MCP `unica`, report it as a `platform-help contract gap` instead of bypassing the public boundary.
 
 ## MCP examples
 

--- a/plugins/unica/skills/platform-help/SKILL.md
+++ b/plugins/unica/skills/platform-help/SKILL.md
@@ -7,14 +7,16 @@ description: "Справка платформы 1С и объектной мод
 
 ## MCP routing
 
-- Preferred path: use MCP `unica` tools `unica.standards.search`, `unica.standards.explain`, `unica.code.search`, `unica.project.map`, and `unica.runtime.execute`.
+- For project context, use MCP `unica` tools `unica.code.search`, `unica.project.map`, and `unica.runtime.execute`.
+- `unica.standards.search` and `unica.standards.explain` return development standards, not platform API/help. Use them only when the question explicitly asks for a standard or code-style rule, and label that source as `development-standard`.
+- Platform behavior, API signatures, and version-dependent mechanics require a `platform-help` source. Until it is exposed by public MCP `unica`, report this as a `platform-help` contract gap rather than substituting a standards result.
 - Use object-specific `unica.*.info` tools when the API question depends on metadata structure.
 - Do not call internal standards, runtime, or package adapters directly. They are hidden behind MCP `unica`.
 
 ## Workflow
 
 1. State the exact platform/API question: object, method/property, platform version, infobase mode, client/server context, managed/ordinary mode, and whether code runs in UI, server, background job, or external integration.
-2. Search standards and platform guidance through `unica.standards.search`; for code fragments use `unica.standards.explain` with `snippet`.
+2. Classify the requested evidence: use platform help for API/mechanics, and use `unica.standards.*` only for development standards. State the source type in the answer.
 3. Validate against local project context with `unica.project.map` and targeted `unica.code.search` if the answer depends on project conventions.
 4. If behavior is version-sensitive, ask for or read the configured platform version before giving a hard answer.
 5. For code examples, run `unica.runtime.execute` with `operation=syntax` when feasible.
@@ -31,36 +33,11 @@ description: "Справка платформы 1С и объектной мод
 
 ## Stop rules
 
-- Do not invent exact method signatures when `unica.standards.*` cannot confirm them.
+- Do not present `unica.standards.*` output as proof of platform API behavior or exact method signatures.
 - If the requested platform-help source is not available through public MCP `unica`, report it as a Unica MCP contract gap instead of bypassing the public boundary.
 
 ## MCP examples
 
-```jsonc
-{
-  "jsonrpc": "2.0",
-  "method": "tools/call",
-  "params": {
-    "name": "unica.standards.search",
-    "arguments": {
-      "query": "Соответствие Вставить Получить платформа 1С",
-      "limit": 5
-    }
-  }
-}
-```
-
-```jsonc
-{
-  "jsonrpc": "2.0",
-  "method": "tools/call",
-  "params": {
-    "name": "unica.standards.explain",
-    "arguments": {
-      "snippet": "Результат = Новый Соответствие; Результат.Вставить(\"Ключ\", Значение);",
-      "language": "bsl",
-      "limit": 5
-    }
-  }
-}
-```
+When the answer requires platform help that the public MCP server does not yet
+expose, report `platform-help contract gap` and identify the required platform
+version and runtime context. Do not replace it with a standards-search call.

--- a/plugins/unica/skills/query-optimize/SKILL.md
+++ b/plugins/unica/skills/query-optimize/SKILL.md
@@ -19,7 +19,7 @@ description: "Оптимизация запросов 1С и СКД. Испол�
 4. Run `unica.code.diagnostics` with `mode=file` when analyzer diagnostics can reveal unreachable code, unresolved calls, or type issues around the query.
 5. Inspect metadata with `unica.meta.profile` when the query is tied to an exact object and you need object modules, subscriptions, roles, functional options, or predefined items. Use `unica.meta.info` for XML-level registers, dimensions, resources, реквизиты, tabular sections, and indexes implied by the platform object type.
 6. Inspect DCS with `unica.dcs.info` when the query lives in a data composition schema.
-7. Search standards with `unica.standards.search` for platform-specific query rules before making a risky rewrite.
+7. Search `unica.standards.search` only for `development-standard` query rules. Exact platform query semantics require a `platform-help` source; if public MCP `unica` does not expose one, report the contract gap before making a platform-dependent rewrite.
 8. Read `references/platform/db-performance.md` when performance depends on DBMS behavior, locks, indexes, temp storage, WAL, TEMPDB, or large table statistics.
 9. Optimize one cause at a time: filters before joins, virtual table parameters, temporary table materialization, repeated queries in loops, dot dereference expansion, unbounded selections, and unnecessary totals.
 10. Verify syntax with `unica.runtime.execute` and ask for real trace/log evidence when performance depends on data volume.

--- a/plugins/unica/skills/test-authoring/SKILL.md
+++ b/plugins/unica/skills/test-authoring/SKILL.md
@@ -8,7 +8,7 @@ description: "Проектирование и запуск тестов 1С: tes
 ## MCP routing
 
 - Preferred path: use MCP `unica` tools `unica.code.search`, `unica.project.map`, `unica.runtime.execute`, and the relevant `unica.*.info` tools.
-- Use `unica.standards.search` or `unica.standards.explain` when test design depends on a platform or standards rule.
+- Use `unica.standards.search` or `unica.standards.explain` only when test design depends on a `development-standard`. Expected platform API or mechanics require a `platform-help` source; if public MCP `unica` does not expose one, report the contract gap.
 - Do not call internal runtime, analyzer, or package adapters directly. They are hidden behind MCP `unica`.
 
 ## Workflow

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -540,7 +540,12 @@ def markdown_routing_units(text: str) -> list[str]:
             flush()
         current.append(stripped)
     flush()
-    return units
+    return [
+        claim.strip()
+        for unit in units
+        for claim in re.split(r"(?<=[.!?;])\s+", unit)
+        if claim.strip()
+    ]
 
 
 def find_unsafe_platform_evidence_routes(
@@ -550,6 +555,7 @@ def find_unsafe_platform_evidence_routes(
         "development-standard",
         "development standards",
         "not platform",
+        "do not infer",
         "do not present",
     ]
     unsafe_routes = []
@@ -718,6 +724,22 @@ class UnicaSkillRoutingTests(unittest.TestCase):
                     "- Use `unica.standards.search` for platform API rules.\n"
                     "- Use `unica.standards.search` only for a "
                     "`development-standard`, not platform evidence.\n",
+                )
+            ]
+        )
+
+        self.assertEqual(len(unsafe_routes), 1)
+        self.assertIn("platform API rules", unsafe_routes[0])
+        self.assertNotIn("development-standard", unsafe_routes[0])
+
+    def test_route_linter_checks_claims_within_one_markdown_item(self) -> None:
+        unsafe_routes = find_unsafe_platform_evidence_routes(
+            [
+                (
+                    "same-item-fixture.md",
+                    "- `unica.standards.search` is a `development-standard`, "
+                    "not platform evidence. Use `unica.standards.search` for "
+                    "platform API rules.\n",
                 )
             ]
         )

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -638,6 +638,46 @@ class UnicaSkillRoutingTests(unittest.TestCase):
                 self.assertRegex(doc, r"не\s+новее `Version8_3_26`")
                 self.assertNotRegex(doc, r"`Version8_3_26`\s+и старше")
 
+    def test_platform_evidence_is_not_routed_to_standards_tools(self) -> None:
+        docs = list(self.skill_root().glob("**/*.md")) + list(
+            self.reference_root().glob("**/*.md")
+        )
+        safe_boundaries = [
+            "development-standard",
+            "development standards",
+            "not platform",
+            "do not present",
+        ]
+        unsafe_routes = []
+
+        for doc_path in docs:
+            text = doc_path.read_text(encoding="utf-8")
+            for paragraph in re.split(r"\n\s*\n", text):
+                normalized = " ".join(line.strip() for line in paragraph.splitlines())
+                lowered = normalized.casefold()
+                mentions_standards_tool = "unica.standards." in lowered
+                mentions_platform_evidence = (
+                    "platform" in lowered or "платформ" in lowered
+                )
+                marks_the_source_boundary = any(
+                    boundary in lowered for boundary in safe_boundaries
+                )
+                if (
+                    mentions_standards_tool
+                    and mentions_platform_evidence
+                    and not marks_the_source_boundary
+                ):
+                    unsafe_routes.append(
+                        f"{doc_path.relative_to(self.repo_root())}: {normalized}"
+                    )
+
+        self.assertEqual(
+            unsafe_routes,
+            [],
+            "standards tools must not be presented as platform evidence:\n"
+            + "\n".join(unsafe_routes),
+        )
+
     def test_all_skills_do_not_expose_internal_mcp_names(self) -> None:
         forbidden = [
             "unica-coder",

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -521,6 +521,57 @@ SCENARIO_PRESERVING_TOKENS = {
 }
 
 
+def markdown_routing_units(text: str) -> list[str]:
+    units = []
+    current = []
+    item_start = re.compile(r"^\s*(?:[-*+]|\d+[.)])\s+")
+
+    def flush() -> None:
+        if current:
+            units.append(" ".join(current))
+            current.clear()
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            flush()
+            continue
+        if item_start.match(line):
+            flush()
+        current.append(stripped)
+    flush()
+    return units
+
+
+def find_unsafe_platform_evidence_routes(
+    documents: list[tuple[str, str]],
+) -> list[str]:
+    safe_boundaries = [
+        "development-standard",
+        "development standards",
+        "not platform",
+        "do not present",
+    ]
+    unsafe_routes = []
+
+    for display_path, text in documents:
+        for normalized in markdown_routing_units(text):
+            lowered = normalized.casefold()
+            mentions_standards_tool = "unica.standards." in lowered
+            mentions_platform_evidence = "platform" in lowered or "платформ" in lowered
+            marks_the_source_boundary = any(
+                boundary in lowered for boundary in safe_boundaries
+            )
+            if (
+                mentions_standards_tool
+                and mentions_platform_evidence
+                and not marks_the_source_boundary
+            ):
+                unsafe_routes.append(f"{display_path}: {normalized}")
+
+    return unsafe_routes
+
+
 class UnicaSkillRoutingTests(unittest.TestCase):
     def repo_root(self) -> Path:
         return Path(__file__).resolve().parents[2]
@@ -642,34 +693,15 @@ class UnicaSkillRoutingTests(unittest.TestCase):
         docs = list(self.skill_root().glob("**/*.md")) + list(
             self.reference_root().glob("**/*.md")
         )
-        safe_boundaries = [
-            "development-standard",
-            "development standards",
-            "not platform",
-            "do not present",
-        ]
-        unsafe_routes = []
-
-        for doc_path in docs:
-            text = doc_path.read_text(encoding="utf-8")
-            for paragraph in re.split(r"\n\s*\n", text):
-                normalized = " ".join(line.strip() for line in paragraph.splitlines())
-                lowered = normalized.casefold()
-                mentions_standards_tool = "unica.standards." in lowered
-                mentions_platform_evidence = (
-                    "platform" in lowered or "платформ" in lowered
+        unsafe_routes = find_unsafe_platform_evidence_routes(
+            [
+                (
+                    str(doc_path.relative_to(self.repo_root())),
+                    doc_path.read_text(encoding="utf-8"),
                 )
-                marks_the_source_boundary = any(
-                    boundary in lowered for boundary in safe_boundaries
-                )
-                if (
-                    mentions_standards_tool
-                    and mentions_platform_evidence
-                    and not marks_the_source_boundary
-                ):
-                    unsafe_routes.append(
-                        f"{doc_path.relative_to(self.repo_root())}: {normalized}"
-                    )
+                for doc_path in docs
+            ]
+        )
 
         self.assertEqual(
             unsafe_routes,
@@ -677,6 +709,30 @@ class UnicaSkillRoutingTests(unittest.TestCase):
             "standards tools must not be presented as platform evidence:\n"
             + "\n".join(unsafe_routes),
         )
+
+    def test_route_linter_checks_adjacent_markdown_items_independently(self) -> None:
+        unsafe_routes = find_unsafe_platform_evidence_routes(
+            [
+                (
+                    "masking-fixture.md",
+                    "- Use `unica.standards.search` for platform API rules.\n"
+                    "- Use `unica.standards.search` only for a "
+                    "`development-standard`, not platform evidence.\n",
+                )
+            ]
+        )
+
+        self.assertEqual(len(unsafe_routes), 1)
+        self.assertIn("platform API rules", unsafe_routes[0])
+        self.assertNotIn("development-standard", unsafe_routes[0])
+
+    def test_platform_help_uses_one_contract_gap_label(self) -> None:
+        platform_help = (self.skill_root() / "platform-help" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertNotIn("Unica MCP contract gap", platform_help)
+        self.assertIn("platform-help contract gap", platform_help)
 
     def test_all_skills_do_not_expose_internal_mcp_names(self) -> None:
         forbidden = [

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -109,8 +109,6 @@ SCENARIO_SKILLS = {
         "unica.runtime.execute",
     ],
     "platform-help": [
-        "unica.standards.search",
-        "unica.standards.explain",
         "unica.code.search",
         "unica.project.map",
         "unica.runtime.execute",
@@ -231,7 +229,11 @@ SCENARIO_REQUIRED_TOKENS = {
     "code-review": ["Findings first", "severity", "file/line"],
     "query-optimize": ["СКД", "virtual", "query-in-loop"],
     "test-authoring": ['"testRunner": "yaxunit"', '"testRunner": "va"'],
-    "platform-help": ["Unica MCP contract gap", "method signatures"],
+    "platform-help": [
+        "platform-help contract gap",
+        "development-standard",
+        "method signatures",
+    ],
     "bsp-patterns": ["БСП", "СведенияОВнешнейОбработке"],
     "integration-implement": ["HTTP-сервис", "webhook", "secrets"],
     "autonomous-server": ["HTTP-сервис", "веб-клиент", "external browser-testing tool"],


### PR DESCRIPTION
## Что исправлено

Адресует #206: это безопасный первый шаг, который прекращает неверную
маршрутизацию до появления публичного platform-help adapter.

- `platform-help` больше не направляет вопросы о поведении API и платформы в
  `unica.standards.*`;
- standards явно маркируются как `development-standard` и используются только
  для правил разработки;
- противоречивые маршруты устранены также в общих platform references и
  связанных skills;
- при отсутствии публичного platform-help источника используется единый label
  `platform-help contract gap`;
- regression-тест проверяет все prompt-visible skills/references по отдельным\n  утверждениям/предложениям и не позволяет соседнему безопасному тексту замаскировать
  standards как platform evidence.

Provider-neutral развитие документационного поиска вынесено в #242. Issue #206
остаётся открытым до появления рабочего platform-help source.

## Проверка

- `python3.12 -m unittest tests.ci.test_unica_skills.UnicaSkillRoutingTests` —
  39 tests;
- `python3.12 -m unittest discover -s tests/ci -p 'test_*.py'` — 359 tests,
  3 skipped;
- `cargo test --workspace` — полный Rust workspace без падений;
- `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `unica.standards.search`/`unica.standards.explain` apply to development standards, not platform contracts.
  * Updated workflows to require exact `platform-help` sourcing for platform mechanics/compatibility boundaries.
  * Added clearer “platform-help contract gap” reporting when required platform evidence isn’t available.
  * Refined guidance across diagnostics, log analysis, query optimization, and test authoring to avoid treating standards output as platform proof.
* **Tests**
  * Added CI checks to prevent platform evidence from being routed via standards-only tools.
  * Updated platform-help scenario expectations and strengthened Markdown routing/lint validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->