### PR TITLE
fix(marketplace): drop "./" prefix from git-subdir catalog path

### DIFF
--- a/scripts/ci/package-unica-plugin.py
+++ b/scripts/ci/package-unica-plugin.py
@@ -292,10 +292,14 @@ def claude_plugin_source(*, release_tag: str) -> dict:
     type; a relative `./plugins/unica` source would load everywhere but would
     follow the marketplace branch instead of a tag.
     """
+    # No "./" prefix: Claude Code feeds this path verbatim to
+    # `git sparse-checkout set --cone`, and git <= 2.34 (Ubuntu 22.04) stores a
+    # leading-"./" argument as a literal pattern that matches nothing, so the
+    # subdirectory never checks out and installation fails.
     return {
         "source": "git-subdir",
         "url": "https://github.com/IngvarConsulting/unica-marketplace.git",
-        "path": f"./plugins/{PLUGIN_ID}",
+        "path": f"plugins/{PLUGIN_ID}",
         "ref": release_tag,
     }
 
@@ -401,10 +405,12 @@ def write_public_marketplace(source_path: Path, dest_path: Path, *, release_tag:
 
     plugin = data["plugins"][0]
     plugin["name"] = PLUGIN_ID
+    # Same constraint as claude_plugin_source: a "./" prefix breaks
+    # sparse-checkout on git <= 2.34, so the path must stay bare.
     plugin["source"] = {
         "source": "git-subdir",
         "url": "https://github.com/IngvarConsulting/unica-marketplace.git",
-        "path": "./plugins/unica",
+        "path": "plugins/unica",
         "ref": release_tag,
     }
     plugin.setdefault("policy", {})["installation"] = "AVAILABLE"

--- a/tests/ci/test_package_unica_plugin.py
+++ b/tests/ci/test_package_unica_plugin.py
@@ -486,7 +486,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
         # The catalog on the marketplace default branch must keep naming a tag,
         # so staged plugin bytes are not served before a promotion moves it.
         self.assertEqual(source["ref"], "v1.2.3")
-        self.assertEqual(source["path"], "./plugins/unica")
+        self.assertEqual(source["path"], "plugins/unica")
         self.assertEqual(source["source"], "git-subdir")
 
     def test_claude_manifest_leaves_skill_discovery_to_the_default_scan(self) -> None:
@@ -1041,7 +1041,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
             source = catalog["plugins"][0]["source"]
             self.assertEqual(source["source"], "git-subdir")
             self.assertEqual(source["ref"], release_tag)
-            self.assertEqual(source["path"], "./plugins/unica")
+            self.assertEqual(source["path"], "plugins/unica")
             self.assertNotIn("source\": \"local", json.dumps(catalog))
             self.assertEqual(list(out_dir.glob("*.tar.gz")), [])
             self.assertEqual(list(out_dir.glob("*.zip")), [])


### PR DESCRIPTION
## Что сделано

Из `git-subdir` источников в генераторе каталога убран префикс `./`: `claude_plugin_source()` и `write_public_marketplace()` теперь пишут `"path": "plugins/unica"`.

## Почему

Claude Code передаёт `path` дословно в `git sparse-checkout set --cone`. В git ≤ 2.34 (дефолт Ubuntu 22.04) у подкоманды `set` ещё нет флага `--cone` — обе строки (`--cone` и `./plugins/unica`) записываются в sparse-файл как буквальные non-cone паттерны, паттерн с ведущим `./` не матчит ничего, каталог плагина не выгружается, и установка падает:

```
✘ Failed to install plugin "unica@unica": Subdirectory './plugins/unica' not found in repository
  https://github.com/IngvarConsulting/unica-marketplace.git (ref: v0.10.0).
```

Форма без `./` работает на всех версиях git, которые поддерживает Claude Code (≥ 2.25). Проверено end-to-end: CC 2.1.218 + git 2.34.1 (Ubuntu 22.04) — с `./` падает, с `plugins/unica` ставится. Матрица версий git — в #248.

Источник `local` (`write_official_marketplace`, local-debug) не трогаю: sparse-checkout там не используется, `./` безвреден.

## Связанное

- Парный PR в unica-marketplace чинит уже опубликованный каталог v0.10.0 и verify-скрипты, которые требуют форму с `./`.

Part of #248

## Проверка

`python3.12 -m unittest discover -s tests/ci -p "test_package_unica_plugin.py"` — 37 OK; `test_product_contracts.py` — 37 OK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed marketplace plugin source paths to avoid a leading `./`, improving compatibility with sparse checkout on older Git versions.
  * Standardized plugin paths across marketplace catalog and packaged marketplace outputs.

* **Tests**
  * Updated validation checks to confirm the normalized plugin path format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->