### PR TITLE
release: prepare Unica v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1657,7 +1657,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unica-bootstrap"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "flate2",
  "fs2",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "unica-coder"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "diffy",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/unica-bootstrap", "crates/unica-coder"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "LGPL-3.0-or-later"
 repository = "https://github.com/IngvarConsulting/unica"

--- a/plugins/unica/.claude-plugin/plugin.json
+++ b/plugins/unica/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unica",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Practical 1C:Enterprise development workflows for Claude Code.",
   "author": {
     "name": "Ingvar Consulting, LLC",

--- a/plugins/unica/.codex-plugin/plugin.json
+++ b/plugins/unica/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unica",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Practical 1C:Enterprise development workflows for Codex.",
   "author": {
     "name": "Ingvar Consulting, LLC",

--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -136,7 +136,7 @@
     },
     {
       "name": "unica",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "repository": "https://github.com/IngvarConsulting/unica",
       "sourceTag": "workspace",
       "sourceCommit": "workspace",


### PR DESCRIPTION
## Summary

Prepare Unica v0.11.0 after 48 commits since v0.10.0.

This is a minor release rather than a patch because the range includes new user-visible capabilities (feat), including exact code-patch text snapshots/EOL policy and role-rights diagnostics.

scripts/dev/bump-version.py 0.11.0 updated every package-contract version surface, and cargo update --workspace --offline refreshed the two workspace package entries in Cargo.lock.

## Changed contract surfaces

- Cargo.toml
- Cargo.lock
- plugins/unica/.codex-plugin/plugin.json
- plugins/unica/.claude-plugin/plugin.json
- plugins/unica/third-party/tools.lock.json

## Verification

- tests/ci: 363 passed, 3 skipped
- tests/dev: 187 passed
- Python compile checks for scripts/ci, scripts/dev, tests/ci, and tests/dev
- check-version-contract.py: 0.11.0
- shell syntax checks for both tracked .sh files
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace -- --test-threads=1: zero failures
- git diff --check

## Release path after merge

Follow docs/release-runbook.md: sign and push source tag v0.11.0; let Release Warden stage the verified thin payload; sign the marketplace staging merge commit as v0.11.0; then let the warden promote the catalog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the package and plugin version to **0.11.0**.
  * Updated the bundled tool version to **0.11.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->