### PR TITLE
test(mcp): remove wall-clock dependence from the EOF grace test

### DIFF
--- a/crates/unica-coder/src/interfaces/mcp.rs
+++ b/crates/unica-coder/src/interfaces/mcp.rs
@@ -293,8 +293,8 @@ impl Drop for InFlightGuard {
 mod tests {
     use super::*;
     use serde_json::json;
-    use std::cell::Cell;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc;
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
     use tokio::time::timeout;
 
@@ -937,28 +937,53 @@ mod tests {
 
     #[test]
     fn eof_cleanup_shares_one_aggregate_grace_between_calls_and_provider_workers() {
+        // The call is released by a channel rather than by a sleep, and the
+        // budget is compared against the *measured* time the call stayed
+        // tracked. A loaded runner moves both sides of that comparison
+        // together, so the aggregate grace only has to outlast the test, not
+        // the scheduler.
+        const AGGREGATE_GRACE: Duration = Duration::from_secs(30);
+
         let registry = Arc::new(InFlightRegistry::default());
         let guard = registry.admit().unwrap();
         let cancellation = guard.token();
+        let (cancelled_tx, cancelled_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
         let guard_thread = std::thread::spawn(move || {
             while !cancellation.is_cancelled() {
                 std::thread::yield_now();
             }
-            std::thread::sleep(Duration::from_millis(80));
+            cancelled_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
             drop(guard);
         });
-        let provider_budget = Cell::new(None);
 
-        assert!(drain_mcp_shutdown_with(
-            &registry,
-            Duration::from_millis(200),
-            |remaining| {
-                provider_budget.set(Some(remaining));
+        let drain_registry = Arc::clone(&registry);
+        let drain_thread = std::thread::spawn(move || {
+            let mut provider_budget = None;
+            let drained = drain_mcp_shutdown_with(&drain_registry, AGGREGATE_GRACE, |remaining| {
+                provider_budget = Some(remaining);
                 true
-            }
-        ));
+            });
+            (drained, provider_budget)
+        });
+
+        // Cancellation only reaches the call from inside the drain, so the
+        // deadline was already running when this arrives: everything measured
+        // from here is budget the call spent before provider cleanup starts.
+        cancelled_rx.recv().unwrap();
+        let held = Instant::now();
+        std::thread::sleep(Duration::from_millis(20));
+        release_tx.send(()).unwrap();
+        let held = held.elapsed();
+
+        let (drained, provider_budget) = drain_thread.join().unwrap();
         assert!(
-            provider_budget.get().unwrap() < Duration::from_millis(150),
+            drained,
+            "the drain gave up while the call was still tracked"
+        );
+        assert!(
+            provider_budget.unwrap() <= AGGREGATE_GRACE - held,
             "provider cleanup received a fresh grace instead of the aggregate remainder"
         );
 

--- a/crates/unica-coder/src/interfaces/mcp.rs
+++ b/crates/unica-coder/src/interfaces/mcp.rs
@@ -971,7 +971,9 @@ mod tests {
         // Cancellation only reaches the call from inside the drain, so the
         // deadline was already running when this arrives: everything measured
         // from here is budget the call spent before provider cleanup starts.
-        cancelled_rx.recv().unwrap();
+        cancelled_rx
+            .recv_timeout(AGGREGATE_GRACE)
+            .expect("cancellation did not reach the tracked call within the aggregate grace");
         let held = Instant::now();
         std::thread::sleep(Duration::from_millis(20));
         release_tx.send(()).unwrap();
@@ -983,7 +985,7 @@ mod tests {
             "the drain gave up while the call was still tracked"
         );
         assert!(
-            provider_budget.unwrap() <= AGGREGATE_GRACE - held,
+            provider_budget.unwrap() <= AGGREGATE_GRACE.saturating_sub(held),
             "provider cleanup received a fresh grace instead of the aggregate remainder"
         );
 


### PR DESCRIPTION
Closes #280.

## Причина флака

`eof_cleanup_shares_one_aggregate_grace_between_calls_and_provider_workers` держал in-flight guard через `sleep(80ms)` и затем утверждал, что `drain_mcp_shutdown_with` уложился в бюджет `200ms`. Запас в 120 мс — это запас планировщика, а не свойство кода: на загруженном macOS-раннере он кончался, `wait_idle` возвращал `false`, и тест падал на коммите, который `interfaces/mcp.rs` вообще не трогал.

## Что сделано

- Вызов освобождается по каналу, а не по сну: рабочий поток сообщает о полученной отмене и ждёт явного разрешения дропнуть guard.
- Сам `drain_mcp_shutdown_with` уходит в отдельный поток, чтобы тест мог им управлять.
- Бюджет провайдерной очистки сравнивается с **измеренным** временем удержания вызова (`AGGREGATE_GRACE - held`), а не с фиксированным порогом. Обе части сравнения растут вместе под нагрузкой, поэтому общий грейс должен пережить только сам тест, а не планировщик.

Проверяемое свойство не ослабло: если провайдеру начнут выдавать свежий грейс вместо остатка, `remaining == AGGREGATE_GRACE > AGGREGATE_GRACE - held`, и тест падает.

## Проверка

- Мутация `drain_providers(grace)` вместо остатка — тест падает с ожидаемым сообщением.
- 25 прогонов подряд под искусственной нагрузкой (6 занятых CPU) — все зелёные.
- `cargo test -p unica-coder --lib`: 1696 passed, 0 failed.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — чисто.

Архитектурный контракт не менялся, запись решения не требуется.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved the shutdown/EOF cleanup timing test for greater reliability under load.
  * Added more deterministic coordination and bounded waiting when validating cancellation handling.
  * Strengthened grace-period assertions using safer remaining-time comparisons to better reflect aggregate grace behavior.
  * Updated test imports to support the channel-based coordination approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->