### PR TITLE
fix(windows): normalize support guard path identity

### DIFF
--- a/crates/unica-coder/src/infrastructure/native_operations/common.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/common.rs
@@ -6,6 +6,7 @@ use crate::domain::format_profile::{
     classify_root_version, ExportFormatVersion, FormatCompatibility, ACTIVE_FORMAT_PROFILE,
 };
 use crate::domain::workspace::WorkspaceContext;
+use crate::infrastructure::source_roots::normalize_path_identity;
 use roxmltree::Document;
 use serde_json::{json, Map, Value};
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -2195,9 +2196,8 @@ pub(crate) fn support_guard_violation(
     target_path: &Path,
     requirement: SupportGuardRequirement,
 ) -> Option<SupportGuardViolation> {
-    let target_path = target_path
-        .canonicalize()
-        .unwrap_or_else(|_| target_path.to_path_buf());
+    let target_path =
+        normalize_path_identity(target_path).unwrap_or_else(|_| target_path.to_path_buf());
     let config_dir = find_support_config_dir(&target_path)?;
     let bin_path = config_dir.join("Ext").join("ParentConfigurations.bin");
     let state = read_support_state(&bin_path)?;

--- a/crates/unica-coder/src/infrastructure/support_guard.rs
+++ b/crates/unica-coder/src/infrastructure/support_guard.rs
@@ -8,6 +8,7 @@ use crate::infrastructure::native_operations::common::{
     absolutize, path_arg, required_string, support_guard_violation, SupportGuardViolation,
 };
 use crate::infrastructure::native_operations::{meta, template};
+use crate::infrastructure::source_roots::normalize_path_identity;
 use serde_json::{Map, Value};
 use std::path::{Path, PathBuf};
 
@@ -196,7 +197,7 @@ fn support_guard_mode_value(value: &str) -> SupportGuardMode {
 }
 
 fn normalize_guard_path(path: &Path) -> PathBuf {
-    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    normalize_path_identity(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 fn support_guard_blocked_outcome(


### PR DESCRIPTION
## Root cause

Release PR #255 activates the toolchain contour and therefore the full Windows Rust matrix. It exposed two deterministic failures introduced on main by #230:

- application::tests::subsystem_compile_guards_locked_parent_before_both_planners
- application::tests::subsystem_compile_retains_locked_configuration_fallback_without_parent

Support guard used std::fs::canonicalize directly, so Windows returned extended-length paths such as \\?\C:\... while the project shared path-identity contract and public artifacts use regular C:\... paths.

Failing proof: workflow run 30249122208, Windows job 89922885633. Linux and macOS passed; Unica CI only reflected the Windows failure.

## Fix

Use source_roots::normalize_path_identity for both support-guard target identity and project config matching, retaining the existing raw-path fallback on normalization errors. This removes Windows extended-length prefixes at the source and avoids another bespoke path normalizer.

## Verification

- Existing Windows regression tests are the RED proof in run 30249122208: 2 failed with exact \\?\ prefix mismatch.
- Targeted subsystem support-guard tests: 2 passed locally.
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace -- --test-threads=1: zero failures
- git diff --check

This PR is intentionally independent and targets main. After it merges, release PR #255 will be updated from main and rerun.