### PR TITLE
fix(workspace): track linked-worktree HEAD in the workspace epoch

### DIFF
--- a/crates/unica-coder/src/infrastructure/workspace.rs
+++ b/crates/unica-coder/src/infrastructure/workspace.rs
@@ -50,11 +50,51 @@ fn workspace_fingerprint(root: &Path) -> u64 {
         "v8project.yaml",
         "Configuration.xml",
         "src/Configuration.xml",
-        ".git/HEAD",
     ] {
         hash_path(&mut hasher, root, rel);
     }
+    hash_head(&mut hasher, root);
     hasher.finish()
+}
+
+/// Hashes the HEAD that actually moves when the workspace is checked out.
+///
+/// In a plain checkout `.git` is a directory and HEAD sits inside it. In a
+/// linked worktree `.git` is a file pointing at the per-worktree git directory,
+/// so `root/.git/HEAD` does not exist and the pointer file itself never changes
+/// on checkout. Hashing the literal `.git/HEAD` path therefore freezes the
+/// epoch across branch switches inside a worktree and serves stale caches.
+fn hash_head(hasher: &mut DefaultHasher, root: &Path) {
+    "git-head".hash(hasher);
+    let Some(git_dir) = resolve_git_dir(root) else {
+        0_u8.hash(hasher);
+        return;
+    };
+    // HEAD is small and its contents are the branch identity, so hash the bytes
+    // instead of size plus second-resolution mtime.
+    match std::fs::read(git_dir.join("HEAD")) {
+        Ok(contents) => contents.hash(hasher),
+        Err(_) => 0_u8.hash(hasher),
+    }
+}
+
+fn resolve_git_dir(root: &Path) -> Option<PathBuf> {
+    let dot_git = root.join(".git");
+    let metadata = std::fs::symlink_metadata(&dot_git).ok()?;
+    if metadata.is_dir() {
+        return Some(dot_git);
+    }
+    let pointer = std::fs::read_to_string(&dot_git).ok()?;
+    let target = pointer.lines().next()?.strip_prefix("gitdir:")?.trim();
+    if target.is_empty() {
+        return None;
+    }
+    let target = PathBuf::from(target);
+    Some(if target.is_absolute() {
+        target
+    } else {
+        root.join(target)
+    })
 }
 
 fn hash_path(hasher: &mut DefaultHasher, root: &Path, rel: &str) {
@@ -164,6 +204,34 @@ mod tests {
         std::fs::write(&marker, "format: DESIGNER\nsource-set: []\n").unwrap();
         let changed = discover_workspace(Some(root.clone())).unwrap();
         assert_ne!(first.workspace_epoch, changed.workspace_epoch);
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn workspace_epoch_tracks_head_inside_a_linked_worktree() {
+        let root = temp_root("unica-workspace-worktree-epoch");
+        let primary_git = root.join("primary/.git");
+        let worktree = root.join("worktrees/feature");
+        let linked_git = primary_git.join("worktrees/feature");
+        std::fs::create_dir_all(&linked_git).unwrap();
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(worktree.join("v8project.yaml"), "format: DESIGNER\n").unwrap();
+        std::fs::write(
+            worktree.join(".git"),
+            format!("gitdir: {}\n", linked_git.display()),
+        )
+        .unwrap();
+        std::fs::write(linked_git.join("HEAD"), "ref: refs/heads/feature-a\n").unwrap();
+
+        let before = discover_workspace(Some(worktree.clone())).unwrap();
+        std::fs::write(linked_git.join("HEAD"), "ref: refs/heads/feature-b\n").unwrap();
+        let after = discover_workspace(Some(worktree.clone())).unwrap();
+
+        assert_ne!(
+            before.workspace_epoch, after.workspace_epoch,
+            "a checkout inside a linked worktree must invalidate workspace caches"
+        );
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/spec/decisions/0003-cache-i-workspace-state-prinadlezhat-orchestratoru.md
+++ b/spec/decisions/0003-cache-i-workspace-state-prinadlezhat-orchestratoru.md
@@ -20,6 +20,13 @@ The `unica` orchestrator owns workspace state and cache coordination.
    or `UNICA_CACHE_DIR`.
 4. Dry-run calls report cache impact without writing state.
 5. Applied successful mutations may persist cache state changes.
+6. A linked git worktree is a first-class workspace. Workspace identity, the
+   workspace epoch, cache roots, and internal service keys must be derived so
+   that each worktree is isolated from the primary checkout and from every other
+   worktree, and so that a checkout inside a worktree invalidates that
+   worktree's caches exactly like a checkout in a plain clone. Any code that
+   reads git state must resolve `.git` as either a directory or a pointer file;
+   assuming the directory layout is a defect, not a limitation.
 
 ## Неграницы
 
@@ -32,6 +39,10 @@ The `unica` orchestrator owns workspace state and cache coordination.
 1. Every mutating tool needs an event mapping.
 2. Cache behavior must be tested at the orchestrator boundary.
 3. Future lazy rebuild should use the same repository and event model.
+4. Worktree isolation is bought with duplicated index and service state: each
+   worktree pays its own first build. That cost is accepted; sharing state
+   across worktrees would reintroduce the cross-branch staleness this clause
+   forbids.
 
 ## План реализации
 
@@ -44,3 +55,6 @@ The `unica` orchestrator owns workspace state and cache coordination.
 - [x] ADR defines orchestrator ownership.
 - [x] ADR covers dry-run behavior.
 - [x] ADR separates internal engine caches from public coordination.
+- [x] ADR requires worktree-correct workspace identity and cache invalidation.
+      Verify with `cargo test -p unica-coder workspace_epoch` and
+      `cargo test -p unica-coder git_worktree_boundary`.


### PR DESCRIPTION
Closes #245.

## Проблема

`workspace_fingerprint` хешировал литеральный путь `root/.git/HEAD`. В linked git worktree `.git` — файл-указатель, такого пути нет, `hash_path` не находит метаданные и хеширует константу `0`. Сам указатель при checkout не меняется.

Итог: внутри worktree переключение веток не двигало `workspace_epoch`, и оркестратор отдавал кеши, собранные для другой ветки. Остальные три маркера фингерпринта молчат, если git при checkout не переписал именно эти файлы.

## Что сделано

1. `resolve_git_dir` разбирает `.git` в обеих формах — каталог и `gitdir:`-указатель, относительный и абсолютный.
2. HEAD хешируется по содержимому, а не по размеру плюс mtime с точностью до секунды: содержимое и есть идентичность ветки, а два переключения в пределах одной секунды между ветками с именами равной длины дали бы одинаковый хеш.
3. ADR-0003 получает пункт 5 в «Решение»: linked worktree является полноправным workspace; workspace identity, epoch, cache root и service key обязаны изолировать каждый worktree от primary checkout и друг от друга; checkout внутри worktree обязан инвалидировать кеши этого worktree; любой код, читающий git-состояние, обязан поддерживать обе формы `.git`. В «Последствия» добавлено, что цена изоляции — свой первый билд индекса на каждый worktree, и это принимается осознанно: общее состояние вернуло бы ровно ту межветочную устарелость, которую пункт запрещает.

## Проверка

Новый тест `workspace_epoch_tracks_head_inside_a_linked_worktree` падает на `main` с

```
assertion `left != right` failed: a checkout inside a linked worktree must invalidate workspace caches
```

и проходит здесь.

```
cargo test -p unica-coder            # 1481 зелёный, 2 ignored
cargo clippy -p unica-coder --all-targets   # чисто
cargo test -p unica-coder -- workspace_epoch git_worktree_boundary   # верификация из ADR
```

## Область

Только фингерпринт workspace. `find_workspace_root` уже корректно останавливается на границе worktree, `service_key` = hash(workspace_root, source_root) уже разводит internal services по worktree — не трогал.

Найдено при ревью #227 и намеренно вынесено отдельным PR в `main`, а не в ветку того PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace changes are now detected correctly when the Git `HEAD` changes inside a linked worktree (workspace epoch updates properly).
  - Cache state remains isolated between the primary checkout and linked worktrees, avoiding stale or cross-worktree reuse.

- **Documentation**
  - Updated the decision record with expanded requirements and verification steps for linked worktree handling, cache isolation, and correctness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->