### PR TITLE
fix(mcp): type meta remove keep-files flag

### DIFF
--- a/crates/unica-coder/src/application/tool_contracts.rs
+++ b/crates/unica-coder/src/application/tool_contracts.rs
@@ -1609,6 +1609,8 @@ fn property_schema(name: &str) -> Value {
             | "createIfMissing"
             | "IsFunction"
             | "isFunction"
+            | "KeepFiles"
+            | "keepFiles"
             | "allExtensions"
             | "checkUseModality"
             | "checkUseSynchronousCalls"
@@ -2587,6 +2589,8 @@ fn expected_scalar_type(key: &str) -> Option<&'static str> {
             | "createIfMissing"
             | "IsFunction"
             | "isFunction"
+            | "KeepFiles"
+            | "keepFiles"
             | "allExtensions"
             | "checkUseModality"
             | "checkUseSynchronousCalls"
@@ -2871,6 +2875,30 @@ mod tests {
         let args = Map::new();
 
         validate_tool_arguments(tool, &args, true).unwrap();
+    }
+
+    #[test]
+    fn meta_remove_keep_files_contract_is_boolean() {
+        let remove = tools()
+            .into_iter()
+            .find(|tool| tool.name == "unica.meta.remove")
+            .expect("unica.meta.remove must be registered");
+        let schema = input_schema_for_tool(&remove);
+
+        assert_eq!(schema["properties"]["KeepFiles"]["type"], "boolean");
+        assert_eq!(schema["properties"]["keepFiles"]["type"], "boolean");
+        validate_tool_arguments(
+            remove,
+            json!({
+                "ConfigDir": "src",
+                "Object": "Catalog.Legacy",
+                "KeepFiles": true,
+            })
+            .as_object()
+            .expect("test arguments must be an object"),
+            false,
+        )
+        .expect("meta.remove must accept boolean KeepFiles");
     }
 
     #[test]


### PR DESCRIPTION
## What

- declares both `KeepFiles` aliases as booleans in the published MCP schema and runtime validator;
- adds a regression test for `unica.meta.remove`.

## Topology

This is the independent, `main`-targeted extraction of the unrelated second commit from #236. It must not be merged through the rmcp migration stack.

## Validation

- `cargo test -p unica-coder application::tool_contracts`
- `cargo fmt --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the `KeepFiles` and `keepFiles` tool arguments to use boolean types.
  * Improved validation so boolean values are accepted correctly.
  * Updated the tool schema to accurately describe these arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->