### PR TITLE
fix(ci): закрепить чтение diff в guard'е синхронизации на UTF-8

### DIFF
--- a/scripts/ci/check-architecture-sync.py
+++ b/scripts/ci/check-architecture-sync.py
@@ -786,6 +786,14 @@ def resolve_base(explicit: str | None) -> str | None:
     target a branch other than `main` is a normal arrangement, and the guard must
     not overrule the caller about it. `main` is only the fallback for a caller
     that named nothing, which is the repository's ordinary flow.
+
+    The decoding is pinned here too, even though a resolved ref prints an ASCII
+    object name. `capture_output` decodes stderr whether or not this function
+    reads it, and git localises its fatal messages: a runner whose `LC_MESSAGES`
+    names a Russian locale while `LC_CTYPE` stays at `C` would turn "no base ref
+    resolved" -- a skip this guard knows how to report -- into a decode error.
+    One decoding policy per file also keeps the next reader from having to work
+    out which of the three reads was the deliberate one.
     """
     for candidate in (explicit, os.environ.get("UNICA_DIFF_BASE")):
         if candidate:
@@ -796,6 +804,8 @@ def resolve_base(explicit: str | None) -> str | None:
             cwd=REPO_ROOT,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
         if result.returncode == 0:
             return candidate
@@ -810,6 +820,12 @@ def read_diff(base: str) -> str | None:
     byte, `core.quotePath=false` keeps a Russian file name literal, and the two
     prefix settings keep `a/`/`b/` where the grammar expects them whatever the
     caller's git configuration says.
+
+    The decoding is pinned rather than left to the locale. `text=True` alone
+    decodes with the runner's preferred encoding, which on a host with no `LANG`
+    is ASCII -- and the record bodies this diff carries are Russian, so the guard
+    would die on a decode error instead of judging the change or reporting itself
+    unusable.
     """
     result = subprocess.run(
         [
@@ -829,6 +845,8 @@ def read_diff(base: str) -> str | None:
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
     )
     if result.returncode != 0:
         return None

--- a/tests/ci/test_architecture_sync_guard.py
+++ b/tests/ci/test_architecture_sync_guard.py
@@ -183,6 +183,33 @@ class CommandLineTests(unittest.TestCase):
     def test_explicit_base_wins_over_discovery(self) -> None:
         self.assertEqual(self.guard.resolve_base("release/1.2"), "release/1.2")
 
+    def test_the_base_resolution_pins_utf_8_as_well(self) -> None:
+        """A resolved ref is ASCII; the fatal git may print alongside it is not.
+
+        `capture_output` decodes stderr whether or not this function reads it,
+        and git localises its fatal messages. Leaving this one call on the locale
+        would turn "no base ref resolved" -- a skip the guard knows how to report
+        -- into a decode error on a runner whose `LC_MESSAGES` and `LC_CTYPE`
+        disagree.
+        """
+        from unittest.mock import patch
+
+        recorded: list[dict] = []
+
+        def fake_run(command, **kwargs):
+            recorded.append(kwargs)
+            return subprocess_result(returncode=1)
+
+        with patch.dict(self.guard.os.environ, {}, clear=True), patch.object(
+            self.guard.subprocess, "run", fake_run
+        ):
+            self.assertIsNone(self.guard.resolve_base(None))
+
+        self.assertTrue(recorded)
+        for kwargs in recorded:
+            self.assertEqual(kwargs.get("encoding"), "utf-8")
+            self.assertEqual(kwargs.get("errors"), "replace")
+
     def test_unresolvable_base_skips_instead_of_failing(self) -> None:
         from unittest.mock import patch
 
@@ -1108,6 +1135,29 @@ class BinarySectionTests(unittest.TestCase):
         self.assertIn("--text", command)
         self.assertIn("--no-ext-diff", command)
         self.assertIn("core.quotePath=false", command)
+
+    def test_the_diff_read_pins_utf_8_instead_of_trusting_the_locale(self) -> None:
+        """The diff carries Russian record bodies, so decoding is not the locale's call.
+
+        `text=True` on its own decodes with the runner's preferred encoding. On a
+        host with no `LANG` that is ASCII, and the read raises `UnicodeDecodeError`
+        the moment a `spec/decisions/` body appears in the diff -- the guard dies
+        instead of judging the change or reporting itself unusable, which is the
+        one outcome this module is written to avoid.
+        """
+        from unittest.mock import patch
+
+        recorded: dict[str, dict] = {}
+
+        def fake_run(command, **kwargs):
+            recorded["kwargs"] = kwargs
+            return subprocess_result(returncode=0, stdout="")
+
+        with patch.object(self.guard.subprocess, "run", fake_run):
+            self.guard.read_diff("origin/main")
+
+        self.assertEqual(recorded["kwargs"].get("encoding"), "utf-8")
+        self.assertEqual(recorded["kwargs"].get("errors"), "replace")
 
 
 class AnchorTests(unittest.TestCase):


### PR DESCRIPTION
## Что меняется

Чинит падение самого guard'а: `read_diff` в `scripts/ci/check-architecture-sync.py` вызывал `subprocess.run(..., capture_output=True, text=True)` без `encoding=`. Один `text=True` декодирует предпочитаемой кодировкой раннера, а на хосте без `LANG` это ASCII (`ansi_x3.4-1968`). Судимый diff несёт русские тела всех затронутых записей `spec/decisions/`, поэтому чтение падало с `UnicodeDecodeError` и уносило guard целиком — он не выносил вердикт и не сообщал о своей неработоспособности, то есть ровно тот исход, против которого написан его docstring. Теперь чтение закреплено на `encoding="utf-8", errors="replace"` — так же, как чтения каталога в #270.

`resolve_base` закреплён тем же способом. Его stdout — ASCII-имя объекта, но `capture_output` декодирует и stderr, независимо от того, читает ли его функция, а git локализует свои `fatal:`-сообщения. `LC_MESSAGES` (gettext) и `LC_CTYPE` (предпочитаемая кодировка Python) — разные переменные: раннер с `LC_MESSAGES=ru_RU.UTF-8` и `LC_CTYPE=C` получает русский `fatal: detected dubious ownership in repository` и то же падение вместо пропуска, о котором guard умеет сообщить. После этого PR все четыре чтения git в файле держатся одной политики декодирования.

Дефект существовал до #270. По правилу топологии PR из AGENTS.md он вынесен независимым PR с базой `main`, а не втянут в #270. Поднято ревью на #270 (CodeRabbit, ветка обсуждения на `read_base_records`).

Уточнение к исходной формулировке: срабатывает именно русский **текст записей**, а не имена файлов — имена в `spec/decisions/` транслитерированы (`0011-canonical-dcs-domain.md`) по правилам именования из AGENTS.md, так что механика цитирования путей здесь не при чём.

## Архитектурный слой

- Затронутые записи реестра: нет (поведение guard'а, публичная поверхность `unica.*` не меняется)
- Решение (ADR), если публичный или архитектурный контракт меняется: нет

- [x] Пройден [чек-лист изменений](../spec/architecture/change-checklist.md)
      в части, относящейся к этому изменению.

## Проверка

Дефект воспроизведён на копии pre-fix версии, запущенной в дереве под ASCII-локалью:

```sh
env -u LANG -u LC_ALL -u LC_CTYPE PYTHONCOERCECLOCALE=0 PYTHONUTF8=0 \
  python3.12 scripts/ci/check-architecture-sync.py --base HEAD~3
```

- до: `UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 201` из `subprocess._translate_newlines` — traceback, ни вердикта, ни сообщения о пропуске;
- после: вердикт выносится нормально.

```sh
python3.12 tests/ci/test_architecture_sync_guard.py
python3.12 -m unittest discover -s tests/ci
python3.12 -m py_compile scripts/ci/*.py tests/ci/*.py
python3.12 scripts/ci/check-architecture-sync.py --base origin/main --strict
git diff --check
```

Набор guard'а — 87 тестов, OK. Полный `tests/ci` — 492 теста, 10 failures + 1 error: это известная локальная база из-за отсутствующего `lxml` (`Missing Python dependency: lxml`), к этим файлам не относится. `check-architecture-sync.py --base origin/main --strict` на собственном изменении — exit 0, «public MCP surface unchanged».

- [x] Новое поведение покрыто тестом, который можно назвать по имени:
      `test_the_diff_read_pins_utf_8_instead_of_trusting_the_locale` (рядом с
      `test_the_read_renders_every_file_as_text`) и
      `test_the_base_resolution_pins_utf_8_as_well` в `CommandLineTests`, где
      живут остальные тесты `resolve_base`. Оба падают на версии без правки
      (`AssertionError: None != 'utf-8'`) и проходят после — проверено подменой
      модуля на версию из `origin/main`, так что ни один из них не вырожден.
- [x] Документация, описывающая изменённое поведение, обновлена в этом же PR:
      docstring'и `read_diff` и `resolve_base` объясняют, почему декодирование
      закреплено, а не отдано локали.

## Разрешение конфликта

#270 влит в `main` squash-коммитом уже после ответвления этой ветки и затронул те же два файла, отсюда конфликт. Ветка перебазирована на `origin/main`; конфликт был только в docstring `resolve_base` — #270 добавил там описание целевой ветки, этот PR — описание декодирования, оставлены оба. Ключевые аргументы `subprocess.run` слились без конфликта. Имя теста переименовано в `test_the_diff_read_pins_utf_8_instead_of_trusting_the_locale`, чтобы не быть омонимом пришедшего из #270 `test_the_reads_pin_utf_8_instead_of_trusting_the_locale` (он про чтения каталога). Ссылка на 13dfa9a в сообщении коммита заменена на #270: squash-merge не сохранил тот SHA в истории `main`.
