### PR TITLE
fix!: finalize response-only read tools

### DIFF
--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -8863,6 +8863,247 @@ mod tests {
         root
     }
 
+    fn source_tree_snapshot(
+        root: &std::path::Path,
+    ) -> Vec<(std::path::PathBuf, &'static str, Vec<u8>, Option<String>)> {
+        fn visit(
+            root: &std::path::Path,
+            current: &std::path::Path,
+            snapshot: &mut Vec<(std::path::PathBuf, &'static str, Vec<u8>, Option<String>)>,
+        ) {
+            let mut entries = std::fs::read_dir(current)
+                .unwrap()
+                .map(Result::unwrap)
+                .collect::<Vec<_>>();
+            entries.sort_by_key(std::fs::DirEntry::file_name);
+            for entry in entries {
+                let path = entry.path();
+                let relative = path.strip_prefix(root).unwrap().to_path_buf();
+                let metadata = std::fs::symlink_metadata(&path).unwrap();
+                if metadata.file_type().is_symlink() {
+                    snapshot.push((
+                        relative,
+                        "symlink",
+                        std::fs::read_link(&path)
+                            .unwrap()
+                            .as_os_str()
+                            .to_string_lossy()
+                            .as_bytes()
+                            .to_vec(),
+                        None,
+                    ));
+                } else if metadata.is_dir() {
+                    snapshot.push((relative, "directory", Vec::new(), None));
+                    visit(root, &path, snapshot);
+                } else {
+                    let file = std::fs::File::open(&path).unwrap();
+                    let identity =
+                        crate::infrastructure::platform::filesystem::file_identity(&file)
+                            .ok()
+                            .zip(
+                                crate::infrastructure::platform::filesystem::hard_link_count(&file)
+                                    .ok(),
+                            )
+                            .map(|(identity, links)| format!("{identity:?}; links={links}"));
+                    snapshot.push((relative, "file", std::fs::read(&path).unwrap(), identity));
+                }
+            }
+        }
+
+        let mut snapshot = Vec::new();
+        visit(root, root, &mut snapshot);
+        snapshot
+    }
+
+    #[test]
+    fn legacy_read_only_output_sinks_cannot_change_source_path_aliases() {
+        let root = test_workspace_root("unica-read-only-output-aliases");
+        let workspace = root.join("workspace");
+        let src = workspace.join("src");
+        let protected = src.join("protected-source.xml");
+        let hard_link = src.join("protected-hard-link.xml");
+        let symlink = src.join("protected-symlink.xml");
+        let outside = root.join("outside/protected-source.xml");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::create_dir_all(outside.parent().unwrap()).unwrap();
+        std::fs::write(
+            workspace.join("v8project.yaml"),
+            "format: DESIGNER\nsource-set:\n  - name: main\n    type: CONFIGURATION\n    path: src\n",
+        )
+        .unwrap();
+        std::fs::write(&protected, b"source bytes").unwrap();
+        std::fs::write(&outside, b"outside bytes").unwrap();
+        std::fs::hard_link(&protected, &hard_link).unwrap();
+        let symlink_created = match create_file_link_fixture_for_test(&protected, &symlink)
+            .expect("unexpected file-link creation error must fail the fixture test")
+        {
+            FileLinkFixtureOutcome::Created => true,
+            FileLinkFixtureOutcome::Unsupported => {
+                eprintln!("[SKIPPED FIXTURE] file links are unsupported on this host");
+                false
+            }
+            FileLinkFixtureOutcome::WindowsPrivilegeUnavailable => {
+                eprintln!("[SKIPPED FIXTURE] Windows file-link privilege is unavailable");
+                false
+            }
+        };
+
+        let mut sink_targets = vec![
+            ("same source", protected.clone()),
+            (
+                "parent traversal",
+                workspace.join("src/../../outside/protected-source.xml"),
+            ),
+            ("hard-link alias", hard_link),
+        ];
+        if symlink_created {
+            sink_targets.push(("symlink alias", symlink));
+        }
+
+        let affected_tools = [
+            ("unica.cf.info", "ConfigPath", "OutFile", "outFile"),
+            ("unica.cf.validate", "ConfigPath", "OutFile", "outFile"),
+            ("unica.cfe.validate", "ExtensionPath", "OutFile", "outFile"),
+            ("unica.meta.info", "ObjectPath", "OutFile", "outFile"),
+            ("unica.meta.validate", "ObjectPath", "OutFile", "outFile"),
+            ("unica.interface.validate", "CIPath", "OutFile", "outFile"),
+            (
+                "unica.subsystem.info",
+                "SubsystemPath",
+                "OutFile",
+                "outFile",
+            ),
+            (
+                "unica.subsystem.validate",
+                "SubsystemPath",
+                "OutFile",
+                "outFile",
+            ),
+            ("unica.dcs.info", "TemplatePath", "OutFile", "outFile"),
+            ("unica.dcs.validate", "TemplatePath", "OutFile", "outFile"),
+            ("unica.role.info", "RightsPath", "OutFile", "outFile"),
+            ("unica.role.validate", "RightsPath", "OutFile", "outFile"),
+            (
+                "unica.mxl.decompile",
+                "TemplatePath",
+                "OutputPath",
+                "outputPath",
+            ),
+        ];
+
+        for (tool, input_argument, sink_argument, sink_alias) in affected_tools {
+            for argument in [sink_argument, sink_alias] {
+                for (target_kind, target) in &sink_targets {
+                    let mut args = Map::new();
+                    args.insert(
+                        "cwd".to_string(),
+                        Value::String(workspace.display().to_string()),
+                    );
+                    args.insert(
+                        input_argument.to_string(),
+                        Value::String("src/protected-source.xml".to_string()),
+                    );
+                    args.insert(
+                        argument.to_string(),
+                        Value::String(target.display().to_string()),
+                    );
+                    let before = source_tree_snapshot(&root);
+
+                    let error = UnicaApplication::new()
+                        .call_tool(tool, &args)
+                        .expect_err("legacy output sink must be rejected by the public contract");
+
+                    assert!(
+                        error.contains(&format!("does not accept argument `{argument}`")),
+                        "{tool} {argument} {target_kind}: {error}"
+                    );
+                    assert_eq!(
+                        source_tree_snapshot(&root),
+                        before,
+                        "{tool} {argument} must not change the tree through {target_kind}"
+                    );
+                }
+            }
+        }
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn metadata_and_dcs_format_warnings_leave_source_trees_unchanged() {
+        let dcs_fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(
+            "../../tests/fixtures/unica_mcp_script_parity/bsp/dcs/DataProcessors__ВыгрузкаЗагрузкаEnterpriseData__СхемаКомпоновкиДанных/Template.xml",
+        );
+
+        for (format, compatibility) in [("2.19", "older"), ("2.21", "newer")] {
+            let root = test_workspace_root(&format!("unica-read-only-format-{format}"));
+            let workspace = root.join("workspace");
+            let src = workspace.join("src");
+            let object = src.join("Catalogs/Items.xml");
+            let template = src.join("Reports/Sales/Templates/Main/Ext/Template.xml");
+            std::fs::create_dir_all(object.parent().unwrap()).unwrap();
+            std::fs::create_dir_all(template.parent().unwrap()).unwrap();
+            std::fs::write(
+                workspace.join("v8project.yaml"),
+                "format: DESIGNER\nsource-set:\n  - name: main\n    type: CONFIGURATION\n    path: src\n",
+            )
+            .unwrap();
+            std::fs::write(
+                src.join("Configuration.xml"),
+                support_test_configuration_xml("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").replacen(
+                    r#"version="2.20""#,
+                    &format!(r#"version="{format}""#),
+                    1,
+                ),
+            )
+            .unwrap();
+            std::fs::write(
+                &object,
+                support_test_catalog_xml("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+            )
+            .unwrap();
+            std::fs::copy(&dcs_fixture, &template).unwrap();
+
+            for (tool, path_argument, path) in [
+                ("unica.meta.info", "ObjectPath", &object),
+                ("unica.meta.validate", "ObjectPath", &object),
+                ("unica.dcs.info", "TemplatePath", &template),
+                ("unica.dcs.validate", "TemplatePath", &template),
+            ] {
+                let mut args = Map::new();
+                args.insert(
+                    "cwd".to_string(),
+                    Value::String(workspace.display().to_string()),
+                );
+                args.insert(
+                    path_argument.to_string(),
+                    Value::String(path.display().to_string()),
+                );
+                let before = source_tree_snapshot(&src);
+
+                let result = UnicaApplication::new().call_tool(tool, &args).unwrap();
+
+                assert!(
+                    !result.warnings.is_empty(),
+                    "{tool} must preserve the {format} warning: {result:?}"
+                );
+                let diagnostic = &result.diagnostics.as_ref().unwrap()["formatCompatibility"];
+                assert_eq!(diagnostic["actualFormat"], format, "{tool}: {result:?}");
+                assert_eq!(
+                    diagnostic["compatibility"], compatibility,
+                    "{tool}: {result:?}"
+                );
+                assert_eq!(
+                    source_tree_snapshot(&src),
+                    before,
+                    "{tool} must not change a {format} source tree"
+                );
+            }
+
+            std::fs::remove_dir_all(root).unwrap();
+        }
+    }
+
     fn temp_meta_compile_workspace(prefix: &str) -> std::path::PathBuf {
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -1501,9 +1501,9 @@ fn cache_access_for(operation: &str, event: Option<DomainEventKind>) -> CacheAcc
 mod tests {
     use super::*;
     use crate::composition::testing::{
-        create_file_link_fixture_for_test, prepare_file_for_removal, set_unix_mode_for_test,
-        unix_mode_for_test, with_publication_lock_contention_signal, with_publication_lock_pause,
-        CompileTransaction, FileLinkFixtureOutcome,
+        create_file_link_fixture_for_test, file_identity_for_test, prepare_file_for_removal,
+        set_unix_mode_for_test, unix_mode_for_test, with_publication_lock_contention_signal,
+        with_publication_lock_pause, CompileTransaction, FileLinkFixtureOutcome,
     };
     use serde_json::Map;
     use std::collections::HashSet;
@@ -8896,15 +8896,7 @@ mod tests {
                     snapshot.push((relative, "directory", Vec::new(), None));
                     visit(root, &path, snapshot);
                 } else {
-                    let file = std::fs::File::open(&path).unwrap();
-                    let identity =
-                        crate::infrastructure::platform::filesystem::file_identity(&file)
-                            .ok()
-                            .zip(
-                                crate::infrastructure::platform::filesystem::hard_link_count(&file)
-                                    .ok(),
-                            )
-                            .map(|(identity, links)| format!("{identity:?}; links={links}"));
+                    let identity = file_identity_for_test(&path).unwrap();
                     snapshot.push((relative, "file", std::fs::read(&path).unwrap(), identity));
                 }
             }

--- a/crates/unica-coder/src/composition.rs
+++ b/crates/unica-coder/src/composition.rs
@@ -22,8 +22,8 @@ pub(crate) mod testing {
     };
     pub(crate) use crate::infrastructure::platform::filesystem::prepare_file_for_removal;
     pub(crate) use crate::infrastructure::platform::testing::{
-        create_file_link_fixture_for_test, set_unix_mode_for_test, unix_mode_for_test,
-        FileLinkFixtureOutcome,
+        create_file_link_fixture_for_test, file_identity_for_test, set_unix_mode_for_test,
+        unix_mode_for_test, FileLinkFixtureOutcome,
     };
 }
 

--- a/crates/unica-coder/src/infrastructure/platform/testing.rs
+++ b/crates/unica-coder/src/infrastructure/platform/testing.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 pub(crate) use super::filesystem::{create_dir_symlink_for_test, create_file_symlink_for_test};
+use super::filesystem::{file_identity, hard_link_count};
 
 pub(crate) fn normalize_path_text_for_test(value: &str) -> String {
     value.replace('\\', "/")
@@ -24,6 +25,21 @@ pub(crate) fn create_file_link_fixture_for_test(
     target: impl AsRef<Path>,
 ) -> io::Result<FileLinkFixtureOutcome> {
     classify_file_link_fixture_result(create_file_symlink_for_test(source, target))
+}
+
+pub(crate) fn file_identity_for_test(path: &Path) -> io::Result<Option<String>> {
+    let file = std::fs::File::open(path)?;
+    let identity = match file_identity(&file) {
+        Ok(identity) => identity,
+        Err(error) if error.kind() == io::ErrorKind::Unsupported => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let links = match hard_link_count(&file) {
+        Ok(links) => links,
+        Err(error) if error.kind() == io::ErrorKind::Unsupported => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    Ok(Some(format!("{identity:?}; links={links}")))
 }
 
 fn classify_file_link_fixture_result(
@@ -214,7 +230,7 @@ pub(crate) fn wait_for_process_exit(_pid: u32, _timeout: Duration) -> bool {
 mod tests {
     use super::{
         classify_file_link_fixture_result, create_file_link_fixture_for_test,
-        set_unix_mode_for_test, unix_mode_for_test, FileLinkFixtureOutcome,
+        file_identity_for_test, set_unix_mode_for_test, unix_mode_for_test, FileLinkFixtureOutcome,
     };
     use std::fs;
     use std::io;
@@ -262,6 +278,24 @@ mod tests {
             FileLinkFixtureOutcome::WindowsPrivilegeUnavailable => {
                 eprintln!("[SKIPPED FIXTURE] Windows file-link privilege is unavailable");
             }
+        }
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn file_identity_fixture_observes_hard_link_aliases_when_supported() {
+        let root = unique_temp_root("file-identity");
+        let source = root.join("source.bin");
+        let alias = root.join("alias.bin");
+        fs::write(&source, b"source").unwrap();
+        fs::hard_link(&source, &alias).unwrap();
+
+        let source_identity = file_identity_for_test(&source).unwrap();
+        let alias_identity = file_identity_for_test(&alias).unwrap();
+
+        assert_eq!(source_identity, alias_identity);
+        if let Some(identity) = source_identity {
+            assert!(identity.contains("links=2"), "{identity}");
         }
         fs::remove_dir_all(root).unwrap();
     }

--- a/plugins/unica/README.md
+++ b/plugins/unica/README.md
@@ -76,6 +76,19 @@ atomically replaces the transliterated `skd` domain with the official
 
 The operation arguments and `DataCompositionSchema` XML format are unchanged.
 
+## Read-only output migration
+
+The release containing [issue #191](https://github.com/IngvarConsulting/unica/issues/191)
+removes caller-controlled file sinks from read-only MCP tools. The affected
+`info`/`validate` tools no longer accept `OutFile` or `outFile`, and
+`unica.mxl.decompile` no longer accepts `OutputPath` or `outputPath`. There is
+no compatibility alias: these arguments are rejected as contract errors.
+
+Reports, exact raw DCS queries, and the MXL JSON DSL are returned in the MCP
+response. Consumers must read `stdout`/structured response data instead of
+reading a file created by Unica. If a durable artifact is needed, the caller
+must save the returned value explicitly outside the read-only tool contract.
+
 ## Runtime delivery
 
 The marketplace plugin contains skills, references, assets, `launch.sh`, and


### PR DESCRIPTION
Closes #191.

## What changed

- added one public-boundary matrix covering all 12 removed `OutFile`/`outFile`
  contracts plus `unica.mxl.decompile.OutputPath`/`outputPath`;
- snapshots paths, bytes, symlink targets, file identity, and hard-link counts
  before and after same-path, `..`, symlink, and hard-link alias attempts;
- proves metadata and DCS read-only warnings for both `2.19` and `2.21` while
  the complete source tree remains unchanged;
- added the durable response-only migration note to the packaged README.

PRs #223 and #225 removed the file sinks themselves. This PR closes the
remaining acceptance-test and documentation boundaries.

## Breaking change

Read-only `info`/`validate` tools reject `OutFile` and `outFile`.
`unica.mxl.decompile` rejects `OutputPath` and `outputPath`. Consumers must use
the MCP response (`stdout` or structured data) and explicitly persist it if
they need a durable artifact. There is no hidden compatibility path.

The `!` in the PR title intentionally contributes this migration boundary to
the repository's generated GitHub release notes; repository-owned release-note
files are forbidden by ADR-0011.

## Root cause

The implementation had already removed the unsafe sinks, but #191 still lacked
the full alias/tree-immutability proof and a durable consumer migration note.
The issue checklist therefore could not be closed from schema tests alone.

## Verification

- mutation-check: a temporary simulated legacy `OutFile` write changed the
  source and hard-link alias, and the new regression failed on that exact tree
  mutation; restoring the implementation made it pass;
- `.venv/bin/python -m unittest discover -s tests/ci --durations 20`
  (361 passed, 3 skipped);
- `.venv/bin/python -m unittest discover -s tests/dev --durations 20`
  (187 passed);
- `.venv/bin/python -m py_compile scripts/ci/*.py tests/ci/*.py scripts/dev/*.py tests/dev/*.py`;
- `.venv/bin/python scripts/ci/check-version-contract.py`;
- `cargo fmt --all -- --check`;
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`;
- `cargo test --workspace -- --test-threads=1`;
- `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Read-only tools no longer accept caller-specified output file parameters.
  * `unica.mxl.decompile` no longer accepts output path parameters.
  * Unsupported parameters are rejected as contract errors; use returned response data instead.

* **Documentation**
  * Added migration guidance for the updated read-only output behavior.

* **Bug Fixes**
  * Added safeguards ensuring read-only operations do not alter source files or aliases.
  * Improved compatibility diagnostics for metadata and DCS format validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->