### PR TITLE
fix(dump): accept Predefined.xml from platform 8.3.27

### DIFF
--- a/crates/unica-coder/src/infrastructure/platform_xml_owner.rs
+++ b/crates/unica-coder/src/infrastructure/platform_xml_owner.rs
@@ -958,6 +958,7 @@ fn known_standalone_root(qname: (Option<&str>, &str)) -> bool {
                 "HomePageWorkArea"
             )
             | (Some("http://v8.1c.ru/8.3/xcf/scheme"), "GraphicalSchema")
+            | (Some("http://v8.1c.ru/8.3/xcf/predef"), "PredefinedData")
             | (Some("http://v8.1c.ru/8.2/roles"), "Rights")
             | (
                 Some("http://v8.1c.ru/8.2/managed-application/core"),
@@ -1098,6 +1099,29 @@ mod tests {
             br#"<?xml version="1.0" encoding="UTF-8"?>
 <GraphicalSchema xmlns="http://v8.1c.ru/8.3/xcf/scheme" version="2.20"><Items/></GraphicalSchema>
 "#,
+        )
+        .unwrap();
+
+        let owners = resolve_platform_xml_owners(&path, &context).unwrap();
+
+        assert_eq!(owners.len(), 1);
+        assert_eq!(owners[0].path, normalized_path(&path));
+        assert_eq!(owners[0].version.as_deref(), Some("2.20"));
+        assert_eq!(owners[0].kind, PlatformXmlOwnerKind::Standalone);
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
+    fn predefined_data_is_a_version_owning_standalone_root() {
+        let context = temp_context("predefined-data-owner");
+        let path = context.cwd.join("Catalogs/Items/Ext/Predefined.xml");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            include_bytes!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../../tests/fixtures/platform_8_3_27/predefined/Predefined.xml"
+            )),
         )
         .unwrap();
 

--- a/plugins/unica/references/specs/1c-config-objects-spec.md
+++ b/plugins/unica/references/specs/1c-config-objects-spec.md
@@ -883,7 +883,7 @@ XML-элемент: `<Catalog>`. Категория InternalInfo: CatalogObject,
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<PredefinedData xmlns="http://v8.1c.ru/8.3/MDClasses" ...>
+<PredefinedData xmlns="http://v8.1c.ru/8.3/xcf/predef" ...>
     <Item>
         <Name>ОсновнаяВалюта</Name>
         <Description>Рубль</Description>

--- a/tests/fixtures/platform_8_3_27/predefined/Predefined.xml
+++ b/tests/fixtures/platform_8_3_27/predefined/Predefined.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PredefinedData xmlns="http://v8.1c.ru/8.3/xcf/predef" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CatalogPredefinedItems" version="2.20">
+  <Item>
+    <Name>Основной</Name>
+    <Description>Основной элемент</Description>
+    <Code>000001</Code>
+  </Item>
+</PredefinedData>


### PR DESCRIPTION
## Что исправлено

Закрывает #217.

- добавлен `{http://v8.1c.ru/8.3/xcf/predef}PredefinedData` в закрытый registry самостоятельных version-owning XML roots;
- добавлена fixture `Predefined.xml` формата 2.20 и регрессионный тест;
- исправлен namespace в reference-spec.

## Проверка

- `cargo test -p unica-coder predefined_data_is_a_version_owning_standalone_root --lib -- --nocapture`
- `cargo fmt --check`
- `cargo clippy -p unica-coder --all-targets -- -D warnings`
- `python3 -m unittest tests.ci.test_unica_skills`