### PR TITLE
fix(runtime): support verified applied full dump on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ uuid = { version = "1", features = ["v4"] }
 windows-sys = { version = "0.59", features = [
   "Win32_Foundation",
   "Win32_Security",
+  "Win32_Security_Authorization",
   "Win32_Storage_FileSystem",
   "Win32_System_Diagnostics_ToolHelp",
   "Win32_System_JobObjects",

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -202,24 +202,61 @@ fn windows_api_path(path: &Path) -> io::Result<Vec<u16>> {
     dead_code,
     reason = "DirectoryAnchor callers are introduced by the following Windows full-dump task"
 )]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EffectiveTokenSource {
+    Thread,
+    Process,
+}
+
+#[cfg(windows)]
+fn verify_thread_token_fallback_error(error: u32) -> io::Result<()> {
+    use windows_sys::Win32::Foundation::ERROR_NO_TOKEN;
+
+    if error == ERROR_NO_TOKEN {
+        Ok(())
+    } else {
+        Err(io::Error::from_raw_os_error(error as i32))
+    }
+}
+
+#[cfg(windows)]
+#[allow(
+    dead_code,
+    reason = "DirectoryAnchor callers are introduced by the following Windows full-dump task"
+)]
 struct ProcessToken {
     handle: windows_sys::Win32::Foundation::HANDLE,
     user: Vec<u8>,
+    source: EffectiveTokenSource,
 }
 
 #[cfg(windows)]
 impl ProcessToken {
     fn current_user() -> io::Result<Self> {
         use std::ptr;
-        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::Foundation::{CloseHandle, ERROR_NO_TOKEN};
         use windows_sys::Win32::Security::{GetTokenInformation, TokenUser, TOKEN_QUERY};
-        use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+        use windows_sys::Win32::System::Threading::{
+            GetCurrentProcess, GetCurrentThread, OpenProcessToken, OpenThreadToken,
+        };
 
         let mut handle = ptr::null_mut();
-        // SAFETY: GetCurrentProcess returns a valid pseudo-handle; handle is writable storage.
-        if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut handle) } == 0 {
-            return Err(io::Error::last_os_error());
-        }
+        // SAFETY: GetCurrentThread returns a valid pseudo-handle; handle is writable storage and
+        // OpenAsSelf is true so an impersonating caller can inspect its effective token.
+        let source =
+            if unsafe { OpenThreadToken(GetCurrentThread(), TOKEN_QUERY, 1, &mut handle) } != 0 {
+                EffectiveTokenSource::Thread
+            } else {
+                let error = io::Error::last_os_error();
+                let error_code = error.raw_os_error().unwrap_or_default() as u32;
+                verify_thread_token_fallback_error(error_code)?;
+                debug_assert_eq!(error_code, ERROR_NO_TOKEN);
+                // SAFETY: GetCurrentProcess returns a valid pseudo-handle; handle is writable storage.
+                if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut handle) } == 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                EffectiveTokenSource::Process
+            };
 
         let mut length = 0;
         // SAFETY: the first call requests the buffer size without supplying a buffer.
@@ -251,7 +288,11 @@ impl ProcessToken {
             return Err(error);
         }
 
-        Ok(Self { handle, user })
+        Ok(Self {
+            handle,
+            user,
+            source,
+        })
     }
 
     fn user_sid(&self) -> windows_sys::Win32::Security::PSID {
@@ -272,7 +313,8 @@ impl Drop for ProcessToken {
     fn drop(&mut self) {
         use windows_sys::Win32::Foundation::CloseHandle;
 
-        // SAFETY: self.handle is an owned token handle returned by OpenProcessToken.
+        // SAFETY: self.handle is an owned token handle returned by OpenThreadToken or
+        // OpenProcessToken.
         unsafe { CloseHandle(self.handle) };
     }
 }
@@ -902,6 +944,13 @@ struct NtIoStatusBlock {
 }
 
 #[cfg(windows)]
+#[repr(C)]
+struct NtFileFsDeviceInformation {
+    device_type: u32,
+    characteristics: u32,
+}
+
+#[cfg(windows)]
 unsafe extern "system" {
     fn NtCreateFile(
         file_handle: *mut windows_sys::Win32::Foundation::HANDLE,
@@ -923,6 +972,13 @@ unsafe extern "system" {
         length: u32,
         file_information_class: u32,
     ) -> i32;
+    fn NtQueryVolumeInformationFile(
+        file_handle: windows_sys::Win32::Foundation::HANDLE,
+        io_status_block: *mut NtIoStatusBlock,
+        fs_information: *mut std::ffi::c_void,
+        length: u32,
+        fs_information_class: u32,
+    ) -> i32;
     fn RtlNtStatusToDosError(status: i32) -> u32;
 }
 
@@ -931,6 +987,73 @@ fn nt_status_error(status: i32) -> io::Error {
     // SAFETY: RtlNtStatusToDosError accepts all NTSTATUS values and returns a Win32 error code.
     let error = unsafe { RtlNtStatusToDosError(status) };
     io::Error::from_raw_os_error(error as i32)
+}
+
+#[cfg(windows)]
+fn verify_windows_local_fixed_device_info(
+    device_type: u32,
+    characteristics: u32,
+) -> io::Result<()> {
+    const FILE_DEVICE_DISK: u32 = 0x0000_0007;
+    const FILE_REMOTE_DEVICE: u32 = 0x0000_0010;
+    const FILE_REMOVABLE_MEDIA: u32 = 0x0000_0001;
+    const FILE_FLOPPY_DISKETTE: u32 = 0x0000_0004;
+    const FILE_WRITE_ONCE_MEDIA: u32 = 0x0000_0008;
+    const FILE_VIRTUAL_VOLUME: u32 = 0x0000_0040;
+    const FILE_REMOTE_DEVICE_VSMB: u32 = 0x0008_0000;
+    const UNTRUSTED_CHARACTERISTICS: u32 = FILE_REMOTE_DEVICE
+        | FILE_REMOVABLE_MEDIA
+        | FILE_FLOPPY_DISKETTE
+        | FILE_WRITE_ONCE_MEDIA
+        | FILE_VIRTUAL_VOLUME
+        | FILE_REMOTE_DEVICE_VSMB;
+
+    if device_type != FILE_DEVICE_DISK || characteristics & UNTRUSTED_CHARACTERISTICS != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "immutable platform volume is not a local fixed disk (device type 0x{device_type:08x}, characteristics 0x{characteristics:08x})"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+pub(crate) fn verify_windows_local_fixed_volume(file: &fs::File) -> io::Result<()> {
+    use std::mem::size_of;
+    use std::os::windows::io::AsRawHandle;
+
+    const FILE_FS_DEVICE_INFORMATION_CLASS: u32 = 4;
+    let mut io_status = NtIoStatusBlock {
+        status: NtIoStatusStatus { status: 0 },
+        information: 0,
+    };
+    let mut information = NtFileFsDeviceInformation {
+        device_type: 0,
+        characteristics: 0,
+    };
+    // SAFETY: file retains a valid handle for the complete call; io_status and information are
+    // writable buffers of the exact native layouts for FileFsDeviceInformation.
+    let status = unsafe {
+        NtQueryVolumeInformationFile(
+            file.as_raw_handle(),
+            &mut io_status,
+            (&mut information as *mut NtFileFsDeviceInformation).cast(),
+            size_of::<NtFileFsDeviceInformation>() as u32,
+            FILE_FS_DEVICE_INFORMATION_CLASS,
+        )
+    };
+    if status < 0 {
+        return Err(nt_status_error(status));
+    }
+    if io_status.information != size_of::<NtFileFsDeviceInformation>() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Windows volume device proof returned an unexpected size",
+        ));
+    }
+    verify_windows_local_fixed_device_info(information.device_type, information.characteristics)
 }
 
 #[cfg(windows)]
@@ -2050,20 +2173,24 @@ mod tests {
             create_owner_only_directory_child, create_owner_only_file, directory_query_is_end,
             file_identity, nt_create_options_for_std_file, open_directory_child_nofollow,
             open_directory_nofollow, parse_directory_information_buffer, read_directory_names,
-            verify_owner_only_acl, verify_windows_elevation_value,
-            verify_windows_immutable_security_descriptor, WindowsImmutableAclProfile,
+            verify_owner_only_acl, verify_thread_token_fallback_error,
+            verify_windows_elevation_value, verify_windows_immutable_security_descriptor,
+            verify_windows_local_fixed_device_info, verify_windows_local_fixed_volume,
+            EffectiveTokenSource, ProcessToken, WindowsImmutableAclProfile,
         };
         use std::ffi::OsString;
         use std::mem::{offset_of, size_of};
         use std::ptr;
         use windows_sys::Win32::Foundation::{LocalFree, GENERIC_ALL, GENERIC_WRITE};
         use windows_sys::Win32::Foundation::{
-            ERROR_ACCESS_DENIED, ERROR_FILE_NOT_FOUND, ERROR_NO_MORE_FILES,
+            ERROR_ACCESS_DENIED, ERROR_CANT_OPEN_ANONYMOUS, ERROR_FILE_NOT_FOUND,
+            ERROR_NO_MORE_FILES, ERROR_NO_TOKEN,
         };
         use windows_sys::Win32::Security::Authorization::{
             ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
         };
         use windows_sys::Win32::Security::PSECURITY_DESCRIPTOR;
+        use windows_sys::Win32::Security::{ImpersonateSelf, RevertToSelf, SecurityImpersonation};
         use windows_sys::Win32::Storage::FileSystem::{
             DELETE, FILE_ADD_FILE, FILE_ADD_SUBDIRECTORY, FILE_DELETE_CHILD, FILE_ID_BOTH_DIR_INFO,
             FILE_WRITE_ATTRIBUTES, FILE_WRITE_DATA, FILE_WRITE_EA, WRITE_DAC, WRITE_OWNER,
@@ -2245,7 +2372,90 @@ mod tests {
         }
 
         #[test]
-        fn windows_immutable_platform_handle_evidence_stays_bound_to_the_open_object() {
+        fn windows_immutable_platform_effective_token_falls_back_only_when_thread_has_no_token() {
+            verify_thread_token_fallback_error(ERROR_NO_TOKEN).unwrap();
+
+            for expected in [ERROR_ACCESS_DENIED, ERROR_CANT_OPEN_ANONYMOUS] {
+                let error = verify_thread_token_fallback_error(expected).unwrap_err();
+                assert_eq!(error.raw_os_error(), Some(expected as i32));
+            }
+        }
+
+        #[test]
+        fn windows_immutable_platform_effective_token_uses_process_token_without_impersonation() {
+            let token = ProcessToken::current_user().unwrap();
+
+            assert_eq!(token.source, EffectiveTokenSource::Process);
+        }
+
+        #[test]
+        fn windows_immutable_platform_effective_token_selects_an_impersonation_token() {
+            struct RevertGuard;
+
+            impl Drop for RevertGuard {
+                fn drop(&mut self) {
+                    // SAFETY: this guard is created only after ImpersonateSelf succeeds.
+                    assert_ne!(unsafe { RevertToSelf() }, 0);
+                }
+            }
+
+            // SAFETY: SecurityImpersonation is a documented impersonation level.
+            assert_ne!(
+                unsafe { ImpersonateSelf(SecurityImpersonation) },
+                0,
+                "{}",
+                io::Error::last_os_error()
+            );
+            let _guard = RevertGuard;
+
+            let token = ProcessToken::current_user().unwrap();
+
+            assert_eq!(token.source, EffectiveTokenSource::Thread);
+        }
+
+        #[test]
+        fn windows_immutable_platform_rejects_nonlocal_or_nonfixed_device_information() {
+            const FILE_DEVICE_CD_ROM: u32 = 0x0000_0002;
+            const FILE_DEVICE_DISK: u32 = 0x0000_0007;
+            const FILE_DEVICE_NETWORK_FILE_SYSTEM: u32 = 0x0000_0014;
+            const FILE_DEVICE_VIRTUAL_DISK: u32 = 0x0000_0024;
+            const FILE_REMOTE_DEVICE: u32 = 0x0000_0010;
+            const FILE_REMOTE_DEVICE_VSMB: u32 = 0x0008_0000;
+            const FILE_REMOVABLE_MEDIA: u32 = 0x0000_0001;
+            const FILE_DEVICE_IS_MOUNTED: u32 = 0x0000_0020;
+
+            verify_windows_local_fixed_device_info(FILE_DEVICE_DISK, FILE_DEVICE_IS_MOUNTED)
+                .unwrap();
+            for (device_type, characteristics) in [
+                (FILE_DEVICE_DISK, FILE_REMOTE_DEVICE),
+                (FILE_DEVICE_DISK, FILE_REMOTE_DEVICE_VSMB),
+                (FILE_DEVICE_DISK, FILE_REMOVABLE_MEDIA),
+                (FILE_DEVICE_NETWORK_FILE_SYSTEM, FILE_DEVICE_IS_MOUNTED),
+                (FILE_DEVICE_CD_ROM, FILE_DEVICE_IS_MOUNTED),
+                (FILE_DEVICE_VIRTUAL_DISK, FILE_DEVICE_IS_MOUNTED),
+                (0xffff_ffff, 0),
+            ] {
+                assert!(
+                    verify_windows_local_fixed_device_info(device_type, characteristics).is_err(),
+                    "device type 0x{device_type:08x}, characteristics 0x{characteristics:08x}"
+                );
+            }
+        }
+
+        #[test]
+        fn windows_immutable_platform_accepts_a_real_local_fixed_volume_handle() {
+            let root = unique_temp_root("immutable-local-volume");
+            fs::create_dir_all(&root).unwrap();
+            let handle = open_directory_nofollow(&root).unwrap();
+
+            verify_windows_local_fixed_volume(&handle).unwrap();
+
+            drop(handle);
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn windows_immutable_platform_attestation_handle_evidence_stays_bound_to_the_open_object() {
             let root = unique_temp_root("immutable-handle-evidence");
             fs::create_dir_all(&root).unwrap();
             let original = root.join("entry");

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -737,6 +737,58 @@ pub(crate) fn open_any_child_nofollow(
 }
 
 #[cfg(windows)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OpenedChildKind {
+    Directory,
+    RegularFile,
+    ReparsePoint,
+    Unsupported,
+}
+
+#[cfg(windows)]
+pub(crate) fn opened_child_kind(file: &fs::File) -> io::Result<OpenedChildKind> {
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_DEVICE, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
+    };
+
+    let attributes = windows_file_information(file)?.dwFileAttributes;
+    if attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        Ok(OpenedChildKind::ReparsePoint)
+    } else if attributes & FILE_ATTRIBUTE_DIRECTORY != 0 {
+        Ok(OpenedChildKind::Directory)
+    } else if attributes & FILE_ATTRIBUTE_DEVICE != 0 {
+        Ok(OpenedChildKind::Unsupported)
+    } else {
+        Ok(OpenedChildKind::RegularFile)
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn open_any_child_for_delete(
+    parent: &fs::File,
+    name: &std::ffi::OsStr,
+) -> io::Result<fs::File> {
+    const FILE_OPEN: u32 = 0x0000_0001;
+    const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    use windows_sys::Win32::Storage::FileSystem::{DELETE, FILE_READ_ATTRIBUTES, SYNCHRONIZE};
+
+    open_relative_child(
+        parent,
+        name,
+        DELETE | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+        0,
+        FILE_OPEN,
+        FILE_OPEN_REPARSE_POINT,
+        None,
+    )
+}
+
+#[cfg(windows)]
+pub(crate) fn delete_open_child(file: &fs::File) -> io::Result<()> {
+    set_delete_disposition(file)
+}
+
+#[cfg(windows)]
 fn directory_query_is_end(restart: bool, error: &io::Error) -> bool {
     use windows_sys::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_NO_MORE_FILES};
 
@@ -1063,6 +1115,11 @@ pub(crate) fn create_owner_only_file_child(
 
 #[cfg(windows)]
 pub(crate) fn discard_created_child(file: &fs::File) -> io::Result<()> {
+    set_delete_disposition(file)
+}
+
+#[cfg(windows)]
+fn set_delete_disposition(file: &fs::File) -> io::Result<()> {
     use std::os::windows::io::AsRawHandle;
 
     const FILE_DISPOSITION_INFORMATION: u32 = 13;

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -14,6 +14,25 @@ pub(crate) fn create_test_directory_link(target: &Path, link: &Path) -> io::Resu
     std::os::windows::fs::symlink_dir(target, link)
 }
 
+#[cfg(all(test, windows))]
+thread_local! {
+    static TEST_CASE_SENSITIVITY_QUERY_FAILURE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+#[cfg(all(test, windows))]
+fn with_case_sensitivity_query_failure<T>(action: impl FnOnce() -> T) -> T {
+    struct Reset(bool);
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            TEST_CASE_SENSITIVITY_QUERY_FAILURE.with(|slot| slot.set(self.0));
+        }
+    }
+
+    let previous = TEST_CASE_SENSITIVITY_QUERY_FAILURE.with(|slot| slot.replace(true));
+    let _reset = Reset(previous);
+    action()
+}
+
 #[cfg(all(test, not(any(unix, windows))))]
 pub(crate) fn create_test_directory_link(_target: &Path, _link: &Path) -> io::Result<()> {
     Err(io::Error::new(
@@ -1127,6 +1146,66 @@ fn nt_create_options_for_std_file(desired_access: u32, create_options: u32) -> i
 }
 
 #[cfg(windows)]
+fn relative_child_object_attributes(parent: &fs::File) -> io::Result<u32> {
+    use std::mem::size_of;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FileCaseSensitiveInfo, GetFileInformationByHandleEx,
+    };
+
+    #[repr(C)]
+    struct FileCaseSensitiveInformation {
+        flags: u32,
+    }
+
+    const OBJ_CASE_INSENSITIVE: u32 = 0x40;
+    const FILE_CS_FLAG_CASE_SENSITIVE_DIR: u32 = 1;
+
+    #[cfg(test)]
+    if TEST_CASE_SENSITIVITY_QUERY_FAILURE.with(|slot| slot.get()) {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "failed to query parent directory case-sensitive state",
+        ));
+    }
+
+    let mut information = FileCaseSensitiveInformation { flags: 0 };
+    // SAFETY: parent retains a valid directory handle and information is a writable buffer with
+    // the exact FileCaseSensitiveInfo layout and size.
+    if unsafe {
+        GetFileInformationByHandleEx(
+            parent.as_raw_handle(),
+            FileCaseSensitiveInfo,
+            (&mut information as *mut FileCaseSensitiveInformation).cast(),
+            size_of::<FileCaseSensitiveInformation>() as u32,
+        )
+    } == 0
+    {
+        let error = io::Error::last_os_error();
+        return Err(io::Error::new(
+            error.kind(),
+            format!("failed to query parent directory case-sensitive state: {error}"),
+        ));
+    }
+    if information.flags & !FILE_CS_FLAG_CASE_SENSITIVE_DIR != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "parent directory reported unsupported case-sensitive flags 0x{:08x}",
+                information.flags
+            ),
+        ));
+    }
+    Ok(
+        if information.flags & FILE_CS_FLAG_CASE_SENSITIVE_DIR != 0 {
+            0
+        } else {
+            OBJ_CASE_INSENSITIVE
+        },
+    )
+}
+
+#[cfg(windows)]
 fn open_relative_child(
     parent: &fs::File,
     name: &std::ffi::OsStr,
@@ -1143,8 +1222,8 @@ fn open_relative_child(
         FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
     };
 
-    const OBJ_CASE_INSENSITIVE: u32 = 0x40;
     let create_options = nt_create_options_for_std_file(desired_access, create_options)?;
+    let object_attributes = relative_child_object_attributes(parent)?;
     let mut name = relative_child_name(name)?;
     let byte_length = name
         .len()
@@ -1160,7 +1239,7 @@ fn open_relative_child(
         length: size_of::<NtObjectAttributes>() as u32,
         root_directory: parent.as_raw_handle(),
         object_name: &mut object_name,
-        attributes: OBJ_CASE_INSENSITIVE,
+        attributes: object_attributes,
         security_descriptor: security_descriptor.unwrap_or(ptr::null_mut()).cast(),
         security_quality_of_service: ptr::null_mut(),
     };
@@ -2269,13 +2348,14 @@ mod tests {
             create_owner_only_file_child, delete_open_child, directory_query_is_end, file_identity,
             nt_create_options_for_std_file, open_any_child_for_delete,
             open_directory_child_for_rename, open_directory_child_nofollow,
-            open_directory_nofollow, opened_child_kind, parse_directory_information_buffer,
-            read_directory_names, rename_directory_handle_child_no_replace, verify_owner_only_acl,
+            open_directory_nofollow, open_regular_child_nofollow, opened_child_kind,
+            parse_directory_information_buffer, read_directory_names,
+            rename_directory_handle_child_no_replace, verify_owner_only_acl,
             verify_owner_only_security_descriptor, verify_thread_token_fallback_error,
             verify_windows_elevation_value, verify_windows_immutable_security_descriptor,
             verify_windows_local_fixed_device_info, verify_windows_local_fixed_volume,
-            EffectiveTokenSource, OpenedChildKind, OwnerOnlySecurityAttributes, ProcessToken,
-            WindowsImmutableAclProfile,
+            with_case_sensitivity_query_failure, EffectiveTokenSource, OpenedChildKind,
+            OwnerOnlySecurityAttributes, ProcessToken, WindowsImmutableAclProfile,
         };
         use std::ffi::OsString;
         use std::mem::{offset_of, size_of};
@@ -2728,6 +2808,23 @@ mod tests {
             drop(handle);
             drop(parent);
             assert_eq!(fs::read(root.join("effective.yaml")).unwrap(), b"private");
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn windows_relative_open_fails_closed_when_parent_case_sensitivity_is_ambiguous() {
+            let root = unique_temp_root("ambiguous-parent-case-sensitivity");
+            fs::create_dir_all(&root).unwrap();
+            fs::write(root.join("entry.txt"), b"entry").unwrap();
+            let parent = open_directory_nofollow(&root).unwrap();
+
+            let error = with_case_sensitivity_query_failure(|| {
+                open_regular_child_nofollow(&parent, std::ffi::OsStr::new("entry.txt"))
+            })
+            .expect_err("an ambiguous parent case-sensitivity query must fail closed");
+
+            assert!(error.to_string().contains("case-sensitive"), "{error}");
+            drop(parent);
             fs::remove_dir_all(root).unwrap();
         }
 

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -633,13 +633,13 @@ pub(crate) fn open_directory_child_nofollow(
     const FILE_DIRECTORY_FILE: u32 = 0x0000_0001;
     const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
     use windows_sys::Win32::Storage::FileSystem::{
-        FILE_READ_ATTRIBUTES, READ_CONTROL, SYNCHRONIZE,
+        DELETE, FILE_READ_ATTRIBUTES, READ_CONTROL, SYNCHRONIZE,
     };
 
     let file = open_relative_child(
         parent,
         name,
-        FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE,
+        DELETE | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE,
         0,
         FILE_OPEN,
         FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT,
@@ -647,6 +647,80 @@ pub(crate) fn open_directory_child_nofollow(
     )?;
     validate_directory_handle(&file)?;
     Ok(file)
+}
+
+#[cfg(windows)]
+pub(crate) fn rename_directory_handle_child_no_replace(
+    source: &fs::File,
+    destination_parent: &fs::File,
+    destination_name: &std::ffi::OsStr,
+) -> io::Result<()> {
+    use std::mem::{offset_of, size_of};
+    use std::os::windows::io::AsRawHandle;
+    use std::ptr;
+
+    #[repr(C)]
+    union RenameFlags {
+        replace_if_exists: u8,
+        flags: u32,
+    }
+
+    #[repr(C)]
+    struct RenameInformation {
+        anonymous: RenameFlags,
+        root_directory: windows_sys::Win32::Foundation::HANDLE,
+        file_name_length: u32,
+        file_name: [u16; 1],
+    }
+
+    const FILE_RENAME_INFORMATION_CLASS: u32 = 10;
+
+    let name = relative_child_name(destination_name)?;
+    let name_bytes = name
+        .len()
+        .checked_mul(size_of::<u16>())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "child name is too long"))?;
+    let information_length = offset_of!(RenameInformation, file_name)
+        .checked_add(name_bytes)
+        .and_then(|length| u32::try_from(length).ok())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "child name is too long"))?;
+    let word_count = (information_length as usize).div_ceil(size_of::<usize>());
+    let mut storage = vec![0usize; word_count];
+    let information = storage.as_mut_ptr().cast::<RenameInformation>();
+    // SAFETY: storage is pointer-aligned and large enough for the fixed header plus the complete
+    // UTF-16 name. All fields are initialized before NtSetInformationFile reads the buffer.
+    unsafe {
+        ptr::addr_of_mut!((*information).anonymous).write(RenameFlags {
+            replace_if_exists: 0,
+        });
+        ptr::addr_of_mut!((*information).root_directory).write(destination_parent.as_raw_handle());
+        ptr::addr_of_mut!((*information).file_name_length).write(name_bytes as u32);
+        ptr::copy_nonoverlapping(
+            name.as_ptr(),
+            ptr::addr_of_mut!((*information).file_name).cast::<u16>(),
+            name.len(),
+        );
+    }
+    let mut status = NtIoStatusBlock {
+        status: NtIoStatusStatus { status: 0 },
+        information: 0,
+    };
+    // SAFETY: source is an owned directory handle opened with DELETE access, destination_parent
+    // remains live, and the initialized buffer describes one relative destination name.
+    let result = unsafe {
+        NtSetInformationFile(
+            source.as_raw_handle(),
+            &mut status,
+            information.cast(),
+            information_length,
+            FILE_RENAME_INFORMATION_CLASS,
+        )
+    };
+    if result < 0 {
+        Err(nt_status_error(result))
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(windows)]

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -394,6 +394,431 @@ impl Drop for LocalSecurityDescriptor {
 }
 
 #[cfg(windows)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WindowsImmutableAclProfile {
+    Ancestry,
+    Installation,
+}
+
+#[cfg(windows)]
+struct SelfRelativeSecurityDescriptor {
+    storage: Vec<usize>,
+    length: usize,
+}
+
+#[cfg(windows)]
+impl SelfRelativeSecurityDescriptor {
+    fn capture(descriptor: windows_sys::Win32::Security::PSECURITY_DESCRIPTOR) -> io::Result<Self> {
+        use std::mem::size_of;
+        use std::ptr;
+        use windows_sys::Win32::Security::{
+            GetSecurityDescriptorControl, GetSecurityDescriptorLength, IsValidSecurityDescriptor,
+            MakeSelfRelativeSD, SE_SELF_RELATIVE,
+        };
+
+        if descriptor.is_null() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "security descriptor is absent",
+            ));
+        }
+        // SAFETY: descriptor is non-null; callers retain the allocation for this call.
+        if unsafe { IsValidSecurityDescriptor(descriptor) } == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "security descriptor is malformed",
+            ));
+        }
+        let mut control = 0;
+        let mut revision = 0;
+        // SAFETY: descriptor was validated and both output pointers are writable.
+        if unsafe { GetSecurityDescriptorControl(descriptor, &mut control, &mut revision) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        if control & SE_SELF_RELATIVE != 0 {
+            // SAFETY: descriptor is a valid self-relative descriptor.
+            let length = unsafe { GetSecurityDescriptorLength(descriptor) } as usize;
+            if length == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "security descriptor has zero length",
+                ));
+            }
+            let mut storage = vec![0usize; length.div_ceil(size_of::<usize>())];
+            // SAFETY: storage has at least length writable bytes and descriptor has that many
+            // readable bytes according to GetSecurityDescriptorLength.
+            unsafe {
+                ptr::copy_nonoverlapping(
+                    descriptor.cast::<u8>(),
+                    storage.as_mut_ptr().cast::<u8>(),
+                    length,
+                )
+            };
+            return Ok(Self { storage, length });
+        }
+
+        let mut length = 0;
+        // SAFETY: this size query reads the validated absolute descriptor and writes length.
+        unsafe { MakeSelfRelativeSD(descriptor, ptr::null_mut(), &mut length) };
+        if length == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let mut storage = vec![0usize; (length as usize).div_ceil(size_of::<usize>())];
+        // SAFETY: storage is aligned and has at least length writable bytes.
+        if unsafe { MakeSelfRelativeSD(descriptor, storage.as_mut_ptr().cast(), &mut length) } == 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Self {
+            storage,
+            length: length as usize,
+        })
+    }
+
+    fn as_ptr(&self) -> windows_sys::Win32::Security::PSECURITY_DESCRIPTOR {
+        self.storage.as_ptr().cast_mut().cast()
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        // SAFETY: storage owns at least length initialized bytes copied or written above.
+        unsafe { std::slice::from_raw_parts(self.storage.as_ptr().cast::<u8>(), self.length) }
+    }
+}
+
+#[cfg(windows)]
+pub(crate) struct WindowsImmutableEntryEvidence {
+    pub(crate) identity: FileIdentity,
+    pub(crate) security_descriptor_sha256: [u8; 32],
+    descriptor: SelfRelativeSecurityDescriptor,
+}
+
+#[cfg(windows)]
+impl WindowsImmutableEntryEvidence {
+    pub(crate) fn verify(&self, profile: WindowsImmutableAclProfile) -> io::Result<()> {
+        verify_windows_immutable_security_descriptor(self.descriptor.as_ptr(), profile)
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn capture_windows_immutable_entry_evidence(
+    file: &fs::File,
+) -> io::Result<WindowsImmutableEntryEvidence> {
+    use std::os::windows::io::AsRawHandle;
+    use std::ptr;
+    use windows_sys::Win32::Security::Authorization::{GetSecurityInfo, SE_FILE_OBJECT};
+    use windows_sys::Win32::Security::{DACL_SECURITY_INFORMATION, OWNER_SECURITY_INFORMATION};
+
+    let mut descriptor = ptr::null_mut();
+    // SAFETY: file owns a valid handle and descriptor is writable output storage.
+    let status = unsafe {
+        GetSecurityInfo(
+            file.as_raw_handle(),
+            SE_FILE_OBJECT,
+            OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            &mut descriptor,
+        )
+    };
+    if status != 0 {
+        return Err(io::Error::from_raw_os_error(status as i32));
+    }
+    let descriptor = LocalSecurityDescriptor(descriptor);
+    let descriptor = SelfRelativeSecurityDescriptor::capture(descriptor.0)?;
+    use sha2::{Digest, Sha256};
+    Ok(WindowsImmutableEntryEvidence {
+        identity: file_identity(file)?,
+        security_descriptor_sha256: Sha256::digest(descriptor.as_bytes()).into(),
+        descriptor,
+    })
+}
+
+#[cfg(windows)]
+fn sid_string(sid: windows_sys::Win32::Security::PSID) -> io::Result<String> {
+    use std::ptr;
+    use windows_sys::Win32::Foundation::LocalFree;
+    use windows_sys::Win32::Security::Authorization::ConvertSidToStringSidW;
+
+    let mut text = ptr::null_mut();
+    // SAFETY: the caller supplies a validated SID and text is writable output storage.
+    if unsafe { ConvertSidToStringSidW(sid, &mut text) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: the API returned a live NUL-terminated UTF-16 allocation.
+    let length = unsafe {
+        let mut length = 0;
+        while *text.add(length) != 0 {
+            length += 1;
+        }
+        length
+    };
+    // SAFETY: length ends before the allocation's terminating NUL.
+    let value = String::from_utf16(unsafe { std::slice::from_raw_parts(text, length) })
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error));
+    // SAFETY: ConvertSidToStringSidW allocates with LocalAlloc.
+    unsafe { LocalFree(text.cast()) };
+    value
+}
+
+#[cfg(windows)]
+fn windows_sid_is_trusted(sid: windows_sys::Win32::Security::PSID) -> io::Result<bool> {
+    const TRUSTED_INSTALLER: &str =
+        "S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464";
+    Ok(matches!(
+        sid_string(sid)?.as_str(),
+        TRUSTED_INSTALLER | "S-1-5-18" | "S-1-5-32-544"
+    ))
+}
+
+#[cfg(windows)]
+fn windows_immutable_mutation_mask(profile: WindowsImmutableAclProfile) -> u32 {
+    use windows_sys::Win32::Foundation::{GENERIC_ALL, GENERIC_WRITE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        DELETE, FILE_ADD_FILE, FILE_ADD_SUBDIRECTORY, FILE_DELETE_CHILD, FILE_WRITE_ATTRIBUTES,
+        FILE_WRITE_DATA, FILE_WRITE_EA, WRITE_DAC, WRITE_OWNER,
+    };
+
+    let substitution =
+        DELETE | FILE_DELETE_CHILD | WRITE_DAC | WRITE_OWNER | GENERIC_WRITE | GENERIC_ALL;
+    match profile {
+        WindowsImmutableAclProfile::Ancestry => substitution,
+        WindowsImmutableAclProfile::Installation => {
+            substitution
+                | FILE_WRITE_DATA
+                | FILE_ADD_FILE
+                | FILE_ADD_SUBDIRECTORY
+                | FILE_WRITE_EA
+                | FILE_WRITE_ATTRIBUTES
+        }
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn verify_windows_immutable_security_descriptor(
+    descriptor: windows_sys::Win32::Security::PSECURITY_DESCRIPTOR,
+    profile: WindowsImmutableAclProfile,
+) -> io::Result<()> {
+    use std::mem::{offset_of, size_of};
+    use std::ptr;
+    use windows_sys::Win32::Security::{
+        AclSizeInformation, GetAce, GetAclInformation, GetLengthSid, GetSecurityDescriptorDacl,
+        GetSecurityDescriptorOwner, IsValidAcl, IsValidSecurityDescriptor, IsValidSid,
+        ACCESS_ALLOWED_ACE, ACE_HEADER, ACL, ACL_SIZE_INFORMATION,
+    };
+
+    const ACCESS_ALLOWED_ACE_TYPE: u8 = 0;
+    const ACCESS_DENIED_ACE_TYPE: u8 = 1;
+    const VALID_INHERIT_FLAGS: u8 = 0x1f;
+    const INHERIT_ONLY_ACE: u8 = 0x08;
+
+    if descriptor.is_null() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "security descriptor is absent",
+        ));
+    }
+    // SAFETY: descriptor is non-null and remains live for this function.
+    if unsafe { IsValidSecurityDescriptor(descriptor) } == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "security descriptor is malformed",
+        ));
+    }
+
+    let mut owner = ptr::null_mut();
+    let mut owner_defaulted = 0;
+    // SAFETY: descriptor was validated and output pointers are writable.
+    if unsafe { GetSecurityDescriptorOwner(descriptor, &mut owner, &mut owner_defaulted) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if owner.is_null() || unsafe { IsValidSid(owner) } == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "immutable platform owner SID is absent or malformed",
+        ));
+    }
+    if !windows_sid_is_trusted(owner)? {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "immutable platform owner SID is not trusted",
+        ));
+    }
+
+    let mut dacl_present = 0;
+    let mut dacl: *mut ACL = ptr::null_mut();
+    let mut dacl_defaulted = 0;
+    // SAFETY: descriptor was validated and output pointers are writable.
+    if unsafe {
+        GetSecurityDescriptorDacl(
+            descriptor,
+            &mut dacl_present,
+            &mut dacl,
+            &mut dacl_defaulted,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    if dacl_present == 0 || dacl.is_null() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "immutable platform security descriptor has an absent or null DACL",
+        ));
+    }
+    // SAFETY: dacl is non-null and points inside the validated descriptor.
+    if unsafe { IsValidAcl(dacl) } == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "immutable platform DACL is malformed",
+        ));
+    }
+
+    let mut information = ACL_SIZE_INFORMATION {
+        AceCount: 0,
+        AclBytesInUse: 0,
+        AclBytesFree: 0,
+    };
+    // SAFETY: dacl is valid and information is writable.
+    if unsafe {
+        GetAclInformation(
+            dacl,
+            (&mut information as *mut ACL_SIZE_INFORMATION).cast(),
+            size_of::<ACL_SIZE_INFORMATION>() as u32,
+            AclSizeInformation,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+
+    let mutation_mask = windows_immutable_mutation_mask(profile);
+    for index in 0..information.AceCount {
+        let mut ace = ptr::null_mut();
+        // SAFETY: index is within the validated ACL's reported ACE count.
+        if unsafe { GetAce(dacl, index, &mut ace) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: GetAce returned a pointer to a complete ACE header in the validated ACL.
+        let header = unsafe { &*ace.cast::<ACE_HEADER>() };
+        if header.AceFlags & !VALID_INHERIT_FLAGS != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "immutable platform DACL contains unsupported ACE flags",
+            ));
+        }
+        if !matches!(
+            header.AceType,
+            ACCESS_ALLOWED_ACE_TYPE | ACCESS_DENIED_ACE_TYPE
+        ) {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "immutable platform DACL contains an unsupported ACE type",
+            ));
+        }
+
+        let sid_offset = offset_of!(ACCESS_ALLOWED_ACE, SidStart);
+        let minimum_sid_bytes = 8usize;
+        let ace_size = usize::from(header.AceSize);
+        if ace_size < sid_offset + minimum_sid_bytes {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "immutable platform DACL contains a truncated ACE SID",
+            ));
+        }
+        // SAFETY: the fixed ACE header and minimum SID were bounds-checked against AceSize.
+        let allowed = unsafe { &*ace.cast::<ACCESS_ALLOWED_ACE>() };
+        let sid: windows_sys::Win32::Security::PSID =
+            (&raw const allowed.SidStart).cast_mut().cast();
+        // SAFETY: the minimum SID header is contained in this ACE.
+        let subauthority_count = unsafe { *sid.cast::<u8>().add(1) } as usize;
+        let sid_length = minimum_sid_bytes
+            .checked_add(
+                subauthority_count
+                    .checked_mul(size_of::<u32>())
+                    .ok_or_else(|| {
+                        io::Error::new(io::ErrorKind::InvalidData, "ACE SID length overflowed")
+                    })?,
+            )
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "ACE SID length overflowed")
+            })?;
+        if sid_offset + sid_length > ace_size {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "immutable platform DACL contains an out-of-bounds ACE SID",
+            ));
+        }
+        // SAFETY: the SID is fully contained in the ACE according to its own length field.
+        if unsafe { IsValidSid(sid) } == 0 || unsafe { GetLengthSid(sid) } as usize != sid_length {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "immutable platform DACL contains a malformed ACE SID",
+            ));
+        }
+
+        if header.AceType == ACCESS_DENIED_ACE_TYPE || header.AceFlags & INHERIT_ONLY_ACE != 0 {
+            continue;
+        }
+        if allowed.Mask & mutation_mask != 0 && !windows_sid_is_trusted(sid)? {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!(
+                    "immutable platform DACL grants mutation rights 0x{:08x} to an untrusted SID",
+                    allowed.Mask & mutation_mask
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+pub(crate) fn verify_windows_elevation_value(is_elevated: u32) -> io::Result<()> {
+    if is_elevated == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "immutable platform execution is refused for an elevated Windows caller",
+        ))
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn verify_unprivileged_windows_platform_caller() -> io::Result<()> {
+    use std::mem::size_of;
+    use windows_sys::Win32::Security::{GetTokenInformation, TokenElevation, TOKEN_ELEVATION};
+
+    let token = ProcessToken::current_user()?;
+    let mut elevation = TOKEN_ELEVATION { TokenIsElevated: 0 };
+    let mut returned = 0;
+    // SAFETY: token is a live process-token handle, elevation is writable storage of the exact
+    // requested type, and returned is writable.
+    if unsafe {
+        GetTokenInformation(
+            token.handle,
+            TokenElevation,
+            (&mut elevation as *mut TOKEN_ELEVATION).cast(),
+            size_of::<TOKEN_ELEVATION>() as u32,
+            &mut returned,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    if returned != size_of::<TOKEN_ELEVATION>() as u32 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Windows token elevation proof returned an unexpected size",
+        ));
+    }
+    verify_windows_elevation_value(elevation.TokenIsElevated)
+}
+
+#[cfg(windows)]
 #[allow(
     dead_code,
     reason = "DirectoryAnchor callers are introduced by the following Windows full-dump task"
@@ -1621,17 +2046,229 @@ mod tests {
     mod windows {
         use super::{fs, io, unique_temp_root};
         use crate::infrastructure::platform::filesystem::{
-            create_owner_only_directory, create_owner_only_directory_child, create_owner_only_file,
-            directory_query_is_end, file_identity, nt_create_options_for_std_file,
-            open_directory_child_nofollow, open_directory_nofollow,
-            parse_directory_information_buffer, read_directory_names, verify_owner_only_acl,
+            capture_windows_immutable_entry_evidence, create_owner_only_directory,
+            create_owner_only_directory_child, create_owner_only_file, directory_query_is_end,
+            file_identity, nt_create_options_for_std_file, open_directory_child_nofollow,
+            open_directory_nofollow, parse_directory_information_buffer, read_directory_names,
+            verify_owner_only_acl, verify_windows_elevation_value,
+            verify_windows_immutable_security_descriptor, WindowsImmutableAclProfile,
         };
         use std::ffi::OsString;
         use std::mem::{offset_of, size_of};
+        use std::ptr;
+        use windows_sys::Win32::Foundation::{LocalFree, GENERIC_ALL, GENERIC_WRITE};
         use windows_sys::Win32::Foundation::{
             ERROR_ACCESS_DENIED, ERROR_FILE_NOT_FOUND, ERROR_NO_MORE_FILES,
         };
-        use windows_sys::Win32::Storage::FileSystem::FILE_ID_BOTH_DIR_INFO;
+        use windows_sys::Win32::Security::Authorization::{
+            ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+        };
+        use windows_sys::Win32::Security::PSECURITY_DESCRIPTOR;
+        use windows_sys::Win32::Storage::FileSystem::{
+            DELETE, FILE_ADD_FILE, FILE_ADD_SUBDIRECTORY, FILE_DELETE_CHILD, FILE_ID_BOTH_DIR_INFO,
+            FILE_WRITE_ATTRIBUTES, FILE_WRITE_DATA, FILE_WRITE_EA, WRITE_DAC, WRITE_OWNER,
+        };
+
+        struct TestSecurityDescriptor(PSECURITY_DESCRIPTOR);
+
+        impl Drop for TestSecurityDescriptor {
+            fn drop(&mut self) {
+                // SAFETY: the SDDL conversion API allocated this descriptor with LocalAlloc.
+                unsafe { LocalFree(self.0) };
+            }
+        }
+
+        fn descriptor_from_sddl(sddl: &str) -> TestSecurityDescriptor {
+            let mut wide = sddl.encode_utf16().collect::<Vec<_>>();
+            wide.push(0);
+            let mut descriptor = ptr::null_mut();
+            // SAFETY: wide is NUL-terminated and descriptor is writable output storage.
+            let converted = unsafe {
+                ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                    wide.as_ptr(),
+                    SDDL_REVISION_1,
+                    &mut descriptor,
+                    ptr::null_mut(),
+                )
+            };
+            assert_ne!(converted, 0, "{}", io::Error::last_os_error());
+            TestSecurityDescriptor(descriptor)
+        }
+
+        fn descriptor_with_untrusted_mask(
+            owner: &str,
+            mask: u32,
+            flags: &str,
+        ) -> TestSecurityDescriptor {
+            descriptor_from_sddl(&format!(
+                "O:{owner}D:(A;;FA;;;SY)(A;{flags};0x{mask:08x};;;BU)"
+            ))
+        }
+
+        #[test]
+        fn windows_immutable_platform_accepts_trusted_owners_and_read_execute_users() {
+            const TRUSTED_INSTALLER: &str =
+                "S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464";
+            for owner in [TRUSTED_INSTALLER, "SY", "BA"] {
+                let descriptor = descriptor_from_sddl(&format!(
+                    "O:{owner}D:(A;;FA;;;SY)(A;;FA;;;BA)(A;;0x001200a9;;;BU)"
+                ));
+
+                verify_windows_immutable_security_descriptor(
+                    descriptor.0,
+                    WindowsImmutableAclProfile::Installation,
+                )
+                .unwrap();
+            }
+        }
+
+        #[test]
+        fn windows_immutable_platform_rejects_an_untrusted_owner() {
+            let descriptor = descriptor_from_sddl("O:BUD:(A;;FA;;;SY)(A;;FRFX;;;BU)");
+
+            let error = verify_windows_immutable_security_descriptor(
+                descriptor.0,
+                WindowsImmutableAclProfile::Installation,
+            )
+            .unwrap_err();
+
+            assert!(error.to_string().contains("owner"), "{error}");
+        }
+
+        #[test]
+        fn windows_immutable_platform_ancestry_allows_sibling_creation_only() {
+            let descriptor =
+                descriptor_with_untrusted_mask("SY", FILE_ADD_FILE | FILE_ADD_SUBDIRECTORY, "");
+
+            verify_windows_immutable_security_descriptor(
+                descriptor.0,
+                WindowsImmutableAclProfile::Ancestry,
+            )
+            .unwrap();
+        }
+
+        #[test]
+        fn windows_immutable_platform_ancestry_rejects_untrusted_substitution_rights() {
+            for mask in [
+                DELETE,
+                FILE_DELETE_CHILD,
+                WRITE_DAC,
+                WRITE_OWNER,
+                GENERIC_WRITE,
+                GENERIC_ALL,
+            ] {
+                let descriptor = descriptor_with_untrusted_mask("SY", mask, "");
+
+                let error = verify_windows_immutable_security_descriptor(
+                    descriptor.0,
+                    WindowsImmutableAclProfile::Ancestry,
+                )
+                .unwrap_err();
+
+                assert!(
+                    error.to_string().contains("mutation"),
+                    "mask 0x{mask:08x}: {error}"
+                );
+            }
+        }
+
+        #[test]
+        fn windows_immutable_platform_inventory_rejects_every_untrusted_mutation_right() {
+            for mask in [
+                FILE_WRITE_DATA,
+                FILE_ADD_FILE,
+                FILE_ADD_SUBDIRECTORY,
+                FILE_WRITE_EA,
+                FILE_WRITE_ATTRIBUTES,
+                FILE_DELETE_CHILD,
+                DELETE,
+                WRITE_DAC,
+                WRITE_OWNER,
+                GENERIC_WRITE,
+                GENERIC_ALL,
+            ] {
+                let descriptor = descriptor_with_untrusted_mask("BA", mask, "");
+
+                let error = verify_windows_immutable_security_descriptor(
+                    descriptor.0,
+                    WindowsImmutableAclProfile::Installation,
+                )
+                .unwrap_err();
+
+                assert!(
+                    error.to_string().contains("mutation"),
+                    "mask 0x{mask:08x}: {error}"
+                );
+            }
+        }
+
+        #[test]
+        fn windows_immutable_platform_ignores_inherit_only_capabilities_on_current_entry() {
+            let descriptor = descriptor_with_untrusted_mask("SY", GENERIC_ALL, "OICIIO");
+
+            verify_windows_immutable_security_descriptor(
+                descriptor.0,
+                WindowsImmutableAclProfile::Installation,
+            )
+            .unwrap();
+        }
+
+        #[test]
+        fn windows_immutable_platform_rejects_missing_null_and_unsupported_dacls() {
+            let absent = descriptor_from_sddl("O:SY");
+            let null = descriptor_from_sddl("O:SYD:NO_ACCESS_CONTROL");
+            let object =
+                descriptor_from_sddl("O:SYD:(OA;;FA;00112233-4455-6677-8899-aabbccddeeff;;BU)");
+            let mut malformed = [0usize; 4];
+
+            for descriptor in [
+                absent.0,
+                null.0,
+                object.0,
+                malformed.as_mut_ptr().cast(),
+                ptr::null_mut(),
+            ] {
+                assert!(verify_windows_immutable_security_descriptor(
+                    descriptor,
+                    WindowsImmutableAclProfile::Installation,
+                )
+                .is_err());
+            }
+        }
+
+        #[test]
+        fn windows_immutable_platform_rejects_an_elevated_caller() {
+            let error = verify_windows_elevation_value(1).unwrap_err();
+
+            assert!(error.to_string().contains("elevated"), "{error}");
+            verify_windows_elevation_value(0).unwrap();
+        }
+
+        #[test]
+        fn windows_immutable_platform_handle_evidence_stays_bound_to_the_open_object() {
+            let root = unique_temp_root("immutable-handle-evidence");
+            fs::create_dir_all(&root).unwrap();
+            let original = root.join("entry");
+            let displaced = root.join("displaced");
+            let original_handle = create_owner_only_file(&original).unwrap();
+            let expected_identity = file_identity(&original_handle).unwrap();
+            fs::rename(&original, &displaced).unwrap();
+            fs::write(&original, b"decoy").unwrap();
+            let decoy_handle = fs::File::open(&original).unwrap();
+
+            let retained = capture_windows_immutable_entry_evidence(&original_handle).unwrap();
+            let decoy = capture_windows_immutable_entry_evidence(&decoy_handle).unwrap();
+
+            assert_eq!(retained.identity, expected_identity);
+            assert_ne!(retained.identity, decoy.identity);
+            assert_ne!(
+                retained.security_descriptor_sha256,
+                decoy.security_descriptor_sha256
+            );
+            drop(decoy_handle);
+            drop(original_handle);
+            fs::remove_dir_all(root).unwrap();
+        }
 
         #[test]
         fn owner_only_directory_is_opened_without_following_reparse_points() {

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -1092,7 +1092,7 @@ fn validate_directory_handle(file: &fs::File) -> io::Result<()> {
         FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
     };
 
-    let attributes = windows_file_information(&file)?.dwFileAttributes;
+    let attributes = windows_file_information(file)?.dwFileAttributes;
     if attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -1381,7 +1381,7 @@ fn parse_directory_information_buffer(
             std::ptr::read_unaligned(buffer.as_ptr().add(offset).cast::<FILE_ID_BOTH_DIR_INFO>())
         };
         let name_bytes = entry.FileNameLength as usize;
-        if name_bytes == 0 || name_bytes % size_of::<u16>() != 0 {
+        if name_bytes == 0 || !name_bytes.is_multiple_of(size_of::<u16>()) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "directory entry has an invalid UTF-16 name length",
@@ -1428,7 +1428,7 @@ fn parse_directory_information_buffer(
                 "directory entry record length overflowed",
             )
         })?;
-        if next < minimum_record_bytes || next % 8 != 0 {
+        if next < minimum_record_bytes || !next.is_multiple_of(8) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "directory entry next-record offset is not 8-byte-aligned or overlaps the name",
@@ -1805,19 +1805,11 @@ pub(crate) fn create_owner_only_file(path: &Path) -> io::Result<fs::File> {
     reason = "DirectoryAnchor callers are introduced by the following Windows full-dump task"
 )]
 pub(crate) fn verify_owner_only_acl(file: &fs::File) -> io::Result<()> {
-    use std::mem::size_of;
     use std::os::windows::io::AsRawHandle;
     use std::ptr;
     use windows_sys::Win32::Security::Authorization::{GetSecurityInfo, SE_FILE_OBJECT};
-    use windows_sys::Win32::Security::{
-        AclSizeInformation, EqualSid, GetAce, GetAclInformation, GetSecurityDescriptorControl,
-        ACCESS_ALLOWED_ACE, ACE_HEADER, ACL_SIZE_INFORMATION, DACL_SECURITY_INFORMATION,
-        INHERITED_ACE, SE_DACL_PROTECTED,
-    };
+    use windows_sys::Win32::Security::DACL_SECURITY_INFORMATION;
 
-    const ACCESS_ALLOWED_ACE_TYPE: u8 = 0;
-
-    let token = ProcessToken::current_user()?;
     let mut dacl = ptr::null_mut();
     let mut descriptor = ptr::null_mut();
     // SAFETY: file owns a valid handle and all requested output pointers are writable.
@@ -1837,7 +1829,47 @@ pub(crate) fn verify_owner_only_acl(file: &fs::File) -> io::Result<()> {
         return Err(io::Error::from_raw_os_error(status as i32));
     }
     let descriptor = LocalSecurityDescriptor(descriptor);
-    if dacl.is_null() {
+    verify_owner_only_security_descriptor(descriptor.0)
+}
+
+#[cfg(windows)]
+fn verify_owner_only_security_descriptor(
+    descriptor: windows_sys::Win32::Security::PSECURITY_DESCRIPTOR,
+) -> io::Result<()> {
+    use std::mem::size_of;
+    use std::ptr;
+    use windows_sys::Win32::Security::{
+        AclSizeInformation, EqualSid, GetAce, GetAclInformation, GetSecurityDescriptorControl,
+        GetSecurityDescriptorDacl, ACCESS_ALLOWED_ACE, ACE_HEADER, ACL_SIZE_INFORMATION,
+        SE_DACL_PROTECTED,
+    };
+    use windows_sys::Win32::Storage::FileSystem::FILE_ALL_ACCESS;
+
+    const ACCESS_ALLOWED_ACE_TYPE: u8 = 0;
+
+    if descriptor.is_null() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "owner-only object has no security descriptor",
+        ));
+    }
+    let token = ProcessToken::current_user()?;
+    let mut dacl_present = 0;
+    let mut dacl = ptr::null_mut();
+    let mut dacl_defaulted = 0;
+    // SAFETY: descriptor is non-null and all requested output pointers are writable.
+    if unsafe {
+        GetSecurityDescriptorDacl(
+            descriptor,
+            &mut dacl_present,
+            &mut dacl,
+            &mut dacl_defaulted,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    if dacl_present == 0 || dacl.is_null() {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
             "owner-only object has no DACL",
@@ -1846,8 +1878,8 @@ pub(crate) fn verify_owner_only_acl(file: &fs::File) -> io::Result<()> {
 
     let mut control = 0;
     let mut revision = 0;
-    // SAFETY: descriptor is valid until its RAII wrapper drops.
-    if unsafe { GetSecurityDescriptorControl(descriptor.0, &mut control, &mut revision) } == 0 {
+    // SAFETY: descriptor is valid for the duration of this call.
+    if unsafe { GetSecurityDescriptorControl(descriptor, &mut control, &mut revision) } == 0 {
         return Err(io::Error::last_os_error());
     }
     if control & SE_DACL_PROTECTED == 0 {
@@ -1888,15 +1920,26 @@ pub(crate) fn verify_owner_only_acl(file: &fs::File) -> io::Result<()> {
     }
     // SAFETY: GetAce returned a pointer to a valid ACE in dacl.
     let header = unsafe { &*ace.cast::<ACE_HEADER>() };
-    if header.AceType != ACCESS_ALLOWED_ACE_TYPE || u32::from(header.AceFlags) & INHERITED_ACE != 0
-    {
+    if header.AceType != ACCESS_ALLOWED_ACE_TYPE {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
             "owner-only object DACL has an unexpected ACE",
         ));
     }
+    if header.AceFlags != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "owner-only object DACL has unexpected ACE flags",
+        ));
+    }
     // SAFETY: the ACE type is ACCESS_ALLOWED_ACE_TYPE, so its payload has this layout.
     let allowed = unsafe { &*ace.cast::<ACCESS_ALLOWED_ACE>() };
+    if allowed.Mask != FILE_ALL_ACCESS {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "owner-only object DACL does not grant full access",
+        ));
+    }
     let ace_sid: windows_sys::Win32::Security::PSID =
         (&raw const allowed.SidStart).cast_mut().cast();
     // SAFETY: both SIDs are valid: one belongs to the ACL and the other to the current token.
@@ -2228,9 +2271,10 @@ mod tests {
             open_directory_child_for_rename, open_directory_child_nofollow,
             open_directory_nofollow, opened_child_kind, parse_directory_information_buffer,
             read_directory_names, rename_directory_handle_child_no_replace, verify_owner_only_acl,
-            verify_thread_token_fallback_error, verify_windows_elevation_value,
-            verify_windows_immutable_security_descriptor, verify_windows_local_fixed_device_info,
-            verify_windows_local_fixed_volume, EffectiveTokenSource, OpenedChildKind, ProcessToken,
+            verify_owner_only_security_descriptor, verify_thread_token_fallback_error,
+            verify_windows_elevation_value, verify_windows_immutable_security_descriptor,
+            verify_windows_local_fixed_device_info, verify_windows_local_fixed_volume,
+            EffectiveTokenSource, OpenedChildKind, OwnerOnlySecurityAttributes, ProcessToken,
             WindowsImmutableAclProfile,
         };
         use std::ffi::OsString;
@@ -2596,6 +2640,78 @@ mod tests {
         }
 
         #[test]
+        fn owner_only_acl_verifier_rejects_a_reduced_access_mask() {
+            use windows_sys::Win32::Security::{
+                GetAce, GetSecurityDescriptorDacl, ACCESS_ALLOWED_ACE,
+            };
+
+            let security = OwnerOnlySecurityAttributes::current_user().unwrap();
+            let mut dacl_present = 0;
+            let mut dacl = ptr::null_mut();
+            let mut dacl_defaulted = 0;
+            // SAFETY: the security owner retains a valid descriptor and all output pointers are
+            // writable for the duration of the call.
+            assert_ne!(
+                unsafe {
+                    GetSecurityDescriptorDacl(
+                        security.security_descriptor(),
+                        &mut dacl_present,
+                        &mut dacl,
+                        &mut dacl_defaulted,
+                    )
+                },
+                0
+            );
+            assert_ne!(dacl_present, 0);
+            let mut ace = ptr::null_mut();
+            // SAFETY: the owner-only descriptor contains exactly one access-allowed ACE.
+            assert_ne!(unsafe { GetAce(dacl, 0, &mut ace) }, 0);
+            // SAFETY: the SDDL fixture creates an ACCESS_ALLOWED_ACE at index zero.
+            unsafe { (*ace.cast::<ACCESS_ALLOWED_ACE>()).Mask = 0 };
+
+            let error =
+                verify_owner_only_security_descriptor(security.security_descriptor()).unwrap_err();
+
+            assert!(error.to_string().contains("full access"), "{error}");
+        }
+
+        #[test]
+        fn owner_only_acl_verifier_rejects_an_unexpected_ace_flag() {
+            use windows_sys::Win32::Security::{
+                GetAce, GetSecurityDescriptorDacl, ACE_HEADER, INHERIT_ONLY_ACE,
+            };
+
+            let security = OwnerOnlySecurityAttributes::current_user().unwrap();
+            let mut dacl_present = 0;
+            let mut dacl = ptr::null_mut();
+            let mut dacl_defaulted = 0;
+            // SAFETY: the security owner retains a valid descriptor and all output pointers are
+            // writable for the duration of the call.
+            assert_ne!(
+                unsafe {
+                    GetSecurityDescriptorDacl(
+                        security.security_descriptor(),
+                        &mut dacl_present,
+                        &mut dacl,
+                        &mut dacl_defaulted,
+                    )
+                },
+                0
+            );
+            assert_ne!(dacl_present, 0);
+            let mut ace = ptr::null_mut();
+            // SAFETY: the owner-only descriptor contains exactly one ACE.
+            assert_ne!(unsafe { GetAce(dacl, 0, &mut ace) }, 0);
+            // SAFETY: GetAce returned a valid ACE header inside the live descriptor.
+            unsafe { (*ace.cast::<ACE_HEADER>()).AceFlags = INHERIT_ONLY_ACE as u8 };
+
+            let error =
+                verify_owner_only_security_descriptor(security.security_descriptor()).unwrap_err();
+
+            assert!(error.to_string().contains("flags"), "{error}");
+        }
+
+        #[test]
         fn owner_only_file_child_is_created_through_its_retained_parent() {
             use std::io::Write;
 
@@ -2847,8 +2963,12 @@ mod tests {
         #[test]
         fn windows_directory_parser_rejects_an_unaligned_next_record() {
             let mut buffer = vec![0u8; 512];
-            let next = 108u32;
             let name_length = 2u32;
+            let minimum_record_bytes =
+                offset_of!(FILE_ID_BOTH_DIR_INFO, FileName) + name_length as usize;
+            let next = (((minimum_record_bytes + 7) & !7) + 4) as u32;
+            assert!(next as usize >= minimum_record_bytes);
+            assert_eq!(next % 8, 4);
             // SAFETY: the test buffer is large enough for each field and unaligned writes accept
             // Vec<u8>'s alignment.
             unsafe {

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -197,6 +197,403 @@ fn windows_api_path(path: &Path) -> io::Result<Vec<u16>> {
     Ok(windows_api_path_from_utf16(encoded, true))
 }
 
+#[cfg(windows)]
+#[allow(
+    dead_code,
+    reason = "DirectoryAnchor callers are introduced by the following Windows full-dump task"
+)]
+struct ProcessToken {
+    handle: windows_sys::Win32::Foundation::HANDLE,
+    user: Vec<u8>,
+}
+
+#[cfg(windows)]
+impl ProcessToken {
+    fn current_user() -> io::Result<Self> {
+        use std::ptr;
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::Security::{GetTokenInformation, TokenUser, TOKEN_QUERY};
+        use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+        let mut handle = ptr::null_mut();
+        // SAFETY: GetCurrentProcess returns a valid pseudo-handle; handle is writable storage.
+        if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut handle) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let mut length = 0;
+        // SAFETY: the first call requests the buffer size without supplying a buffer.
+        unsafe {
+            GetTokenInformation(handle, TokenUser, ptr::null_mut(), 0, &mut length);
+        }
+        if length == 0 {
+            let error = io::Error::last_os_error();
+            // SAFETY: OpenProcessToken returned this owned handle.
+            unsafe { CloseHandle(handle) };
+            return Err(error);
+        }
+
+        let mut user = vec![0; length as usize];
+        // SAFETY: user provides the byte capacity requested by the preceding call.
+        if unsafe {
+            GetTokenInformation(
+                handle,
+                TokenUser,
+                user.as_mut_ptr().cast(),
+                length,
+                &mut length,
+            )
+        } == 0
+        {
+            let error = io::Error::last_os_error();
+            // SAFETY: OpenProcessToken returned this owned handle.
+            unsafe { CloseHandle(handle) };
+            return Err(error);
+        }
+
+        Ok(Self { handle, user })
+    }
+
+    fn user_sid(&self) -> windows_sys::Win32::Security::PSID {
+        use windows_sys::Win32::Security::TOKEN_USER;
+
+        // SAFETY: GetTokenInformation initialized the buffer as TOKEN_USER, including the SID
+        // pointer, and the buffer remains owned by self for this borrow.
+        unsafe {
+            std::ptr::read_unaligned(self.user.as_ptr().cast::<TOKEN_USER>())
+                .User
+                .Sid
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for ProcessToken {
+    fn drop(&mut self) {
+        use windows_sys::Win32::Foundation::CloseHandle;
+
+        // SAFETY: self.handle is an owned token handle returned by OpenProcessToken.
+        unsafe { CloseHandle(self.handle) };
+    }
+}
+
+#[cfg(windows)]
+#[allow(
+    dead_code,
+    reason = "DirectoryAnchor callers are introduced by the following Windows full-dump task"
+)]
+struct OwnerOnlySecurityAttributes {
+    token: ProcessToken,
+    sid_string: windows_sys::core::PWSTR,
+    security_descriptor: windows_sys::Win32::Security::PSECURITY_DESCRIPTOR,
+    attributes: windows_sys::Win32::Security::SECURITY_ATTRIBUTES,
+}
+
+#[cfg(windows)]
+impl OwnerOnlySecurityAttributes {
+    fn current_user() -> io::Result<Self> {
+        use std::mem::size_of;
+        use std::ptr;
+        use windows_sys::Win32::Foundation::LocalFree;
+        use windows_sys::Win32::Security::Authorization::{
+            ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW,
+            SDDL_REVISION_1,
+        };
+        use windows_sys::Win32::Security::SECURITY_ATTRIBUTES;
+
+        let token = ProcessToken::current_user()?;
+        let mut sid_string = ptr::null_mut();
+        // SAFETY: token.user_sid() is valid while token is live, and sid_string is writable.
+        if unsafe { ConvertSidToStringSidW(token.user_sid(), &mut sid_string) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let mut sddl = "D:P(A;;FA;;;".encode_utf16().collect::<Vec<_>>();
+        // SAFETY: ConvertSidToStringSidW returned a NUL-terminated UTF-16 string allocated by
+        // LocalAlloc, which remains live until OwnerOnlySecurityAttributes is dropped.
+        let sid_length = unsafe {
+            let mut length = 0;
+            while *sid_string.add(length) != 0 {
+                length += 1;
+            }
+            length
+        };
+        // SAFETY: sid_length stops at the allocation's terminating NUL.
+        sddl.extend_from_slice(unsafe { std::slice::from_raw_parts(sid_string, sid_length) });
+        sddl.extend(")".encode_utf16());
+        sddl.push(0);
+
+        let mut security_descriptor = ptr::null_mut();
+        // SAFETY: sddl is NUL-terminated for the duration of the call and the descriptor output
+        // pointer is writable.
+        if unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                sddl.as_ptr(),
+                SDDL_REVISION_1,
+                &mut security_descriptor,
+                ptr::null_mut(),
+            )
+        } == 0
+        {
+            let error = io::Error::last_os_error();
+            // SAFETY: ConvertSidToStringSidW allocated sid_string with LocalAlloc.
+            unsafe { LocalFree(sid_string.cast()) };
+            return Err(error);
+        }
+
+        Ok(Self {
+            token,
+            sid_string,
+            security_descriptor,
+            attributes: SECURITY_ATTRIBUTES {
+                nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
+                lpSecurityDescriptor: security_descriptor,
+                bInheritHandle: 0,
+            },
+        })
+    }
+
+    fn as_ptr(&self) -> *const windows_sys::Win32::Security::SECURITY_ATTRIBUTES {
+        let _ = self.token.handle;
+        &self.attributes
+    }
+}
+
+#[cfg(windows)]
+impl Drop for OwnerOnlySecurityAttributes {
+    fn drop(&mut self) {
+        use windows_sys::Win32::Foundation::LocalFree;
+
+        // SAFETY: both pointers were allocated by documented APIs with LocalAlloc semantics.
+        unsafe {
+            LocalFree(self.security_descriptor);
+            LocalFree(self.sid_string.cast());
+        }
+    }
+}
+
+#[cfg(windows)]
+#[allow(
+    dead_code,
+    reason = "DirectoryAnchor callers are introduced by the following Windows full-dump task"
+)]
+struct LocalSecurityDescriptor(windows_sys::Win32::Security::PSECURITY_DESCRIPTOR);
+
+#[cfg(windows)]
+impl Drop for LocalSecurityDescriptor {
+    fn drop(&mut self) {
+        use windows_sys::Win32::Foundation::LocalFree;
+
+        // SAFETY: GetSecurityInfo returns this descriptor through LocalAlloc.
+        unsafe { LocalFree(self.0) };
+    }
+}
+
+#[cfg(windows)]
+#[allow(
+    dead_code,
+    reason = "DirectoryAnchor callers are introduced by the following Windows full-dump task"
+)]
+pub(crate) fn open_directory_nofollow(path: &Path) -> io::Result<fs::File> {
+    use std::os::windows::io::FromRawHandle;
+    use std::ptr;
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_BACKUP_SEMANTICS,
+        FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ,
+        FILE_SHARE_WRITE, OPEN_EXISTING, READ_CONTROL,
+    };
+
+    let path = windows_api_path(path)?;
+    // SAFETY: path is NUL-terminated and all scalar arguments are documented Win32 flags.
+    let handle = unsafe {
+        CreateFileW(
+            path.as_ptr(),
+            FILE_READ_ATTRIBUTES | READ_CONTROL,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: CreateFileW returned an owned, valid file handle.
+    let file = unsafe { fs::File::from_raw_handle(handle) };
+    if windows_file_information(&file)?.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "directory path resolves to a reparse point",
+        ));
+    }
+    Ok(file)
+}
+
+#[cfg(windows)]
+#[allow(
+    dead_code,
+    reason = "DirectoryAnchor callers are introduced by the following Windows full-dump task"
+)]
+pub(crate) fn create_owner_only_directory(path: &Path) -> io::Result<fs::File> {
+    use windows_sys::Win32::Storage::FileSystem::CreateDirectoryW;
+
+    let api_path = windows_api_path(path)?;
+    let security = OwnerOnlySecurityAttributes::current_user()?;
+    // SAFETY: path is NUL-terminated and security owns the descriptor for this call.
+    if unsafe { CreateDirectoryW(api_path.as_ptr(), security.as_ptr()) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    open_directory_nofollow(path)
+}
+
+#[cfg(windows)]
+#[allow(
+    dead_code,
+    reason = "DirectoryAnchor callers are introduced by the following Windows full-dump task"
+)]
+pub(crate) fn create_owner_only_file(path: &Path) -> io::Result<fs::File> {
+    use std::os::windows::io::FromRawHandle;
+    use std::ptr;
+    use windows_sys::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_DELETE,
+    };
+
+    let path = windows_api_path(path)?;
+    let security = OwnerOnlySecurityAttributes::current_user()?;
+    // SAFETY: path is NUL-terminated and security owns the descriptor for this call.
+    let handle = unsafe {
+        CreateFileW(
+            path.as_ptr(),
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_DELETE,
+            security.as_ptr(),
+            CREATE_NEW,
+            FILE_ATTRIBUTE_NORMAL,
+            ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        Err(io::Error::last_os_error())
+    } else {
+        // SAFETY: CreateFileW returned an owned, valid file handle.
+        Ok(unsafe { fs::File::from_raw_handle(handle) })
+    }
+}
+
+#[cfg(windows)]
+#[allow(
+    dead_code,
+    reason = "DirectoryAnchor callers are introduced by the following Windows full-dump task"
+)]
+pub(crate) fn verify_owner_only_acl(file: &fs::File) -> io::Result<()> {
+    use std::mem::size_of;
+    use std::os::windows::io::AsRawHandle;
+    use std::ptr;
+    use windows_sys::Win32::Security::Authorization::{GetSecurityInfo, SE_FILE_OBJECT};
+    use windows_sys::Win32::Security::{
+        EqualSid, GetAce, GetAclInformation, GetSecurityDescriptorControl, ACCESS_ALLOWED_ACE,
+        ACL_SIZE_INFORMATION, AclSizeInformation, ACE_HEADER, DACL_SECURITY_INFORMATION,
+        INHERITED_ACE, SE_DACL_PROTECTED,
+    };
+
+    const ACCESS_ALLOWED_ACE_TYPE: u8 = 0;
+
+    let token = ProcessToken::current_user()?;
+    let mut dacl = ptr::null_mut();
+    let mut descriptor = ptr::null_mut();
+    // SAFETY: file owns a valid handle and all requested output pointers are writable.
+    let status = unsafe {
+        GetSecurityInfo(
+            file.as_raw_handle(),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            &mut dacl,
+            ptr::null_mut(),
+            &mut descriptor,
+        )
+    };
+    if status != 0 {
+        return Err(io::Error::from_raw_os_error(status as i32));
+    }
+    let descriptor = LocalSecurityDescriptor(descriptor);
+    if dacl.is_null() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "owner-only object has no DACL",
+        ));
+    }
+
+    let mut control = 0;
+    let mut revision = 0;
+    // SAFETY: descriptor is valid until its RAII wrapper drops.
+    if unsafe { GetSecurityDescriptorControl(descriptor.0, &mut control, &mut revision) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if control & SE_DACL_PROTECTED == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "owner-only object DACL is not protected",
+        ));
+    }
+
+    let mut information = ACL_SIZE_INFORMATION {
+        AceCount: 0,
+        AclBytesInUse: 0,
+        AclBytesFree: 0,
+    };
+    // SAFETY: dacl is valid for the descriptor lifetime and information is writable storage.
+    if unsafe {
+        GetAclInformation(
+            dacl,
+            (&mut information as *mut ACL_SIZE_INFORMATION).cast(),
+            size_of::<ACL_SIZE_INFORMATION>() as u32,
+            AclSizeInformation,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    if information.AceCount != 1 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "owner-only object DACL does not contain exactly one ACE",
+        ));
+    }
+
+    let mut ace = ptr::null_mut();
+    // SAFETY: dacl is valid and ACE index zero is within the exactly-one ACE DACL.
+    if unsafe { GetAce(dacl, 0, &mut ace) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: GetAce returned a pointer to a valid ACE in dacl.
+    let header = unsafe { &*ace.cast::<ACE_HEADER>() };
+    if header.AceType != ACCESS_ALLOWED_ACE_TYPE
+        || u32::from(header.AceFlags) & INHERITED_ACE != 0
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "owner-only object DACL has an unexpected ACE",
+        ));
+    }
+    // SAFETY: the ACE type is ACCESS_ALLOWED_ACE_TYPE, so its payload has this layout.
+    let allowed = unsafe { &*ace.cast::<ACCESS_ALLOWED_ACE>() };
+    let ace_sid: windows_sys::Win32::Security::PSID =
+        (&raw const allowed.SidStart).cast_mut().cast();
+    // SAFETY: both SIDs are valid: one belongs to the ACL and the other to the current token.
+    if unsafe { EqualSid(ace_sid, token.user_sid()) } == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "owner-only object DACL grants access to a different SID",
+        ));
+    }
+    Ok(())
+}
+
 pub(crate) fn install_file_no_clobber(source: &Path, target: &Path) -> io::Result<()> {
     fs::hard_link(source, target)
 }
@@ -504,6 +901,60 @@ mod tests {
 
     #[cfg(windows)]
     use super::strip_windows_extended_length_prefix;
+
+    #[cfg(windows)]
+    mod windows {
+        use super::{fs, io, unique_temp_root};
+        use crate::infrastructure::platform::filesystem::{
+            create_owner_only_directory, create_owner_only_file, file_identity,
+            open_directory_nofollow, verify_owner_only_acl,
+        };
+
+        #[test]
+        fn owner_only_directory_is_opened_without_following_reparse_points() {
+            let root = unique_temp_root("owner-only-directory");
+            fs::create_dir_all(&root).unwrap();
+            let private = root.join("private");
+
+            let handle = create_owner_only_directory(&private).unwrap();
+
+            verify_owner_only_acl(&handle).unwrap();
+            assert_eq!(
+                file_identity(&handle).unwrap(),
+                file_identity(&open_directory_nofollow(&private).unwrap()).unwrap()
+            );
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn directory_open_rejects_a_reparse_point() {
+            let root = unique_temp_root("directory-reparse");
+            let real = root.join("real");
+            let link = root.join("link");
+            fs::create_dir_all(&real).unwrap();
+            std::os::windows::fs::symlink_dir(&real, &link).unwrap();
+
+            let error = open_directory_nofollow(&link).unwrap_err();
+
+            assert!(matches!(
+                error.kind(),
+                io::ErrorKind::InvalidInput | io::ErrorKind::PermissionDenied
+            ));
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn owner_only_file_has_the_final_acl_at_creation() {
+            let root = unique_temp_root("owner-only-file");
+            fs::create_dir_all(&root).unwrap();
+            let private = root.join("effective.yaml");
+
+            let handle = create_owner_only_file(&private).unwrap();
+
+            verify_owner_only_acl(&handle).unwrap();
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
 
     fn unique_temp_root(name: &str) -> PathBuf {
         let nanos = SystemTime::now()

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -1340,12 +1340,10 @@ pub(crate) fn open_regular_child_nofollow(
 pub(crate) fn open_any_child_nofollow(
     parent: &fs::File,
     name: &std::ffi::OsStr,
-) -> io::Result<fs::File> {
+) -> io::Result<(fs::File, OpenedChildKind)> {
     const FILE_OPEN: u32 = 0x0000_0001;
     const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-    use windows_sys::Win32::Storage::FileSystem::{
-        FILE_ATTRIBUTE_REPARSE_POINT, FILE_READ_ATTRIBUTES, SYNCHRONIZE,
-    };
+    use windows_sys::Win32::Storage::FileSystem::{FILE_READ_ATTRIBUTES, SYNCHRONIZE};
 
     let file = open_relative_child(
         parent,
@@ -1356,13 +1354,8 @@ pub(crate) fn open_any_child_nofollow(
         FILE_OPEN_REPARSE_POINT,
         None,
     )?;
-    if windows_file_information(&file)?.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "child resolves to a reparse point",
-        ));
-    }
-    Ok(file)
+    let kind = opened_child_kind(&file)?;
+    Ok((file, kind))
 }
 
 #[cfg(windows)]
@@ -2346,7 +2339,7 @@ mod tests {
             capture_windows_immutable_entry_evidence, create_owner_only_directory,
             create_owner_only_directory_child, create_owner_only_file,
             create_owner_only_file_child, delete_open_child, directory_query_is_end, file_identity,
-            nt_create_options_for_std_file, open_any_child_for_delete,
+            nt_create_options_for_std_file, open_any_child_for_delete, open_any_child_nofollow,
             open_directory_child_for_rename, open_directory_child_nofollow,
             open_directory_nofollow, open_regular_child_nofollow, opened_child_kind,
             parse_directory_information_buffer, read_directory_names,
@@ -2857,6 +2850,25 @@ mod tests {
             drop(created);
             drop(parent);
             drop(root_handle);
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn windows_open_any_child_nofollow_classifies_a_reparse_point() {
+            let root = unique_temp_root("open-any-reparse");
+            fs::create_dir_all(&root).unwrap();
+            let target = root.join("target.txt");
+            fs::write(&target, b"target").unwrap();
+            std::os::windows::fs::symlink_file(&target, root.join("link.txt")).unwrap();
+            let parent = open_directory_nofollow(&root).unwrap();
+
+            let (opened, kind) = open_any_child_nofollow(&parent, std::ffi::OsStr::new("link.txt"))
+                .expect("a no-follow open must return the reparse point itself");
+
+            assert_eq!(kind, OpenedChildKind::ReparsePoint);
+            assert_eq!(opened_child_kind(&opened).unwrap(), kind);
+            drop(opened);
+            drop(parent);
             fs::remove_dir_all(root).unwrap();
         }
 

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -633,6 +633,31 @@ pub(crate) fn open_directory_child_nofollow(
     const FILE_DIRECTORY_FILE: u32 = 0x0000_0001;
     const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
     use windows_sys::Win32::Storage::FileSystem::{
+        FILE_READ_ATTRIBUTES, READ_CONTROL, SYNCHRONIZE,
+    };
+
+    let file = open_relative_child(
+        parent,
+        name,
+        FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE,
+        0,
+        FILE_OPEN,
+        FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT,
+        None,
+    )?;
+    validate_directory_handle(&file)?;
+    Ok(file)
+}
+
+#[cfg(windows)]
+pub(crate) fn open_directory_child_for_rename(
+    parent: &fs::File,
+    name: &std::ffi::OsStr,
+) -> io::Result<fs::File> {
+    const FILE_OPEN: u32 = 0x0000_0001;
+    const FILE_DIRECTORY_FILE: u32 = 0x0000_0001;
+    const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    use windows_sys::Win32::Storage::FileSystem::{
         DELETE, FILE_READ_ATTRIBUTES, READ_CONTROL, SYNCHRONIZE,
     };
 

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -559,6 +559,24 @@ fn validate_directory_handle(file: &fs::File) -> io::Result<()> {
 }
 
 #[cfg(windows)]
+fn nt_create_options_for_std_file(desired_access: u32, create_options: u32) -> io::Result<u32> {
+    use windows_sys::Win32::Foundation::{
+        GENERIC_ALL, GENERIC_EXECUTE, GENERIC_READ, GENERIC_WRITE,
+    };
+    use windows_sys::Win32::Storage::FileSystem::SYNCHRONIZE;
+
+    const FILE_SYNCHRONOUS_IO_NONALERT: u32 = 0x0000_0020;
+    let generic_synchronous_access = GENERIC_ALL | GENERIC_EXECUTE | GENERIC_READ | GENERIC_WRITE;
+    if desired_access & SYNCHRONIZE == 0 && desired_access & generic_synchronous_access == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "std::fs::File native handles require SYNCHRONIZE-compatible access",
+        ));
+    }
+    Ok(create_options | FILE_SYNCHRONOUS_IO_NONALERT)
+}
+
+#[cfg(windows)]
 fn open_relative_child(
     parent: &fs::File,
     name: &std::ffi::OsStr,
@@ -576,6 +594,7 @@ fn open_relative_child(
     };
 
     const OBJ_CASE_INSENSITIVE: u32 = 0x40;
+    let create_options = nt_create_options_for_std_file(desired_access, create_options)?;
     let mut name = relative_child_name(name)?;
     let byte_length = name
         .len()
@@ -718,18 +737,127 @@ pub(crate) fn open_any_child_nofollow(
 }
 
 #[cfg(windows)]
+fn directory_query_is_end(restart: bool, error: &io::Error) -> bool {
+    use windows_sys::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_NO_MORE_FILES};
+
+    matches!(
+        error.raw_os_error(),
+        Some(code)
+            if code == ERROR_NO_MORE_FILES as i32
+                || restart && code == ERROR_FILE_NOT_FOUND as i32
+    )
+}
+
+#[cfg(windows)]
+fn parse_directory_information_buffer(
+    buffer: &[u8],
+    names: &mut Vec<std::ffi::OsString>,
+) -> io::Result<()> {
+    use std::mem::{offset_of, size_of};
+    use std::os::windows::ffi::OsStringExt;
+    use windows_sys::Win32::Storage::FileSystem::FILE_ID_BOTH_DIR_INFO;
+
+    let file_name_offset = offset_of!(FILE_ID_BOTH_DIR_INFO, FileName);
+    let complete_header_size = size_of::<FILE_ID_BOTH_DIR_INFO>();
+    let mut offset = 0usize;
+    loop {
+        let complete_header_end = offset.checked_add(complete_header_size).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "directory entry complete header offset overflowed",
+            )
+        })?;
+        if complete_header_end > buffer.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "directory entry complete header exceeds the enumeration buffer",
+            ));
+        }
+        // SAFETY: the complete Rust structure was bounds-checked above; read_unaligned accepts
+        // every record offset supplied by the filesystem.
+        let entry = unsafe {
+            std::ptr::read_unaligned(buffer.as_ptr().add(offset).cast::<FILE_ID_BOTH_DIR_INFO>())
+        };
+        let name_bytes = entry.FileNameLength as usize;
+        if name_bytes == 0 || name_bytes % size_of::<u16>() != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "directory entry has an invalid UTF-16 name length",
+            ));
+        }
+        let name_start = offset.checked_add(file_name_offset).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "directory entry name offset overflowed",
+            )
+        })?;
+        let name_end = name_start.checked_add(name_bytes).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "directory entry name offset overflowed",
+            )
+        })?;
+        if name_end > buffer.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "directory entry name exceeds the enumeration buffer",
+            ));
+        }
+        let mut name = Vec::with_capacity(name_bytes / size_of::<u16>());
+        for unit_offset in (name_start..name_end).step_by(size_of::<u16>()) {
+            // SAFETY: every two-byte unit lies within the checked name range; read_unaligned
+            // accepts the byte buffer's alignment.
+            name.push(unsafe {
+                std::ptr::read_unaligned(buffer.as_ptr().add(unit_offset).cast::<u16>())
+            });
+        }
+        let name = std::ffi::OsString::from_wide(&name);
+        if name != "." && name != ".." {
+            names.push(name);
+        }
+
+        let next = entry.NextEntryOffset as usize;
+        if next == 0 {
+            break;
+        }
+        let minimum_record_bytes = file_name_offset.checked_add(name_bytes).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "directory entry record length overflowed",
+            )
+        })?;
+        if next < minimum_record_bytes || next % 8 != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "directory entry next-record offset is not 8-byte-aligned or overlaps the name",
+            ));
+        }
+        offset = offset.checked_add(next).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "directory entry offset overflowed",
+            )
+        })?;
+        if offset >= buffer.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "directory entry offset exceeds the enumeration buffer",
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
 #[allow(
     dead_code,
     reason = "the following Windows full-dump tree-inspection task consumes retained enumeration"
 )]
 pub(crate) fn read_directory_names(directory: &fs::File) -> io::Result<Vec<std::ffi::OsString>> {
-    use std::mem::{offset_of, size_of};
-    use std::os::windows::ffi::OsStringExt;
+    use std::mem::size_of;
     use std::os::windows::io::AsRawHandle;
-    use windows_sys::Win32::Foundation::ERROR_NO_MORE_FILES;
     use windows_sys::Win32::Storage::FileSystem::{
         FileIdBothDirectoryInfo, FileIdBothDirectoryRestartInfo, GetFileInformationByHandleEx,
-        FILE_ID_BOTH_DIR_INFO,
     };
 
     const BUFFER_BYTES: usize = 64 * 1024;
@@ -738,7 +866,6 @@ pub(crate) fn read_directory_names(directory: &fs::File) -> io::Result<Vec<std::
     let word_count = BUFFER_BYTES.div_ceil(size_of::<usize>());
     let mut storage = vec![0usize; word_count];
     let buffer_bytes = storage.len() * size_of::<usize>();
-    let file_name_offset = offset_of!(FILE_ID_BOTH_DIR_INFO, FileName);
     let mut names = Vec::new();
     let mut restart = true;
     loop {
@@ -760,100 +887,18 @@ pub(crate) fn read_directory_names(directory: &fs::File) -> io::Result<Vec<std::
         };
         if succeeded == 0 {
             let error = io::Error::last_os_error();
-            if error.raw_os_error() == Some(ERROR_NO_MORE_FILES as i32) {
+            if directory_query_is_end(restart, &error) {
                 break;
             }
             return Err(error);
         }
         restart = false;
 
-        let mut offset = 0usize;
-        loop {
-            let header_end = offset.checked_add(file_name_offset).ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "directory entry header offset overflowed",
-                )
-            })?;
-            if header_end > buffer_bytes {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "directory entry header exceeds the enumeration buffer",
-                ));
-            }
-            // SAFETY: the fixed header was bounds-checked above; read_unaligned also accepts any
-            // offset alignment returned by the filesystem.
-            let entry = unsafe {
-                std::ptr::read_unaligned(
-                    storage
-                        .as_ptr()
-                        .cast::<u8>()
-                        .add(offset)
-                        .cast::<FILE_ID_BOTH_DIR_INFO>(),
-                )
-            };
-            let name_bytes = usize::try_from(entry.FileNameLength).map_err(|_| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "directory entry name length is not representable",
-                )
-            })?;
-            if name_bytes == 0 || name_bytes % size_of::<u16>() != 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "directory entry has an invalid UTF-16 name length",
-                ));
-            }
-            let name_end = header_end.checked_add(name_bytes).ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "directory entry name offset overflowed",
-                )
-            })?;
-            if name_end > buffer_bytes {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "directory entry name exceeds the enumeration buffer",
-                ));
-            }
-            // SAFETY: the complete name byte range was bounds-checked and the length is even.
-            let name = unsafe {
-                std::slice::from_raw_parts(
-                    storage.as_ptr().cast::<u8>().add(header_end).cast::<u16>(),
-                    name_bytes / size_of::<u16>(),
-                )
-            };
-            let name = std::ffi::OsString::from_wide(name);
-            if name != "." && name != ".." {
-                names.push(name);
-            }
-
-            let next = entry.NextEntryOffset as usize;
-            if next == 0 {
-                break;
-            }
-            if next < file_name_offset
-                || next < file_name_offset + name_bytes
-                || next % size_of::<u32>() != 0
-            {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "directory entry has an invalid next-record offset",
-                ));
-            }
-            offset = offset.checked_add(next).ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "directory entry offset overflowed",
-                )
-            })?;
-            if offset >= buffer_bytes {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "directory entry offset exceeds the enumeration buffer",
-                ));
-            }
-        }
+        // SAFETY: storage owns buffer_bytes initialized bytes for this query. The parser performs
+        // complete structure, name, and next-record bounds checks before reading each field.
+        let buffer =
+            unsafe { std::slice::from_raw_parts(storage.as_ptr().cast::<u8>(), buffer_bytes) };
+        parse_directory_information_buffer(buffer, &mut names)?;
     }
     names.sort();
     Ok(names)
@@ -1520,10 +1565,16 @@ mod tests {
         use super::{fs, io, unique_temp_root};
         use crate::infrastructure::platform::filesystem::{
             create_owner_only_directory, create_owner_only_directory_child, create_owner_only_file,
-            file_identity, open_directory_child_nofollow, open_directory_nofollow,
-            read_directory_names, verify_owner_only_acl,
+            directory_query_is_end, file_identity, nt_create_options_for_std_file,
+            open_directory_child_nofollow, open_directory_nofollow,
+            parse_directory_information_buffer, read_directory_names, verify_owner_only_acl,
         };
         use std::ffi::OsString;
+        use std::mem::{offset_of, size_of};
+        use windows_sys::Win32::Foundation::{
+            ERROR_ACCESS_DENIED, ERROR_FILE_NOT_FOUND, ERROR_NO_MORE_FILES,
+        };
+        use windows_sys::Win32::Storage::FileSystem::FILE_ID_BOTH_DIR_INFO;
 
         #[test]
         fn owner_only_directory_is_opened_without_following_reparse_points() {
@@ -1639,6 +1690,125 @@ mod tests {
             drop(child);
             drop(parent);
             fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn windows_nt_create_options_for_std_file_are_synchronous() {
+            const FILE_DIRECTORY_FILE: u32 = 0x0000_0001;
+            const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+            const FILE_SYNCHRONOUS_IO_ALERT: u32 = 0x0000_0010;
+            const FILE_SYNCHRONOUS_IO_NONALERT: u32 = 0x0000_0020;
+            use windows_sys::Win32::Storage::FileSystem::SYNCHRONIZE;
+
+            let options = nt_create_options_for_std_file(
+                SYNCHRONIZE,
+                FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT,
+            )
+            .unwrap();
+
+            assert_ne!(options & FILE_SYNCHRONOUS_IO_NONALERT, 0);
+            assert_eq!(options & FILE_SYNCHRONOUS_IO_ALERT, 0);
+            assert_ne!(options & FILE_DIRECTORY_FILE, 0);
+            assert_ne!(options & FILE_OPEN_REPARSE_POINT, 0);
+        }
+
+        #[test]
+        fn windows_nt_create_options_reject_asynchronous_std_file_access() {
+            let error = nt_create_options_for_std_file(0, 0).unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+            assert!(error.to_string().contains("SYNCHRONIZE"), "{error}");
+        }
+
+        #[test]
+        fn windows_directory_enumeration_status_classifier_distinguishes_first_query_eos() {
+            let no_more = io::Error::from_raw_os_error(ERROR_NO_MORE_FILES as i32);
+            let no_match = io::Error::from_raw_os_error(ERROR_FILE_NOT_FOUND as i32);
+            let denied = io::Error::from_raw_os_error(ERROR_ACCESS_DENIED as i32);
+
+            assert!(directory_query_is_end(true, &no_more));
+            assert!(directory_query_is_end(false, &no_more));
+            assert!(directory_query_is_end(true, &no_match));
+            assert!(!directory_query_is_end(false, &no_match));
+            assert!(!directory_query_is_end(true, &denied));
+        }
+
+        #[test]
+        fn windows_directory_enumeration_accepts_an_empty_retained_directory() {
+            let root = unique_temp_root("empty-enumeration");
+            fs::create_dir_all(&root).unwrap();
+            let directory = open_directory_nofollow(&root).unwrap();
+
+            assert!(read_directory_names(&directory).unwrap().is_empty());
+
+            drop(directory);
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn windows_directory_enumeration_reads_multiple_native_buffers() {
+            let root = unique_temp_root("multi-buffer-enumeration");
+            fs::create_dir_all(&root).unwrap();
+            let mut expected = Vec::new();
+            for index in 0..900 {
+                let name = format!("{index:04}-{}.xml", "x".repeat(80));
+                fs::write(root.join(&name), b"x").unwrap();
+                expected.push(OsString::from(name));
+            }
+            let directory = open_directory_nofollow(&root).unwrap();
+
+            let names = read_directory_names(&directory).unwrap();
+
+            assert_eq!(names, expected);
+            drop(directory);
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn windows_directory_parser_rejects_an_unaligned_next_record() {
+            let mut buffer = vec![0u8; 512];
+            let next = 108u32;
+            let name_length = 2u32;
+            // SAFETY: the test buffer is large enough for each field and unaligned writes accept
+            // Vec<u8>'s alignment.
+            unsafe {
+                std::ptr::write_unaligned(
+                    buffer
+                        .as_mut_ptr()
+                        .add(offset_of!(FILE_ID_BOTH_DIR_INFO, NextEntryOffset))
+                        .cast::<u32>(),
+                    next,
+                );
+                std::ptr::write_unaligned(
+                    buffer
+                        .as_mut_ptr()
+                        .add(offset_of!(FILE_ID_BOTH_DIR_INFO, FileNameLength))
+                        .cast::<u32>(),
+                    name_length,
+                );
+                std::ptr::write_unaligned(
+                    buffer
+                        .as_mut_ptr()
+                        .add(offset_of!(FILE_ID_BOTH_DIR_INFO, FileName))
+                        .cast::<u16>(),
+                    b'a' as u16,
+                );
+            }
+            let mut names = Vec::new();
+
+            let error = parse_directory_information_buffer(&buffer, &mut names).unwrap_err();
+
+            assert!(error.to_string().contains("8-byte-aligned"), "{error}");
+        }
+
+        #[test]
+        fn windows_directory_parser_rejects_a_truncated_rust_header() {
+            let buffer = vec![0u8; size_of::<FILE_ID_BOTH_DIR_INFO>() - 1];
+            let mut names = Vec::new();
+
+            let error = parse_directory_information_buffer(&buffer, &mut names).unwrap_err();
+
+            assert!(error.to_string().contains("complete header"), "{error}");
         }
     }
 

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -399,9 +399,9 @@ pub(crate) fn open_directory_nofollow(path: &Path) -> io::Result<fs::File> {
     use std::ptr;
     use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
     use windows_sys::Win32::Storage::FileSystem::{
-        CreateFileW, FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_BACKUP_SEMANTICS,
-        FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ,
-        FILE_SHARE_WRITE, OPEN_EXISTING, READ_CONTROL,
+        CreateFileW, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING, READ_CONTROL,
     };
 
     let path = windows_api_path(path)?;
@@ -422,10 +422,17 @@ pub(crate) fn open_directory_nofollow(path: &Path) -> io::Result<fs::File> {
     }
     // SAFETY: CreateFileW returned an owned, valid file handle.
     let file = unsafe { fs::File::from_raw_handle(handle) };
-    if windows_file_information(&file)?.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+    let attributes = windows_file_information(&file)?.dwFileAttributes;
+    if attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "directory path resolves to a reparse point",
+        ));
+    }
+    if attributes & FILE_ATTRIBUTE_DIRECTORY == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "directory path does not resolve to a directory",
         ));
     }
     Ok(file)
@@ -940,6 +947,19 @@ mod tests {
                 error.kind(),
                 io::ErrorKind::InvalidInput | io::ErrorKind::PermissionDenied
             ));
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn directory_open_rejects_an_ordinary_file() {
+            let root = unique_temp_root("directory-file");
+            fs::create_dir_all(&root).unwrap();
+            let file = root.join("not-a-directory");
+            fs::write(&file, b"not a directory").unwrap();
+
+            let error = open_directory_nofollow(&file).unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
             fs::remove_dir_all(root).unwrap();
         }
 

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -357,6 +357,10 @@ impl OwnerOnlySecurityAttributes {
         let _ = self.token.handle;
         &self.attributes
     }
+
+    fn security_descriptor(&self) -> windows_sys::Win32::Security::PSECURITY_DESCRIPTOR {
+        self.security_descriptor
+    }
 }
 
 #[cfg(windows)]
@@ -436,6 +440,304 @@ pub(crate) fn open_directory_nofollow(path: &Path) -> io::Result<fs::File> {
         ));
     }
     Ok(file)
+}
+
+#[cfg(windows)]
+#[repr(C)]
+struct NtUnicodeString {
+    length: u16,
+    maximum_length: u16,
+    buffer: windows_sys::core::PWSTR,
+}
+
+#[cfg(windows)]
+#[repr(C)]
+struct NtObjectAttributes {
+    length: u32,
+    root_directory: windows_sys::Win32::Foundation::HANDLE,
+    object_name: *mut NtUnicodeString,
+    attributes: u32,
+    security_descriptor: *mut std::ffi::c_void,
+    security_quality_of_service: *mut std::ffi::c_void,
+}
+
+#[cfg(windows)]
+#[repr(C)]
+union NtIoStatusStatus {
+    status: i32,
+    pointer: *mut std::ffi::c_void,
+}
+
+#[cfg(windows)]
+#[repr(C)]
+struct NtIoStatusBlock {
+    status: NtIoStatusStatus,
+    information: usize,
+}
+
+#[cfg(windows)]
+unsafe extern "system" {
+    fn NtCreateFile(
+        file_handle: *mut windows_sys::Win32::Foundation::HANDLE,
+        desired_access: u32,
+        object_attributes: *mut NtObjectAttributes,
+        io_status_block: *mut NtIoStatusBlock,
+        allocation_size: *mut i64,
+        file_attributes: u32,
+        share_access: u32,
+        create_disposition: u32,
+        create_options: u32,
+        ea_buffer: *mut std::ffi::c_void,
+        ea_length: u32,
+    ) -> i32;
+    fn NtSetInformationFile(
+        file_handle: windows_sys::Win32::Foundation::HANDLE,
+        io_status_block: *mut NtIoStatusBlock,
+        file_information: *mut std::ffi::c_void,
+        length: u32,
+        file_information_class: u32,
+    ) -> i32;
+    fn RtlNtStatusToDosError(status: i32) -> u32;
+}
+
+#[cfg(windows)]
+fn nt_status_error(status: i32) -> io::Error {
+    // SAFETY: RtlNtStatusToDosError accepts all NTSTATUS values and returns a Win32 error code.
+    let error = unsafe { RtlNtStatusToDosError(status) };
+    io::Error::from_raw_os_error(error as i32)
+}
+
+#[cfg(windows)]
+fn relative_child_name(name: &std::ffi::OsStr) -> io::Result<Vec<u16>> {
+    use std::os::windows::ffi::OsStrExt;
+    use std::path::Component;
+
+    let mut components = Path::new(name).components();
+    if !matches!(components.next(), Some(Component::Normal(component)) if component == name)
+        || components.next().is_some()
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "directory child name must be exactly one normal relative component",
+        ));
+    }
+    let wide = name.encode_wide().collect::<Vec<_>>();
+    if wide.is_empty()
+        || wide
+            .iter()
+            .any(|unit| {
+                *unit == 0
+                    || *unit == b'\\' as u16
+                    || *unit == b'/' as u16
+                    || *unit == b':' as u16
+            })
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "directory child name must not contain separators, a stream name, or NUL",
+        ));
+    }
+    Ok(wide)
+}
+
+#[cfg(windows)]
+fn validate_directory_handle(file: &fs::File) -> io::Result<()> {
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
+    };
+
+    let attributes = windows_file_information(&file)?.dwFileAttributes;
+    if attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "directory child resolves to a reparse point",
+        ));
+    }
+    if attributes & FILE_ATTRIBUTE_DIRECTORY == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "directory child does not resolve to a directory",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn open_relative_child(
+    parent: &fs::File,
+    name: &std::ffi::OsStr,
+    desired_access: u32,
+    file_attributes: u32,
+    create_disposition: u32,
+    create_options: u32,
+    security_descriptor: Option<windows_sys::Win32::Security::PSECURITY_DESCRIPTOR>,
+) -> io::Result<fs::File> {
+    use std::mem::size_of;
+    use std::os::windows::io::{AsRawHandle, FromRawHandle};
+    use std::ptr;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    };
+
+    const OBJ_CASE_INSENSITIVE: u32 = 0x40;
+    let mut name = relative_child_name(name)?;
+    let byte_length = name
+        .len()
+        .checked_mul(size_of::<u16>())
+        .and_then(|length| u16::try_from(length).ok())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "child name is too long"))?;
+    let mut object_name = NtUnicodeString {
+        length: byte_length,
+        maximum_length: byte_length,
+        buffer: name.as_mut_ptr(),
+    };
+    let mut attributes = NtObjectAttributes {
+        length: size_of::<NtObjectAttributes>() as u32,
+        root_directory: parent.as_raw_handle(),
+        object_name: &mut object_name,
+        attributes: OBJ_CASE_INSENSITIVE,
+        security_descriptor: security_descriptor.unwrap_or(ptr::null_mut()).cast(),
+        security_quality_of_service: ptr::null_mut(),
+    };
+    let mut status = NtIoStatusBlock {
+        status: NtIoStatusStatus { status: 0 },
+        information: 0,
+    };
+    let mut handle = ptr::null_mut();
+    // SAFETY: the root handle is borrowed from parent, and all pointers refer to valid mutable
+    // storage for the duration of NtCreateFile. The child name is validated as one relative
+    // component, so RootDirectory binds the operation to the retained parent handle.
+    let result = unsafe {
+        NtCreateFile(
+            &mut handle,
+            desired_access,
+            &mut attributes,
+            &mut status,
+            ptr::null_mut(),
+            file_attributes,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            create_disposition,
+            create_options,
+            ptr::null_mut(),
+            0,
+        )
+    };
+    if result < 0 {
+        return Err(nt_status_error(result));
+    }
+    // SAFETY: a non-error NtCreateFile result returns an owned file handle.
+    Ok(unsafe { fs::File::from_raw_handle(handle) })
+}
+
+#[cfg(windows)]
+pub(crate) fn open_directory_child_nofollow(
+    parent: &fs::File,
+    name: &std::ffi::OsStr,
+) -> io::Result<fs::File> {
+    const FILE_OPEN: u32 = 0x0000_0001;
+    const FILE_DIRECTORY_FILE: u32 = 0x0000_0001;
+    const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_READ_ATTRIBUTES, READ_CONTROL, SYNCHRONIZE,
+    };
+
+    let file = open_relative_child(
+        parent,
+        name,
+        FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE,
+        0,
+        FILE_OPEN,
+        FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT,
+        None,
+    )?;
+    validate_directory_handle(&file)?;
+    Ok(file)
+}
+
+#[cfg(windows)]
+pub(crate) fn create_owner_only_directory_child(
+    parent: &fs::File,
+    name: &std::ffi::OsStr,
+) -> io::Result<fs::File> {
+    const FILE_CREATE: u32 = 0x0000_0002;
+    const FILE_DIRECTORY_FILE: u32 = 0x0000_0001;
+    const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    use windows_sys::Win32::Storage::FileSystem::{
+        DELETE, FILE_ATTRIBUTE_DIRECTORY, FILE_READ_ATTRIBUTES, READ_CONTROL, SYNCHRONIZE,
+    };
+
+    let security = OwnerOnlySecurityAttributes::current_user()?;
+    let file = open_relative_child(
+        parent,
+        name,
+        DELETE | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE,
+        FILE_ATTRIBUTE_DIRECTORY,
+        FILE_CREATE,
+        FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT,
+        Some(security.security_descriptor()),
+    )?;
+    if let Err(error) = validate_directory_handle(&file) {
+        return match discard_created_child(&file) {
+            Ok(()) => Err(error),
+            Err(cleanup) => Err(io::Error::new(
+                error.kind(),
+                format!("{error}; failed to remove invalid created directory: {cleanup}"),
+            )),
+        };
+    }
+    Ok(file)
+}
+
+#[cfg(windows)]
+pub(crate) fn create_owner_only_file_child(
+    parent: &fs::File,
+    name: &std::ffi::OsStr,
+) -> io::Result<fs::File> {
+    const FILE_CREATE: u32 = 0x0000_0002;
+    const FILE_NON_DIRECTORY_FILE: u32 = 0x0000_0040;
+    const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    use windows_sys::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE};
+    use windows_sys::Win32::Storage::FileSystem::{DELETE, FILE_ATTRIBUTE_NORMAL};
+
+    let security = OwnerOnlySecurityAttributes::current_user()?;
+    open_relative_child(
+        parent,
+        name,
+        GENERIC_READ | GENERIC_WRITE | DELETE,
+        FILE_ATTRIBUTE_NORMAL,
+        FILE_CREATE,
+        FILE_NON_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT,
+        Some(security.security_descriptor()),
+    )
+}
+
+#[cfg(windows)]
+pub(crate) fn discard_created_child(file: &fs::File) -> io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+
+    const FILE_DISPOSITION_INFORMATION: u32 = 13;
+    let mut delete_file = 1u8;
+    let mut status = NtIoStatusBlock {
+        status: NtIoStatusStatus { status: 0 },
+        information: 0,
+    };
+    // SAFETY: file is an owned handle opened with DELETE access by the child-creation helpers,
+    // and delete_file/status remain writable for the duration of the native call. Once marked,
+    // the only subsequent operation on the handle is Drop/close.
+    let result = unsafe {
+        NtSetInformationFile(
+            file.as_raw_handle(),
+            &mut status,
+            (&mut delete_file as *mut u8).cast(),
+            std::mem::size_of_val(&delete_file) as u32,
+            FILE_DISPOSITION_INFORMATION,
+        )
+    };
+    if result < 0 {
+        Err(nt_status_error(result))
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(windows)]

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -523,14 +523,9 @@ fn relative_child_name(name: &std::ffi::OsStr) -> io::Result<Vec<u16>> {
     }
     let wide = name.encode_wide().collect::<Vec<_>>();
     if wide.is_empty()
-        || wide
-            .iter()
-            .any(|unit| {
-                *unit == 0
-                    || *unit == b'\\' as u16
-                    || *unit == b'/' as u16
-                    || *unit == b':' as u16
-            })
+        || wide.iter().any(|unit| {
+            *unit == 0 || *unit == b'\\' as u16 || *unit == b'/' as u16 || *unit == b':' as u16
+        })
     {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -803,8 +798,8 @@ pub(crate) fn verify_owner_only_acl(file: &fs::File) -> io::Result<()> {
     use std::ptr;
     use windows_sys::Win32::Security::Authorization::{GetSecurityInfo, SE_FILE_OBJECT};
     use windows_sys::Win32::Security::{
-        EqualSid, GetAce, GetAclInformation, GetSecurityDescriptorControl, ACCESS_ALLOWED_ACE,
-        ACL_SIZE_INFORMATION, AclSizeInformation, ACE_HEADER, DACL_SECURITY_INFORMATION,
+        AclSizeInformation, EqualSid, GetAce, GetAclInformation, GetSecurityDescriptorControl,
+        ACCESS_ALLOWED_ACE, ACE_HEADER, ACL_SIZE_INFORMATION, DACL_SECURITY_INFORMATION,
         INHERITED_ACE, SE_DACL_PROTECTED,
     };
 
@@ -881,8 +876,7 @@ pub(crate) fn verify_owner_only_acl(file: &fs::File) -> io::Result<()> {
     }
     // SAFETY: GetAce returned a pointer to a valid ACE in dacl.
     let header = unsafe { &*ace.cast::<ACE_HEADER>() };
-    if header.AceType != ACCESS_ALLOWED_ACE_TYPE
-        || u32::from(header.AceFlags) & INHERITED_ACE != 0
+    if header.AceType != ACCESS_ALLOWED_ACE_TYPE || u32::from(header.AceFlags) & INHERITED_ACE != 0
     {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -1619,7 +1619,7 @@ pub(crate) fn create_owner_only_directory_child(
     };
 
     let security = OwnerOnlySecurityAttributes::current_user()?;
-    let file = open_relative_child(
+    let created = open_relative_child(
         parent,
         name,
         DELETE | FILE_LIST_DIRECTORY | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE,
@@ -1628,8 +1628,8 @@ pub(crate) fn create_owner_only_directory_child(
         FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT,
         Some(security.security_descriptor()),
     )?;
-    if let Err(error) = validate_directory_handle(&file) {
-        return match discard_created_child(&file) {
+    if let Err(error) = validate_directory_handle(&created) {
+        return match discard_created_child(&created) {
             Ok(()) => Err(error),
             Err(cleanup) => Err(io::Error::new(
                 error.kind(),
@@ -1637,7 +1637,57 @@ pub(crate) fn create_owner_only_directory_child(
             )),
         };
     }
-    Ok(file)
+    let expected_identity = match file_identity(&created) {
+        Ok(identity) => identity,
+        Err(error) => {
+            return match discard_created_child(&created) {
+                Ok(()) => Err(error),
+                Err(cleanup) => Err(io::Error::new(
+                    error.kind(),
+                    format!("{error}; failed to remove unverified created directory: {cleanup}"),
+                )),
+            };
+        }
+    };
+    let reopened = match open_directory_child_nofollow(parent, name) {
+        Ok(reopened) => reopened,
+        Err(error) => {
+            return match discard_created_child(&created) {
+                Ok(()) => Err(error),
+                Err(cleanup) => Err(io::Error::new(
+                    error.kind(),
+                    format!("{error}; failed to remove unreopenable created directory: {cleanup}"),
+                )),
+            };
+        }
+    };
+    let actual_identity = match file_identity(&reopened) {
+        Ok(identity) => identity,
+        Err(error) => {
+            return match discard_created_child(&created) {
+                Ok(()) => Err(error),
+                Err(cleanup) => Err(io::Error::new(
+                    error.kind(),
+                    format!("{error}; failed to remove unverified created directory: {cleanup}"),
+                )),
+            };
+        }
+    };
+    if actual_identity != expected_identity {
+        let error = io::Error::new(
+            io::ErrorKind::InvalidData,
+            "created directory identity changed before least-privilege reopen",
+        );
+        return match discard_created_child(&created) {
+            Ok(()) => Err(error),
+            Err(cleanup) => Err(io::Error::new(
+                error.kind(),
+                format!("{error}; failed to remove replaced created directory: {cleanup}"),
+            )),
+        };
+    }
+    drop(created);
+    Ok(reopened)
 }
 
 #[cfg(windows)]
@@ -1649,13 +1699,13 @@ pub(crate) fn create_owner_only_file_child(
     const FILE_NON_DIRECTORY_FILE: u32 = 0x0000_0040;
     const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
     use windows_sys::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE};
-    use windows_sys::Win32::Storage::FileSystem::{DELETE, FILE_ATTRIBUTE_NORMAL};
+    use windows_sys::Win32::Storage::FileSystem::{DELETE, FILE_ATTRIBUTE_NORMAL, SYNCHRONIZE};
 
     let security = OwnerOnlySecurityAttributes::current_user()?;
     open_relative_child(
         parent,
         name,
-        GENERIC_READ | GENERIC_WRITE | DELETE,
+        GENERIC_READ | GENERIC_WRITE | DELETE | SYNCHRONIZE,
         FILE_ATTRIBUTE_NORMAL,
         FILE_CREATE,
         FILE_NON_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT,
@@ -2172,13 +2222,16 @@ mod tests {
         use super::{fs, io, unique_temp_root};
         use crate::infrastructure::platform::filesystem::{
             capture_windows_immutable_entry_evidence, create_owner_only_directory,
-            create_owner_only_directory_child, create_owner_only_file, directory_query_is_end,
-            file_identity, nt_create_options_for_std_file, open_directory_child_nofollow,
-            open_directory_nofollow, parse_directory_information_buffer, read_directory_names,
-            verify_owner_only_acl, verify_thread_token_fallback_error,
-            verify_windows_elevation_value, verify_windows_immutable_security_descriptor,
-            verify_windows_local_fixed_device_info, verify_windows_local_fixed_volume,
-            EffectiveTokenSource, ProcessToken, WindowsImmutableAclProfile,
+            create_owner_only_directory_child, create_owner_only_file,
+            create_owner_only_file_child, delete_open_child, directory_query_is_end, file_identity,
+            nt_create_options_for_std_file, open_any_child_for_delete,
+            open_directory_child_for_rename, open_directory_child_nofollow,
+            open_directory_nofollow, opened_child_kind, parse_directory_information_buffer,
+            read_directory_names, rename_directory_handle_child_no_replace, verify_owner_only_acl,
+            verify_thread_token_fallback_error, verify_windows_elevation_value,
+            verify_windows_immutable_security_descriptor, verify_windows_local_fixed_device_info,
+            verify_windows_local_fixed_volume, EffectiveTokenSource, OpenedChildKind, ProcessToken,
+            WindowsImmutableAclProfile,
         };
         use std::ffi::OsString;
         use std::mem::{offset_of, size_of};
@@ -2539,6 +2592,125 @@ mod tests {
             let handle = create_owner_only_file(&private).unwrap();
 
             verify_owner_only_acl(&handle).unwrap();
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn owner_only_file_child_is_created_through_its_retained_parent() {
+            use std::io::Write;
+
+            let root = unique_temp_root("owner-only-file-child");
+            fs::create_dir_all(&root).unwrap();
+            let parent = open_directory_nofollow(&root).unwrap();
+
+            let mut handle =
+                create_owner_only_file_child(&parent, std::ffi::OsStr::new("effective.yaml"))
+                    .unwrap();
+
+            handle.write_all(b"private").unwrap();
+            verify_owner_only_acl(&handle).unwrap();
+            drop(handle);
+            drop(parent);
+            assert_eq!(fs::read(root.join("effective.yaml")).unwrap(), b"private");
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn owner_only_directory_child_can_be_reopened_for_delete() {
+            let root = unique_temp_root("owner-only-directory-delete-reopen");
+            fs::create_dir_all(&root).unwrap();
+            let root_handle = open_directory_nofollow(&root).unwrap();
+            let parent =
+                create_owner_only_directory_child(&root_handle, std::ffi::OsStr::new("parent"))
+                    .unwrap();
+            let created =
+                create_owner_only_directory_child(&parent, std::ffi::OsStr::new("private"))
+                    .unwrap();
+            let retained_file =
+                create_owner_only_file_child(&created, std::ffi::OsStr::new("retained.txt"))
+                    .unwrap();
+            let expected_identity = file_identity(&created).unwrap();
+
+            let reopened =
+                open_any_child_for_delete(&parent, std::ffi::OsStr::new("private")).unwrap();
+
+            assert_eq!(
+                opened_child_kind(&reopened).unwrap(),
+                OpenedChildKind::Directory
+            );
+            assert_eq!(file_identity(&reopened).unwrap(), expected_identity);
+            drop(reopened);
+            drop(retained_file);
+            drop(created);
+            drop(parent);
+            drop(root_handle);
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn populated_child_moves_between_live_owner_only_parent_handles() {
+            use std::io::Write;
+
+            let root = unique_temp_root("owner-only-directory-rename");
+            fs::create_dir_all(&root).unwrap();
+            let root_handle = open_directory_nofollow(&root).unwrap();
+            let source_parent = create_owner_only_directory_child(
+                &root_handle,
+                std::ffi::OsStr::new("source-parent"),
+            )
+            .unwrap();
+            let destination_parent = create_owner_only_directory_child(
+                &root_handle,
+                std::ffi::OsStr::new("destination-parent"),
+            )
+            .unwrap();
+            let mut effective =
+                create_owner_only_file_child(&source_parent, std::ffi::OsStr::new("config.yaml"))
+                    .unwrap();
+            effective.write_all(b"private").unwrap();
+            let source =
+                create_owner_only_directory_child(&source_parent, std::ffi::OsStr::new("payload"))
+                    .unwrap();
+            let mut payload =
+                create_owner_only_file_child(&source, std::ffi::OsStr::new("new.txt")).unwrap();
+            payload.write_all(b"new").unwrap();
+            drop(payload);
+            drop(source);
+            let source_for_rename =
+                open_directory_child_for_rename(&source_parent, std::ffi::OsStr::new("payload"))
+                    .unwrap();
+
+            rename_directory_handle_child_no_replace(
+                &source_for_rename,
+                &destination_parent,
+                std::ffi::OsStr::new("payload"),
+            )
+            .unwrap();
+            let effective_for_delete =
+                open_any_child_for_delete(&source_parent, std::ffi::OsStr::new("config.yaml"))
+                    .unwrap();
+            delete_open_child(&effective_for_delete).unwrap();
+            drop(effective_for_delete);
+            drop(effective);
+            let source_parent_for_delete =
+                open_any_child_for_delete(&root_handle, std::ffi::OsStr::new("source-parent"))
+                    .unwrap();
+
+            assert!(!root.join("source-parent").join("payload").exists());
+            assert_eq!(
+                fs::read(
+                    root.join("destination-parent")
+                        .join("payload")
+                        .join("new.txt")
+                )
+                .unwrap(),
+                b"new"
+            );
+            drop(source_parent_for_delete);
+            drop(source_for_rename);
+            drop(destination_parent);
+            drop(source_parent);
+            drop(root_handle);
             fs::remove_dir_all(root).unwrap();
         }
 

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -1000,12 +1000,14 @@ fn verify_windows_local_fixed_device_info(
     const FILE_FLOPPY_DISKETTE: u32 = 0x0000_0004;
     const FILE_WRITE_ONCE_MEDIA: u32 = 0x0000_0008;
     const FILE_VIRTUAL_VOLUME: u32 = 0x0000_0040;
+    const FILE_PORTABLE_DEVICE: u32 = 0x0000_4000;
     const FILE_REMOTE_DEVICE_VSMB: u32 = 0x0008_0000;
     const UNTRUSTED_CHARACTERISTICS: u32 = FILE_REMOTE_DEVICE
         | FILE_REMOVABLE_MEDIA
         | FILE_FLOPPY_DISKETTE
         | FILE_WRITE_ONCE_MEDIA
         | FILE_VIRTUAL_VOLUME
+        | FILE_PORTABLE_DEVICE
         | FILE_REMOTE_DEVICE_VSMB;
 
     if device_type != FILE_DEVICE_DISK || characteristics & UNTRUSTED_CHARACTERISTICS != 0 {
@@ -2419,6 +2421,7 @@ mod tests {
             const FILE_DEVICE_DISK: u32 = 0x0000_0007;
             const FILE_DEVICE_NETWORK_FILE_SYSTEM: u32 = 0x0000_0014;
             const FILE_DEVICE_VIRTUAL_DISK: u32 = 0x0000_0024;
+            const FILE_PORTABLE_DEVICE: u32 = 0x0000_4000;
             const FILE_REMOTE_DEVICE: u32 = 0x0000_0010;
             const FILE_REMOTE_DEVICE_VSMB: u32 = 0x0008_0000;
             const FILE_REMOVABLE_MEDIA: u32 = 0x0000_0001;
@@ -2429,6 +2432,7 @@ mod tests {
             for (device_type, characteristics) in [
                 (FILE_DEVICE_DISK, FILE_REMOTE_DEVICE),
                 (FILE_DEVICE_DISK, FILE_REMOTE_DEVICE_VSMB),
+                (FILE_DEVICE_DISK, FILE_PORTABLE_DEVICE),
                 (FILE_DEVICE_DISK, FILE_REMOVABLE_MEDIA),
                 (FILE_DEVICE_NETWORK_FILE_SYSTEM, FILE_DEVICE_IS_MOUNTED),
                 (FILE_DEVICE_CD_ROM, FILE_DEVICE_IS_MOUNTED),

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -404,8 +404,9 @@ pub(crate) fn open_directory_nofollow(path: &Path) -> io::Result<fs::File> {
     use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
     use windows_sys::Win32::Storage::FileSystem::{
         CreateFileW, FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT,
-        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES,
-        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING, READ_CONTROL,
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_LIST_DIRECTORY,
+        FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+        READ_CONTROL,
     };
 
     let path = windows_api_path(path)?;
@@ -413,7 +414,7 @@ pub(crate) fn open_directory_nofollow(path: &Path) -> io::Result<fs::File> {
     let handle = unsafe {
         CreateFileW(
             path.as_ptr(),
-            FILE_READ_ATTRIBUTES | READ_CONTROL,
+            FILE_LIST_DIRECTORY | FILE_READ_ATTRIBUTES | READ_CONTROL,
             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
             ptr::null(),
             OPEN_EXISTING,
@@ -633,13 +634,13 @@ pub(crate) fn open_directory_child_nofollow(
     const FILE_DIRECTORY_FILE: u32 = 0x0000_0001;
     const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
     use windows_sys::Win32::Storage::FileSystem::{
-        FILE_READ_ATTRIBUTES, READ_CONTROL, SYNCHRONIZE,
+        FILE_LIST_DIRECTORY, FILE_READ_ATTRIBUTES, READ_CONTROL, SYNCHRONIZE,
     };
 
     let file = open_relative_child(
         parent,
         name,
-        FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE,
+        FILE_LIST_DIRECTORY | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE,
         0,
         FILE_OPEN,
         FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT,
@@ -647,6 +648,215 @@ pub(crate) fn open_directory_child_nofollow(
     )?;
     validate_directory_handle(&file)?;
     Ok(file)
+}
+
+#[cfg(windows)]
+pub(crate) fn open_regular_child_nofollow(
+    parent: &fs::File,
+    name: &std::ffi::OsStr,
+) -> io::Result<fs::File> {
+    const FILE_OPEN: u32 = 0x0000_0001;
+    const FILE_NON_DIRECTORY_FILE: u32 = 0x0000_0040;
+    const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    use windows_sys::Win32::Foundation::GENERIC_READ;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_REPARSE_POINT, FILE_READ_ATTRIBUTES, SYNCHRONIZE,
+    };
+
+    let file = open_relative_child(
+        parent,
+        name,
+        GENERIC_READ | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+        0,
+        FILE_OPEN,
+        FILE_NON_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT,
+        None,
+    )?;
+    let attributes = windows_file_information(&file)?.dwFileAttributes;
+    if attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "regular child resolves to a reparse point",
+        ));
+    }
+    if attributes & FILE_ATTRIBUTE_DIRECTORY != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "entry is not a regular file",
+        ));
+    }
+    Ok(file)
+}
+
+#[cfg(windows)]
+pub(crate) fn open_any_child_nofollow(
+    parent: &fs::File,
+    name: &std::ffi::OsStr,
+) -> io::Result<fs::File> {
+    const FILE_OPEN: u32 = 0x0000_0001;
+    const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_ATTRIBUTE_REPARSE_POINT, FILE_READ_ATTRIBUTES, SYNCHRONIZE,
+    };
+
+    let file = open_relative_child(
+        parent,
+        name,
+        FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+        0,
+        FILE_OPEN,
+        FILE_OPEN_REPARSE_POINT,
+        None,
+    )?;
+    if windows_file_information(&file)?.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "child resolves to a reparse point",
+        ));
+    }
+    Ok(file)
+}
+
+#[cfg(windows)]
+#[allow(
+    dead_code,
+    reason = "the following Windows full-dump tree-inspection task consumes retained enumeration"
+)]
+pub(crate) fn read_directory_names(directory: &fs::File) -> io::Result<Vec<std::ffi::OsString>> {
+    use std::mem::{offset_of, size_of};
+    use std::os::windows::ffi::OsStringExt;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::ERROR_NO_MORE_FILES;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FileIdBothDirectoryInfo, FileIdBothDirectoryRestartInfo, GetFileInformationByHandleEx,
+        FILE_ID_BOTH_DIR_INFO,
+    };
+
+    const BUFFER_BYTES: usize = 64 * 1024;
+
+    validate_directory_handle(directory)?;
+    let word_count = BUFFER_BYTES.div_ceil(size_of::<usize>());
+    let mut storage = vec![0usize; word_count];
+    let buffer_bytes = storage.len() * size_of::<usize>();
+    let file_name_offset = offset_of!(FILE_ID_BOTH_DIR_INFO, FileName);
+    let mut names = Vec::new();
+    let mut restart = true;
+    loop {
+        storage.fill(0);
+        let information_class = if restart {
+            FileIdBothDirectoryRestartInfo
+        } else {
+            FileIdBothDirectoryInfo
+        };
+        // SAFETY: storage is writable and pointer-aligned, its byte capacity is supplied exactly,
+        // and directory remains a live retained handle throughout enumeration.
+        let succeeded = unsafe {
+            GetFileInformationByHandleEx(
+                directory.as_raw_handle(),
+                information_class,
+                storage.as_mut_ptr().cast(),
+                u32::try_from(buffer_bytes).expect("fixed directory buffer fits u32"),
+            )
+        };
+        if succeeded == 0 {
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() == Some(ERROR_NO_MORE_FILES as i32) {
+                break;
+            }
+            return Err(error);
+        }
+        restart = false;
+
+        let mut offset = 0usize;
+        loop {
+            let header_end = offset.checked_add(file_name_offset).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "directory entry header offset overflowed",
+                )
+            })?;
+            if header_end > buffer_bytes {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "directory entry header exceeds the enumeration buffer",
+                ));
+            }
+            // SAFETY: the fixed header was bounds-checked above; read_unaligned also accepts any
+            // offset alignment returned by the filesystem.
+            let entry = unsafe {
+                std::ptr::read_unaligned(
+                    storage
+                        .as_ptr()
+                        .cast::<u8>()
+                        .add(offset)
+                        .cast::<FILE_ID_BOTH_DIR_INFO>(),
+                )
+            };
+            let name_bytes = usize::try_from(entry.FileNameLength).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "directory entry name length is not representable",
+                )
+            })?;
+            if name_bytes == 0 || name_bytes % size_of::<u16>() != 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "directory entry has an invalid UTF-16 name length",
+                ));
+            }
+            let name_end = header_end.checked_add(name_bytes).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "directory entry name offset overflowed",
+                )
+            })?;
+            if name_end > buffer_bytes {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "directory entry name exceeds the enumeration buffer",
+                ));
+            }
+            // SAFETY: the complete name byte range was bounds-checked and the length is even.
+            let name = unsafe {
+                std::slice::from_raw_parts(
+                    storage.as_ptr().cast::<u8>().add(header_end).cast::<u16>(),
+                    name_bytes / size_of::<u16>(),
+                )
+            };
+            let name = std::ffi::OsString::from_wide(name);
+            if name != "." && name != ".." {
+                names.push(name);
+            }
+
+            let next = entry.NextEntryOffset as usize;
+            if next == 0 {
+                break;
+            }
+            if next < file_name_offset
+                || next < file_name_offset + name_bytes
+                || next % size_of::<u32>() != 0
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "directory entry has an invalid next-record offset",
+                ));
+            }
+            offset = offset.checked_add(next).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "directory entry offset overflowed",
+                )
+            })?;
+            if offset >= buffer_bytes {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "directory entry offset exceeds the enumeration buffer",
+                ));
+            }
+        }
+    }
+    names.sort();
+    Ok(names)
 }
 
 #[cfg(windows)]
@@ -757,14 +967,15 @@ pub(crate) fn create_owner_only_directory_child(
     const FILE_DIRECTORY_FILE: u32 = 0x0000_0001;
     const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
     use windows_sys::Win32::Storage::FileSystem::{
-        DELETE, FILE_ATTRIBUTE_DIRECTORY, FILE_READ_ATTRIBUTES, READ_CONTROL, SYNCHRONIZE,
+        DELETE, FILE_ATTRIBUTE_DIRECTORY, FILE_LIST_DIRECTORY, FILE_READ_ATTRIBUTES, READ_CONTROL,
+        SYNCHRONIZE,
     };
 
     let security = OwnerOnlySecurityAttributes::current_user()?;
     let file = open_relative_child(
         parent,
         name,
-        DELETE | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE,
+        DELETE | FILE_LIST_DIRECTORY | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE,
         FILE_ATTRIBUTE_DIRECTORY,
         FILE_CREATE,
         FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT,
@@ -1308,9 +1519,11 @@ mod tests {
     mod windows {
         use super::{fs, io, unique_temp_root};
         use crate::infrastructure::platform::filesystem::{
-            create_owner_only_directory, create_owner_only_file, file_identity,
-            open_directory_nofollow, verify_owner_only_acl,
+            create_owner_only_directory, create_owner_only_directory_child, create_owner_only_file,
+            file_identity, open_directory_child_nofollow, open_directory_nofollow,
+            read_directory_names, verify_owner_only_acl,
         };
+        use std::ffi::OsString;
 
         #[test]
         fn owner_only_directory_is_opened_without_following_reparse_points() {
@@ -1367,6 +1580,64 @@ mod tests {
             let handle = create_owner_only_file(&private).unwrap();
 
             verify_owner_only_acl(&handle).unwrap();
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn windows_handle_enumeration_uses_the_retained_directory_after_path_replacement() {
+            let root = unique_temp_root("retained-enumeration");
+            let original = root.join("directory");
+            let displaced = root.join("directory-displaced");
+            fs::create_dir_all(&original).unwrap();
+            fs::write(original.join("alpha.txt"), b"alpha").unwrap();
+            fs::write(original.join("zeta.txt"), b"zeta").unwrap();
+            let directory = open_directory_nofollow(&original).unwrap();
+            fs::rename(&original, &displaced).unwrap();
+            fs::create_dir(&original).unwrap();
+            fs::write(original.join("decoy.txt"), b"decoy").unwrap();
+
+            let names = read_directory_names(&directory).unwrap();
+
+            assert_eq!(
+                names,
+                vec![OsString::from("alpha.txt"), OsString::from("zeta.txt")]
+            );
+            drop(directory);
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn windows_handle_enumeration_accepts_a_handle_relative_child() {
+            let root = unique_temp_root("child-enumeration");
+            let child_path = root.join("child");
+            fs::create_dir_all(&child_path).unwrap();
+            fs::write(child_path.join("entry.txt"), b"entry").unwrap();
+            let parent = open_directory_nofollow(&root).unwrap();
+            let child =
+                open_directory_child_nofollow(&parent, std::ffi::OsStr::new("child")).unwrap();
+
+            let names = read_directory_names(&child).unwrap();
+
+            assert_eq!(names, vec![OsString::from("entry.txt")]);
+            drop(child);
+            drop(parent);
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn windows_handle_enumeration_accepts_a_new_private_child() {
+            let root = unique_temp_root("private-child-enumeration");
+            fs::create_dir_all(&root).unwrap();
+            let parent = open_directory_nofollow(&root).unwrap();
+            let child =
+                create_owner_only_directory_child(&parent, std::ffi::OsStr::new("child")).unwrap();
+            fs::write(root.join("child").join("entry.txt"), b"entry").unwrap();
+
+            let names = read_directory_names(&child).unwrap();
+
+            assert_eq!(names, vec![OsString::from("entry.txt")]);
+            drop(child);
+            drop(parent);
             fs::remove_dir_all(root).unwrap();
         }
     }

--- a/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+++ b/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
@@ -84,8 +84,10 @@ mod windows_anchor_tests {
         capture_directory_snapshot, capture_tree_child_nofollow,
         capture_windows_immutable_platform_children, parse_windows_local_platform_path,
         remove_bound_directory_child, rename_child_no_replace, secure_path_is_absent,
-        secure_read_regular_file_snapshot, unlink_bound_regular_child, with_secure_read_hook,
-        with_tree_open_hook, DirectoryAnchor, PrivateDumpStage, TreeEntryKind, TreeSnapshot,
+        secure_read_regular_file_snapshot, unlink_bound_regular_child,
+        with_private_cleanup_failpoint, with_private_creation_failpoint, with_secure_read_hook,
+        with_tree_open_hook, DirectoryAnchor, PrivateCleanupCheckpoint, PrivateCreationCheckpoint,
+        PrivateDumpStage, TreeEntryKind, TreeSnapshot,
     };
     use crate::infrastructure::platform::filesystem::{
         file_identity, open_directory_nofollow, verify_owner_only_acl,
@@ -657,6 +659,166 @@ mod windows_anchor_tests {
         stage.cleanup_now().unwrap();
 
         assert!(!private_root.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_effective_config_scrub_failure_keeps_cleanup_retry_and_drop_safe() {
+        let root = unique_temp_root("private-stage-scrub-cleanup-retry");
+        let workspace = root.join("workspace");
+        fs::create_dir_all(&workspace).unwrap();
+        let target_parent = DirectoryAnchor::capture_exact(&workspace).unwrap();
+        let mut stage = PrivateDumpStage::create(&target_parent).unwrap();
+        stage
+            .write_effective_config(&serde_yaml::Value::String("secret".to_string()))
+            .unwrap();
+        let private_root = stage.root.clone();
+
+        let drop_result = with_private_cleanup_failpoint(
+            PrivateCleanupCheckpoint::BeforeEffectiveConfigScrub,
+            || {
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    for _ in 0..2 {
+                        let error = stage.cleanup_now().expect_err(
+                            "faulted effective-config scrubbing must fail cleanup without advancing anchors",
+                        );
+                        assert!(error.contains("injected"), "{error}");
+                        assert!(stage.effective_config_handle.is_some());
+                        assert!(stage.execution_anchor.is_some());
+                    }
+                    drop(stage);
+                }))
+            },
+        );
+
+        assert!(
+            drop_result.is_ok(),
+            "Drop must retry cleanup without panicking after a scrub failure"
+        );
+        fs::remove_dir_all(private_root).unwrap();
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_effective_config_scrub_failure_keeps_recovery_retry_and_drop_safe() {
+        let root = unique_temp_root("private-stage-scrub-recovery-retry");
+        let workspace = root.join("workspace");
+        fs::create_dir_all(&workspace).unwrap();
+        let target_parent = DirectoryAnchor::capture_exact(&workspace).unwrap();
+        let mut stage = PrivateDumpStage::create(&target_parent).unwrap();
+        stage
+            .write_effective_config(&serde_yaml::Value::String("secret".to_string()))
+            .unwrap();
+        let private_root = stage.root.clone();
+
+        let drop_result = with_private_cleanup_failpoint(
+            PrivateCleanupCheckpoint::BeforeEffectiveConfigScrub,
+            || {
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    for _ in 0..2 {
+                        let error = stage.preserve_for_recovery().expect_err(
+                            "faulted effective-config scrubbing must fail recovery preservation without advancing anchors",
+                        );
+                        assert!(error.contains("injected"), "{error}");
+                        assert!(stage.effective_config_handle.is_some());
+                        assert!(stage.execution_anchor.is_some());
+                    }
+                    drop(stage);
+                }))
+            },
+        );
+
+        assert!(
+            drop_result.is_ok(),
+            "Drop must retry cleanup without panicking after recovery preservation failed"
+        );
+        fs::remove_dir_all(private_root).unwrap();
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_private_stage_cleanup_requires_parent_relative_root_absence() {
+        let root = unique_temp_root("private-stage-root-absence");
+        let workspace = root.join("workspace");
+        fs::create_dir_all(&workspace).unwrap();
+        let target_parent = DirectoryAnchor::capture_exact(&workspace).unwrap();
+        let mut stage = PrivateDumpStage::create(&target_parent).unwrap();
+        let private_root = stage.root.clone();
+        let extra_root_handle = open_directory_nofollow(&private_root).unwrap();
+
+        let error = stage
+            .cleanup_now()
+            .expect_err("a delete-pending root is not proven absent");
+
+        assert!(
+            error.contains("absen") || error.contains("pending"),
+            "{error}"
+        );
+        assert!(!stage.root_removed);
+        assert!(stage.cleanup_on_drop);
+        drop(extra_root_handle);
+
+        stage.cleanup_now().unwrap();
+
+        assert!(stage.root_removed);
+        assert!(!stage.cleanup_on_drop);
+        assert!(!private_root.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_failure_after_execution_creation_leaves_no_private_root() {
+        let root = unique_temp_root("private-stage-partial-execution");
+        let workspace = root.join("workspace");
+        fs::create_dir_all(&workspace).unwrap();
+        let target_parent = DirectoryAnchor::capture_exact(&workspace).unwrap();
+
+        let result = with_private_creation_failpoint(
+            PrivateCreationCheckpoint::AfterExecutionCreation,
+            || PrivateDumpStage::create(&target_parent),
+        );
+
+        let error = match result {
+            Ok(stage) => {
+                drop(stage);
+                panic!("construction unexpectedly passed its injected execution checkpoint")
+            }
+            Err(error) => error,
+        };
+        assert!(error.contains("injected"), "{error}");
+        assert!(fs::read_dir(&workspace).unwrap().all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".unica-dump-guard-")));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_failure_after_recovery_creation_leaves_no_private_root() {
+        let root = unique_temp_root("private-stage-partial-recovery");
+        let workspace = root.join("workspace");
+        fs::create_dir_all(&workspace).unwrap();
+        let target_parent = DirectoryAnchor::capture_exact(&workspace).unwrap();
+
+        let result = with_private_creation_failpoint(
+            PrivateCreationCheckpoint::AfterRecoveryCreation,
+            || PrivateDumpStage::create(&target_parent),
+        );
+
+        let error = match result {
+            Ok(stage) => {
+                drop(stage);
+                panic!("construction unexpectedly passed its injected recovery checkpoint")
+            }
+            Err(error) => error,
+        };
+        assert!(error.contains("injected"), "{error}");
+        assert!(fs::read_dir(&workspace).unwrap().all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".unica-dump-guard-")));
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -3251,6 +3413,8 @@ struct PrivateDumpStage {
     #[cfg(windows)]
     root_removed: bool,
     #[cfg(windows)]
+    root_disposition_requested: bool,
+    #[cfg(windows)]
     execution_removed: bool,
     #[cfg(windows)]
     recovery_removed: bool,
@@ -3273,6 +3437,19 @@ impl PrivateDumpStage {
         let execution_anchor = match root_anchor.create_child(OsStr::new("execution"), &execution) {
             Ok(anchor) => anchor,
             Err(error) => {
+                #[cfg(windows)]
+                return Err(windows_private_creation_error(
+                    &parent_anchor,
+                    root_anchor,
+                    &root_name,
+                    &root,
+                    None,
+                    &execution,
+                    None,
+                    &recovery,
+                    error,
+                ));
+                #[cfg(not(windows))]
                 return Err(private_creation_error(
                     &parent_anchor,
                     &root_anchor,
@@ -3282,9 +3459,38 @@ impl PrivateDumpStage {
                 ));
             }
         };
+        #[cfg(windows)]
+        if let Err(error) =
+            run_private_creation_failpoint(PrivateCreationCheckpoint::AfterExecutionCreation)
+        {
+            return Err(windows_private_creation_error(
+                &parent_anchor,
+                root_anchor,
+                &root_name,
+                &root,
+                Some(execution_anchor),
+                &execution,
+                None,
+                &recovery,
+                error,
+            ));
+        }
         let recovery_anchor = match root_anchor.create_child(OsStr::new("recovery"), &recovery) {
             Ok(anchor) => anchor,
             Err(error) => {
+                #[cfg(windows)]
+                return Err(windows_private_creation_error(
+                    &parent_anchor,
+                    root_anchor,
+                    &root_name,
+                    &root,
+                    Some(execution_anchor),
+                    &execution,
+                    None,
+                    &recovery,
+                    error,
+                ));
+                #[cfg(not(windows))]
                 return Err(private_creation_error(
                     &parent_anchor,
                     &root_anchor,
@@ -3294,7 +3500,36 @@ impl PrivateDumpStage {
                 ));
             }
         };
+        #[cfg(windows)]
+        if let Err(error) =
+            run_private_creation_failpoint(PrivateCreationCheckpoint::AfterRecoveryCreation)
+        {
+            return Err(windows_private_creation_error(
+                &parent_anchor,
+                root_anchor,
+                &root_name,
+                &root,
+                Some(execution_anchor),
+                &execution,
+                Some(recovery_anchor),
+                &recovery,
+                error,
+            ));
+        }
         if let Err(error) = parent_anchor.verify_path_binding() {
+            #[cfg(windows)]
+            return Err(windows_private_creation_error(
+                &parent_anchor,
+                root_anchor,
+                &root_name,
+                &root,
+                Some(execution_anchor),
+                &execution,
+                Some(recovery_anchor),
+                &recovery,
+                error,
+            ));
+            #[cfg(not(windows))]
             return Err(private_creation_error(
                 &parent_anchor,
                 &root_anchor,
@@ -3324,6 +3559,8 @@ impl PrivateDumpStage {
             recovery_identity,
             #[cfg(windows)]
             root_removed: false,
+            #[cfg(windows)]
+            root_disposition_requested: false,
             #[cfg(windows)]
             execution_removed: false,
             #[cfg(windows)]
@@ -3410,6 +3647,8 @@ impl PrivateDumpStage {
         let Some(file) = self.effective_config_handle.as_ref() else {
             return Ok(());
         };
+        #[cfg(windows)]
+        run_private_cleanup_failpoint(PrivateCleanupCheckpoint::BeforeEffectiveConfigScrub)?;
         let identity = file_identity(file).map_err(|error| {
             format!(
                 "private effective config identity check failed for {}: {error}; secret-bearing private data may remain",
@@ -3480,10 +3719,8 @@ impl PrivateDumpStage {
 
     #[cfg(windows)]
     fn preserve_for_recovery(&mut self) -> Result<(), String> {
+        self.remove_effective_config()?;
         let mut errors = Vec::new();
-        if let Err(error) = self.remove_effective_config() {
-            errors.push(error);
-        }
         let root_directory =
             self.root_anchor().directory.try_clone().map_err(|error| {
                 format!("failed to clone private root anchor for cleanup: {error}")
@@ -3563,10 +3800,8 @@ impl PrivateDumpStage {
         if !self.cleanup_on_drop {
             return Ok(());
         }
+        self.remove_effective_config()?;
         let mut errors = Vec::new();
-        if let Err(error) = self.remove_effective_config() {
-            errors.push(error);
-        }
 
         if self.root_anchor.is_none() && (!self.execution_removed || !self.recovery_removed) {
             errors.push(
@@ -3615,7 +3850,7 @@ impl PrivateDumpStage {
                     ));
                 }
             }
-            if errors.is_empty() {
+            if errors.is_empty() && !self.root_disposition_requested {
                 self.root_anchor.take();
                 match remove_bound_directory_child(
                     &self.parent_anchor.directory,
@@ -3623,11 +3858,21 @@ impl PrivateDumpStage {
                     self.root_identity,
                     &self.root,
                 ) {
-                    Ok(()) => self.root_removed = true,
+                    Ok(()) => self.root_disposition_requested = true,
                     Err(error) => errors.push(format!(
                         "private dump root cleanup failed for {}: {error}",
                         self.root.display()
                     )),
+                }
+            }
+            if errors.is_empty() && self.root_disposition_requested {
+                match prove_windows_child_absent(
+                    &self.parent_anchor.directory,
+                    &self.root_name,
+                    &self.root,
+                ) {
+                    Ok(()) => self.root_removed = true,
+                    Err(error) => errors.push(error),
                 }
             }
         }
@@ -3638,6 +3883,28 @@ impl PrivateDumpStage {
         } else {
             Err(errors.join("; "))
         }
+    }
+}
+
+#[cfg(windows)]
+fn prove_windows_child_absent(
+    parent: &File,
+    name: &OsStr,
+    display_path: &Path,
+) -> Result<(), String> {
+    match open_any_child_nofollow(parent, name) {
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Ok(child) => {
+            drop(child);
+            Err(format!(
+                "private path is still present after cleanup; absence was not proven: {}",
+                display_path.display()
+            ))
+        }
+        Err(error) => Err(format!(
+            "failed to prove private path absent through its retained parent anchor {}: {error}",
+            display_path.display()
+        )),
     }
 }
 
@@ -3662,6 +3929,91 @@ fn release_anchor_and_remove_private_child(
     Ok(())
 }
 
+#[cfg(windows)]
+fn windows_private_creation_error(
+    parent_anchor: &DirectoryAnchor,
+    root_anchor: DirectoryAnchor,
+    root_name: &OsStr,
+    root: &Path,
+    mut execution_anchor: Option<DirectoryAnchor>,
+    execution: &Path,
+    mut recovery_anchor: Option<DirectoryAnchor>,
+    recovery: &Path,
+    primary: String,
+) -> String {
+    let root_identity = root_anchor.identity;
+    let mut cleanup_errors = Vec::new();
+
+    if let Some(execution_identity) = execution_anchor.as_ref().map(|anchor| anchor.identity) {
+        let mut removed = false;
+        if let Err(error) = release_anchor_and_remove_private_child(
+            &root_anchor.directory,
+            &mut execution_anchor,
+            &mut removed,
+            OsStr::new("execution"),
+            execution_identity,
+            execution,
+        ) {
+            cleanup_errors.push(format!(
+                "private execution cleanup failed during construction rollback {}: {error}",
+                execution.display()
+            ));
+        }
+    }
+    execution_anchor.take();
+
+    if let Some(recovery_identity) = recovery_anchor.as_ref().map(|anchor| anchor.identity) {
+        let mut removed = false;
+        if let Err(error) = release_anchor_and_remove_private_child(
+            &root_anchor.directory,
+            &mut recovery_anchor,
+            &mut removed,
+            OsStr::new("recovery"),
+            recovery_identity,
+            recovery,
+        ) {
+            cleanup_errors.push(format!(
+                "private recovery cleanup failed during construction rollback {}: {error}",
+                recovery.display()
+            ));
+        }
+    }
+    recovery_anchor.take();
+
+    if let Err(error) = remove_directory_contents_nofollow(&root_anchor.directory, root) {
+        cleanup_errors.push(format!(
+            "private dump contents cleanup failed for {}: {error}",
+            root.display()
+        ));
+    }
+    drop(root_anchor);
+
+    let root_disposition_requested = match remove_bound_directory_child(
+        &parent_anchor.directory,
+        root_name,
+        root_identity,
+        root,
+    ) {
+        Ok(()) => true,
+        Err(error) => {
+            cleanup_errors.push(format!(
+                "private dump root cleanup failed for {}: {error}",
+                root.display()
+            ));
+            false
+        }
+    };
+    if let Err(error) = prove_windows_child_absent(&parent_anchor.directory, root_name, root) {
+        cleanup_errors.push(error);
+    }
+    if root_disposition_requested && cleanup_errors.is_empty() {
+        primary
+    } else {
+        format!("{primary}; {}", cleanup_errors.join("; "))
+    }
+}
+
+#[cfg(not(windows))]
 fn private_creation_error(
     parent_anchor: &DirectoryAnchor,
     root_anchor: &DirectoryAnchor,
@@ -5867,6 +6219,19 @@ enum PublicationCheckpoint {
     AfterStageInstall,
 }
 
+#[cfg(windows)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PrivateCleanupCheckpoint {
+    BeforeEffectiveConfigScrub,
+}
+
+#[cfg(windows)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PrivateCreationCheckpoint {
+    AfterExecutionCreation,
+    AfterRecoveryCreation,
+}
+
 #[cfg(test)]
 type PublicationHook = (PublicationCheckpoint, Box<dyn FnOnce()>);
 #[cfg(test)]
@@ -5887,6 +6252,10 @@ thread_local! {
     static TEST_TREE_OPEN_HOOK: RefCell<Option<PathHook>> = const { RefCell::new(None) };
     static TEST_PRIVATE_CREATE_HOOK: RefCell<Option<PathHook>> = const { RefCell::new(None) };
     static TEST_TARGET_PARENT_CAPTURE_HOOK: RefCell<Option<PathHook>> = const { RefCell::new(None) };
+    #[cfg(windows)]
+    static TEST_PRIVATE_CLEANUP_FAILPOINT: RefCell<Option<PrivateCleanupCheckpoint>> = const { RefCell::new(None) };
+    #[cfg(windows)]
+    static TEST_PRIVATE_CREATION_FAILPOINT: RefCell<Option<PrivateCreationCheckpoint>> = const { RefCell::new(None) };
 }
 
 #[cfg(test)]
@@ -6016,6 +6385,66 @@ fn with_target_parent_capture_hook<T>(
     let previous = TEST_TARGET_PARENT_CAPTURE_HOOK.with(|slot| slot.replace(Some(Box::new(hook))));
     let _reset = Reset(previous);
     action()
+}
+
+#[cfg(all(test, windows))]
+fn with_private_cleanup_failpoint<T>(
+    checkpoint: PrivateCleanupCheckpoint,
+    action: impl FnOnce() -> T,
+) -> T {
+    struct Reset(Option<PrivateCleanupCheckpoint>);
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            TEST_PRIVATE_CLEANUP_FAILPOINT.with(|slot| {
+                slot.replace(self.0.take());
+            });
+        }
+    }
+    let previous = TEST_PRIVATE_CLEANUP_FAILPOINT.with(|slot| slot.replace(Some(checkpoint)));
+    let _reset = Reset(previous);
+    action()
+}
+
+#[cfg(all(test, windows))]
+fn with_private_creation_failpoint<T>(
+    checkpoint: PrivateCreationCheckpoint,
+    action: impl FnOnce() -> T,
+) -> T {
+    struct Reset(Option<PrivateCreationCheckpoint>);
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            TEST_PRIVATE_CREATION_FAILPOINT.with(|slot| {
+                slot.replace(self.0.take());
+            });
+        }
+    }
+    let previous = TEST_PRIVATE_CREATION_FAILPOINT.with(|slot| slot.replace(Some(checkpoint)));
+    let _reset = Reset(previous);
+    action()
+}
+
+#[cfg(windows)]
+fn run_private_cleanup_failpoint(checkpoint: PrivateCleanupCheckpoint) -> Result<(), String> {
+    #[cfg(test)]
+    if TEST_PRIVATE_CLEANUP_FAILPOINT.with(|slot| slot.borrow().as_ref() == Some(&checkpoint)) {
+        return Err(format!(
+            "injected private dump cleanup failure at {checkpoint:?}"
+        ));
+    }
+    let _ = checkpoint;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn run_private_creation_failpoint(checkpoint: PrivateCreationCheckpoint) -> Result<(), String> {
+    #[cfg(test)]
+    if TEST_PRIVATE_CREATION_FAILPOINT.with(|slot| slot.borrow().as_ref() == Some(&checkpoint)) {
+        return Err(format!(
+            "injected private dump creation failure at {checkpoint:?}"
+        ));
+    }
+    let _ = checkpoint;
+    Ok(())
 }
 
 fn run_private_create_hook(_path: &Path) {

--- a/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+++ b/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
@@ -26,10 +26,10 @@ use crate::infrastructure::platform::filesystem::hard_link_count;
 #[cfg(windows)]
 use crate::infrastructure::platform::filesystem::{
     capture_windows_immutable_entry_evidence, create_owner_only_directory_child,
-    create_owner_only_file_child, delete_open_child, discard_created_child,
-    open_any_child_for_delete, open_any_child_nofollow, open_directory_child_for_rename,
-    open_directory_child_nofollow, open_directory_nofollow, open_regular_child_nofollow,
-    opened_child_kind, rename_directory_handle_child_no_replace, verify_owner_only_acl,
+    create_owner_only_file_child, delete_open_child, open_any_child_for_delete,
+    open_any_child_nofollow, open_directory_child_for_rename, open_directory_child_nofollow,
+    open_directory_nofollow, open_regular_child_nofollow, opened_child_kind,
+    rename_directory_handle_child_no_replace, verify_owner_only_acl,
     verify_unprivileged_windows_platform_caller, verify_windows_local_fixed_volume,
     OpenedChildKind, WindowsImmutableAclProfile,
 };
@@ -85,7 +85,7 @@ mod windows_anchor_tests {
         capture_windows_immutable_platform_children, parse_windows_local_platform_path,
         remove_bound_directory_child, rename_child_no_replace, secure_path_is_absent,
         secure_read_regular_file_snapshot, unlink_bound_regular_child, with_secure_read_hook,
-        with_tree_open_hook, DirectoryAnchor, TreeEntryKind, TreeSnapshot,
+        with_tree_open_hook, DirectoryAnchor, PrivateDumpStage, TreeEntryKind, TreeSnapshot,
     };
     use crate::infrastructure::platform::filesystem::{
         file_identity, open_directory_nofollow, verify_owner_only_acl,
@@ -646,6 +646,21 @@ mod windows_anchor_tests {
     }
 
     #[test]
+    fn windows_private_stage_cleanup_closes_retained_anchors_before_deleting_root() {
+        let root = unique_temp_root("private-stage-cleanup-lifecycle");
+        let workspace = root.join("workspace");
+        fs::create_dir_all(&workspace).unwrap();
+        let target_parent = DirectoryAnchor::capture_exact(&workspace).unwrap();
+        let mut stage = PrivateDumpStage::create(&target_parent).unwrap();
+        let private_root = stage.root.clone();
+
+        stage.cleanup_now().unwrap();
+
+        assert!(!private_root.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn windows_handle_cleanup_leaves_an_identity_replacement_untouched() {
         let root = unique_temp_root("handle-cleanup-replacement");
         let parent_path = root.join("parent");
@@ -1157,21 +1172,6 @@ struct PreparedDump {
 }
 
 impl PreparedDump {
-    #[cfg(windows)]
-    fn prepare(
-        _args: &Map<String, Value>,
-        _context: &WorkspaceContext,
-        _platform_resolver: &dyn PlatformResolver,
-        _runner: &dyn ProcessRunner,
-        _cancellation: &CancellationToken,
-    ) -> Result<Self, String> {
-        Err(
-            "verified applied full dump is fail-closed on Windows until owner-only ACLs and handle-safe no-clobber directory publication are implemented"
-                .to_string(),
-        )
-    }
-
-    #[cfg(not(windows))]
     fn prepare(
         args: &Map<String, Value>,
         context: &WorkspaceContext,
@@ -3089,21 +3089,21 @@ impl DirectoryAnchor {
                     display_path.display()
                 )
             })?;
-        let cleanup_error = |error: String| {
-            match discard_created_child(&directory) {
-            Ok(()) => error,
-            Err(cleanup) => format!(
-                "{error}; failed to remove private directory created through the retained parent anchor {}: {cleanup}",
-                display_path.display()
-            ),
-        }
-        };
         let identity = file_identity(&directory).map_err(|error| {
-            cleanup_error(format!(
-                "failed to inspect private directory identity {}: {error}",
+            format!(
+                "failed to inspect private directory identity {}; the unverified directory was left untouched: {error}",
                 display_path.display()
-            ))
+            )
         })?;
+        let cleanup_error = |error: String| {
+            match remove_bound_directory_child(&self.directory, name, identity, display_path) {
+                Ok(()) => error,
+                Err(cleanup) => format!(
+                    "{error}; failed to remove private directory created through the retained parent anchor {}: {cleanup}",
+                    display_path.display()
+                ),
+            }
+        };
         if let Err(error) = verify_owner_only_acl(&directory) {
             return Err(cleanup_error(format!(
                 "failed to verify private directory ACL {}: {error}",
@@ -3237,13 +3237,23 @@ impl DirectoryAnchor {
 
 struct PrivateDumpStage {
     parent_anchor: DirectoryAnchor,
-    root_anchor: DirectoryAnchor,
+    root_anchor: Option<DirectoryAnchor>,
     root_name: OsString,
     root: PathBuf,
     execution: PathBuf,
     recovery: PathBuf,
-    execution_anchor: DirectoryAnchor,
-    recovery_anchor: DirectoryAnchor,
+    execution_anchor: Option<DirectoryAnchor>,
+    recovery_anchor: Option<DirectoryAnchor>,
+    root_identity: FileIdentity,
+    execution_identity: FileIdentity,
+    #[cfg(windows)]
+    recovery_identity: FileIdentity,
+    #[cfg(windows)]
+    root_removed: bool,
+    #[cfg(windows)]
+    execution_removed: bool,
+    #[cfg(windows)]
+    recovery_removed: bool,
     staged_tree: PathBuf,
     effective_config: PathBuf,
     effective_config_handle: Option<File>,
@@ -3293,29 +3303,61 @@ impl PrivateDumpStage {
                 error,
             ));
         };
+        let root_identity = root_anchor.identity;
+        let execution_identity = execution_anchor.identity;
+        #[cfg(windows)]
+        let recovery_identity = recovery_anchor.identity;
         Ok(Self {
             staged_tree: execution.join("staged-source"),
             effective_config: execution.join(EFFECTIVE_CONFIG_NAME),
             parent_anchor,
-            root_anchor,
+            root_anchor: Some(root_anchor),
             root_name,
             root,
             execution,
             recovery,
-            execution_anchor,
-            recovery_anchor,
+            execution_anchor: Some(execution_anchor),
+            recovery_anchor: Some(recovery_anchor),
+            root_identity,
+            execution_identity,
+            #[cfg(windows)]
+            recovery_identity,
+            #[cfg(windows)]
+            root_removed: false,
+            #[cfg(windows)]
+            execution_removed: false,
+            #[cfg(windows)]
+            recovery_removed: false,
             effective_config_handle: None,
             effective_config_secret_present: false,
             cleanup_on_drop: true,
         })
     }
 
+    fn root_anchor(&self) -> &DirectoryAnchor {
+        self.root_anchor
+            .as_ref()
+            .expect("private root anchor remains open before cleanup")
+    }
+
+    fn execution_anchor(&self) -> &DirectoryAnchor {
+        self.execution_anchor
+            .as_ref()
+            .expect("private execution anchor remains open before cleanup")
+    }
+
+    fn recovery_anchor(&self) -> &DirectoryAnchor {
+        self.recovery_anchor
+            .as_ref()
+            .expect("private recovery anchor remains open before cleanup")
+    }
+
     fn write_effective_config(&mut self, value: &YamlValue) -> Result<(), String> {
         let bytes = serde_yaml::to_string(value)
             .map_err(|error| format!("failed to serialize effective dump config: {error}"))?;
-        self.execution_anchor.verify_path_binding()?;
+        self.execution_anchor().verify_path_binding()?;
         let file = create_regular_child_owner_only(
-            &self.execution_anchor.directory,
+            &self.execution_anchor().directory,
             OsStr::new(EFFECTIVE_CONFIG_NAME),
             &self.effective_config,
         )
@@ -3353,7 +3395,7 @@ impl PrivateDumpStage {
                     self.effective_config.display()
                 )
             })?;
-        self.execution_anchor
+        self.execution_anchor()
             .verify_path_binding()
             .map_err(|error| {
                 format!(
@@ -3385,10 +3427,10 @@ impl PrivateDumpStage {
                 "private effective config scrub sync failed for {}: {error}; secret-bearing private data may remain",
                 self.effective_config.display()
             )
-        })?;
+            })?;
         self.effective_config_secret_present = false;
         let unlink = unlink_bound_regular_child(
-            &self.execution_anchor.directory,
+            &self.execution_anchor().directory,
             OsStr::new(EFFECTIVE_CONFIG_NAME),
             identity,
         )
@@ -3402,15 +3444,16 @@ impl PrivateDumpStage {
         unlink
     }
 
+    #[cfg(not(windows))]
     fn preserve_for_recovery(&mut self) -> Result<(), String> {
         let mut errors = Vec::new();
         if let Err(error) = self.remove_effective_config() {
             errors.push(error);
         }
         if let Err(error) = remove_bound_directory_child(
-            &self.root_anchor.directory,
+            &self.root_anchor().directory,
             OsStr::new("execution"),
-            self.execution_anchor.identity,
+            self.execution_identity,
             &self.execution,
         ) {
             errors.push(format!(
@@ -3418,12 +3461,12 @@ impl PrivateDumpStage {
                 self.execution.display()
             ));
         }
-        if let Err(error) = self.root_anchor.verify_path_binding() {
+        if let Err(error) = self.root_anchor().verify_path_binding() {
             errors.push(format!(
                 "private recovery root is no longer bound to its visible path: {error}"
             ));
         }
-        if let Err(error) = self.recovery_anchor.verify_path_binding() {
+        if let Err(error) = self.recovery_anchor().verify_path_binding() {
             errors.push(format!(
                 "private recovery directory is no longer bound to its visible path: {error}"
             ));
@@ -3435,6 +3478,51 @@ impl PrivateDumpStage {
         Ok(())
     }
 
+    #[cfg(windows)]
+    fn preserve_for_recovery(&mut self) -> Result<(), String> {
+        let mut errors = Vec::new();
+        if let Err(error) = self.remove_effective_config() {
+            errors.push(error);
+        }
+        let root_directory =
+            self.root_anchor().directory.try_clone().map_err(|error| {
+                format!("failed to clone private root anchor for cleanup: {error}")
+            })?;
+        if let Err(error) = release_anchor_and_remove_private_child(
+            &root_directory,
+            &mut self.execution_anchor,
+            &mut self.execution_removed,
+            OsStr::new("execution"),
+            self.execution_identity,
+            &self.execution,
+        ) {
+            errors.push(format!(
+                "private execution cleanup failed before retaining recovery {}: {error}",
+                self.execution.display()
+            ));
+        }
+        if let Some(root_anchor) = self.root_anchor.as_ref() {
+            if let Err(error) = root_anchor.verify_path_binding() {
+                errors.push(format!(
+                    "private recovery root is no longer bound to its visible path: {error}"
+                ));
+            }
+        }
+        if let Some(recovery_anchor) = self.recovery_anchor.as_ref() {
+            if let Err(error) = recovery_anchor.verify_path_binding() {
+                errors.push(format!(
+                    "private recovery directory is no longer bound to its visible path: {error}"
+                ));
+            }
+        }
+        if !errors.is_empty() {
+            return Err(errors.join("; "));
+        }
+        self.cleanup_on_drop = false;
+        Ok(())
+    }
+
+    #[cfg(not(windows))]
     fn cleanup_now(&mut self) -> Result<(), String> {
         if !self.cleanup_on_drop {
             return Ok(());
@@ -3444,7 +3532,7 @@ impl PrivateDumpStage {
             errors.push(error);
         }
         if let Err(error) =
-            remove_directory_contents_nofollow(&self.root_anchor.directory, &self.root)
+            remove_directory_contents_nofollow(&self.root_anchor().directory, &self.root)
         {
             errors.push(format!(
                 "private dump contents cleanup failed for {}: {error}",
@@ -3454,7 +3542,7 @@ impl PrivateDumpStage {
         if let Err(error) = remove_bound_directory_child(
             &self.parent_anchor.directory,
             &self.root_name,
-            self.root_anchor.identity,
+            self.root_identity,
             &self.root,
         ) {
             errors.push(format!(
@@ -3469,6 +3557,109 @@ impl PrivateDumpStage {
             Err(errors.join("; "))
         }
     }
+
+    #[cfg(windows)]
+    fn cleanup_now(&mut self) -> Result<(), String> {
+        if !self.cleanup_on_drop {
+            return Ok(());
+        }
+        let mut errors = Vec::new();
+        if let Err(error) = self.remove_effective_config() {
+            errors.push(error);
+        }
+
+        if self.root_anchor.is_none() && (!self.execution_removed || !self.recovery_removed) {
+            errors.push(
+                "private root anchor closed before its child directories were removed".to_string(),
+            );
+        } else if let Some(root_anchor) = self.root_anchor.as_ref() {
+            let root_directory = root_anchor.directory.try_clone().map_err(|error| {
+                format!("failed to clone private root anchor for cleanup: {error}")
+            })?;
+            if let Err(error) = release_anchor_and_remove_private_child(
+                &root_directory,
+                &mut self.execution_anchor,
+                &mut self.execution_removed,
+                OsStr::new("execution"),
+                self.execution_identity,
+                &self.execution,
+            ) {
+                errors.push(format!(
+                    "private execution cleanup failed for {}: {error}",
+                    self.execution.display()
+                ));
+            }
+            if let Err(error) = release_anchor_and_remove_private_child(
+                &root_directory,
+                &mut self.recovery_anchor,
+                &mut self.recovery_removed,
+                OsStr::new("recovery"),
+                self.recovery_identity,
+                &self.recovery,
+            ) {
+                errors.push(format!(
+                    "private recovery cleanup failed for {}: {error}",
+                    self.recovery.display()
+                ));
+            }
+        }
+
+        if errors.is_empty() && !self.root_removed {
+            if let Some(root_anchor) = self.root_anchor.as_ref() {
+                if let Err(error) =
+                    remove_directory_contents_nofollow(&root_anchor.directory, &self.root)
+                {
+                    errors.push(format!(
+                        "private dump contents cleanup failed for {}: {error}",
+                        self.root.display()
+                    ));
+                }
+            }
+            if errors.is_empty() {
+                self.root_anchor.take();
+                match remove_bound_directory_child(
+                    &self.parent_anchor.directory,
+                    &self.root_name,
+                    self.root_identity,
+                    &self.root,
+                ) {
+                    Ok(()) => self.root_removed = true,
+                    Err(error) => errors.push(format!(
+                        "private dump root cleanup failed for {}: {error}",
+                        self.root.display()
+                    )),
+                }
+            }
+        }
+
+        if errors.is_empty() && self.root_removed {
+            self.cleanup_on_drop = false;
+            Ok(())
+        } else {
+            Err(errors.join("; "))
+        }
+    }
+}
+
+#[cfg(windows)]
+fn release_anchor_and_remove_private_child(
+    parent: &File,
+    anchor: &mut Option<DirectoryAnchor>,
+    removed: &mut bool,
+    name: &OsStr,
+    expected_identity: FileIdentity,
+    display_path: &Path,
+) -> Result<(), String> {
+    if *removed {
+        return Ok(());
+    }
+    if let Some(retained) = anchor.as_ref() {
+        remove_directory_contents_nofollow(&retained.directory, display_path)?;
+    }
+    anchor.take();
+    remove_bound_directory_child(parent, name, expected_identity, display_path)?;
+    *removed = true;
+    Ok(())
 }
 
 fn private_creation_error(
@@ -4883,10 +5074,10 @@ fn publish_staged_tree(
 
     run_publication_failpoint(PublicationCheckpoint::BeforeStageInstall)?;
     rename_prechecked_directory_child_no_replace(
-        &private.execution_anchor,
+        private.execution_anchor(),
         OsStr::new("staged-source"),
         staged_identity,
-        &private.recovery_anchor,
+        private.recovery_anchor(),
         &sealed_name,
     )
     .map_err(|error| {
@@ -4897,7 +5088,7 @@ fn publish_staged_tree(
         )
     })?;
     let sealed_snapshot = private
-        .recovery_anchor
+        .recovery_anchor()
         .capture_child(&sealed_name, &sealed)?;
     if &sealed_snapshot != staged {
         return Err(format!(
@@ -4910,7 +5101,7 @@ fn publish_staged_tree(
         rename_child_no_replace(
             target_parent,
             target_name,
-            &private.recovery_anchor,
+            private.recovery_anchor(),
             &backup_name,
         )
         .map_err(|error| {
@@ -4926,7 +5117,10 @@ fn publish_staged_tree(
                 format!("dump target parent changed after the atomic backup move: {error}"),
             ));
         }
-        let moved = match private.recovery_anchor.capture_child(&backup_name, &backup) {
+        let moved = match private
+            .recovery_anchor()
+            .capture_child(&backup_name, &backup)
+        {
             Ok(moved) => moved,
             Err(error) => {
                 return Err(retain_recovery_error(
@@ -4982,7 +5176,7 @@ fn publish_staged_tree(
     // name-swapped source is atomically removed from the Git-visible target into
     // private quarantine before rollback or lock release.
     if let Err(error) = rename_child_no_replace(
-        &private.recovery_anchor,
+        private.recovery_anchor(),
         &sealed_name,
         target_parent,
         target_name,
@@ -5154,7 +5348,7 @@ fn publish_staged_tree(
             if let Err(move_error) = rename_child_no_replace(
                 target_parent,
                 target_name,
-                &private.recovery_anchor,
+                private.recovery_anchor(),
                 &failed_name,
             ) {
                 return Err(retain_recovery_error(
@@ -5166,7 +5360,9 @@ fn publish_staged_tree(
                     ),
                 ));
             }
-            let failed_snapshot = match private.recovery_anchor.capture_child(&failed_name, &failed)
+            let failed_snapshot = match private
+                .recovery_anchor()
+                .capture_child(&failed_name, &failed)
             {
                 Ok(snapshot) => snapshot,
                 Err(snapshot_error) => {
@@ -5272,7 +5468,7 @@ fn quarantine_unverified_install(
     rename_child_no_replace(
         target_parent,
         target_name,
-        &private.recovery_anchor,
+        private.recovery_anchor(),
         quarantine_name,
     )
     .map_err(|error| {
@@ -5284,7 +5480,7 @@ fn quarantine_unverified_install(
     })?;
     if let Some(installed) = installed {
         let quarantined = private
-            .recovery_anchor
+            .recovery_anchor()
             .capture_child(quarantine_name, quarantine_path)
             .map_err(|error| {
                 format!(
@@ -5363,7 +5559,7 @@ fn rollback_before_stage_install(
 ) -> Result<Vec<String>, String> {
     let backup = private.recovery.join(backup_name);
     if let Err(error) = rename_child_no_replace(
-        &private.recovery_anchor,
+        private.recovery_anchor(),
         backup_name,
         target_parent,
         target_name,
@@ -5432,7 +5628,7 @@ fn rollback_before_stage_install(
             let quarantine = rename_child_no_replace(
                 target_parent,
                 target_name,
-                &private.recovery_anchor,
+                private.recovery_anchor(),
                 backup_name,
             );
             let detail = match quarantine {
@@ -6789,10 +6985,13 @@ mod tests {
 
         let normalized = normalize_key_value_connection(connection, config_dir).unwrap();
 
-        assert_eq!(
-            normalized,
-            r#"File="/workspace/project/build/ib;archive";Usr=O'Brien;Pwd="secret;with:semicolon""#
-        );
+        #[cfg(windows)]
+        let expected =
+            r#"File="/workspace/project\build/ib;archive";Usr=O'Brien;Pwd="secret;with:semicolon""#;
+        #[cfg(not(windows))]
+        let expected =
+            r#"File="/workspace/project/build/ib;archive";Usr=O'Brien;Pwd="secret;with:semicolon""#;
+        assert_eq!(normalized, expected);
     }
 
     struct FixedPlatform {
@@ -7051,9 +7250,10 @@ mod tests {
     }
 
     fn fixed_platform(root: &Path) -> FixedPlatform {
-        let executable = root.join("8.3.27.2074/1cv8");
+        let install = root.join("8.3.27.2074");
+        let executable = install.join(PlatformUtility::Designer.executable_name());
         make_platform_executable(&executable);
-        make_platform_executable(&executable.parent().unwrap().join("ibcmd"));
+        make_platform_executable(&install.join(PlatformUtility::Ibcmd.executable_name()));
         FixedPlatform {
             executable,
             version: "8.3.27.2074".to_string(),
@@ -7113,6 +7313,22 @@ mod tests {
         invoke_with_args(runner, platform, invocation, context, &args())
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn windows_applied_full_dump_reaches_runner_and_commits_validated_tree() {
+        let (root, context, _) = workspace("windows-applied-full-dump");
+        let target = context.cwd.join("src");
+        let platform = fixed_platform(&root);
+        let runner = DumpRunner::valid();
+
+        let result = invoke(&runner, &platform, FullDumpInvocation::BuildDump, &context);
+
+        assert!(result.ok, "{result:?}");
+        assert_eq!(runner.calls.load(Ordering::SeqCst), 1);
+        assert!(target.join("Configuration.xml").is_file());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
     #[test]
     fn selected_source_set_target_must_be_relative_and_physically_contained_in_workspace() {
         for case in [
@@ -7130,7 +7346,10 @@ mod tests {
                 "symlink-parent" => {
                     #[cfg(unix)]
                     std::os::unix::fs::symlink(&outside, context.cwd.join("linked")).unwrap();
-                    #[cfg(not(unix))]
+                    #[cfg(windows)]
+                    std::os::windows::fs::symlink_dir(&outside, context.cwd.join("linked"))
+                        .unwrap();
+                    #[cfg(not(any(unix, windows)))]
                     std::fs::create_dir_all(context.cwd.join("linked")).unwrap();
                     "linked/symlink-src".to_string()
                 }
@@ -7139,7 +7358,10 @@ mod tests {
                     std::fs::create_dir_all(&real_target).unwrap();
                     #[cfg(unix)]
                     std::os::unix::fs::symlink(&real_target, context.cwd.join("src")).unwrap();
-                    #[cfg(not(unix))]
+                    #[cfg(windows)]
+                    std::os::windows::fs::symlink_dir(&real_target, context.cwd.join("src"))
+                        .unwrap();
+                    #[cfg(not(any(unix, windows)))]
                     std::fs::create_dir_all(context.cwd.join("src")).unwrap();
                     "src".to_string()
                 }
@@ -7759,7 +7981,6 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    #[ignore = "enabled when Task 4 removes the Windows preparation guard"]
     fn windows_destination_race_after_backup_survives_rollback() {
         let (root, context, _) = workspace("windows-destination-race");
         let target = context.cwd.join("src");

--- a/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+++ b/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
@@ -25,10 +25,11 @@ use crate::infrastructure::native_operations::single_file_publisher::{
 use crate::infrastructure::platform::filesystem::hard_link_count;
 #[cfg(windows)]
 use crate::infrastructure::platform::filesystem::{
-    create_owner_only_directory_child, create_owner_only_file_child, discard_created_child,
-    open_any_child_nofollow, open_directory_child_for_rename, open_directory_child_nofollow,
-    open_directory_nofollow, open_regular_child_nofollow, rename_directory_handle_child_no_replace,
-    verify_owner_only_acl,
+    create_owner_only_directory_child, create_owner_only_file_child, delete_open_child,
+    discard_created_child, open_any_child_for_delete, open_any_child_nofollow,
+    open_directory_child_for_rename, open_directory_child_nofollow, open_directory_nofollow,
+    open_regular_child_nofollow, opened_child_kind, rename_directory_handle_child_no_replace,
+    verify_owner_only_acl, OpenedChildKind,
 };
 use crate::infrastructure::platform::filesystem::{
     file_identity, metadata_is_link_or_reparse_point, restrict_stage_to_owner, FileIdentity,
@@ -78,15 +79,22 @@ pub(crate) enum FullDumpInvocation {
 #[cfg(all(test, windows))]
 mod windows_anchor_tests {
     use super::{
+        capture_directory_snapshot, capture_tree_child_nofollow, remove_bound_directory_child,
         rename_child_no_replace, secure_path_is_absent, secure_read_regular_file_snapshot,
-        with_secure_read_hook, DirectoryAnchor,
+        unlink_bound_regular_child, with_secure_read_hook, with_tree_open_hook, DirectoryAnchor,
+        TreeEntryKind, TreeSnapshot,
     };
-    use crate::infrastructure::platform::filesystem::verify_owner_only_acl;
+    use crate::infrastructure::platform::filesystem::{
+        file_identity, open_directory_nofollow, verify_owner_only_acl,
+    };
     use std::cell::Cell;
     use std::ffi::OsStr;
     use std::fs;
+    use std::os::windows::io::AsRawHandle;
     use std::path::PathBuf;
     use std::rc::Rc;
+    use windows_sys::Win32::Foundation::FILETIME;
+    use windows_sys::Win32::Storage::FileSystem::SetFileTime;
 
     #[test]
     fn windows_anchor_detects_parent_name_replacement() {
@@ -339,6 +347,291 @@ mod windows_anchor_tests {
 
         assert!(secure_path_is_absent(&missing).unwrap());
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_tree_snapshot_captures_nested_identities_sizes_and_digests() {
+        let root = unique_temp_root("tree-snapshot-stable");
+        let nested = root.join("nested");
+        let payload = nested.join("payload.txt");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(&payload, b"abc").unwrap();
+        let expected_file_identity = file_identity(&fs::File::open(&payload).unwrap()).unwrap();
+        let expected_directory_identity =
+            file_identity(&open_directory_nofollow(&nested).unwrap()).unwrap();
+
+        let first = capture_directory_snapshot(&root).unwrap();
+        let second = capture_directory_snapshot(&root).unwrap();
+
+        assert_eq!(
+            first, second,
+            "a stable tree must produce a stable snapshot"
+        );
+        assert_eq!(first.len(), 2);
+        assert!(first.iter().any(|entry| {
+            entry.relative_path == PathBuf::from("nested")
+                && entry.kind
+                    == TreeEntryKind::Directory {
+                        identity: expected_directory_identity,
+                    }
+        }));
+        assert!(first.iter().any(|entry| {
+            entry.relative_path == PathBuf::from("nested/payload.txt")
+                && entry.kind
+                    == TreeEntryKind::File {
+                        identity: expected_file_identity,
+                        size: 3,
+                        sha256: [
+                            0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea, 0x41, 0x41, 0x40, 0xde,
+                            0x5d, 0xae, 0x22, 0x23, 0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
+                            0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad,
+                        ],
+                    }
+        }));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_tree_snapshot_rejects_a_reparse_target_without_traversal() {
+        let root = unique_temp_root("tree-snapshot-root-reparse");
+        let outside = root.join("outside");
+        let target = root.join("target");
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(outside.join("sentinel.txt"), b"outside").unwrap();
+        std::os::windows::fs::symlink_dir(&outside, &target).unwrap();
+
+        let error = TreeSnapshot::capture_target(&target).unwrap_err();
+
+        assert!(!error.contains("unavailable"), "{error}");
+        assert!(
+            error.contains("reparse") || error.contains("link") || error.contains("real directory"),
+            "{error}"
+        );
+        assert_eq!(fs::read(outside.join("sentinel.txt")).unwrap(), b"outside");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_tree_snapshot_reports_a_missing_target_as_absent() {
+        let root = unique_temp_root("tree-snapshot-absent");
+        let target = root.join("target");
+        fs::create_dir_all(&root).unwrap();
+
+        assert_eq!(
+            TreeSnapshot::capture_target(&target).unwrap(),
+            TreeSnapshot::Absent
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_tree_snapshot_rejects_a_nested_reparse_entry_without_traversal() {
+        let root = unique_temp_root("tree-snapshot-nested-reparse");
+        let target = root.join("target");
+        let outside = root.join("outside");
+        fs::create_dir_all(&target).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(outside.join("sentinel.txt"), b"outside").unwrap();
+        std::os::windows::fs::symlink_dir(&outside, target.join("link")).unwrap();
+
+        let error = capture_directory_snapshot(&target).unwrap_err();
+
+        assert!(!error.contains("unavailable"), "{error}");
+        assert!(
+            error.contains("reparse") || error.contains("link") || error.contains("unsupported"),
+            "{error}"
+        );
+        assert_eq!(fs::read(outside.join("sentinel.txt")).unwrap(), b"outside");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_tree_snapshot_detects_identical_byte_name_replacement() {
+        let root = unique_temp_root("tree-snapshot-name-replacement");
+        let target = root.join("target");
+        let file = target.join("payload.txt");
+        let displaced = root.join("payload.displaced.txt");
+        let replacement = root.join("payload.replacement.txt");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(&file, b"identical").unwrap();
+        fs::write(&replacement, b"identical").unwrap();
+        let parent = open_directory_nofollow(&root).unwrap();
+        let hook_file = file.clone();
+        let hook_displaced = displaced.clone();
+        let hook_replacement = replacement.clone();
+
+        let result = with_tree_open_hook(
+            move |path| {
+                assert_eq!(path, hook_file);
+                fs::rename(&hook_file, &hook_displaced).unwrap();
+                fs::rename(&hook_replacement, &hook_file).unwrap();
+            },
+            || capture_tree_child_nofollow(&parent, OsStr::new("target"), target.as_path()),
+        );
+
+        let error = result.expect_err("snapshotting must bind each child name to its identity");
+        assert!(!error.contains("unavailable"), "{error}");
+        assert!(
+            error.contains("identity") || error.contains("changed"),
+            "{error}"
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_tree_snapshot_rejects_multiply_linked_files() {
+        let root = unique_temp_root("tree-snapshot-hard-link");
+        let target = root.join("target");
+        let file = target.join("payload.txt");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(&file, b"payload").unwrap();
+        fs::hard_link(&file, target.join("alias.txt")).unwrap();
+
+        let error = capture_directory_snapshot(&target).unwrap_err();
+
+        assert!(!error.contains("unavailable"), "{error}");
+        assert!(error.contains("exactly one hard link"), "{error}");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_tree_snapshot_detects_last_write_metadata_mutation() {
+        let root = unique_temp_root("tree-snapshot-metadata");
+        let target = root.join("target");
+        let file = target.join("payload.txt");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(&file, b"payload").unwrap();
+        set_last_write_time(&file, 0x01d9_0000, 0x1111_1111);
+        let parent = open_directory_nofollow(&root).unwrap();
+        let hook_file = file.clone();
+
+        let result = with_tree_open_hook(
+            move |path| {
+                assert_eq!(path, hook_file);
+                set_last_write_time(&hook_file, 0x01da_0000, 0x2222_2222);
+            },
+            || capture_tree_child_nofollow(&parent, OsStr::new("target"), target.as_path()),
+        );
+
+        let error = result.expect_err("snapshotting must reject last-write metadata mutation");
+        assert!(!error.contains("unavailable"), "{error}");
+        assert!(error.contains("changed"), "{error}");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_handle_cleanup_removes_reparse_entries_without_traversal() {
+        let root = unique_temp_root("handle-cleanup-reparse");
+        let parent_path = root.join("parent");
+        let tree = parent_path.join("tree");
+        let nested = tree.join("nested");
+        let outside = root.join("outside");
+        fs::create_dir_all(&nested).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        fs::write(nested.join("inside.txt"), b"inside").unwrap();
+        fs::write(outside.join("sentinel.txt"), b"outside").unwrap();
+        std::os::windows::fs::symlink_dir(&outside, tree.join("unsupported-link")).unwrap();
+        let parent = open_directory_nofollow(&parent_path).unwrap();
+        let expected_identity = file_identity(&open_directory_nofollow(&tree).unwrap()).unwrap();
+
+        remove_bound_directory_child(&parent, OsStr::new("tree"), expected_identity, &tree)
+            .unwrap();
+
+        assert!(!tree.exists());
+        assert_eq!(fs::read(outside.join("sentinel.txt")).unwrap(), b"outside");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_handle_cleanup_leaves_an_identity_replacement_untouched() {
+        let root = unique_temp_root("handle-cleanup-replacement");
+        let parent_path = root.join("parent");
+        let tree = parent_path.join("tree");
+        let displaced = parent_path.join("tree-displaced");
+        fs::create_dir_all(&tree).unwrap();
+        fs::write(tree.join("owned.txt"), b"owned").unwrap();
+        let parent = open_directory_nofollow(&parent_path).unwrap();
+        let expected_identity = file_identity(&open_directory_nofollow(&tree).unwrap()).unwrap();
+        fs::rename(&tree, &displaced).unwrap();
+        fs::create_dir(&tree).unwrap();
+        fs::write(tree.join("replacement.txt"), b"replacement").unwrap();
+
+        let error =
+            remove_bound_directory_child(&parent, OsStr::new("tree"), expected_identity, &tree)
+                .unwrap_err();
+
+        assert!(
+            error.contains("identity") || error.contains("changed"),
+            "{error}"
+        );
+        assert_eq!(
+            fs::read(tree.join("replacement.txt")).unwrap(),
+            b"replacement"
+        );
+        assert_eq!(fs::read(displaced.join("owned.txt")).unwrap(), b"owned");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_handle_cleanup_removes_an_expected_regular_file() {
+        let root = unique_temp_root("handle-cleanup-file");
+        let parent_path = root.join("parent");
+        let file = parent_path.join("effective.yaml");
+        fs::create_dir_all(&parent_path).unwrap();
+        fs::write(&file, b"private").unwrap();
+        let parent = open_directory_nofollow(&parent_path).unwrap();
+        let expected_identity = file_identity(&fs::File::open(&file).unwrap()).unwrap();
+
+        unlink_bound_regular_child(&parent, OsStr::new("effective.yaml"), expected_identity)
+            .unwrap();
+
+        assert!(!file.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_handle_cleanup_leaves_a_regular_file_replacement_untouched() {
+        let root = unique_temp_root("handle-cleanup-file-replacement");
+        let parent_path = root.join("parent");
+        let file = parent_path.join("effective.yaml");
+        let displaced = parent_path.join("effective.displaced.yaml");
+        fs::create_dir_all(&parent_path).unwrap();
+        fs::write(&file, b"owned").unwrap();
+        let parent = open_directory_nofollow(&parent_path).unwrap();
+        let expected_identity = file_identity(&fs::File::open(&file).unwrap()).unwrap();
+        fs::rename(&file, &displaced).unwrap();
+        fs::write(&file, b"replacement").unwrap();
+
+        let error =
+            unlink_bound_regular_child(&parent, OsStr::new("effective.yaml"), expected_identity)
+                .unwrap_err();
+
+        assert!(error.contains("identity"), "{error}");
+        assert_eq!(fs::read(&file).unwrap(), b"replacement");
+        assert_eq!(fs::read(&displaced).unwrap(), b"owned");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    fn set_last_write_time(path: &std::path::Path, high: u32, low: u32) {
+        let file = fs::OpenOptions::new().write(true).open(path).unwrap();
+        let last_write = FILETIME {
+            dwLowDateTime: low,
+            dwHighDateTime: high,
+        };
+        // SAFETY: file owns a valid writable handle and last_write remains live for the call.
+        assert_ne!(
+            unsafe {
+                SetFileTime(
+                    file.as_raw_handle(),
+                    std::ptr::null(),
+                    std::ptr::null(),
+                    &last_write,
+                )
+            },
+            0,
+            "{}",
+            std::io::Error::last_os_error()
+        );
     }
 
     fn unique_temp_root(name: &str) -> PathBuf {
@@ -1841,6 +2134,7 @@ fn secure_read_regular_file_snapshot(
     let mut raw = Vec::new();
     file.read_to_end(&mut raw)
         .map_err(|error| format!("failed to read {role} {}: {error}", path.display()))?;
+    run_secure_read_after_hook(path);
     let after = file.metadata().map_err(|error| {
         format!(
             "failed to recheck opened {role} {}: {error}",
@@ -1868,7 +2162,6 @@ fn secure_read_regular_file_snapshot(
             path.display()
         ));
     }
-    run_secure_read_after_hook(path);
     Ok(SecureFileSnapshot { identity, raw })
 }
 
@@ -2854,7 +3147,36 @@ fn unlink_bound_regular_child(
         .map_err(|error| format!("secure unlinkat failed: {error}"))
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn unlink_bound_regular_child(
+    parent: &File,
+    name: &OsStr,
+    expected_identity: FileIdentity,
+) -> Result<(), String> {
+    let child = open_any_child_for_delete(parent, name)
+        .map_err(|error| format!("failed to rebind the private file before cleanup: {error}"))?;
+    if opened_child_kind(&child)
+        .map_err(|error| format!("failed to classify the private file before cleanup: {error}"))?
+        != OpenedChildKind::RegularFile
+    {
+        return Err(
+            "private file changed kind before cleanup; the replacement was left untouched"
+                .to_string(),
+        );
+    }
+    let actual_identity = file_identity(&child)
+        .map_err(|error| format!("failed to inspect the private file before cleanup: {error}"))?;
+    if actual_identity != expected_identity {
+        return Err(
+            "private file identity changed before cleanup; the replacement was left untouched"
+                .to_string(),
+        );
+    }
+    delete_open_child(&child)
+        .map_err(|error| format!("secure handle-relative file cleanup failed: {error}"))
+}
+
+#[cfg(not(any(unix, windows)))]
 fn unlink_bound_regular_child(
     _parent: &File,
     _name: &OsStr,
@@ -2931,7 +3253,103 @@ fn remove_directory_contents_nofollow(directory: &File, display_path: &Path) -> 
     Ok(())
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn remove_directory_contents_nofollow(directory: &File, display_path: &Path) -> Result<(), String> {
+    for name in crate::infrastructure::platform::filesystem::read_directory_names(directory)
+        .map_err(|error| {
+            format!(
+                "failed to enumerate the retained private directory anchor {}: {error}",
+                display_path.display()
+            )
+        })?
+    {
+        let child_path = display_path.join(&name);
+        let child = match open_any_child_for_delete(directory, &name) {
+            Ok(child) => child,
+            Err(error) if error.kind() == ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(format!(
+                    "failed to inspect private entry {} before cleanup: {error}",
+                    child_path.display()
+                ));
+            }
+        };
+        let identity = file_identity(&child).map_err(|error| {
+            format!(
+                "failed to inspect private entry identity {} before cleanup: {error}",
+                child_path.display()
+            )
+        })?;
+        let kind = opened_child_kind(&child).map_err(|error| {
+            format!(
+                "failed to classify private entry {} before cleanup: {error}",
+                child_path.display()
+            )
+        })?;
+
+        if kind == OpenedChildKind::Directory {
+            let directory_child =
+                open_directory_child_nofollow(directory, &name).map_err(|error| {
+                    format!(
+                        "failed to bind private directory {} before cleanup: {error}",
+                        child_path.display()
+                    )
+                })?;
+            if file_identity(&directory_child).map_err(|error| {
+                format!(
+                    "failed to inspect private directory {} before cleanup: {error}",
+                    child_path.display()
+                )
+            })? != identity
+            {
+                return Err(format!(
+                    "private directory identity changed before cleanup; replacement left untouched: {}",
+                    child_path.display()
+                ));
+            }
+            remove_directory_contents_nofollow(&directory_child, &child_path)?;
+        } else if kind == OpenedChildKind::Unsupported {
+            return Err(format!(
+                "private tree contains an unsupported entry that cannot be securely removed: {}",
+                child_path.display()
+            ));
+        }
+
+        let rebound = open_any_child_for_delete(directory, &name).map_err(|error| {
+            format!(
+                "failed to rebind private entry {} before cleanup: {error}",
+                child_path.display()
+            )
+        })?;
+        let rebound_identity = file_identity(&rebound).map_err(|error| {
+            format!(
+                "failed to recheck private entry {} before cleanup: {error}",
+                child_path.display()
+            )
+        })?;
+        let rebound_kind = opened_child_kind(&rebound).map_err(|error| {
+            format!(
+                "failed to reclassify private entry {} before cleanup: {error}",
+                child_path.display()
+            )
+        })?;
+        if rebound_identity != identity || rebound_kind != kind {
+            return Err(format!(
+                "private entry identity or kind changed before cleanup; replacement left untouched: {}",
+                child_path.display()
+            ));
+        }
+        delete_open_child(&rebound).map_err(|error| {
+            format!(
+                "failed to remove private entry {} through its retained parent anchor: {error}",
+                child_path.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
 fn remove_directory_contents_nofollow(
     _directory: &File,
     display_path: &Path,
@@ -2994,7 +3412,97 @@ fn remove_bound_directory_child(
     })
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn remove_bound_directory_child(
+    parent: &File,
+    name: &OsStr,
+    expected_identity: FileIdentity,
+    display_path: &Path,
+) -> Result<(), String> {
+    let delete_handle = open_any_child_for_delete(parent, name).map_err(|error| {
+        format!(
+            "failed to rebind expected private directory {} before cleanup: {error}",
+            display_path.display()
+        )
+    })?;
+    if opened_child_kind(&delete_handle).map_err(|error| {
+        format!(
+            "failed to classify expected private directory {} before cleanup: {error}",
+            display_path.display()
+        )
+    })? != OpenedChildKind::Directory
+    {
+        return Err(format!(
+            "private directory changed kind before cleanup; replacement left untouched: {}",
+            display_path.display()
+        ));
+    }
+    if file_identity(&delete_handle).map_err(|error| {
+        format!(
+            "failed to inspect expected private directory {} before cleanup: {error}",
+            display_path.display()
+        )
+    })? != expected_identity
+    {
+        return Err(format!(
+            "private directory identity changed before cleanup; replacement left untouched: {}",
+            display_path.display()
+        ));
+    }
+
+    let directory = open_directory_child_nofollow(parent, name).map_err(|error| {
+        format!(
+            "failed to retain expected private directory {} before cleanup: {error}",
+            display_path.display()
+        )
+    })?;
+    if file_identity(&directory).map_err(|error| {
+        format!(
+            "failed to inspect retained private directory {} before cleanup: {error}",
+            display_path.display()
+        )
+    })? != expected_identity
+    {
+        return Err(format!(
+            "private directory identity changed before cleanup; replacement left untouched: {}",
+            display_path.display()
+        ));
+    }
+    remove_directory_contents_nofollow(&directory, display_path)?;
+
+    let rebound = open_any_child_for_delete(parent, name).map_err(|error| {
+        format!(
+            "failed to rebind expected private directory {} after cleanup: {error}",
+            display_path.display()
+        )
+    })?;
+    if file_identity(&rebound).map_err(|error| {
+        format!(
+            "failed to recheck expected private directory {} after cleanup: {error}",
+            display_path.display()
+        )
+    })? != expected_identity
+        || opened_child_kind(&rebound).map_err(|error| {
+            format!(
+                "failed to reclassify expected private directory {} after cleanup: {error}",
+                display_path.display()
+            )
+        })? != OpenedChildKind::Directory
+    {
+        return Err(format!(
+            "private directory identity or kind changed after cleanup; replacement left untouched: {}",
+            display_path.display()
+        ));
+    }
+    delete_open_child(&rebound).map_err(|error| {
+        format!(
+            "failed to remove expected private directory {} through its retained parent anchor: {error}",
+            display_path.display()
+        )
+    })
+}
+
+#[cfg(not(any(unix, windows)))]
 fn remove_bound_directory_child(
     _parent: &File,
     _name: &OsStr,
@@ -3051,7 +3559,7 @@ impl TreeSnapshot {
 fn capture_directory_snapshot(root: &Path) -> Result<Vec<TreeEntrySnapshot>, String> {
     let normalized = normalize_leaf_path(root)?;
     let (parent_path, name) = split_parent_and_name(&normalized)?;
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = (parent_path, name);
         Err(format!(
@@ -3059,7 +3567,7 @@ fn capture_directory_snapshot(root: &Path) -> Result<Vec<TreeEntrySnapshot>, Str
             root.display()
         ))
     }
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     {
         let directory = {
             let parent = open_directory_nofollow(&parent_path).map_err(|error| {
@@ -3150,7 +3658,67 @@ fn capture_tree_child_nofollow(
     Ok(TreeSnapshot::Directory { identity, entries })
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn capture_tree_target_nofollow(path: &Path) -> Result<TreeSnapshot, String> {
+    let normalized = normalize_leaf_path(path)?;
+    let (parent_path, name) = split_parent_and_name(&normalized)?;
+    let parent = open_directory_nofollow(&parent_path).map_err(|error| {
+        format!(
+            "failed to securely open dump target parent {}: {error}",
+            parent_path.display()
+        )
+    })?;
+    run_tree_open_hook(path);
+    capture_tree_child_nofollow(&parent, &name, path)
+}
+
+#[cfg(windows)]
+fn capture_tree_child_nofollow(
+    parent: &File,
+    name: &OsStr,
+    display_path: &Path,
+) -> Result<TreeSnapshot, String> {
+    let directory = match open_directory_child_nofollow(parent, name) {
+        Ok(directory) => directory,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(TreeSnapshot::Absent),
+        Err(error) => {
+            return Err(format!(
+                "dump target must be a real directory or absent {}: {error}",
+                display_path.display()
+            ));
+        }
+    };
+    let identity = file_identity(&directory).map_err(|error| {
+        format!(
+            "failed to inspect dump target directory identity {}: {error}",
+            display_path.display()
+        )
+    })?;
+    let mut entries = Vec::new();
+    capture_directory_snapshot_recursive(&directory, Path::new(""), display_path, &mut entries)?;
+    let rebound = open_directory_child_nofollow(parent, name).map_err(|error| {
+        format!(
+            "failed to rebind dump target directory {}: {error}",
+            display_path.display()
+        )
+    })?;
+    if file_identity(&rebound).map_err(|error| {
+        format!(
+            "failed to recheck dump target identity {}: {error}",
+            display_path.display()
+        )
+    })? != identity
+    {
+        return Err(format!(
+            "dump target directory identity changed while snapshotting: {}",
+            display_path.display()
+        ));
+    }
+    entries.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    Ok(TreeSnapshot::Directory { identity, entries })
+}
+
+#[cfg(not(any(unix, windows)))]
 fn capture_tree_target_nofollow(path: &Path) -> Result<TreeSnapshot, String> {
     Err(format!(
         "secure no-follow directory snapshots are unavailable on this host: {}",
@@ -3158,7 +3726,7 @@ fn capture_tree_target_nofollow(path: &Path) -> Result<TreeSnapshot, String> {
     ))
 }
 
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 fn capture_tree_child_nofollow(
     _parent: &File,
     _name: &OsStr,
@@ -3168,6 +3736,197 @@ fn capture_tree_child_nofollow(
         "secure no-follow directory snapshots are unavailable on this host: {}",
         display_path.display()
     ))
+}
+
+#[cfg(windows)]
+fn capture_directory_snapshot_recursive(
+    directory: &File,
+    relative_root: &Path,
+    display_root: &Path,
+    entries: &mut Vec<TreeEntrySnapshot>,
+) -> Result<(), String> {
+    for name in crate::infrastructure::platform::filesystem::read_directory_names(directory)
+        .map_err(|error| {
+            format!(
+                "failed to securely enumerate {}: {error}",
+                display_root.join(relative_root).display()
+            )
+        })?
+    {
+        let relative = relative_root.join(&name);
+        let display_path = display_root.join(&relative);
+        let opened = open_any_child_nofollow(directory, &name).map_err(|error| {
+            format!(
+                "dump tree contains an unsupported entry {}: {error}",
+                display_path.display()
+            )
+        })?;
+        let identity = file_identity(&opened).map_err(|error| {
+            format!(
+                "failed to inspect entry identity {}: {error}",
+                display_path.display()
+            )
+        })?;
+        let metadata = opened.metadata().map_err(|error| {
+            format!(
+                "failed to inspect opened entry {}: {error}",
+                display_path.display()
+            )
+        })?;
+
+        if metadata.is_dir() {
+            let child = open_directory_child_nofollow(directory, &name).map_err(|error| {
+                format!(
+                    "failed to securely bind directory {}: {error}",
+                    display_path.display()
+                )
+            })?;
+            if file_identity(&child).map_err(|error| {
+                format!(
+                    "failed to inspect directory identity {}: {error}",
+                    display_path.display()
+                )
+            })? != identity
+            {
+                return Err(format!(
+                    "dump tree directory identity changed while opening: {}",
+                    display_path.display()
+                ));
+            }
+            entries.push(TreeEntrySnapshot {
+                relative_path: relative.clone(),
+                kind: TreeEntryKind::Directory { identity },
+            });
+            capture_directory_snapshot_recursive(&child, &relative, display_root, entries)?;
+            let rebound = open_directory_child_nofollow(directory, &name).map_err(|error| {
+                format!(
+                    "failed to rebind directory {}: {error}",
+                    display_path.display()
+                )
+            })?;
+            if file_identity(&rebound).map_err(|error| {
+                format!(
+                    "failed to recheck directory identity {}: {error}",
+                    display_path.display()
+                )
+            })? != identity
+            {
+                return Err(format!(
+                    "dump tree directory identity changed while snapshotting: {}",
+                    display_path.display()
+                ));
+            }
+            continue;
+        }
+
+        if !metadata.is_file() {
+            return Err(format!(
+                "dump tree contains an unsupported entry kind: {}",
+                display_path.display()
+            ));
+        }
+        let mut file = open_regular_child_nofollow(directory, &name).map_err(|error| {
+            format!(
+                "dump tree contains an unsupported entry {}: {error}",
+                display_path.display()
+            )
+        })?;
+        if file_identity(&file).map_err(|error| {
+            format!(
+                "failed to inspect file identity {}: {error}",
+                display_path.display()
+            )
+        })? != identity
+        {
+            return Err(format!(
+                "dump tree file identity changed while opening: {}",
+                display_path.display()
+            ));
+        }
+        if hard_link_count(&file).map_err(|error| {
+            format!(
+                "failed to inspect hard links for {}: {error}",
+                display_path.display()
+            )
+        })? != 1
+        {
+            return Err(format!(
+                "dump tree file must have exactly one hard link: {}",
+                display_path.display()
+            ));
+        }
+        let before = file.metadata().map_err(|error| {
+            format!(
+                "failed to inspect opened file {}: {error}",
+                display_path.display()
+            )
+        })?;
+        let mut hasher = Sha256::new();
+        let mut size = 0_u64;
+        let mut buffer = [0_u8; 64 * 1024];
+        loop {
+            let read = file
+                .read(&mut buffer)
+                .map_err(|error| format!("failed to read {}: {error}", display_path.display()))?;
+            if read == 0 {
+                break;
+            }
+            size += read as u64;
+            hasher.update(&buffer[..read]);
+        }
+        run_tree_open_hook(&display_path);
+        let after = file.metadata().map_err(|error| {
+            format!(
+                "failed to recheck opened file {}: {error}",
+                display_path.display()
+            )
+        })?;
+        if before.len() != after.len()
+            || before.modified().ok() != after.modified().ok()
+            || after.len() != size
+        {
+            return Err(format!(
+                "dump tree file changed while snapshotting: {}",
+                display_path.display()
+            ));
+        }
+        if hard_link_count(&file).map_err(|error| {
+            format!(
+                "failed to recheck hard links for {}: {error}",
+                display_path.display()
+            )
+        })? != 1
+        {
+            return Err(format!(
+                "dump tree file hard-link count changed while snapshotting: {}",
+                display_path.display()
+            ));
+        }
+        let rebound = open_regular_child_nofollow(directory, &name).map_err(|error| {
+            format!("failed to rebind file {}: {error}", display_path.display())
+        })?;
+        if file_identity(&rebound).map_err(|error| {
+            format!(
+                "failed to recheck file identity {}: {error}",
+                display_path.display()
+            )
+        })? != identity
+        {
+            return Err(format!(
+                "dump tree file identity changed while snapshotting: {}",
+                display_path.display()
+            ));
+        }
+        entries.push(TreeEntrySnapshot {
+            relative_path: relative,
+            kind: TreeEntryKind::File {
+                identity,
+                size,
+                sha256: hasher.finalize().into(),
+            },
+        });
+    }
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -3365,7 +4124,7 @@ fn read_directory_names(directory: &File) -> std::io::Result<Vec<OsString>> {
     Ok(names)
 }
 
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 fn capture_directory_snapshot_recursive(
     _directory: &File,
     _relative_root: &Path,

--- a/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+++ b/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
@@ -28,7 +28,8 @@ use crate::infrastructure::platform::filesystem::{
 };
 #[cfg(windows)]
 use crate::infrastructure::platform::filesystem::{
-    create_owner_only_directory, create_owner_only_file, open_directory_nofollow,
+    create_owner_only_directory_child, create_owner_only_file_child, discard_created_child,
+    open_directory_child_nofollow, open_directory_nofollow, verify_owner_only_acl,
 };
 use crate::infrastructure::platform_xml_owner::root_version_literal;
 use crate::infrastructure::plugin_runtime::find_plugin_root;
@@ -109,6 +110,23 @@ mod windows_anchor_tests {
 
         child.verify_path_binding().unwrap();
         verify_owner_only_acl(&child.directory).unwrap();
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_anchor_rejects_a_display_path_outside_the_parent() {
+        let root = unique_temp_root("anchor-containment");
+        let parent = root.join("parent");
+        let outside = root.join("outside");
+        fs::create_dir_all(&parent).unwrap();
+        let anchor = DirectoryAnchor::capture_exact(&parent).unwrap();
+
+        let error = anchor
+            .create_child(OsStr::new("child"), &outside)
+            .unwrap_err();
+
+        assert!(error.contains("does not match anchored child"), "{error}");
+        assert!(!outside.exists());
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -1780,11 +1798,11 @@ fn create_regular_child_owner_only(
 
 #[cfg(windows)]
 fn create_regular_child_owner_only(
-    _parent: &File,
-    _name: &OsStr,
-    display_path: &Path,
+    parent: &File,
+    name: &OsStr,
+    _display_path: &Path,
 ) -> std::io::Result<File> {
-    create_owner_only_file(display_path)
+    create_owner_only_file_child(parent, name)
 }
 
 #[cfg(not(any(unix, windows)))]
@@ -2036,38 +2054,61 @@ impl DirectoryAnchor {
     }
 
     #[cfg(windows)]
-    fn create_child(&self, _name: &OsStr, display_path: &Path) -> Result<Self, String> {
+    fn create_child(&self, name: &OsStr, display_path: &Path) -> Result<Self, String> {
+        let expected_path = self.path.join(name);
+        if display_path != expected_path {
+            return Err(format!(
+                "private directory display path does not match anchored child {}: {}",
+                expected_path.display(),
+                display_path.display()
+            ));
+        }
         self.verify_path_binding()?;
-        let directory = create_owner_only_directory(display_path).map_err(|error| {
+        let directory = create_owner_only_directory_child(&self.directory, name).map_err(|error| {
             format!(
                 "failed to create private directory {}: {error}",
                 display_path.display()
             )
         })?;
+        let cleanup_error = |error: String| match discard_created_child(&directory) {
+            Ok(()) => error,
+            Err(cleanup) => format!(
+                "{error}; failed to remove private directory created through the retained parent anchor {}: {cleanup}",
+                display_path.display()
+            ),
+        };
         let identity = file_identity(&directory).map_err(|error| {
-            format!(
+            cleanup_error(format!(
                 "failed to inspect private directory identity {}: {error}",
                 display_path.display()
-            )
+            ))
         })?;
-        self.verify_path_binding()?;
-        let rebound = open_directory_nofollow(display_path).map_err(|error| {
-            format!(
+        if let Err(error) = verify_owner_only_acl(&directory) {
+            return Err(cleanup_error(format!(
+                "failed to verify private directory ACL {}: {error}",
+                display_path.display()
+            )));
+        }
+        if let Err(error) = self.verify_path_binding() {
+            return Err(cleanup_error(error));
+        }
+        let rebound = open_directory_child_nofollow(&self.directory, name).map_err(|error| {
+            cleanup_error(format!(
                 "failed to bind newly created private directory {}: {error}",
                 display_path.display()
-            )
+            ))
         })?;
         let rebound_identity = file_identity(&rebound).map_err(|error| {
-            format!(
+            cleanup_error(format!(
                 "failed to recheck private directory identity {}: {error}",
                 display_path.display()
-            )
+            ))
         })?;
         if rebound_identity != identity {
-            return Err(format!(
+            return Err(cleanup_error(format!(
                 "private directory identity changed during creation: {}",
                 display_path.display()
-            ));
+            )));
         }
         Ok(Self {
             path: display_path.to_path_buf(),

--- a/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+++ b/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
@@ -26,6 +26,10 @@ use crate::infrastructure::platform::filesystem::hard_link_count;
 use crate::infrastructure::platform::filesystem::{
     file_identity, metadata_is_link_or_reparse_point, restrict_stage_to_owner, FileIdentity,
 };
+#[cfg(windows)]
+use crate::infrastructure::platform::filesystem::{
+    create_owner_only_directory, create_owner_only_file, open_directory_nofollow,
+};
 use crate::infrastructure::platform_xml_owner::root_version_literal;
 use crate::infrastructure::plugin_runtime::find_plugin_root;
 use crate::infrastructure::project_sources::classify_physical_source_inventory;
@@ -66,6 +70,54 @@ const PLATFORM_PROBE_TIMEOUT: Duration = Duration::from_secs(15);
 pub(crate) enum FullDumpInvocation {
     BuildDump,
     RuntimeExecute,
+}
+
+#[cfg(all(test, windows))]
+mod windows_anchor_tests {
+    use super::DirectoryAnchor;
+    use crate::infrastructure::platform::filesystem::verify_owner_only_acl;
+    use std::ffi::OsStr;
+    use std::fs;
+    use std::path::PathBuf;
+
+    #[test]
+    fn windows_anchor_detects_parent_name_replacement() {
+        let root = unique_temp_root("anchor-replacement");
+        let parent = root.join("parent");
+        fs::create_dir_all(&parent).unwrap();
+        let anchor = DirectoryAnchor::capture_exact(&parent).unwrap();
+        let moved = root.join("moved");
+        fs::rename(&parent, &moved).unwrap();
+        fs::create_dir(&parent).unwrap();
+
+        let error = anchor.verify_path_binding().unwrap_err();
+
+        assert!(error.contains("identity"), "{error}");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_anchor_creates_a_private_bound_child() {
+        let root = unique_temp_root("anchor-child");
+        fs::create_dir_all(&root).unwrap();
+        let anchor = DirectoryAnchor::capture_exact(&root).unwrap();
+        let child_path = root.join("child");
+
+        let child = anchor
+            .create_child(OsStr::new("child"), &child_path)
+            .unwrap();
+
+        child.verify_path_binding().unwrap();
+        verify_owner_only_acl(&child.directory).unwrap();
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    fn unique_temp_root(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "unica-full-dump-{name}-{}",
+            uuid::Uuid::new_v4()
+        ))
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1701,7 +1753,11 @@ fn open_regular_child_nofollow(parent: &File, name: &OsStr) -> std::io::Result<F
 }
 
 #[cfg(unix)]
-fn create_regular_child_owner_only(parent: &File, name: &OsStr) -> std::io::Result<File> {
+fn create_regular_child_owner_only(
+    parent: &File,
+    name: &OsStr,
+    _display_path: &Path,
+) -> std::io::Result<File> {
     let name = CString::new(name.as_bytes())?;
     // SAFETY: parent remains open for the call and name is a live
     // NUL-terminated string. The file starts owner-only; there is no
@@ -1722,8 +1778,21 @@ fn create_regular_child_owner_only(parent: &File, name: &OsStr) -> std::io::Resu
     }
 }
 
-#[cfg(not(unix))]
-fn create_regular_child_owner_only(_parent: &File, _name: &OsStr) -> std::io::Result<File> {
+#[cfg(windows)]
+fn create_regular_child_owner_only(
+    _parent: &File,
+    _name: &OsStr,
+    display_path: &Path,
+) -> std::io::Result<File> {
+    create_owner_only_file(display_path)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn create_regular_child_owner_only(
+    _parent: &File,
+    _name: &OsStr,
+    _display_path: &Path,
+) -> std::io::Result<File> {
     Err(std::io::Error::new(
         ErrorKind::Unsupported,
         "secure openat config creation is unavailable on this host",
@@ -1776,7 +1845,7 @@ struct DirectoryAnchor {
 }
 
 impl DirectoryAnchor {
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     fn capture_exact(path: &Path) -> Result<Self, String> {
         if !path.is_absolute() {
             return Err(format!(
@@ -1879,7 +1948,7 @@ impl DirectoryAnchor {
         ))
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     fn try_clone(&self) -> Result<Self, String> {
         let directory = self.directory.try_clone().map_err(|error| {
             format!(
@@ -1894,7 +1963,7 @@ impl DirectoryAnchor {
         })
     }
 
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     fn try_clone(&self) -> Result<Self, String> {
         Err(format!(
             "secure directory anchors are unavailable on this host: {}",
@@ -1966,7 +2035,48 @@ impl DirectoryAnchor {
         })
     }
 
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    fn create_child(&self, _name: &OsStr, display_path: &Path) -> Result<Self, String> {
+        self.verify_path_binding()?;
+        let directory = create_owner_only_directory(display_path).map_err(|error| {
+            format!(
+                "failed to create private directory {}: {error}",
+                display_path.display()
+            )
+        })?;
+        let identity = file_identity(&directory).map_err(|error| {
+            format!(
+                "failed to inspect private directory identity {}: {error}",
+                display_path.display()
+            )
+        })?;
+        self.verify_path_binding()?;
+        let rebound = open_directory_nofollow(display_path).map_err(|error| {
+            format!(
+                "failed to bind newly created private directory {}: {error}",
+                display_path.display()
+            )
+        })?;
+        let rebound_identity = file_identity(&rebound).map_err(|error| {
+            format!(
+                "failed to recheck private directory identity {}: {error}",
+                display_path.display()
+            )
+        })?;
+        if rebound_identity != identity {
+            return Err(format!(
+                "private directory identity changed during creation: {}",
+                display_path.display()
+            ));
+        }
+        Ok(Self {
+            path: display_path.to_path_buf(),
+            identity,
+            directory,
+        })
+    }
+
+    #[cfg(not(any(unix, windows)))]
     fn create_child(&self, _name: &OsStr, display_path: &Path) -> Result<Self, String> {
         Err(format!(
             "secure mkdirat private directories are unavailable on this host: {}",
@@ -1974,7 +2084,7 @@ impl DirectoryAnchor {
         ))
     }
 
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     fn capture_exact(path: &Path) -> Result<Self, String> {
         Err(format!(
             "secure directory anchors are unavailable on this host: {}",
@@ -1982,7 +2092,7 @@ impl DirectoryAnchor {
         ))
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     fn verify_path_binding(&self) -> Result<(), String> {
         let directory = open_directory_nofollow(&self.path).map_err(|error| {
             format!(
@@ -2005,7 +2115,7 @@ impl DirectoryAnchor {
         Ok(())
     }
 
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     fn verify_path_binding(&self) -> Result<(), String> {
         Err(format!(
             "secure directory anchors are unavailable on this host: {}",
@@ -2145,6 +2255,7 @@ impl PrivateDumpStage {
         let file = create_regular_child_owner_only(
             &self.execution_anchor.directory,
             OsStr::new(EFFECTIVE_CONFIG_NAME),
+            &self.effective_config,
         )
         .map_err(|error| {
             format!(

--- a/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+++ b/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
@@ -21,13 +21,14 @@ use crate::infrastructure::internal_adapters::{
 use crate::infrastructure::native_operations::single_file_publisher::{
     with_publication_locks_mode, PublicationTreeLockMode,
 };
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use crate::infrastructure::platform::filesystem::hard_link_count;
 #[cfg(windows)]
 use crate::infrastructure::platform::filesystem::{
     create_owner_only_directory_child, create_owner_only_file_child, discard_created_child,
-    open_directory_child_for_rename, open_directory_child_nofollow, open_directory_nofollow,
-    rename_directory_handle_child_no_replace, verify_owner_only_acl,
+    open_any_child_nofollow, open_directory_child_for_rename, open_directory_child_nofollow,
+    open_directory_nofollow, open_regular_child_nofollow, rename_directory_handle_child_no_replace,
+    verify_owner_only_acl,
 };
 use crate::infrastructure::platform::filesystem::{
     file_identity, metadata_is_link_or_reparse_point, restrict_stage_to_owner, FileIdentity,
@@ -48,7 +49,7 @@ use std::env;
 use std::ffi::CString;
 use std::ffi::{OsStr, OsString};
 use std::fs::{self, File};
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use std::io::Read;
 use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
@@ -76,11 +77,16 @@ pub(crate) enum FullDumpInvocation {
 
 #[cfg(all(test, windows))]
 mod windows_anchor_tests {
-    use super::{rename_child_no_replace, DirectoryAnchor};
+    use super::{
+        rename_child_no_replace, secure_path_is_absent, secure_read_regular_file_snapshot,
+        with_secure_read_hook, DirectoryAnchor,
+    };
     use crate::infrastructure::platform::filesystem::verify_owner_only_acl;
+    use std::cell::Cell;
     use std::ffi::OsStr;
     use std::fs;
     use std::path::PathBuf;
+    use std::rc::Rc;
 
     #[test]
     fn windows_anchor_detects_parent_name_replacement() {
@@ -128,6 +134,78 @@ mod windows_anchor_tests {
 
         assert!(error.contains("does not match anchored child"), "{error}");
         assert!(!outside.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_descendant_anchor_walks_multiple_components_from_the_retained_root() {
+        let root = unique_temp_root("descendant-walk");
+        let descendant = root.join("sources").join("configuration");
+        fs::create_dir_all(&descendant).unwrap();
+        let anchor = DirectoryAnchor::capture_exact(&root).unwrap();
+
+        let captured = anchor
+            .capture_descendant(
+                PathBuf::from("sources/configuration").as_path(),
+                &descendant,
+            )
+            .unwrap();
+
+        assert_eq!(captured.path, descendant);
+        captured.verify_path_binding().unwrap();
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_descendant_anchor_rejects_a_replaced_intermediate_component() {
+        let root = unique_temp_root("descendant-replacement");
+        let first = root.join("sources");
+        let descendant = first.join("configuration");
+        fs::create_dir_all(&descendant).unwrap();
+        let anchor = DirectoryAnchor::capture_exact(&root).unwrap();
+        let captured = anchor
+            .capture_descendant(
+                PathBuf::from("sources/configuration").as_path(),
+                &descendant,
+            )
+            .unwrap();
+        let captured_identity = captured.identity;
+        drop(captured);
+        let displaced = root.join("sources-displaced");
+        fs::rename(&first, &displaced).unwrap();
+        fs::create_dir_all(&descendant).unwrap();
+
+        let error = anchor
+            .verify_descendant_identity(
+                PathBuf::from("sources/configuration").as_path(),
+                captured_identity,
+                &descendant,
+            )
+            .unwrap_err();
+
+        assert!(
+            error.contains("identity") || error.contains("changed"),
+            "{error}"
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_descendant_anchor_captures_child_root_identity_and_absence() {
+        let root = unique_temp_root("descendant-child-root");
+        let child = root.join("source");
+        fs::create_dir_all(&child).unwrap();
+        let anchor = DirectoryAnchor::capture_exact(&root).unwrap();
+
+        let identity = anchor
+            .capture_child_root_identity(OsStr::new("source"), &child)
+            .unwrap();
+        let missing = anchor
+            .capture_child_root_identity(OsStr::new("missing"), &root.join("missing"))
+            .unwrap();
+
+        assert!(identity.is_some());
+        assert_eq!(missing, None);
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -183,6 +261,83 @@ mod windows_anchor_tests {
 
         assert!(!source.exists());
         assert_eq!(fs::read(destination.join("new.txt")).unwrap(), b"new");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_secure_read_rejects_a_final_reparse_point() {
+        let root = unique_temp_root("secure-read-reparse");
+        fs::create_dir_all(&root).unwrap();
+        let real = root.join("real.yaml");
+        let link = root.join("v8project.yaml");
+        fs::write(&real, b"project: real").unwrap();
+        std::os::windows::fs::symlink_file(&real, &link).unwrap();
+
+        let error = secure_read_regular_file_snapshot(&link, "project config").unwrap_err();
+
+        assert!(!error.contains("unavailable"), "{error}");
+        assert!(
+            error.contains("reparse") || error.contains("link"),
+            "{error}"
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_secure_read_detects_child_name_identity_replacement() {
+        let root = unique_temp_root("secure-read-identity");
+        fs::create_dir_all(&root).unwrap();
+        let config = root.join("v8project.yaml");
+        let displaced = root.join("v8project.displaced.yaml");
+        let replacement = root.join("v8project.replacement.yaml");
+        fs::write(&config, b"project: original").unwrap();
+        fs::write(&replacement, b"project: replacement").unwrap();
+        let hook_config = config.clone();
+        let hook_displaced = displaced.clone();
+        let hook_replacement = replacement.clone();
+        let hook_ran = Rc::new(Cell::new(false));
+        let hook_ran_inside = Rc::clone(&hook_ran);
+
+        let result = with_secure_read_hook(
+            move |path| {
+                assert_eq!(path, hook_config);
+                hook_ran_inside.set(true);
+                fs::rename(&hook_config, &hook_displaced).unwrap();
+                fs::rename(&hook_replacement, &hook_config).unwrap();
+            },
+            || secure_read_regular_file_snapshot(&config, "project config"),
+        );
+
+        let error = result.expect_err("the retained child identity must reject replacement");
+        assert!(hook_ran.get(), "the secure-read hook must run");
+        assert!(!error.contains("unavailable"), "{error}");
+        assert!(
+            error.contains("identity") || error.contains("changed"),
+            "{error}"
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_secure_read_absence_treats_reparse_points_as_present() {
+        let root = unique_temp_root("secure-absence-reparse");
+        fs::create_dir_all(&root).unwrap();
+        let real = root.join("real.yaml");
+        let link = root.join("v8project.local.yaml");
+        fs::write(&real, b"project: local").unwrap();
+        std::os::windows::fs::symlink_file(&real, &link).unwrap();
+
+        assert!(!secure_path_is_absent(&link).unwrap());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_secure_read_absence_accepts_only_a_missing_child() {
+        let root = unique_temp_root("secure-absence-missing");
+        fs::create_dir_all(&root).unwrap();
+        let missing = root.join("v8project.local.yaml");
+
+        assert!(secure_path_is_absent(&missing).unwrap());
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -1623,7 +1778,101 @@ fn secure_read_regular_file_snapshot(
     Ok(SecureFileSnapshot { identity, raw })
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn secure_read_regular_file_snapshot(
+    path: &Path,
+    role: &str,
+) -> Result<SecureFileSnapshot, String> {
+    let normalized = normalize_leaf_path(path)?;
+    let (parent_path, name) = split_parent_and_name(&normalized)?;
+    let parent = open_directory_nofollow(&parent_path).map_err(|error| {
+        format!(
+            "failed to securely open parent for {role} {}: {error}",
+            normalized.display()
+        )
+    })?;
+    let mut file = open_regular_child_nofollow(&parent, &name)
+        .map_err(|error| format!("failed to securely open {role} {}: {error}", path.display()))?;
+    let identity = file_identity(&file).map_err(|error| {
+        format!(
+            "failed to inspect opened {role} identity {}: {error}",
+            path.display()
+        )
+    })?;
+    if hard_link_count(&file).map_err(|error| {
+        format!(
+            "failed to inspect hard links for {role} {}: {error}",
+            path.display()
+        )
+    })? != 1
+    {
+        return Err(format!(
+            "{role} must have exactly one hard link: {}",
+            path.display()
+        ));
+    }
+    let opened = file.metadata().map_err(|error| {
+        format!(
+            "failed to inspect opened {role} {}: {error}",
+            path.display()
+        )
+    })?;
+
+    run_secure_read_hook(path);
+    let rebound = open_regular_child_nofollow(&parent, &name).map_err(|error| {
+        format!(
+            "failed to rebind {role} name before reading {}: {error}",
+            path.display()
+        )
+    })?;
+    if file_identity(&rebound).map_err(|error| {
+        format!(
+            "failed to recheck {role} identity {}: {error}",
+            path.display()
+        )
+    })? != identity
+    {
+        return Err(format!(
+            "{role} identity changed before reading: {}",
+            path.display()
+        ));
+    }
+
+    let mut raw = Vec::new();
+    file.read_to_end(&mut raw)
+        .map_err(|error| format!("failed to read {role} {}: {error}", path.display()))?;
+    let after = file.metadata().map_err(|error| {
+        format!(
+            "failed to recheck opened {role} {}: {error}",
+            path.display()
+        )
+    })?;
+    if opened.len() != after.len() || opened.modified().ok() != after.modified().ok() {
+        return Err(format!("{role} changed while reading: {}", path.display()));
+    }
+    let rebound = open_regular_child_nofollow(&parent, &name).map_err(|error| {
+        format!(
+            "failed to rebind {role} name after reading {}: {error}",
+            path.display()
+        )
+    })?;
+    if file_identity(&rebound).map_err(|error| {
+        format!(
+            "failed to recheck {role} identity {}: {error}",
+            path.display()
+        )
+    })? != identity
+    {
+        return Err(format!(
+            "{role} identity changed while reading: {}",
+            path.display()
+        ));
+    }
+    run_secure_read_after_hook(path);
+    Ok(SecureFileSnapshot { identity, raw })
+}
+
+#[cfg(not(any(unix, windows)))]
 fn secure_read_regular_file_snapshot(
     path: &Path,
     role: &str,
@@ -1702,7 +1951,44 @@ fn secure_path_is_absent(path: &Path) -> Result<bool, String> {
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn secure_path_is_absent(path: &Path) -> Result<bool, String> {
+    use windows_sys::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND};
+
+    let normalized = normalize_leaf_path(path)?;
+    let (parent_path, name) = split_parent_and_name(&normalized)?;
+    let parent = open_directory_nofollow(&parent_path).map_err(|error| {
+        format!(
+            "failed to securely open parent while checking {}: {error}",
+            normalized.display()
+        )
+    })?;
+    match open_any_child_nofollow(&parent, &name) {
+        Ok(_) => Ok(false),
+        Err(error)
+            if matches!(
+                error.raw_os_error(),
+                Some(code)
+                    if code == ERROR_FILE_NOT_FOUND as i32
+                        || code == ERROR_PATH_NOT_FOUND as i32
+            ) =>
+        {
+            Ok(true)
+        }
+        Err(error)
+            if error.kind() == ErrorKind::InvalidInput
+                && error.to_string().contains("reparse point") =>
+        {
+            Ok(false)
+        }
+        Err(error) => Err(format!(
+            "failed to securely inspect {}: {error}",
+            normalized.display()
+        )),
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
 fn secure_path_is_absent(path: &Path) -> Result<bool, String> {
     Err(format!(
         "secure no-follow absence checks are unavailable on this host: {}",
@@ -1751,7 +2037,7 @@ fn open_directory_nofollow(path: &Path) -> std::io::Result<File> {
     Ok(current)
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn open_directory_relative_nofollow(root: &File, relative: &Path) -> std::io::Result<File> {
     use std::path::Component;
 
@@ -1944,7 +2230,7 @@ impl DirectoryAnchor {
         })
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     fn capture_descendant(&self, relative: &Path, display_path: &Path) -> Result<Self, String> {
         self.verify_path_binding()?;
         let directory =
@@ -1968,7 +2254,7 @@ impl DirectoryAnchor {
         })
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     fn verify_descendant_identity(
         &self,
         relative: &Path,
@@ -1998,7 +2284,7 @@ impl DirectoryAnchor {
         self.verify_path_binding()
     }
 
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     fn capture_descendant(&self, _relative: &Path, display_path: &Path) -> Result<Self, String> {
         Err(format!(
             "secure workspace-relative directory anchors are unavailable on this host: {}",
@@ -2006,7 +2292,7 @@ impl DirectoryAnchor {
         ))
     }
 
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     fn verify_descendant_identity(
         &self,
         _relative: &Path,
@@ -2227,7 +2513,7 @@ impl DirectoryAnchor {
         Ok(snapshot)
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     fn capture_child_root_identity(
         &self,
         name: &OsStr,
@@ -2257,7 +2543,7 @@ impl DirectoryAnchor {
         Ok(Some(identity))
     }
 
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     fn capture_child_root_identity(
         &self,
         _name: &OsStr,

--- a/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+++ b/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
@@ -479,6 +479,34 @@ mod windows_anchor_tests {
     }
 
     #[test]
+    fn windows_tree_snapshot_detects_a_sibling_inserted_after_enumeration() {
+        let root = unique_temp_root("tree-snapshot-sibling-insertion");
+        let target = root.join("target");
+        let original = target.join("original.txt");
+        let inserted = target.join("inserted.txt");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(&original, b"original").unwrap();
+        let parent = open_directory_nofollow(&root).unwrap();
+        let hook_original = original.clone();
+        let hook_inserted = inserted.clone();
+
+        let result = with_tree_open_hook(
+            move |path| {
+                assert_eq!(path, hook_original);
+                fs::write(&hook_inserted, b"inserted").unwrap();
+            },
+            || capture_tree_child_nofollow(&parent, OsStr::new("target"), target.as_path()),
+        );
+
+        let error = result.expect_err("snapshotting must reject a changed directory name set");
+        assert!(
+            error.contains("name") || error.contains("changed"),
+            "{error}"
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn windows_tree_snapshot_rejects_multiply_linked_files() {
         let root = unique_temp_root("tree-snapshot-hard-link");
         let target = root.join("target");
@@ -3745,14 +3773,16 @@ fn capture_directory_snapshot_recursive(
     display_root: &Path,
     entries: &mut Vec<TreeEntrySnapshot>,
 ) -> Result<(), String> {
-    for name in crate::infrastructure::platform::filesystem::read_directory_names(directory)
-        .map_err(|error| {
-            format!(
-                "failed to securely enumerate {}: {error}",
-                display_root.join(relative_root).display()
-            )
-        })?
-    {
+    let initial_names = crate::infrastructure::platform::filesystem::read_directory_names(
+        directory,
+    )
+    .map_err(|error| {
+        format!(
+            "failed to securely enumerate {}: {error}",
+            display_root.join(relative_root).display()
+        )
+    })?;
+    for name in initial_names.iter().cloned() {
         let relative = relative_root.join(&name);
         let display_path = display_root.join(&relative);
         let opened = open_any_child_nofollow(directory, &name).map_err(|error| {
@@ -3925,6 +3955,19 @@ fn capture_directory_snapshot_recursive(
                 sha256: hasher.finalize().into(),
             },
         });
+    }
+    let final_names = crate::infrastructure::platform::filesystem::read_directory_names(directory)
+        .map_err(|error| {
+            format!(
+                "failed to securely re-enumerate {}: {error}",
+                display_root.join(relative_root).display()
+            )
+        })?;
+    if final_names != initial_names {
+        return Err(format!(
+            "dump tree directory name set changed while snapshotting: {}",
+            display_root.join(relative_root).display()
+        ));
     }
     Ok(())
 }

--- a/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+++ b/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
@@ -30,7 +30,8 @@ use crate::infrastructure::platform::filesystem::{
     open_any_child_for_delete, open_any_child_nofollow, open_directory_child_for_rename,
     open_directory_child_nofollow, open_directory_nofollow, open_regular_child_nofollow,
     opened_child_kind, rename_directory_handle_child_no_replace, verify_owner_only_acl,
-    verify_unprivileged_windows_platform_caller, OpenedChildKind, WindowsImmutableAclProfile,
+    verify_unprivileged_windows_platform_caller, verify_windows_local_fixed_volume,
+    OpenedChildKind, WindowsImmutableAclProfile,
 };
 use crate::infrastructure::platform::filesystem::{
     file_identity, metadata_is_link_or_reparse_point, restrict_stage_to_owner, FileIdentity,
@@ -81,10 +82,10 @@ pub(crate) enum FullDumpInvocation {
 mod windows_anchor_tests {
     use super::{
         capture_directory_snapshot, capture_tree_child_nofollow,
-        capture_windows_immutable_platform_children, remove_bound_directory_child,
-        rename_child_no_replace, secure_path_is_absent, secure_read_regular_file_snapshot,
-        unlink_bound_regular_child, with_secure_read_hook, with_tree_open_hook, DirectoryAnchor,
-        TreeEntryKind, TreeSnapshot,
+        capture_windows_immutable_platform_children, parse_windows_local_platform_path,
+        remove_bound_directory_child, rename_child_no_replace, secure_path_is_absent,
+        secure_read_regular_file_snapshot, unlink_bound_regular_child, with_secure_read_hook,
+        with_tree_open_hook, DirectoryAnchor, TreeEntryKind, TreeSnapshot,
     };
     use crate::infrastructure::platform::filesystem::{
         file_identity, open_directory_nofollow, verify_owner_only_acl,
@@ -97,6 +98,39 @@ mod windows_anchor_tests {
     use std::rc::Rc;
     use windows_sys::Win32::Foundation::FILETIME;
     use windows_sys::Win32::Storage::FileSystem::SetFileTime;
+
+    #[test]
+    fn windows_immutable_platform_path_accepts_only_normal_or_verbatim_local_disks() {
+        for path in [
+            PathBuf::from(r"C:\Program Files\1cv8\8.3.27.1859"),
+            PathBuf::from(r"\\?\C:\Program Files\1cv8\8.3.27.1859"),
+        ] {
+            let (root, names) = parse_windows_local_platform_path(&path).unwrap();
+            assert!(
+                root.as_path() == std::path::Path::new(r"C:\")
+                    || root.as_path() == std::path::Path::new(r"\\?\C:\"),
+                "{}",
+                root.display()
+            );
+            assert_eq!(
+                names.last().unwrap(),
+                &std::ffi::OsString::from("8.3.27.1859")
+            );
+        }
+
+        for path in [
+            PathBuf::from(r"\\server\share\1cv8"),
+            PathBuf::from(r"\\?\UNC\server\share\1cv8"),
+            PathBuf::from(r"\\.\C:\Program Files\1cv8"),
+            PathBuf::from(r"\\?\Volume{01234567-89ab-cdef-0123-456789abcdef}\1cv8"),
+        ] {
+            assert!(
+                parse_windows_local_platform_path(&path).is_err(),
+                "{}",
+                path.display()
+            );
+        }
+    }
 
     #[test]
     fn windows_anchor_detects_parent_name_replacement() {
@@ -1785,10 +1819,8 @@ impl ImmutablePlatformTrustSnapshot {
 }
 
 #[cfg(windows)]
-fn capture_windows_immutable_platform_ancestry(
-    install: &Path,
-) -> Result<(Vec<ImmutablePlatformEntry>, File), String> {
-    use std::path::Component;
+fn parse_windows_local_platform_path(install: &Path) -> Result<(PathBuf, Vec<OsString>), String> {
+    use std::path::{Component, Prefix};
 
     if !install.is_absolute() {
         return Err(format!(
@@ -1806,6 +1838,12 @@ fn capture_windows_immutable_platform_ancestry(
             ))
         }
     };
+    if !matches!(prefix.kind(), Prefix::Disk(_) | Prefix::VerbatimDisk(_)) {
+        return Err(format!(
+            "Windows immutable platform path must use a local disk prefix: {}",
+            install.display()
+        ));
+    }
     if !matches!(components.next(), Some(Component::RootDir)) {
         return Err(format!(
             "Windows immutable platform path has no volume root: {}",
@@ -1828,9 +1866,23 @@ fn capture_windows_immutable_platform_ancestry(
 
     let mut root_path = PathBuf::from(prefix.as_os_str());
     root_path.push(Path::new(r"\"));
+    Ok((root_path, names))
+}
+
+#[cfg(windows)]
+fn capture_windows_immutable_platform_ancestry(
+    install: &Path,
+) -> Result<(Vec<ImmutablePlatformEntry>, File), String> {
+    let (root_path, names) = parse_windows_local_platform_path(install)?;
     let root = open_directory_nofollow(&root_path).map_err(|error| {
         format!(
             "failed to securely open immutable platform volume root {}: {error}",
+            root_path.display()
+        )
+    })?;
+    verify_windows_local_fixed_volume(&root).map_err(|error| {
+        format!(
+            "failed to prove a local fixed immutable platform volume from retained handle {}: {error}",
             root_path.display()
         )
     })?;
@@ -1868,6 +1920,12 @@ fn capture_windows_immutable_platform_ancestry(
             profile,
         )?);
     }
+    verify_windows_local_fixed_volume(&current).map_err(|error| {
+        format!(
+            "failed to prove a local fixed immutable platform installation from retained handle {}: {error}",
+            current_path.display()
+        )
+    })?;
     Ok((entries, current))
 }
 
@@ -7462,7 +7520,7 @@ mod tests {
     }
 
     #[test]
-    fn system_resolver_does_not_trust_an_explicit_platform_path_or_broad_claim() {
+    fn platform_resolver_does_not_trust_an_explicit_platform_path_or_broad_claim() {
         let root = std::env::temp_dir().join(format!(
             "unica-platform-resolution-{}",
             uuid::Uuid::new_v4()
@@ -7566,7 +7624,7 @@ mod tests {
     }
 
     #[test]
-    fn system_resolver_rejects_fake_binary_even_under_exact_version_directory_name() {
+    fn platform_resolver_rejects_fake_binary_even_under_exact_version_directory_name() {
         let root = std::env::temp_dir().join(format!(
             "unica-platform-fake-resolution-{}",
             uuid::Uuid::new_v4()

--- a/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+++ b/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
@@ -26,7 +26,7 @@ use crate::infrastructure::platform::filesystem::hard_link_count;
 #[cfg(windows)]
 use crate::infrastructure::platform::filesystem::{
     create_owner_only_directory_child, create_owner_only_file_child, discard_created_child,
-    open_directory_child_nofollow, open_directory_nofollow,
+    open_directory_child_for_rename, open_directory_child_nofollow, open_directory_nofollow,
     rename_directory_handle_child_no_replace, verify_owner_only_acl,
 };
 use crate::infrastructure::platform::filesystem::{
@@ -134,20 +134,22 @@ mod windows_anchor_tests {
     #[test]
     fn no_clobber_directory_move_preserves_an_existing_destination() {
         let root = unique_temp_root("no-clobber");
-        let source = root.join("source");
-        let destination = root.join("destination");
+        let source_parent_path = root.join("source-parent");
+        let destination_parent_path = root.join("destination-parent");
+        let source = source_parent_path.join("payload");
+        let destination = destination_parent_path.join("payload");
         fs::create_dir_all(&source).unwrap();
         fs::create_dir_all(&destination).unwrap();
         fs::write(source.join("new.txt"), b"new").unwrap();
         fs::write(destination.join("old.txt"), b"old").unwrap();
 
-        let source_parent = DirectoryAnchor::capture_exact(&root).unwrap();
-        let destination_parent = source_parent.try_clone().unwrap();
+        let source_parent = DirectoryAnchor::capture_exact(&source_parent_path).unwrap();
+        let destination_parent = DirectoryAnchor::capture_exact(&destination_parent_path).unwrap();
         let error = rename_child_no_replace(
             &source_parent,
-            OsStr::new("source"),
+            OsStr::new("payload"),
             &destination_parent,
-            OsStr::new("destination"),
+            OsStr::new("payload"),
         )
         .unwrap_err();
 
@@ -161,18 +163,21 @@ mod windows_anchor_tests {
     #[test]
     fn directory_move_installs_when_destination_is_absent() {
         let root = unique_temp_root("rename-success");
-        let source = root.join("source");
-        let destination = root.join("destination");
+        let source_parent_path = root.join("source-parent");
+        let destination_parent_path = root.join("destination-parent");
+        let source = source_parent_path.join("payload");
+        let destination = destination_parent_path.join("payload");
         fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(&destination_parent_path).unwrap();
         fs::write(source.join("new.txt"), b"new").unwrap();
 
-        let source_parent = DirectoryAnchor::capture_exact(&root).unwrap();
-        let destination_parent = source_parent.try_clone().unwrap();
+        let source_parent = DirectoryAnchor::capture_exact(&source_parent_path).unwrap();
+        let destination_parent = DirectoryAnchor::capture_exact(&destination_parent_path).unwrap();
         rename_child_no_replace(
             &source_parent,
-            OsStr::new("source"),
+            OsStr::new("payload"),
             &destination_parent,
-            OsStr::new("destination"),
+            OsStr::new("payload"),
         )
         .unwrap();
 
@@ -4054,13 +4059,14 @@ fn rename_prechecked_directory_child_no_replace(
     destination_parent: &DirectoryAnchor,
     destination_name: &OsStr,
 ) -> Result<(), String> {
-    let source =
-        open_directory_child_nofollow(&source_parent.directory, source_name).map_err(|error| {
+    let source = open_directory_child_for_rename(&source_parent.directory, source_name).map_err(
+        |error| {
             format!(
                 "failed to open staged child {}: {error}",
                 source_parent.path.join(source_name).display()
             )
-        })?;
+        },
+    )?;
     if file_identity(&source).map_err(|error| error.to_string())? != expected_identity {
         return Err("staged directory identity changed".to_string());
     }
@@ -4152,13 +4158,14 @@ fn rename_child_no_replace(
     destination_parent: &DirectoryAnchor,
     destination_name: &OsStr,
 ) -> Result<(), String> {
-    let source =
-        open_directory_child_nofollow(&source_parent.directory, source_name).map_err(|error| {
+    let source = open_directory_child_for_rename(&source_parent.directory, source_name).map_err(
+        |error| {
             format!(
                 "failed to bind source directory {}: {error}",
                 source_parent.path.join(source_name).display()
             )
-        })?;
+        },
+    )?;
     rename_open_directory_child_no_replace(source, destination_parent, destination_name)
 }
 

--- a/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+++ b/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
@@ -96,7 +96,7 @@ mod windows_anchor_tests {
     use std::ffi::OsStr;
     use std::fs;
     use std::os::windows::io::AsRawHandle;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::rc::Rc;
     use windows_sys::Win32::Foundation::FILETIME;
     use windows_sys::Win32::Storage::FileSystem::SetFileTime;
@@ -446,14 +446,14 @@ mod windows_anchor_tests {
         );
         assert_eq!(first.len(), 2);
         assert!(first.iter().any(|entry| {
-            entry.relative_path == PathBuf::from("nested")
+            entry.relative_path.as_path() == Path::new("nested")
                 && entry.kind
                     == TreeEntryKind::Directory {
                         identity: expected_directory_identity,
                     }
         }));
         assert!(first.iter().any(|entry| {
-            entry.relative_path == PathBuf::from("nested/payload.txt")
+            entry.relative_path.as_path() == Path::new("nested/payload.txt")
                 && entry.kind
                     == TreeEntryKind::File {
                         identity: expected_file_identity,
@@ -3439,15 +3439,17 @@ impl PrivateDumpStage {
             Err(error) => {
                 #[cfg(windows)]
                 return Err(windows_private_creation_error(
-                    &parent_anchor,
-                    root_anchor,
-                    &root_name,
-                    &root,
-                    None,
-                    &execution,
-                    None,
-                    &recovery,
-                    error,
+                    WindowsPrivateCreationRollback {
+                        parent_anchor: &parent_anchor,
+                        root_anchor,
+                        root_name: &root_name,
+                        root: &root,
+                        execution_anchor: None,
+                        execution: &execution,
+                        recovery_anchor: None,
+                        recovery: &recovery,
+                        primary: error,
+                    },
                 ));
                 #[cfg(not(windows))]
                 return Err(private_creation_error(
@@ -3464,15 +3466,17 @@ impl PrivateDumpStage {
             run_private_creation_failpoint(PrivateCreationCheckpoint::AfterExecutionCreation)
         {
             return Err(windows_private_creation_error(
-                &parent_anchor,
-                root_anchor,
-                &root_name,
-                &root,
-                Some(execution_anchor),
-                &execution,
-                None,
-                &recovery,
-                error,
+                WindowsPrivateCreationRollback {
+                    parent_anchor: &parent_anchor,
+                    root_anchor,
+                    root_name: &root_name,
+                    root: &root,
+                    execution_anchor: Some(execution_anchor),
+                    execution: &execution,
+                    recovery_anchor: None,
+                    recovery: &recovery,
+                    primary: error,
+                },
             ));
         }
         let recovery_anchor = match root_anchor.create_child(OsStr::new("recovery"), &recovery) {
@@ -3480,15 +3484,17 @@ impl PrivateDumpStage {
             Err(error) => {
                 #[cfg(windows)]
                 return Err(windows_private_creation_error(
-                    &parent_anchor,
-                    root_anchor,
-                    &root_name,
-                    &root,
-                    Some(execution_anchor),
-                    &execution,
-                    None,
-                    &recovery,
-                    error,
+                    WindowsPrivateCreationRollback {
+                        parent_anchor: &parent_anchor,
+                        root_anchor,
+                        root_name: &root_name,
+                        root: &root,
+                        execution_anchor: Some(execution_anchor),
+                        execution: &execution,
+                        recovery_anchor: None,
+                        recovery: &recovery,
+                        primary: error,
+                    },
                 ));
                 #[cfg(not(windows))]
                 return Err(private_creation_error(
@@ -3505,29 +3511,33 @@ impl PrivateDumpStage {
             run_private_creation_failpoint(PrivateCreationCheckpoint::AfterRecoveryCreation)
         {
             return Err(windows_private_creation_error(
-                &parent_anchor,
-                root_anchor,
-                &root_name,
-                &root,
-                Some(execution_anchor),
-                &execution,
-                Some(recovery_anchor),
-                &recovery,
-                error,
+                WindowsPrivateCreationRollback {
+                    parent_anchor: &parent_anchor,
+                    root_anchor,
+                    root_name: &root_name,
+                    root: &root,
+                    execution_anchor: Some(execution_anchor),
+                    execution: &execution,
+                    recovery_anchor: Some(recovery_anchor),
+                    recovery: &recovery,
+                    primary: error,
+                },
             ));
         }
         if let Err(error) = parent_anchor.verify_path_binding() {
             #[cfg(windows)]
             return Err(windows_private_creation_error(
-                &parent_anchor,
-                root_anchor,
-                &root_name,
-                &root,
-                Some(execution_anchor),
-                &execution,
-                Some(recovery_anchor),
-                &recovery,
-                error,
+                WindowsPrivateCreationRollback {
+                    parent_anchor: &parent_anchor,
+                    root_anchor,
+                    root_name: &root_name,
+                    root: &root,
+                    execution_anchor: Some(execution_anchor),
+                    execution: &execution,
+                    recovery_anchor: Some(recovery_anchor),
+                    recovery: &recovery,
+                    primary: error,
+                },
             ));
             #[cfg(not(windows))]
             return Err(private_creation_error(
@@ -3930,17 +3940,31 @@ fn release_anchor_and_remove_private_child(
 }
 
 #[cfg(windows)]
-fn windows_private_creation_error(
-    parent_anchor: &DirectoryAnchor,
+struct WindowsPrivateCreationRollback<'a> {
+    parent_anchor: &'a DirectoryAnchor,
     root_anchor: DirectoryAnchor,
-    root_name: &OsStr,
-    root: &Path,
-    mut execution_anchor: Option<DirectoryAnchor>,
-    execution: &Path,
-    mut recovery_anchor: Option<DirectoryAnchor>,
-    recovery: &Path,
+    root_name: &'a OsStr,
+    root: &'a Path,
+    execution_anchor: Option<DirectoryAnchor>,
+    execution: &'a Path,
+    recovery_anchor: Option<DirectoryAnchor>,
+    recovery: &'a Path,
     primary: String,
-) -> String {
+}
+
+#[cfg(windows)]
+fn windows_private_creation_error(rollback: WindowsPrivateCreationRollback<'_>) -> String {
+    let WindowsPrivateCreationRollback {
+        parent_anchor,
+        root_anchor,
+        root_name,
+        root,
+        mut execution_anchor,
+        execution,
+        mut recovery_anchor,
+        recovery,
+        primary,
+    } = rollback;
     let root_identity = root_anchor.identity;
     let mut cleanup_errors = Vec::new();
 
@@ -4683,10 +4707,10 @@ fn capture_directory_snapshot_recursive(
             display_root.join(relative_root).display()
         )
     })?;
-    for name in initial_names.iter().cloned() {
-        let relative = relative_root.join(&name);
+    for name in &initial_names {
+        let relative = relative_root.join(name);
         let display_path = display_root.join(&relative);
-        let opened = open_any_child_nofollow(directory, &name).map_err(|error| {
+        let opened = open_any_child_nofollow(directory, name).map_err(|error| {
             format!(
                 "dump tree contains an unsupported entry {}: {error}",
                 display_path.display()
@@ -4706,7 +4730,7 @@ fn capture_directory_snapshot_recursive(
         })?;
 
         if metadata.is_dir() {
-            let child = open_directory_child_nofollow(directory, &name).map_err(|error| {
+            let child = open_directory_child_nofollow(directory, name).map_err(|error| {
                 format!(
                     "failed to securely bind directory {}: {error}",
                     display_path.display()
@@ -4729,7 +4753,7 @@ fn capture_directory_snapshot_recursive(
                 kind: TreeEntryKind::Directory { identity },
             });
             capture_directory_snapshot_recursive(&child, &relative, display_root, entries)?;
-            let rebound = open_directory_child_nofollow(directory, &name).map_err(|error| {
+            let rebound = open_directory_child_nofollow(directory, name).map_err(|error| {
                 format!(
                     "failed to rebind directory {}: {error}",
                     display_path.display()
@@ -4756,7 +4780,7 @@ fn capture_directory_snapshot_recursive(
                 display_path.display()
             ));
         }
-        let mut file = open_regular_child_nofollow(directory, &name).map_err(|error| {
+        let mut file = open_regular_child_nofollow(directory, name).map_err(|error| {
             format!(
                 "dump tree contains an unsupported entry {}: {error}",
                 display_path.display()
@@ -4833,7 +4857,7 @@ fn capture_directory_snapshot_recursive(
                 display_path.display()
             ));
         }
-        let rebound = open_regular_child_nofollow(directory, &name).map_err(|error| {
+        let rebound = open_regular_child_nofollow(directory, name).map_err(|error| {
             format!("failed to rebind file {}: {error}", display_path.display())
         })?;
         if file_identity(&rebound).map_err(|error| {

--- a/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+++ b/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
@@ -961,6 +961,32 @@ mod windows_anchor_tests {
     }
 
     #[test]
+    fn windows_effective_config_cleanup_without_execution_anchor_returns_an_error() {
+        let root = unique_temp_root("private-stage-missing-execution-anchor");
+        let workspace = root.join("workspace");
+        fs::create_dir_all(&workspace).unwrap();
+        let target_parent = DirectoryAnchor::capture_exact(&workspace).unwrap();
+        let mut stage = PrivateDumpStage::create(&target_parent).unwrap();
+        stage
+            .write_effective_config(&serde_yaml::Value::String("secret".to_string()))
+            .unwrap();
+        let execution_anchor = stage.execution_anchor.take().unwrap();
+
+        let cleanup =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| stage.cleanup_now()));
+        let error = cleanup
+            .expect("cleanup must return an error instead of panicking")
+            .expect_err("cleanup without the execution anchor must fail");
+
+        assert!(error.contains("execution anchor"), "{error}");
+        assert!(!stage.effective_config_secret_present);
+        assert!(stage.effective_config_handle.is_some());
+        stage.execution_anchor = Some(execution_anchor);
+        stage.cleanup_now().unwrap();
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn windows_private_stage_cleanup_requires_parent_relative_root_absence() {
         let root = unique_temp_root("private-stage-root-absence");
         let workspace = root.join("workspace");
@@ -3029,7 +3055,8 @@ fn secure_path_is_absent(path: &Path) -> Result<bool, String> {
         )
     })?;
     match open_any_child_nofollow(&parent, &name) {
-        Ok(_) => Ok(false),
+        Ok((_child, OpenedChildKind::ReparsePoint)) => Ok(false),
+        Ok((_child, _kind)) => Ok(false),
         Err(error)
             if matches!(
                 error.raw_os_error(),
@@ -3039,12 +3066,6 @@ fn secure_path_is_absent(path: &Path) -> Result<bool, String> {
             ) =>
         {
             Ok(true)
-        }
-        Err(error)
-            if error.kind() == ErrorKind::InvalidInput
-                && error.to_string().contains("reparse point") =>
-        {
-            Ok(false)
         }
         Err(error) => Err(format!(
             "failed to securely inspect {}: {error}",
@@ -3923,10 +3944,16 @@ impl PrivateDumpStage {
                 "private effective config scrub sync failed for {}: {error}; secret-bearing private data may remain",
                 self.effective_config.display()
             )
-            })?;
+        })?;
         self.effective_config_secret_present = false;
+        let execution_anchor = self.execution_anchor.as_ref().ok_or_else(|| {
+            format!(
+                "private effective config cleanup cannot unlink {} because the execution anchor is closed; the scrubbed private file may remain",
+                self.effective_config.display()
+            )
+        })?;
         let unlink = unlink_bound_regular_child(
-            &self.execution_anchor().directory,
+            &execution_anchor.directory,
             OsStr::new(EFFECTIVE_CONFIG_NAME),
             identity,
         )
@@ -4151,7 +4178,7 @@ fn prove_windows_child_absent(
 ) -> Result<(), String> {
     match open_any_child_nofollow(parent, name) {
         Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
-        Ok(child) => {
+        Ok((child, _kind)) => {
             drop(child);
             Err(format!(
                 "private path is still present after cleanup; absence was not proven: {}",
@@ -4957,7 +4984,7 @@ fn capture_directory_snapshot_recursive(
     for name in &initial_names {
         let relative = relative_root.join(name);
         let display_path = display_root.join(&relative);
-        let opened = open_any_child_nofollow(directory, name).map_err(|error| {
+        let (opened, opened_kind) = open_any_child_nofollow(directory, name).map_err(|error| {
             format!(
                 "dump tree contains an unsupported entry {}: {error}",
                 display_path.display()
@@ -4969,14 +4996,7 @@ fn capture_directory_snapshot_recursive(
                 display_path.display()
             )
         })?;
-        let metadata = opened.metadata().map_err(|error| {
-            format!(
-                "failed to inspect opened entry {}: {error}",
-                display_path.display()
-            )
-        })?;
-
-        if metadata.is_dir() {
+        if opened_kind == OpenedChildKind::Directory {
             let child = open_directory_child_nofollow(directory, name).map_err(|error| {
                 format!(
                     "failed to securely bind directory {}: {error}",
@@ -5021,7 +5041,7 @@ fn capture_directory_snapshot_recursive(
             continue;
         }
 
-        if !metadata.is_file() {
+        if opened_kind != OpenedChildKind::RegularFile {
             return Err(format!(
                 "dump tree contains an unsupported entry kind: {}",
                 display_path.display()
@@ -8846,10 +8866,35 @@ mod tests {
         let platform = fixed_platform(&root);
         let runner = DumpRunner::valid();
         let raced_target = target.clone();
+        let hook_workspace = context.cwd.clone();
 
         let result = with_publication_hook(
-            PublicationCheckpoint::BeforeStageInstall,
+            PublicationCheckpoint::AfterBackup,
             move || {
+                assert!(
+                    !raced_target.exists(),
+                    "the original destination must already be moved to backup"
+                );
+                let private_root = std::fs::read_dir(&hook_workspace)
+                    .unwrap()
+                    .flatten()
+                    .map(|entry| entry.path())
+                    .find(|path| {
+                        path.file_name().is_some_and(|name| {
+                            name.to_string_lossy().starts_with(".unica-dump-guard-")
+                        })
+                    })
+                    .expect("private dump root");
+                assert!(
+                    std::fs::read_dir(private_root.join("recovery"))
+                        .unwrap()
+                        .flatten()
+                        .any(|entry| entry
+                            .file_name()
+                            .to_string_lossy()
+                            .starts_with("target-backup-")),
+                    "the original destination backup must be retained for rollback"
+                );
                 std::fs::create_dir_all(&raced_target).unwrap();
                 std::fs::write(raced_target.join("racer.txt"), b"racer").unwrap();
             },

--- a/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+++ b/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
@@ -23,13 +23,13 @@ use crate::infrastructure::native_operations::single_file_publisher::{
 };
 #[cfg(unix)]
 use crate::infrastructure::platform::filesystem::hard_link_count;
-use crate::infrastructure::platform::filesystem::{
-    file_identity, metadata_is_link_or_reparse_point, restrict_stage_to_owner, FileIdentity,
-};
 #[cfg(windows)]
 use crate::infrastructure::platform::filesystem::{
     create_owner_only_directory_child, create_owner_only_file_child, discard_created_child,
     open_directory_child_nofollow, open_directory_nofollow, verify_owner_only_acl,
+};
+use crate::infrastructure::platform::filesystem::{
+    file_identity, metadata_is_link_or_reparse_point, restrict_stage_to_owner, FileIdentity,
 };
 use crate::infrastructure::platform_xml_owner::root_version_literal;
 use crate::infrastructure::plugin_runtime::find_plugin_root;
@@ -131,10 +131,7 @@ mod windows_anchor_tests {
     }
 
     fn unique_temp_root(name: &str) -> PathBuf {
-        std::env::temp_dir().join(format!(
-            "unica-full-dump-{name}-{}",
-            uuid::Uuid::new_v4()
-        ))
+        std::env::temp_dir().join(format!("unica-full-dump-{name}-{}", uuid::Uuid::new_v4()))
     }
 }
 
@@ -2064,18 +2061,21 @@ impl DirectoryAnchor {
             ));
         }
         self.verify_path_binding()?;
-        let directory = create_owner_only_directory_child(&self.directory, name).map_err(|error| {
-            format!(
-                "failed to create private directory {}: {error}",
-                display_path.display()
-            )
-        })?;
-        let cleanup_error = |error: String| match discard_created_child(&directory) {
+        let directory =
+            create_owner_only_directory_child(&self.directory, name).map_err(|error| {
+                format!(
+                    "failed to create private directory {}: {error}",
+                    display_path.display()
+                )
+            })?;
+        let cleanup_error = |error: String| {
+            match discard_created_child(&directory) {
             Ok(()) => error,
             Err(cleanup) => format!(
                 "{error}; failed to remove private directory created through the retained parent anchor {}: {cleanup}",
                 display_path.display()
             ),
+        }
         };
         let identity = file_identity(&directory).map_err(|error| {
             cleanup_error(format!(

--- a/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+++ b/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
@@ -26,7 +26,8 @@ use crate::infrastructure::platform::filesystem::hard_link_count;
 #[cfg(windows)]
 use crate::infrastructure::platform::filesystem::{
     create_owner_only_directory_child, create_owner_only_file_child, discard_created_child,
-    open_directory_child_nofollow, open_directory_nofollow, verify_owner_only_acl,
+    open_directory_child_nofollow, open_directory_nofollow,
+    rename_directory_handle_child_no_replace, verify_owner_only_acl,
 };
 use crate::infrastructure::platform::filesystem::{
     file_identity, metadata_is_link_or_reparse_point, restrict_stage_to_owner, FileIdentity,
@@ -75,7 +76,7 @@ pub(crate) enum FullDumpInvocation {
 
 #[cfg(all(test, windows))]
 mod windows_anchor_tests {
-    use super::DirectoryAnchor;
+    use super::{rename_child_no_replace, DirectoryAnchor};
     use crate::infrastructure::platform::filesystem::verify_owner_only_acl;
     use std::ffi::OsStr;
     use std::fs;
@@ -127,6 +128,56 @@ mod windows_anchor_tests {
 
         assert!(error.contains("does not match anchored child"), "{error}");
         assert!(!outside.exists());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn no_clobber_directory_move_preserves_an_existing_destination() {
+        let root = unique_temp_root("no-clobber");
+        let source = root.join("source");
+        let destination = root.join("destination");
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(&destination).unwrap();
+        fs::write(source.join("new.txt"), b"new").unwrap();
+        fs::write(destination.join("old.txt"), b"old").unwrap();
+
+        let source_parent = DirectoryAnchor::capture_exact(&root).unwrap();
+        let destination_parent = source_parent.try_clone().unwrap();
+        let error = rename_child_no_replace(
+            &source_parent,
+            OsStr::new("source"),
+            &destination_parent,
+            OsStr::new("destination"),
+        )
+        .unwrap_err();
+
+        assert!(destination.join("old.txt").is_file());
+        assert!(!destination.join("new.txt").exists());
+        assert!(source.join("new.txt").is_file());
+        assert!(!error.is_empty());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn directory_move_installs_when_destination_is_absent() {
+        let root = unique_temp_root("rename-success");
+        let source = root.join("source");
+        let destination = root.join("destination");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("new.txt"), b"new").unwrap();
+
+        let source_parent = DirectoryAnchor::capture_exact(&root).unwrap();
+        let destination_parent = source_parent.try_clone().unwrap();
+        rename_child_no_replace(
+            &source_parent,
+            OsStr::new("source"),
+            &destination_parent,
+            OsStr::new("destination"),
+        )
+        .unwrap();
+
+        assert!(!source.exists());
+        assert_eq!(fs::read(destination.join("new.txt")).unwrap(), b"new");
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -3995,7 +4046,28 @@ fn rename_prechecked_directory_child_no_replace(
     )
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn rename_prechecked_directory_child_no_replace(
+    source_parent: &DirectoryAnchor,
+    source_name: &OsStr,
+    expected_identity: FileIdentity,
+    destination_parent: &DirectoryAnchor,
+    destination_name: &OsStr,
+) -> Result<(), String> {
+    let source =
+        open_directory_child_nofollow(&source_parent.directory, source_name).map_err(|error| {
+            format!(
+                "failed to open staged child {}: {error}",
+                source_parent.path.join(source_name).display()
+            )
+        })?;
+    if file_identity(&source).map_err(|error| error.to_string())? != expected_identity {
+        return Err("staged directory identity changed".to_string());
+    }
+    rename_open_directory_child_no_replace(source, destination_parent, destination_name)
+}
+
+#[cfg(not(any(unix, windows)))]
 fn rename_prechecked_directory_child_no_replace(
     _source_parent: &DirectoryAnchor,
     _source_name: &OsStr,
@@ -4073,7 +4145,62 @@ fn rename_child_no_replace(
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn rename_child_no_replace(
+    source_parent: &DirectoryAnchor,
+    source_name: &OsStr,
+    destination_parent: &DirectoryAnchor,
+    destination_name: &OsStr,
+) -> Result<(), String> {
+    let source =
+        open_directory_child_nofollow(&source_parent.directory, source_name).map_err(|error| {
+            format!(
+                "failed to bind source directory {}: {error}",
+                source_parent.path.join(source_name).display()
+            )
+        })?;
+    rename_open_directory_child_no_replace(source, destination_parent, destination_name)
+}
+
+#[cfg(windows)]
+fn rename_open_directory_child_no_replace(
+    source: File,
+    destination_parent: &DirectoryAnchor,
+    destination_name: &OsStr,
+) -> Result<(), String> {
+    let expected_identity = file_identity(&source)
+        .map_err(|error| format!("failed to inspect source directory identity: {error}"))?;
+    rename_directory_handle_child_no_replace(
+        &source,
+        &destination_parent.directory,
+        destination_name,
+    )
+    .map_err(|error| error.to_string())?;
+    let destination =
+        open_directory_child_nofollow(&destination_parent.directory, destination_name).map_err(
+            |error| {
+                format!(
+                    "failed to reopen renamed destination {}: {error}",
+                    destination_parent.path.join(destination_name).display()
+                )
+            },
+        )?;
+    let actual_identity = file_identity(&destination).map_err(|error| {
+        format!(
+            "failed to inspect renamed destination identity {}: {error}",
+            destination_parent.path.join(destination_name).display()
+        )
+    })?;
+    if actual_identity != expected_identity {
+        return Err(format!(
+            "renamed destination identity does not match source: {}",
+            destination_parent.path.join(destination_name).display()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
 fn rename_child_no_replace(
     _source_parent: &DirectoryAnchor,
     _source_name: &OsStr,
@@ -5182,8 +5309,9 @@ fn parse_exact_platform_version(value: &str) -> Option<[u32; 4]> {
     (parts.len() == 4).then(|| [parts[0], parts[1], parts[2], parts[3]])
 }
 
-#[cfg(all(test, not(windows)))]
+#[cfg(test)]
 mod tests {
+    #[cfg_attr(windows, allow(unused_imports))]
     use super::{
         normalize_key_value_connection, staged_root_version_policy, validate_staged_dump,
         with_private_create_hook, with_publication_failpoint, with_publication_hook,
@@ -6173,6 +6301,31 @@ mod tests {
             std::fs::read_to_string(target.join("Configuration.xml")).unwrap(),
             valid_configuration_owner()
         );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    #[ignore = "enabled when Task 4 removes the Windows preparation guard"]
+    fn windows_destination_race_after_backup_survives_rollback() {
+        let (root, context, _) = workspace("windows-destination-race");
+        let target = context.cwd.join("src");
+        seed_valid_target(&target);
+        let platform = fixed_platform(&root);
+        let runner = DumpRunner::valid();
+        let raced_target = target.clone();
+
+        let result = with_publication_hook(
+            PublicationCheckpoint::BeforeStageInstall,
+            move || {
+                std::fs::create_dir_all(&raced_target).unwrap();
+                std::fs::write(raced_target.join("racer.txt"), b"racer").unwrap();
+            },
+            || invoke(&runner, &platform, FullDumpInvocation::BuildDump, &context),
+        );
+
+        assert!(!result.ok, "{result:?}");
+        assert_eq!(std::fs::read(target.join("racer.txt")).unwrap(), b"racer");
         std::fs::remove_dir_all(root).unwrap();
     }
 

--- a/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+++ b/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
@@ -25,11 +25,12 @@ use crate::infrastructure::native_operations::single_file_publisher::{
 use crate::infrastructure::platform::filesystem::hard_link_count;
 #[cfg(windows)]
 use crate::infrastructure::platform::filesystem::{
-    create_owner_only_directory_child, create_owner_only_file_child, delete_open_child,
-    discard_created_child, open_any_child_for_delete, open_any_child_nofollow,
-    open_directory_child_for_rename, open_directory_child_nofollow, open_directory_nofollow,
-    open_regular_child_nofollow, opened_child_kind, rename_directory_handle_child_no_replace,
-    verify_owner_only_acl, OpenedChildKind,
+    capture_windows_immutable_entry_evidence, create_owner_only_directory_child,
+    create_owner_only_file_child, delete_open_child, discard_created_child,
+    open_any_child_for_delete, open_any_child_nofollow, open_directory_child_for_rename,
+    open_directory_child_nofollow, open_directory_nofollow, open_regular_child_nofollow,
+    opened_child_kind, rename_directory_handle_child_no_replace, verify_owner_only_acl,
+    verify_unprivileged_windows_platform_caller, OpenedChildKind, WindowsImmutableAclProfile,
 };
 use crate::infrastructure::platform::filesystem::{
     file_identity, metadata_is_link_or_reparse_point, restrict_stage_to_owner, FileIdentity,
@@ -79,7 +80,8 @@ pub(crate) enum FullDumpInvocation {
 #[cfg(all(test, windows))]
 mod windows_anchor_tests {
     use super::{
-        capture_directory_snapshot, capture_tree_child_nofollow, remove_bound_directory_child,
+        capture_directory_snapshot, capture_tree_child_nofollow,
+        capture_windows_immutable_platform_children, remove_bound_directory_child,
         rename_child_no_replace, secure_path_is_absent, secure_read_regular_file_snapshot,
         unlink_bound_regular_child, with_secure_read_hook, with_tree_open_hook, DirectoryAnchor,
         TreeEntryKind, TreeSnapshot,
@@ -126,6 +128,45 @@ mod windows_anchor_tests {
         child.verify_path_binding().unwrap();
         verify_owner_only_acl(&child.directory).unwrap();
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_immutable_platform_inventory_rejects_a_multiply_linked_file() {
+        let root = unique_temp_root("immutable-hard-link");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join("1cv8.exe"), b"platform").unwrap();
+        fs::hard_link(root.join("1cv8.exe"), root.join("alias.exe")).unwrap();
+        let directory = open_directory_nofollow(&root).unwrap();
+        let mut entries = Vec::new();
+
+        let error = capture_windows_immutable_platform_children(&directory, &root, &mut entries)
+            .unwrap_err();
+
+        assert!(error.contains("exactly one hard link"), "{error}");
+        drop(directory);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_immutable_platform_inventory_rejects_a_reparse_point() {
+        let root = unique_temp_root("immutable-reparse");
+        let outside = unique_temp_root("immutable-reparse-outside");
+        fs::create_dir_all(&root).unwrap();
+        fs::write(&outside, b"outside").unwrap();
+        std::os::windows::fs::symlink_file(&outside, root.join("1cv8.exe")).unwrap();
+        let directory = open_directory_nofollow(&root).unwrap();
+        let mut entries = Vec::new();
+
+        let error = capture_windows_immutable_platform_children(&directory, &root, &mut entries)
+            .unwrap_err();
+
+        assert!(
+            error.contains("reparse") || error.contains("unsupported"),
+            "{error}"
+        );
+        drop(directory);
+        fs::remove_dir_all(root).unwrap();
+        fs::remove_file(outside).unwrap();
     }
 
     #[test]
@@ -1570,8 +1611,12 @@ struct ImmutablePlatformEntry {
     path: PathBuf,
     kind: ImmutablePlatformEntryKind,
     identity: FileIdentity,
+    #[cfg(unix)]
     owner: u32,
+    #[cfg(unix)]
     mode: u32,
+    #[cfg(windows)]
+    security_descriptor_sha256: [u8; 32],
 }
 
 impl PlatformAttestation {
@@ -1636,7 +1681,7 @@ impl PlatformAttestation {
                     )?);
                 if after != trust_before {
                     return Err(format!(
-                        "immutable platform ownership or mode changed during attestation: {}",
+                        "immutable platform trust metadata changed during attestation: {}",
                         install_path.display()
                     ));
                 }
@@ -1703,10 +1748,265 @@ impl ImmutablePlatformTrustSnapshot {
         Ok(Self { entries })
     }
 
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    fn capture(install: &Path, executable: &Path, probe: &Path) -> Result<Self, String> {
+        verify_unprivileged_windows_platform_caller().map_err(|error| {
+            format!("failed to prove an unprivileged Windows platform caller: {error}")
+        })?;
+        let (mut entries, install_directory) =
+            capture_windows_immutable_platform_ancestry(install)?;
+        capture_windows_immutable_platform_children(&install_directory, install, &mut entries)?;
+        entries.sort_by(|left, right| left.path.cmp(&right.path));
+        entries.dedup();
+        for (path, role) in [
+            (executable, "platform executable"),
+            (probe, "platform version probe"),
+        ] {
+            let Some(entry) = entries.iter().find(|entry| entry.path == path) else {
+                return Err(format!(
+                    "{role} is outside the immutable platform inventory: {}",
+                    path.display()
+                ));
+            };
+            if entry.kind != ImmutablePlatformEntryKind::File {
+                return Err(format!(
+                    "{role} is not an immutable regular file: {}",
+                    path.display()
+                ));
+            }
+        }
+        Ok(Self { entries })
+    }
+
+    #[cfg(not(any(unix, windows)))]
     fn capture(_install: &Path, _executable: &Path, _probe: &Path) -> Result<Self, String> {
         Err("immutable platform trust verification is unavailable on this host".to_string())
     }
+}
+
+#[cfg(windows)]
+fn capture_windows_immutable_platform_ancestry(
+    install: &Path,
+) -> Result<(Vec<ImmutablePlatformEntry>, File), String> {
+    use std::path::Component;
+
+    if !install.is_absolute() {
+        return Err(format!(
+            "immutable platform installation path must be absolute: {}",
+            install.display()
+        ));
+    }
+    let mut components = install.components();
+    let prefix = match components.next() {
+        Some(Component::Prefix(prefix)) => prefix,
+        _ => {
+            return Err(format!(
+                "Windows immutable platform path has no volume prefix: {}",
+                install.display()
+            ))
+        }
+    };
+    if !matches!(components.next(), Some(Component::RootDir)) {
+        return Err(format!(
+            "Windows immutable platform path has no volume root: {}",
+            install.display()
+        ));
+    }
+    let mut names = Vec::new();
+    for component in components {
+        match component {
+            Component::Normal(name) => names.push(name.to_os_string()),
+            Component::CurDir => {}
+            Component::ParentDir | Component::Prefix(_) | Component::RootDir => {
+                return Err(format!(
+                    "immutable platform installation path contains a non-normal component: {}",
+                    install.display()
+                ))
+            }
+        }
+    }
+
+    let mut root_path = PathBuf::from(prefix.as_os_str());
+    root_path.push(Path::new(r"\"));
+    let root = open_directory_nofollow(&root_path).map_err(|error| {
+        format!(
+            "failed to securely open immutable platform volume root {}: {error}",
+            root_path.display()
+        )
+    })?;
+    let root_profile = if names.is_empty() {
+        WindowsImmutableAclProfile::Installation
+    } else {
+        WindowsImmutableAclProfile::Ancestry
+    };
+    let mut entries = vec![capture_windows_immutable_platform_entry(
+        &root,
+        &root_path,
+        ImmutablePlatformEntryKind::Directory,
+        root_profile,
+    )?];
+    let mut current = root;
+    let mut current_path = root_path;
+    let final_index = names.len().saturating_sub(1);
+    for (index, name) in names.into_iter().enumerate() {
+        current = open_directory_child_nofollow(&current, &name).map_err(|error| {
+            format!(
+                "platform ancestry contains a reparse point, non-directory, or inaccessible component {}: {error}",
+                current_path.join(&name).display()
+            )
+        })?;
+        current_path.push(&name);
+        let profile = if index == final_index {
+            WindowsImmutableAclProfile::Installation
+        } else {
+            WindowsImmutableAclProfile::Ancestry
+        };
+        entries.push(capture_windows_immutable_platform_entry(
+            &current,
+            &current_path,
+            ImmutablePlatformEntryKind::Directory,
+            profile,
+        )?);
+    }
+    Ok((entries, current))
+}
+
+#[cfg(windows)]
+fn capture_windows_immutable_platform_children(
+    directory: &File,
+    display_path: &Path,
+    entries: &mut Vec<ImmutablePlatformEntry>,
+) -> Result<(), String> {
+    let initial_names = crate::infrastructure::platform::filesystem::read_directory_names(
+        directory,
+    )
+    .map_err(|error| {
+        format!(
+            "failed to enumerate immutable platform installation {}: {error}",
+            display_path.display()
+        )
+    })?;
+    for name in &initial_names {
+        let child_path = display_path.join(name);
+        match open_directory_child_nofollow(directory, name) {
+            Ok(child) => {
+                let entry = capture_windows_immutable_platform_entry(
+                    &child,
+                    &child_path,
+                    ImmutablePlatformEntryKind::Directory,
+                    WindowsImmutableAclProfile::Installation,
+                )?;
+                let expected_identity = entry.identity;
+                entries.push(entry);
+                capture_windows_immutable_platform_children(&child, &child_path, entries)?;
+                let rebound = open_directory_child_nofollow(directory, name).map_err(|error| {
+                    format!(
+                        "failed to rebind immutable platform directory {}: {error}",
+                        child_path.display()
+                    )
+                })?;
+                if file_identity(&rebound).map_err(|error| {
+                    format!(
+                        "failed to recheck immutable platform directory {}: {error}",
+                        child_path.display()
+                    )
+                })? != expected_identity
+                {
+                    return Err(format!(
+                        "immutable platform directory identity changed while inspecting: {}",
+                        child_path.display()
+                    ));
+                }
+            }
+            Err(directory_error) => {
+                let file = open_regular_child_nofollow(directory, name).map_err(|file_error| {
+                    format!(
+                        "immutable platform inventory contains an unsupported or reparse entry {}: directory open failed ({directory_error}); regular-file open failed ({file_error})",
+                        child_path.display()
+                    )
+                })?;
+                if hard_link_count(&file).map_err(|error| {
+                    format!(
+                        "failed to inspect hard links for immutable platform file {}: {error}",
+                        child_path.display()
+                    )
+                })? != 1
+                {
+                    return Err(format!(
+                        "immutable platform file must have exactly one hard link: {}",
+                        child_path.display()
+                    ));
+                }
+                let entry = capture_windows_immutable_platform_entry(
+                    &file,
+                    &child_path,
+                    ImmutablePlatformEntryKind::File,
+                    WindowsImmutableAclProfile::Installation,
+                )?;
+                let expected_identity = entry.identity;
+                entries.push(entry);
+                let rebound = open_regular_child_nofollow(directory, name).map_err(|error| {
+                    format!(
+                        "failed to rebind immutable platform file {}: {error}",
+                        child_path.display()
+                    )
+                })?;
+                if file_identity(&rebound).map_err(|error| {
+                    format!(
+                        "failed to recheck immutable platform file {}: {error}",
+                        child_path.display()
+                    )
+                })? != expected_identity
+                {
+                    return Err(format!(
+                        "immutable platform file identity changed while inspecting: {}",
+                        child_path.display()
+                    ));
+                }
+            }
+        }
+    }
+    let final_names = crate::infrastructure::platform::filesystem::read_directory_names(directory)
+        .map_err(|error| {
+            format!(
+                "failed to re-enumerate immutable platform installation {}: {error}",
+                display_path.display()
+            )
+        })?;
+    if final_names != initial_names {
+        return Err(format!(
+            "immutable platform directory name set changed while inspecting: {}",
+            display_path.display()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn capture_windows_immutable_platform_entry(
+    file: &File,
+    path: &Path,
+    kind: ImmutablePlatformEntryKind,
+    profile: WindowsImmutableAclProfile,
+) -> Result<ImmutablePlatformEntry, String> {
+    let evidence = capture_windows_immutable_entry_evidence(file).map_err(|error| {
+        format!(
+            "failed to capture immutable Windows platform evidence {}: {error}",
+            path.display()
+        )
+    })?;
+    evidence.verify(profile).map_err(|error| {
+        format!(
+            "immutable Windows platform ACL is not trusted {}: {error}",
+            path.display()
+        )
+    })?;
+    Ok(ImmutablePlatformEntry {
+        path: path.to_path_buf(),
+        kind,
+        identity: evidence.identity,
+        security_descriptor_sha256: evidence.security_descriptor_sha256,
+    })
 }
 
 #[cfg(unix)]

--- a/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+++ b/crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
@@ -26,10 +26,10 @@ use crate::infrastructure::platform::filesystem::hard_link_count;
 #[cfg(windows)]
 use crate::infrastructure::platform::filesystem::{
     capture_windows_immutable_entry_evidence, create_owner_only_directory_child,
-    create_owner_only_file_child, delete_open_child, open_any_child_for_delete,
-    open_any_child_nofollow, open_directory_child_for_rename, open_directory_child_nofollow,
-    open_directory_nofollow, open_regular_child_nofollow, opened_child_kind,
-    rename_directory_handle_child_no_replace, verify_owner_only_acl,
+    create_owner_only_file_child, delete_open_child, discard_created_child,
+    open_any_child_for_delete, open_any_child_nofollow, open_directory_child_for_rename,
+    open_directory_child_nofollow, open_directory_nofollow, open_regular_child_nofollow,
+    opened_child_kind, rename_directory_handle_child_no_replace, verify_owner_only_acl,
     verify_unprivileged_windows_platform_caller, verify_windows_local_fixed_volume,
     OpenedChildKind, WindowsImmutableAclProfile,
 };
@@ -90,16 +90,124 @@ mod windows_anchor_tests {
         PrivateDumpStage, TreeEntryKind, TreeSnapshot,
     };
     use crate::infrastructure::platform::filesystem::{
-        file_identity, open_directory_nofollow, verify_owner_only_acl,
+        create_owner_only_file_child, file_identity, open_directory_nofollow,
+        open_regular_child_nofollow, read_directory_names, verify_owner_only_acl,
     };
     use std::cell::Cell;
-    use std::ffi::OsStr;
+    use std::ffi::{OsStr, OsString};
     use std::fs;
     use std::os::windows::io::AsRawHandle;
     use std::path::{Path, PathBuf};
     use std::rc::Rc;
     use windows_sys::Win32::Foundation::FILETIME;
     use windows_sys::Win32::Storage::FileSystem::SetFileTime;
+
+    fn enable_directory_case_sensitivity(path: &Path) {
+        use std::mem::size_of;
+        use std::os::windows::ffi::OsStrExt;
+        use std::os::windows::io::FromRawHandle;
+        use std::ptr;
+        use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+        use windows_sys::Win32::Storage::FileSystem::{
+            CreateFileW, SetFileInformationByHandle, FILE_ADD_FILE, FILE_ADD_SUBDIRECTORY,
+            FILE_DELETE_CHILD, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+            FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_WRITE_ATTRIBUTES,
+            OPEN_EXISTING, SYNCHRONIZE,
+        };
+
+        #[repr(C)]
+        struct FileCaseSensitiveInfo {
+            flags: u32,
+        }
+
+        const FILE_CASE_SENSITIVE_INFO_CLASS: i32 = 23;
+        const FILE_CS_FLAG_CASE_SENSITIVE_DIR: u32 = 1;
+
+        let mut path = path.as_os_str().encode_wide().collect::<Vec<_>>();
+        path.push(0);
+        // SAFETY: path is NUL-terminated and the requested rights are the documented rights for
+        // changing an empty directory's case-sensitivity flag.
+        let handle = unsafe {
+            CreateFileW(
+                path.as_ptr(),
+                FILE_ADD_FILE
+                    | FILE_ADD_SUBDIRECTORY
+                    | FILE_DELETE_CHILD
+                    | FILE_WRITE_ATTRIBUTES
+                    | SYNCHRONIZE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                ptr::null(),
+                OPEN_EXISTING,
+                FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+                ptr::null_mut(),
+            )
+        };
+        assert_ne!(
+            handle,
+            INVALID_HANDLE_VALUE,
+            "{}",
+            std::io::Error::last_os_error()
+        );
+        // SAFETY: CreateFileW returned an owned handle.
+        let directory = unsafe { fs::File::from_raw_handle(handle) };
+        let information = FileCaseSensitiveInfo {
+            flags: FILE_CS_FLAG_CASE_SENSITIVE_DIR,
+        };
+        // SAFETY: directory is a live empty-directory handle and information has the exact
+        // FileCaseSensitiveInfo layout and size.
+        assert_ne!(
+            unsafe {
+                SetFileInformationByHandle(
+                    directory.as_raw_handle(),
+                    FILE_CASE_SENSITIVE_INFO_CLASS,
+                    (&raw const information).cast(),
+                    size_of::<FileCaseSensitiveInfo>() as u32,
+                )
+            },
+            0,
+            "{}",
+            std::io::Error::last_os_error()
+        );
+    }
+
+    fn create_case_sensitive_file(path: &Path, contents: &[u8]) -> fs::File {
+        use std::io::Write;
+        use std::os::windows::ffi::OsStrExt;
+        use std::os::windows::io::FromRawHandle;
+        use std::ptr;
+        use windows_sys::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE, INVALID_HANDLE_VALUE};
+        use windows_sys::Win32::Storage::FileSystem::{
+            CreateFileW, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, FILE_FLAG_POSIX_SEMANTICS,
+            FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        };
+
+        let mut path = path.as_os_str().encode_wide().collect::<Vec<_>>();
+        path.push(0);
+        // SAFETY: path is NUL-terminated. POSIX semantics make the independently prepared fixture
+        // honor the already-enabled per-directory case-sensitive state.
+        let handle = unsafe {
+            CreateFileW(
+                path.as_ptr(),
+                GENERIC_READ | GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                ptr::null(),
+                CREATE_NEW,
+                FILE_ATTRIBUTE_NORMAL | FILE_FLAG_POSIX_SEMANTICS,
+                ptr::null_mut(),
+            )
+        };
+        assert_ne!(
+            handle,
+            INVALID_HANDLE_VALUE,
+            "{}",
+            std::io::Error::last_os_error()
+        );
+        // SAFETY: CreateFileW returned an owned handle.
+        let mut file = unsafe { fs::File::from_raw_handle(handle) };
+        file.write_all(contents).unwrap();
+        file.sync_all().unwrap();
+        file
+    }
 
     #[test]
     fn windows_immutable_platform_path_accepts_only_normal_or_verbatim_local_disks() {
@@ -465,6 +573,122 @@ mod windows_anchor_tests {
                         ],
                     }
         }));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_relative_lookup_preserves_ordinary_case_insensitive_ntfs_semantics() {
+        let root = unique_temp_root("ordinary-case-insensitive-lookup");
+        fs::create_dir_all(&root).unwrap();
+        let exact = root.join("Entry.txt");
+        fs::write(&exact, b"ordinary").unwrap();
+        let expected_identity = file_identity(&fs::File::open(&exact).unwrap()).unwrap();
+        let parent = open_directory_nofollow(&root).unwrap();
+
+        let collision = create_owner_only_file_child(&parent, OsStr::new("eNTRY.TxT")).unwrap_err();
+        assert_eq!(collision.kind(), std::io::ErrorKind::AlreadyExists);
+        let differently_cased =
+            open_regular_child_nofollow(&parent, OsStr::new("eNTRY.TxT")).unwrap();
+
+        assert_eq!(
+            file_identity(&differently_cased).unwrap(),
+            expected_identity
+        );
+        drop(differently_cased);
+        drop(parent);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn windows_case_sensitive_siblings_bind_snapshot_inventory_and_cleanup_to_exact_names() {
+        use std::io::{Read, Write};
+
+        let root = unique_temp_root("case-sensitive-siblings");
+        let target = root.join("target");
+        fs::create_dir_all(&target).unwrap();
+        enable_directory_case_sensitivity(&target);
+        let lower_path = target.join("entry.txt");
+        let lower = create_case_sensitive_file(&lower_path, b"lower-content");
+        let parent = open_directory_nofollow(&target).unwrap();
+        let mut upper = create_owner_only_file_child(&parent, OsStr::new("ENTRY.txt")).unwrap();
+        upper.write_all(b"UPPER-CONTENT").unwrap();
+        upper.sync_all().unwrap();
+        let lower_identity = file_identity(&lower).unwrap();
+        let upper_identity = file_identity(&upper).unwrap();
+        assert_ne!(lower_identity, upper_identity);
+        drop(lower);
+        drop(upper);
+
+        let ambiguous = open_regular_child_nofollow(&parent, OsStr::new("Entry.txt"))
+            .expect_err("a case-sensitive parent must reject a non-exact child spelling");
+        assert_eq!(ambiguous.kind(), std::io::ErrorKind::NotFound);
+
+        let names = read_directory_names(&parent).unwrap();
+        assert_eq!(
+            names,
+            vec![OsString::from("ENTRY.txt"), OsString::from("entry.txt")]
+        );
+        for (name, expected_identity, expected_contents) in [
+            (
+                OsStr::new("entry.txt"),
+                lower_identity,
+                b"lower-content".as_slice(),
+            ),
+            (
+                OsStr::new("ENTRY.txt"),
+                upper_identity,
+                b"UPPER-CONTENT".as_slice(),
+            ),
+        ] {
+            let mut child = open_regular_child_nofollow(&parent, name).unwrap();
+            let mut contents = Vec::new();
+            child.read_to_end(&mut contents).unwrap();
+            assert_eq!(
+                file_identity(&child).unwrap(),
+                expected_identity,
+                "{name:?}"
+            );
+            assert_eq!(contents, expected_contents, "{name:?}");
+        }
+
+        let snapshot = capture_directory_snapshot(&target).unwrap();
+        assert_eq!(snapshot.len(), 2);
+        assert!(snapshot.iter().any(|entry| {
+            entry.relative_path.as_path() == Path::new("entry.txt")
+                && entry.kind
+                    == TreeEntryKind::File {
+                        identity: lower_identity,
+                        size: 13,
+                        sha256: [
+                            0xd4, 0x82, 0x15, 0xe7, 0x47, 0xb9, 0xf0, 0x6a, 0xdc, 0x06, 0xee, 0x08,
+                            0x67, 0xdb, 0xfb, 0xf7, 0x94, 0x00, 0x67, 0x47, 0xe0, 0xf5, 0xff, 0x23,
+                            0x30, 0xaf, 0x82, 0x20, 0x9f, 0x21, 0xca, 0xa3,
+                        ],
+                    }
+        }));
+        assert!(snapshot.iter().any(|entry| {
+            entry.relative_path.as_path() == Path::new("ENTRY.txt")
+                && entry.kind
+                    == TreeEntryKind::File {
+                        identity: upper_identity,
+                        size: 13,
+                        sha256: [
+                            0xdc, 0xd4, 0x17, 0x49, 0xde, 0x8a, 0x50, 0x74, 0x7e, 0x82, 0x18, 0x46,
+                            0x4a, 0x98, 0xa8, 0xbb, 0xfc, 0xe0, 0xec, 0x85, 0xb1, 0x76, 0xae, 0x0a,
+                            0x77, 0xb8, 0x5e, 0xd5, 0x30, 0xc9, 0xe7, 0xd9,
+                        ],
+                    }
+        }));
+
+        unlink_bound_regular_child(&parent, OsStr::new("entry.txt"), lower_identity).unwrap();
+        let mut survivor = open_regular_child_nofollow(&parent, OsStr::new("ENTRY.txt")).unwrap();
+        let mut survivor_contents = Vec::new();
+        survivor.read_to_end(&mut survivor_contents).unwrap();
+        assert_eq!(file_identity(&survivor).unwrap(), upper_identity);
+        assert_eq!(survivor_contents, b"UPPER-CONTENT");
+        drop(survivor);
+        drop(parent);
+        assert!(!lower_path.exists());
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -2980,9 +3204,32 @@ fn create_regular_child_owner_only(
 fn create_regular_child_owner_only(
     parent: &File,
     name: &OsStr,
-    _display_path: &Path,
+    display_path: &Path,
 ) -> std::io::Result<File> {
-    create_owner_only_file_child(parent, name)
+    let created = create_owner_only_file_child(parent, name)?;
+    let cleanup_error = |primary: std::io::Error| {
+        match discard_created_child(&created) {
+        Ok(()) => primary,
+        Err(cleanup) => std::io::Error::new(
+            primary.kind(),
+            format!(
+                "{primary}; failed to remove unverified effective config through its created handle: {cleanup}"
+            ),
+        ),
+    }
+    };
+    let expected_identity = file_identity(&created).map_err(cleanup_error)?;
+    run_effective_config_create_hook(display_path);
+    verify_owner_only_acl(&created).map_err(cleanup_error)?;
+    let rebound = open_regular_child_nofollow(parent, name).map_err(cleanup_error)?;
+    let rebound_identity = file_identity(&rebound).map_err(cleanup_error)?;
+    if rebound_identity != expected_identity {
+        return Err(cleanup_error(std::io::Error::new(
+            ErrorKind::InvalidData,
+            "private effective config identity changed before verified reopen",
+        )));
+    }
+    Ok(created)
 }
 
 #[cfg(not(any(unix, windows)))]
@@ -6275,6 +6522,8 @@ thread_local! {
     static TEST_TARGETED_READ_HOOKS: RefCell<Option<TargetedReadHooks>> = const { RefCell::new(None) };
     static TEST_TREE_OPEN_HOOK: RefCell<Option<PathHook>> = const { RefCell::new(None) };
     static TEST_PRIVATE_CREATE_HOOK: RefCell<Option<PathHook>> = const { RefCell::new(None) };
+    #[cfg(windows)]
+    static TEST_EFFECTIVE_CONFIG_CREATE_HOOK: RefCell<Option<PathHook>> = const { RefCell::new(None) };
     static TEST_TARGET_PARENT_CAPTURE_HOOK: RefCell<Option<PathHook>> = const { RefCell::new(None) };
     #[cfg(windows)]
     static TEST_PRIVATE_CLEANUP_FAILPOINT: RefCell<Option<PrivateCleanupCheckpoint>> = const { RefCell::new(None) };
@@ -6393,6 +6642,25 @@ fn with_private_create_hook<T>(
     action()
 }
 
+#[cfg(all(test, windows))]
+fn with_effective_config_create_hook<T>(
+    hook: impl FnOnce(&Path) + 'static,
+    action: impl FnOnce() -> T,
+) -> T {
+    struct Reset(Option<PathHook>);
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            TEST_EFFECTIVE_CONFIG_CREATE_HOOK.with(|slot| {
+                slot.replace(self.0.take());
+            });
+        }
+    }
+    let previous =
+        TEST_EFFECTIVE_CONFIG_CREATE_HOOK.with(|slot| slot.replace(Some(Box::new(hook))));
+    let _reset = Reset(previous);
+    action()
+}
+
 #[cfg(test)]
 fn with_target_parent_capture_hook<T>(
     hook: impl FnOnce(&Path) + 'static,
@@ -6474,6 +6742,14 @@ fn run_private_creation_failpoint(checkpoint: PrivateCreationCheckpoint) -> Resu
 fn run_private_create_hook(_path: &Path) {
     #[cfg(test)]
     if let Some(hook) = TEST_PRIVATE_CREATE_HOOK.with(|slot| slot.borrow_mut().take()) {
+        hook(_path);
+    }
+}
+
+#[cfg(windows)]
+fn run_effective_config_create_hook(_path: &Path) {
+    #[cfg(test)]
+    if let Some(hook) = TEST_EFFECTIVE_CONFIG_CREATE_HOOK.with(|slot| slot.borrow_mut().take()) {
         hook(_path);
     }
 }
@@ -7413,6 +7689,8 @@ fn parse_exact_platform_version(value: &str) -> Option<[u32; 4]> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(windows)]
+    use super::with_effective_config_create_hook;
     #[cfg_attr(windows, allow(unused_imports))]
     use super::{
         normalize_key_value_connection, staged_root_version_policy, validate_staged_dump,
@@ -7779,6 +8057,133 @@ mod tests {
         assert!(result.ok, "{result:?}");
         assert_eq!(runner.calls.load(Ordering::SeqCst), 1);
         assert!(target.join("Configuration.xml").is_file());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_applied_full_dump_rejects_effective_config_acl_mutation_before_runner_and_cleans_created_identity(
+    ) {
+        use std::os::windows::ffi::OsStrExt;
+        use std::ptr;
+        use windows_sys::Win32::Security::Authorization::{SetNamedSecurityInfoW, SE_FILE_OBJECT};
+        use windows_sys::Win32::Security::{
+            DACL_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION,
+        };
+
+        let (root, context, _) = workspace("windows-effective-config-acl-mutation");
+        let platform = fixed_platform(&root);
+        let runner = DumpRunner::valid();
+        let displaced = context.cwd.join("created-effective-config.yaml");
+        let hook_displaced = displaced.clone();
+
+        let result = with_effective_config_create_hook(
+            move |path| {
+                std::fs::rename(path, &hook_displaced).unwrap();
+                let mut path = hook_displaced.as_os_str().encode_wide().collect::<Vec<_>>();
+                path.push(0);
+                // SAFETY: path is NUL-terminated and names the newly created file. A null DACL is
+                // intentional test corruption that the production verifier must reject.
+                let status = unsafe {
+                    SetNamedSecurityInfoW(
+                        path.as_ptr(),
+                        SE_FILE_OBJECT,
+                        DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+                        ptr::null_mut(),
+                        ptr::null_mut(),
+                        ptr::null(),
+                        ptr::null(),
+                    )
+                };
+                assert_eq!(
+                    status,
+                    0,
+                    "{}",
+                    std::io::Error::from_raw_os_error(status as i32)
+                );
+            },
+            || invoke(&runner, &platform, FullDumpInvocation::BuildDump, &context),
+        );
+
+        assert!(!result.ok, "{result:?}");
+        assert_eq!(runner.calls.load(Ordering::SeqCst), 0);
+        assert!(
+            !displaced.exists(),
+            "the originally created identity escaped cleanup: {}",
+            displaced.display()
+        );
+        assert!(std::fs::read_dir(&context.cwd).unwrap().all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".unica-dump-guard-")));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_applied_full_dump_rejects_effective_config_name_swap_before_runner_and_preserves_replacement_identity(
+    ) {
+        use std::cell::Cell;
+
+        let (root, context, _) = workspace("windows-effective-config-name-swap");
+        let platform = fixed_platform(&root);
+        let runner = DumpRunner::valid();
+        let displaced = context.cwd.join("created-effective-config.yaml");
+        let replacement = context.cwd.join("replacement-effective-config.yaml");
+        std::fs::write(&replacement, b"replacement sentinel").unwrap();
+        let expected_replacement_identity =
+            crate::infrastructure::platform::filesystem::file_identity(
+                &std::fs::File::open(&replacement).unwrap(),
+            )
+            .unwrap();
+        let created_identity = std::rc::Rc::new(Cell::new(None));
+        let hook_created_identity = std::rc::Rc::clone(&created_identity);
+        let hook_displaced = displaced.clone();
+        let hook_replacement = replacement.clone();
+
+        let result = with_effective_config_create_hook(
+            move |path| {
+                hook_created_identity.set(Some(
+                    crate::infrastructure::platform::filesystem::file_identity(
+                        &std::fs::File::open(path).unwrap(),
+                    )
+                    .unwrap(),
+                ));
+                std::fs::rename(path, &hook_displaced).unwrap();
+                std::fs::hard_link(&hook_replacement, path).unwrap();
+            },
+            || invoke(&runner, &platform, FullDumpInvocation::BuildDump, &context),
+        );
+
+        assert!(!result.ok, "{result:?}");
+        assert_eq!(runner.calls.load(Ordering::SeqCst), 0);
+        assert!(
+            created_identity.get().is_some(),
+            "the post-create hook did not run"
+        );
+        assert!(
+            !displaced.exists(),
+            "the originally created identity escaped cleanup: {}",
+            displaced.display()
+        );
+        assert_eq!(
+            crate::infrastructure::platform::filesystem::file_identity(
+                &std::fs::File::open(&replacement).unwrap(),
+            )
+            .unwrap(),
+            expected_replacement_identity,
+            "cleanup followed the replaced effective-config name"
+        );
+        assert_eq!(
+            std::fs::read(&replacement).unwrap(),
+            b"replacement sentinel"
+        );
+        assert!(std::fs::read_dir(&context.cwd).unwrap().all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with(".unica-dump-guard-")));
         std::fs::remove_dir_all(root).unwrap();
     }
 

--- a/docs/design/2026-07-30-windows-applied-full-dump-design.md
+++ b/docs/design/2026-07-30-windows-applied-full-dump-design.md
@@ -254,8 +254,10 @@ is intentionally unavailable on Windows from:
 
 - `plugins/unica/skills/v8-runner/SKILL.md`;
 - `plugins/unica/skills/v8-runner/references/file-and-artifact-workflows.md`;
-- `plugins/unica/references/tooling/v8project.md`.
+- `plugins/unica/references/tooling/v8project.md`;
+- `plugins/unica/references/tooling/runtime-build.md`.
 
 The replacement text states that applied full dump uses verified transactional
 publication on all supported hosts. It references the owning invariants instead
-of restating them as a new architectural rule.
+of restating them as a new architectural rule. The documentation contract is
+enforced by `tests/ci/test_unica_skills.py`.

--- a/docs/design/2026-07-30-windows-applied-full-dump-design.md
+++ b/docs/design/2026-07-30-windows-applied-full-dump-design.md
@@ -1,0 +1,261 @@
+# Windows applied full dump
+
+- Date: `2026-07-30`
+- Status: `approved`
+- Decision: `none` — no architectural contract changed
+
+## Context
+
+Issue #268 reports that an applied full dump of a `CONFIGURATION` or
+`EXTENSION` source set is unavailable on Windows. The request reaches
+`PreparedDump::prepare`, but the Windows implementation returns a deliberate
+fail-closed error before resolving the platform or launching `v8-runner`.
+
+The guard was introduced because the verified full-dump transaction relies on
+two guarantees that were implemented only for Unix:
+
+1. the private staging tree and its effective configuration are inaccessible to
+   unrelated users from the instant they are created;
+2. directory publication is bound to captured parent identities and cannot
+   overwrite an entry created concurrently at the destination name.
+
+The public operation, dump format, validation profile, and publication
+transaction already exist. Supporting Windows implements the platform half of
+the existing contract under ADR-0009; it does not change the public MCP surface,
+the writable format selected by ADR-0016, or the ownership of workspace state.
+
+## Goals
+
+- Permit applied `mode=full` dump for `CONFIGURATION` and `EXTENSION` source
+  sets on Windows.
+- Preserve the existing validation, conflict detection, rollback, quarantine,
+  and cleanup semantics.
+- Create private staging directories and files with an explicit owner-only
+  Windows DACL without a permissive inheritance window.
+- Bind security-sensitive path operations to live directory handles and reject
+  reparse-point substitution.
+- Publish directories with an atomic no-replace operation.
+- Keep all OS-dependent implementation under
+  `crates/unica-coder/src/infrastructure/platform/`.
+
+## Non-goals
+
+- No bypass flag or caller-confirmed unsafe publication mode.
+- No support for incremental dump without the receipts required by the existing
+  source synchronization guard.
+- No change to asynchronous runtime-job support.
+- No change to the public arguments or result payloads of `unica.runtime.*` or
+  `unica.build.dump`.
+- No general Windows filesystem abstraction beyond the primitives required by
+  the verified full-dump transaction.
+
+## Chosen approach
+
+Extend the existing `DirectoryAnchor` transaction model on Windows instead of
+creating a second publisher.
+
+### Windows directory anchors
+
+A Windows directory anchor owns a directory handle opened by `CreateFileW`
+with directory and reparse-point semantics. Its captured identity consists of
+the volume serial number and file index returned by
+`GetFileInformationByHandle`.
+
+`capture_exact`, child creation, path-binding verification, and identity checks
+use the same platform-neutral `DirectoryAnchor` interface as Unix. Child opens
+and creates use `NtCreateFile` with the retained parent handle in
+`OBJECT_ATTRIBUTES.RootDirectory` and a single relative child name.
+`FILE_OPEN_REPARSE_POINT` prevents final-component traversal. Relative names
+must contain exactly one non-empty component and no separator, `.` or `..`.
+
+Path-based Win32 operations bracketed by identity checks are not sufficient:
+an intermediate component can be replaced inside the check/use window. Such
+operations are permitted only to capture the initial workspace anchor. Once an
+anchor exists, every security-sensitive child operation is handle-relative.
+
+### Owner-only staging
+
+Private stage directories and files are created through relative `NtCreateFile`
+calls whose `OBJECT_ATTRIBUTES.SecurityDescriptor` points to the explicit
+protected security descriptor. The descriptor contains a protected DACL that
+grants the required access to the current process token's user SID and does not
+inherit ambient directory permissions.
+
+Private regular files are created with the corresponding explicit security
+attributes. Existing post-creation Unix permission tightening remains unchanged;
+Windows must not rely on a post-creation ACL rewrite because that would expose a
+race window.
+
+After creation, Unica opens the object without following reparse points, checks
+its identity and DACL, and only then exposes it to the rest of the transaction.
+Failure to create or prove the private ACL aborts before `v8-runner` starts.
+
+### No-clobber directory publication
+
+The Windows platform facade opens the source child relative to its retained
+parent and renames that open object with `NtSetInformationFile` using
+`FILE_RENAME_INFORMATION.RootDirectory` for the retained destination parent.
+`ReplaceIfExists` is false, so an occupied destination name is an atomic error.
+
+The full-dump publisher performs the existing sequence:
+
+1. verify source and destination parent anchors;
+2. verify the source child identity captured during staging;
+3. execute the handle-relative no-replace rename;
+4. verify both parents again;
+5. open the published child without following reparse points and verify that
+   its identity equals the staged identity.
+
+The same primitive is used for backup, stage installation, rollback, and
+quarantine. An entry concurrently installed under any destination name is never
+replaced.
+
+### Handle-relative reads and tree inspection
+
+The verified transaction also reads configuration preimages, captures target
+and staged-tree snapshots, and walks workspace descendants. Windows implements
+these operations through retained handles rather than reopening child paths.
+
+Regular files and arbitrary children are opened with `NtCreateFile`,
+`OBJECT_ATTRIBUTES.RootDirectory`, one validated relative component, and
+`FILE_OPEN_REPARSE_POINT`. Directory descendants are traversed one component at
+a time. Directory names are enumerated from the retained handle with
+`GetFileInformationByHandleEx(FileIdBothDirectoryInfo)`; enumeration never
+reconstructs a path for a child open.
+
+Secure file snapshots retain the file handle while hashing, compare size and
+last-write metadata before and after the read, require one hard link, then
+reopen the same name relative to the retained parent and compare identities.
+Tree snapshots apply the same rule recursively to every directory and regular
+file. Reparse points and unsupported entry kinds fail closed. An absence check
+opens the name relative to the retained parent and treats only the native
+not-found statuses as absent; a reparse point is present, not absent.
+
+### Handle-relative cleanup
+
+Cleanup enumerates the retained private directory handle, opens each entry
+relative to that handle with delete access and
+`FILE_OPEN_REPARSE_POINT`, and removes the opened object with
+`NtSetInformationFile(FileDispositionInformation)`. Directories are emptied
+recursively before disposition. Reparse points are removed as entries and are
+never followed.
+
+Before removing an expected file or directory, cleanup compares the opened
+identity with the identity captured by the transaction. An identity mismatch
+leaves the replacement untouched and reports an integrity failure. Display
+paths remain diagnostic only.
+
+Windows delete disposition does not make a directory name disappear while a
+retained handle to that directory remains open. Private cleanup therefore owns
+takeable child and root anchors: it empties a child through the retained handle,
+closes that handle, performs the identity-bound disposition through the parent,
+and only then verifies the parent. The private root anchor is likewise closed
+before root deletion and final absence verification. A delete-pending name is
+not treated as an absent or successfully verified replacement.
+
+### Immutable Windows platform attestation
+
+The production platform resolver must not execute a mutable `1cv8.exe` or
+`ibcmd.exe`. Windows therefore receives a platform trust attestation equivalent
+to the existing Unix policy rather than using the test-fixture bypass.
+
+The attestation rejects an elevated effective caller. It inspects the current
+thread token first and falls back to the process token only when the thread is
+not impersonating. It also requires a local-volume proof from the retained
+installation handle; UNC, device, mapped-remote, and other network filesystems
+are not trusted to attest their own owner, DACL, identity, or link-count
+metadata.
+
+The attestation walks the local installation ancestry and inventory through
+no-follow handles, requires files to have one hard link, and captures each
+entry's identity and security descriptor. The owner must be a trusted Windows
+installation principal (TrustedInstaller, LocalSystem, or the built-in
+Administrators group).
+
+Ancestry and installation contents use different mutation profiles. For
+ancestors above the installation directory, DACL inspection rejects rights that
+can delete, replace, or retarget an existing path component, including
+`DELETE`, `FILE_DELETE_CHILD`, `WRITE_DAC`, and `WRITE_OWNER`. Creating an
+unrelated sibling under a protected ancestor is not by itself a way to replace
+the retained component and is permitted. For the installation directory and
+its complete inventory, inspection rejects the full mutation set: file or
+directory creation, write/append, attribute or extended-attribute writes,
+delete/delete-child, DACL changes, and ownership changes. Read and execute
+access for ordinary users remains permitted.
+
+The security-descriptor digest is part of the immutable entry snapshot.
+Executable and probe digests, the complete installation inventory, and trust
+metadata are captured before execution and compared again before publication.
+An unreadable, unsupported, reparse-point, or ambiguously protected entry fails
+closed.
+
+### Failure handling
+
+- A changed parent identity or reparse-point substitution fails closed.
+- An occupied destination fails without altering the occupant.
+- If failure occurs after moving the old target to backup, the existing rollback
+  state machine attempts a no-clobber restoration.
+- If the destination is occupied during rollback, the occupant survives and
+  the owned tree is quarantined according to the existing transaction rules.
+- ACL inspection or identity inspection failure is an integrity failure, not a
+  warning.
+- Cleanup after a committed publication remains best-effort only where the
+  current transaction already classifies it as such.
+
+## Code structure
+
+- `crates/unica-coder/src/infrastructure/platform/filesystem.rs`
+  owns reusable Win32 handle, identity, relative `NtCreateFile`,
+  handle enumeration, `NtSetInformationFile`, explicit-DACL creation, ACL and
+  immutable-trust verification, and handle-relative removal primitives.
+- `crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs`
+  keeps the platform-neutral transaction and implements Windows
+  `DirectoryAnchor` operations by calling the platform facade.
+- `crates/unica-coder/tests/platform/` contains Windows integration tests that
+  exercise real filesystem behavior.
+- Existing Unix implementations and tests remain the reference for transaction
+  semantics.
+
+No OS-dependent code may move into application or domain modules
+(`INV-PLATFORM-OS-BEHIND-FACADE`), and platform tests remain colocated with the
+adapters (`INV-PLATFORM-COLOCATED-TESTS`).
+
+## Testing
+
+The implementation follows test-driven development.
+
+1. A Windows regression proves that applied full dump reaches the runner and
+   commits a validated configuration tree instead of returning the current
+   pre-flight guard.
+2. Platform tests prove that a private directory and file are created with a
+   protected owner-only DACL.
+3. No-clobber tests prove that an existing destination survives unchanged.
+4. Reparse substitution and parent-identity replacement tests prove that the
+   transaction fails closed.
+5. Secure-read and tree-snapshot tests prove that file and directory name
+   replacement is detected and that reparse points are rejected.
+6. Cleanup tests prove that an expected tree is removed through retained
+   handles while an identity-replaced child survives.
+7. Windows platform-attestation tests accept a protected installation fixture
+   owned by a trusted principal and reject an elevated caller, an untrusted
+   owner, or a DACL granting mutation to ordinary users.
+8. Rollback tests cover a destination race after backup and after stage
+   installation.
+9. Existing Unix full-dump and cross-platform compilation tests must remain
+   green.
+
+Windows-specific tests run on a Windows host. Platform-neutral transaction tests
+continue to run in the ordinary Rust workspace suite.
+
+## Documentation impact
+
+After the Windows regression is green, remove statements that applied full dump
+is intentionally unavailable on Windows from:
+
+- `plugins/unica/skills/v8-runner/SKILL.md`;
+- `plugins/unica/skills/v8-runner/references/file-and-artifact-workflows.md`;
+- `plugins/unica/references/tooling/v8project.md`.
+
+The replacement text states that applied full dump uses verified transactional
+publication on all supported hosts. It references the owning invariants instead
+of restating them as a new architectural rule.

--- a/docs/plans/2026-07-30-windows-applied-full-dump.md
+++ b/docs/plans/2026-07-30-windows-applied-full-dump.md
@@ -1,0 +1,1043 @@
+# Windows Applied Full Dump Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable verified applied full dumps for `CONFIGURATION` and `EXTENSION` source sets on Windows without weakening private staging, path-binding, no-clobber publication, or rollback guarantees.
+
+**Architecture:** Extend the existing platform filesystem facade with Win32 directory-handle, descriptor-relative inspection and cleanup, explicit-DACL, immutable-platform-attestation, and no-clobber rename primitives, then implement the current `DirectoryAnchor` and publication transaction for Windows. The public MCP routes and transaction state machine remain unchanged; only the deliberate Windows pre-flight guard is removed after real Windows filesystem tests prove parity.
+
+**Tech Stack:** Rust 2021, `windows-sys 0.59`, Win32 Security and FileSystem APIs, existing `unica-coder` platform adapters, Rust integration/unit tests, Python contract tests.
+
+## Global Constraints
+
+- Follow `docs/design/2026-07-30-windows-applied-full-dump-design.md`.
+- Keep OS-dependent production code under `crates/unica-coder/src/infrastructure/platform/` (`INV-PLATFORM-OS-BEHIND-FACADE`, ADR-0009).
+- Keep platform tests beside the adapters or under `crates/unica-coder/tests/platform/` (`INV-PLATFORM-COLOCATED-TESTS`).
+- Do not add a bypass flag, unsafe publication mode, or new public MCP argument/result field.
+- Preserve the existing platform `8.3.27`, export format `2.20` write gate (ADR-0016).
+- Create private Windows objects with their final protected DACL; do not create permissively and tighten afterward.
+- After the initial absolute anchor capture, every security-sensitive child
+  create, open, remove, and rename on Windows must be relative to a retained
+  parent handle; path-based check/use bracketing is insufficient.
+- Windows no-clobber directory rename uses `NtSetInformationFile` with a
+  destination `RootDirectory` handle and `ReplaceIfExists = false`.
+- Every production change starts with a test observed failing for the intended missing behavior.
+- Local commits require the user to configure `git user.name` and `git user.email`; until then, keep completed task changes staged by exact path without changing repository identity.
+
+---
+
+## File structure
+
+- Modify `Cargo.toml` only to expose the Win32 authorization APIs already supplied by `windows-sys`.
+- Modify `crates/unica-coder/src/infrastructure/platform/filesystem.rs` for reusable Windows handles, identity, protected-DACL creation, handle-relative opens, enumeration and removal, ACL/trust verification, and atomic no-replace rename.
+- Modify `crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs` for Windows `DirectoryAnchor` operations and transaction wiring.
+- Keep real Windows filesystem boundary tests in the existing
+  `full_dump_publication.rs` test module so private transaction failpoints remain
+  inaccessible to release builds.
+- Modify `tests/ci/test_unica_skills.py` and the four runtime documentation files that currently declare Windows fail-closed.
+
+### Task 1: Owner-only Win32 filesystem primitives
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `crates/unica-coder/src/infrastructure/platform/filesystem.rs:1-285`
+- Test: `crates/unica-coder/src/infrastructure/platform/filesystem.rs`
+
+**Interfaces:**
+- Consumes: absolute `Path` values inside an already validated workspace.
+- Produces:
+
+```rust
+#[cfg(windows)]
+pub(crate) fn open_directory_nofollow(path: &Path) -> io::Result<fs::File>;
+
+#[cfg(windows)]
+pub(crate) fn create_owner_only_directory(path: &Path) -> io::Result<fs::File>;
+
+#[cfg(windows)]
+pub(crate) fn create_owner_only_file(path: &Path) -> io::Result<fs::File>;
+
+#[cfg(windows)]
+pub(crate) fn verify_owner_only_acl(file: &fs::File) -> io::Result<()>;
+```
+
+- The returned handles must support `file_identity` and remain valid while callers bracket path mutations.
+
+- [ ] **Step 1: Enable only the required Win32 API feature**
+
+Add `Win32_Security_Authorization` beside the existing Windows features:
+
+```toml
+windows-sys = { version = "0.59", features = [
+  "Win32_Foundation",
+  "Win32_Security",
+  "Win32_Security_Authorization",
+  "Win32_Storage_FileSystem",
+  "Win32_System_Threading",
+] }
+```
+
+- [ ] **Step 2: Write failing Windows tests for private creation**
+
+Add tests guarded by `#[cfg(windows)]`:
+
+```rust
+#[test]
+fn owner_only_directory_is_opened_without_following_reparse_points() {
+    let root = unique_temp_root("owner-only-directory");
+    fs::create_dir_all(&root).unwrap();
+    let private = root.join("private");
+
+    let handle = create_owner_only_directory(&private).unwrap();
+
+    verify_owner_only_acl(&handle).unwrap();
+    assert_eq!(file_identity(&handle).unwrap(), file_identity(&open_directory_nofollow(&private).unwrap()).unwrap());
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn directory_open_rejects_a_reparse_point() {
+    let root = unique_temp_root("directory-reparse");
+    let real = root.join("real");
+    let link = root.join("link");
+    fs::create_dir_all(&real).unwrap();
+    std::os::windows::fs::symlink_dir(&real, &link).unwrap();
+
+    let error = open_directory_nofollow(&link).unwrap_err();
+
+    assert!(matches!(error.kind(), io::ErrorKind::InvalidInput | io::ErrorKind::PermissionDenied));
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn owner_only_file_has_the_final_acl_at_creation() {
+    let root = unique_temp_root("owner-only-file");
+    fs::create_dir_all(&root).unwrap();
+    let private = root.join("effective.yaml");
+
+    let handle = create_owner_only_file(&private).unwrap();
+
+    verify_owner_only_acl(&handle).unwrap();
+    fs::remove_dir_all(root).unwrap();
+}
+```
+
+The production mutation caught by these tests is replacing explicit protected-DACL creation with inherited/default creation, or opening a directory while following a reparse point.
+
+- [ ] **Step 3: Run the focused tests and verify RED**
+
+Run:
+
+```powershell
+cargo test -p unica-coder infrastructure::platform::filesystem::tests::windows -- --nocapture
+```
+
+Expected: compilation fails because `create_owner_only_directory`,
+`create_owner_only_file`, `open_directory_nofollow`, and
+`verify_owner_only_acl` do not exist.
+
+- [ ] **Step 4: Implement the minimal Win32 security owner**
+
+Add a private RAII owner that:
+
+1. opens the current process token with `TOKEN_QUERY`;
+2. reads `TokenUser`;
+3. converts the SID to its string form;
+4. creates SDDL `D:P(A;;FA;;;<current-user-sid>)`;
+5. calls `ConvertStringSecurityDescriptorToSecurityDescriptorW`;
+6. exposes a `SECURITY_ATTRIBUTES` whose lifetime is bounded by the owner;
+7. releases token, SID string, and security descriptor with their documented
+   Win32 release functions.
+
+Use the owner only inside the create calls:
+
+```rust
+let security = OwnerOnlySecurityAttributes::current_user()?;
+let created = unsafe {
+    CreateDirectoryW(path.as_ptr(), security.as_ptr())
+};
+```
+
+Open directories with:
+
+```rust
+CreateFileW(
+    path.as_ptr(),
+    FILE_READ_ATTRIBUTES | READ_CONTROL,
+    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+    std::ptr::null(),
+    OPEN_EXISTING,
+    FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+    std::ptr::null_mut(),
+)
+```
+
+Reject a final `FILE_ATTRIBUTE_REPARSE_POINT` from
+`GetFileInformationByHandle`. Create files with `CREATE_NEW`, the explicit
+security attributes, `FILE_ATTRIBUTE_NORMAL`, and no sharing broader than the
+existing transaction requires.
+
+`verify_owner_only_acl` must read the DACL through `GetSecurityInfo`, require a
+protected DACL, enumerate its ACEs, and accept exactly one allow ACE for the
+current token user with no deny or inherited ACEs.
+
+- [ ] **Step 5: Run focused tests and verify GREEN**
+
+Run:
+
+```powershell
+cargo test -p unica-coder infrastructure::platform::filesystem::tests::windows -- --nocapture
+cargo check -p unica-coder --all-targets
+```
+
+Expected: all Windows filesystem tests pass and `cargo check` has no warnings.
+
+- [ ] **Step 6: Commit or stage the task**
+
+```powershell
+git add -- Cargo.toml Cargo.lock crates/unica-coder/src/infrastructure/platform/filesystem.rs
+git commit -m "feat(windows): add private directory handles"
+```
+
+If Git identity remains unavailable, do not alter it; leave only these paths staged.
+
+### Task 2: Windows DirectoryAnchor parity
+
+**Files:**
+- Modify: `crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs:1500-2055`
+- Test: `crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs`
+
+**Interfaces:**
+- Consumes Task 1:
+
+```rust
+open_directory_nofollow(path: &Path) -> io::Result<File>
+create_owner_only_directory(path: &Path) -> io::Result<File>
+create_owner_only_file(path: &Path) -> io::Result<File>
+verify_owner_only_acl(file: &File) -> io::Result<()>
+```
+
+- Produces the existing platform-neutral API:
+
+```rust
+impl DirectoryAnchor {
+    fn capture_exact(path: &Path) -> Result<Self, String>;
+    fn try_clone(&self) -> Result<Self, String>;
+    fn create_child(&self, name: &OsStr, display_path: &Path) -> Result<Self, String>;
+    fn verify_path_binding(&self) -> Result<(), String>;
+}
+```
+
+- Also produces Windows platform primitives:
+
+```rust
+#[cfg(windows)]
+pub(crate) fn open_directory_child_nofollow(
+    parent: &fs::File,
+    name: &OsStr,
+) -> io::Result<fs::File>;
+
+#[cfg(windows)]
+pub(crate) fn create_owner_only_directory_child(
+    parent: &fs::File,
+    name: &OsStr,
+) -> io::Result<fs::File>;
+
+#[cfg(windows)]
+pub(crate) fn create_owner_only_file_child(
+    parent: &fs::File,
+    name: &OsStr,
+) -> io::Result<fs::File>;
+```
+
+- [ ] **Step 1: Write failing Windows anchor tests**
+
+Add `#[cfg(windows)]` tests that exercise the real anchor:
+
+```rust
+#[test]
+fn windows_anchor_detects_parent_name_replacement() {
+    let root = unique_temp_root("anchor-replacement");
+    let parent = root.join("parent");
+    fs::create_dir_all(&parent).unwrap();
+    let anchor = DirectoryAnchor::capture_exact(&parent).unwrap();
+    let moved = root.join("moved");
+    fs::rename(&parent, &moved).unwrap();
+    fs::create_dir(&parent).unwrap();
+
+    let error = anchor.verify_path_binding().unwrap_err();
+
+    assert!(error.contains("identity"));
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn windows_anchor_creates_a_private_bound_child() {
+    let root = unique_temp_root("anchor-child");
+    fs::create_dir_all(&root).unwrap();
+    let anchor = DirectoryAnchor::capture_exact(&root).unwrap();
+    let child_path = root.join("child");
+
+    let child = anchor.create_child(OsStr::new("child"), &child_path).unwrap();
+
+    child.verify_path_binding().unwrap();
+    verify_owner_only_acl(&child.directory).unwrap();
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn windows_anchor_rejects_a_display_path_outside_the_parent() {
+    let root = unique_temp_root("anchor-containment");
+    let parent = root.join("parent");
+    let outside = root.join("outside");
+    fs::create_dir_all(&parent).unwrap();
+    let anchor = DirectoryAnchor::capture_exact(&parent).unwrap();
+
+    let error = anchor.create_child(OsStr::new("child"), &outside).unwrap_err();
+
+    assert!(error.contains("does not match anchored child"));
+    assert!(!outside.exists());
+    fs::remove_dir_all(root).unwrap();
+}
+```
+
+The production mutation caught is accepting a same-name replacement after the
+anchor was captured, or creating a stage child with inherited permissions.
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```powershell
+cargo test -p unica-coder windows_anchor -- --nocapture
+```
+
+Expected: the current `#[cfg(not(unix))]` stubs return
+`secure directory anchors are unavailable on this host`.
+
+- [ ] **Step 3: Implement Windows anchor operations**
+
+Split the current fallback cfgs so Windows receives real implementations and
+only unsupported hosts retain stubs:
+
+```rust
+#[cfg(windows)]
+fn capture_exact(path: &Path) -> Result<Self, String> {
+    let directory = open_directory_nofollow(path)
+        .map_err(|error| format!("failed to open directory anchor {}: {error}", path.display()))?;
+    let identity = file_identity(&directory)
+        .map_err(|error| format!("failed to identify directory anchor {}: {error}", path.display()))?;
+    Ok(Self { path: path.to_path_buf(), directory, identity })
+}
+```
+
+Declare the documented user-mode `NtCreateFile` entrypoint from `ntdll`.
+Construct `UNICODE_STRING`, `OBJECT_ATTRIBUTES`, and `IO_STATUS_BLOCK` with
+`OBJECT_ATTRIBUTES.RootDirectory = parent.as_raw_handle()`. Accept exactly one
+relative child component. Use `FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT`
+for directories and `FILE_NON_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT` for
+files. Create with `FILE_CREATE`, so an existing name is never opened.
+
+`verify_path_binding` reopens `self.path` without following reparse points and
+requires equality with `self.identity`. `create_child` first requires
+`display_path == self.path.join(name)`, creates and reopens the child relative
+to `self.directory`, verifies the returned handle identity and owner-only ACL,
+then returns the child anchor. It must not use `display_path` for the create or
+reopen operation.
+
+Replace `create_regular_child_owner_only`'s Windows fallback with
+`create_owner_only_file_child(parent, name)`, preserving create-new behavior
+without using its display path.
+
+- [ ] **Step 4: Run anchor and existing transaction tests**
+
+Run:
+
+```powershell
+cargo test -p unica-coder windows_anchor -- --nocapture
+cargo test -p unica-coder infrastructure::platform::full_dump_publication -- --test-threads=1
+```
+
+Expected: the Windows tests pass; existing platform-neutral transaction tests remain green.
+
+- [ ] **Step 5: Commit or stage the task**
+
+```powershell
+git add -- crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+git commit -m "feat(windows): bind full dump directories to handles"
+```
+
+If Git identity remains unavailable, keep the path staged without changing Git configuration.
+
+### Task 3: Atomic no-clobber Windows directory publication
+
+**Files:**
+- Modify: `crates/unica-coder/src/infrastructure/platform/filesystem.rs:200-285`
+- Modify: `crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs:3170-3932`
+- Test: `crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs`
+
+**Interfaces:**
+- Consumes: Task 2 `DirectoryAnchor` and existing `FileIdentity`.
+- Produces:
+
+```rust
+#[cfg(windows)]
+fn rename_prechecked_directory_child_no_replace(
+    source_parent: &DirectoryAnchor,
+    source_name: &OsStr,
+    expected_identity: FileIdentity,
+    destination_parent: &DirectoryAnchor,
+    destination_name: &OsStr,
+) -> Result<(), String>;
+
+#[cfg(windows)]
+fn rename_child_no_replace(
+    source_parent: &DirectoryAnchor,
+    source_name: &OsStr,
+    destination_parent: &DirectoryAnchor,
+    destination_name: &OsStr,
+) -> Result<(), String>;
+```
+
+- [ ] **Step 1: Add a real-filesystem no-clobber test**
+
+Add this `#[cfg(windows)]` test to the existing
+`full_dump_publication.rs` test module:
+
+```rust
+#[test]
+fn no_clobber_directory_move_preserves_an_existing_destination() {
+    let root = unique_temp_root("no-clobber");
+    let source = root.join("source");
+    let destination = root.join("destination");
+    fs::create_dir_all(&source).unwrap();
+    fs::create_dir_all(&destination).unwrap();
+    fs::write(source.join("new.txt"), b"new").unwrap();
+    fs::write(destination.join("old.txt"), b"old").unwrap();
+
+    let source_parent = DirectoryAnchor::capture_exact(&root).unwrap();
+    let destination_parent = source_parent.try_clone().unwrap();
+    let error = rename_child_no_replace(
+        &source_parent,
+        OsStr::new("source"),
+        &destination_parent,
+        OsStr::new("destination"),
+    )
+    .unwrap_err();
+
+    assert!(destination.join("old.txt").is_file());
+    assert!(!destination.join("new.txt").exists());
+    assert!(source.join("new.txt").is_file());
+    assert!(!error.is_empty());
+    fs::remove_dir_all(root).unwrap();
+}
+```
+
+The mutation caught is adding `MOVEFILE_REPLACE_EXISTING` or deleting the
+destination before moving.
+
+- [ ] **Step 2: Add transaction race tests**
+
+Add Windows-enabled variants of the existing publication failpoint tests:
+
+```rust
+#[test]
+fn windows_destination_race_after_backup_survives_rollback() {
+    let (root, context, target) = workspace("windows-destination-race");
+    let runner = DumpRunner::valid();
+
+    let result = with_publication_hook(PublicationCheckpoint::BeforeStageInstall, {
+        let target = target.clone();
+        move || {
+            fs::create_dir_all(&target).unwrap();
+            fs::write(target.join("racer.txt"), b"racer").unwrap();
+        }
+    }, || invoke(&runner, &platform(), FullDumpInvocation::BuildDump, &context));
+
+    assert!(result.is_err());
+    assert_eq!(fs::read(target.join("racer.txt")).unwrap(), b"racer");
+    fs::remove_dir_all(root).unwrap();
+}
+```
+
+- [ ] **Step 3: Run the tests and verify RED**
+
+Run:
+
+```powershell
+cargo test -p unica-coder no_clobber_directory_move_preserves_an_existing_destination -- --nocapture
+cargo test -p unica-coder windows_destination_race_after_backup_survives_rollback -- --nocapture
+```
+
+Expected: tests fail because the full-dump Windows rename functions still return
+`atomic no-clobber directory rename is unavailable on this host`.
+
+- [ ] **Step 4: Implement the Windows rename path**
+
+Open the source child relative to `source_parent.directory`, retaining the
+source handle and identity. Declare the user-mode `NtSetInformationFile`
+entrypoint from `ntdll` and build `FILE_RENAME_INFORMATION` with
+`RootDirectory = destination_parent.directory.as_raw_handle()`,
+`ReplaceIfExists = false`, and a single relative destination name.
+
+For `rename_prechecked_directory_child_no_replace`:
+
+```rust
+let source = open_directory_child_nofollow(&source_parent.directory, source_name)
+    .map_err(|error| format!("failed to open staged child: {error}"))?;
+if file_identity(&source).map_err(|error| error.to_string())? != expected_identity {
+    return Err("staged directory identity changed".to_string());
+}
+rename_child_no_replace(source_parent, source_name, destination_parent, destination_name)
+```
+
+For `rename_child_no_replace`, use only the source child handle and destination
+parent handle for the mutation. Convert `NTSTATUS` failures through
+`RtlNtStatusToDosError` into `io::Error`. Reopen the destination relative to
+the destination parent and require its identity to equal the pre-move source
+identity. Handle-relative disposition/removal must be used for cleanup and
+quarantine; do not reconstruct an absolute child path for a mutation.
+
+- [ ] **Step 5: Run publication and rollback tests and verify GREEN**
+
+Run:
+
+```powershell
+cargo test -p unica-coder no_clobber_directory_move_preserves_an_existing_destination -- --nocapture
+cargo test -p unica-coder infrastructure::platform::full_dump_publication -- --test-threads=1
+```
+
+Expected: no-clobber, race, rollback, quarantine, and existing transaction tests pass.
+
+- [ ] **Step 6: Commit or stage the task**
+
+```powershell
+git add -- crates/unica-coder/src/infrastructure/platform/filesystem.rs crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+git commit -m "feat(windows): publish full dumps without clobber"
+```
+
+If Git identity remains unavailable, keep only these paths staged.
+
+### Task 4: Windows handle-relative reads and descendant inspection
+
+**Files:**
+- Modify: `crates/unica-coder/src/infrastructure/platform/filesystem.rs`
+- Modify: `crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs:1539-2270`
+- Test: both modified platform modules
+
+**Interfaces:**
+- Consumes: Task 2 retained directory handles and `FileIdentity`.
+- Produces Windows implementations for:
+
+```rust
+open_regular_child_nofollow(parent: &File, name: &OsStr) -> io::Result<File>;
+open_any_child_nofollow(parent: &File, name: &OsStr) -> io::Result<File>;
+read_directory_names(directory: &File) -> io::Result<Vec<OsString>>;
+secure_read_regular_file_snapshot(path: &Path, role: &str)
+    -> Result<SecureFileSnapshot, String>;
+secure_path_is_absent(path: &Path) -> Result<bool, String>;
+DirectoryAnchor::capture_descendant(...);
+DirectoryAnchor::verify_descendant_identity(...);
+DirectoryAnchor::capture_child_root_identity(...);
+```
+
+- [ ] **Step 1: Add failing Windows inspection regressions**
+
+Add Windows tests that prove:
+
+1. secure config reads reject a final reparse point and detect a child-name
+   identity replacement at the existing secure-read hook;
+2. an absence check returns `false` for a reparse point and `true` only for a
+   genuinely missing relative child;
+3. `capture_descendant` walks two or more components below the retained
+   workspace anchor and rejects a replaced component;
+4. handle enumeration returns names from the retained directory even if its
+   original path is moved and replaced.
+
+The production mutation caught is falling back to `fs::read`,
+`Path::exists`, `read_dir(display_path)`, or another child-path operation after
+the parent handle has been captured.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+```powershell
+cargo test -p unica-coder windows_secure_read -- --nocapture
+cargo test -p unica-coder windows_descendant_anchor -- --nocapture
+cargo test -p unica-coder windows_handle_enumeration -- --nocapture
+```
+
+Expected: current `#[cfg(not(unix))]` functions return their fail-closed
+unavailable errors.
+
+- [ ] **Step 3: Implement the minimal handle-relative facade**
+
+Extend the existing `NtCreateFile` wrapper:
+
+- a regular-file open requests `GENERIC_READ | FILE_READ_ATTRIBUTES |
+  SYNCHRONIZE` with `FILE_NON_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT`;
+- an arbitrary-child probe requests `FILE_READ_ATTRIBUTES | SYNCHRONIZE` with
+  `FILE_OPEN_REPARSE_POINT` and no directory-type option;
+- both reject a final reparse-point attribute;
+- directory enumeration uses
+  `GetFileInformationByHandleEx(FileIdBothDirectoryInfo)` on the retained
+  handle, validates record offsets/name lengths, skips `.` and `..`, and
+  returns sorted names.
+
+Implement descendant traversal one component at a time with
+`open_directory_child_nofollow`. Implement secure reads by holding the parent
+and child handles for the whole read, requiring one hard link, comparing
+metadata before/after, reopening the same relative name, and comparing
+identities. Implement absence by probing the relative name and treating only
+native not-found errors as absent.
+
+- [ ] **Step 4: Run inspection and existing anchor tests**
+
+```powershell
+cargo test -p unica-coder windows_secure_read -- --nocapture
+cargo test -p unica-coder windows_descendant_anchor -- --nocapture
+cargo test -p unica-coder windows_handle_enumeration -- --nocapture
+cargo test -p unica-coder windows_anchor -- --nocapture
+cargo check -p unica-coder --all-targets
+```
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add -- crates/unica-coder/src/infrastructure/platform/filesystem.rs crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+git commit -m "feat(windows): inspect dump inputs through handles"
+```
+
+### Task 5: Windows tree snapshots and handle-relative cleanup
+
+**Files:**
+- Modify: `crates/unica-coder/src/infrastructure/platform/filesystem.rs`
+- Modify: `crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs:2510-3100`
+- Test: `crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs`
+
+**Interfaces:**
+- Consumes: Task 4 handle-relative open and enumeration primitives.
+- Produces Windows implementations for `capture_tree_target_nofollow`,
+  `capture_tree_child_nofollow`, `capture_directory_snapshot_recursive`,
+  `unlink_bound_regular_child`, `remove_directory_contents_nofollow`, and
+  `remove_bound_directory_child`.
+
+- [ ] **Step 1: Add failing Windows tree and cleanup tests**
+
+Add Windows real-filesystem tests that prove:
+
+1. a nested regular tree receives a stable snapshot containing identities,
+   sizes, and SHA-256 digests;
+2. a reparse point anywhere in the target or staged tree fails snapshotting
+   without traversal;
+3. changing a file name at the existing snapshot hook is detected even when
+   the replacement has identical bytes;
+4. recursive cleanup removes an expected retained tree, including an
+   unsupported reparse entry as an entry rather than following it;
+5. replacing an expected child before cleanup leaves the replacement untouched
+   and returns an identity error.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+```powershell
+cargo test -p unica-coder windows_tree_snapshot -- --nocapture
+cargo test -p unica-coder windows_handle_cleanup -- --nocapture
+```
+
+Expected: the current Windows fallbacks report secure snapshot/cleanup as
+unavailable.
+
+- [ ] **Step 3: Implement descriptor-relative snapshots**
+
+Use Task 4 enumeration and relative opens recursively. For each directory,
+capture identity, enumerate and inspect children, reopen each relative child,
+and compare identity. For each file, require one hard link, hash through the
+open handle, compare size and last-write metadata before/after, then reopen and
+compare identity. Treat reparse points and unsupported entry kinds as errors.
+Use an initial absolute parent capture only at `capture_tree_target_nofollow`;
+all child operations are handle-relative.
+
+- [ ] **Step 4: Implement descriptor-relative cleanup**
+
+Add a delete-capable arbitrary-child open using `NtCreateFile` with
+`FILE_OPEN_REPARSE_POINT`. Normal directories are enumerated and emptied
+recursively; regular files and reparse entries are never followed. Mark the
+opened object for deletion with
+`NtSetInformationFile(FileDispositionInformation)`. Expected-object cleanup
+must compare `FileIdentity` before mutation and leave a replacement untouched.
+
+- [ ] **Step 5: Run tree, validation, and cleanup suites**
+
+```powershell
+cargo test -p unica-coder windows_tree_snapshot -- --nocapture
+cargo test -p unica-coder windows_handle_cleanup -- --nocapture
+cargo test -p unica-coder staged_ -- --nocapture
+cargo test -p unica-coder windows_anchor -- --nocapture
+cargo check -p unica-coder --all-targets
+```
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add -- crates/unica-coder/src/infrastructure/platform/filesystem.rs crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+git commit -m "feat(windows): snapshot and clean dump trees"
+```
+
+### Task 6: Windows immutable platform attestation
+
+**Files:**
+- Modify: `Cargo.toml` only if an additional `windows-sys` feature is required.
+- Modify: `crates/unica-coder/src/infrastructure/platform/filesystem.rs`
+- Modify: `crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs:1047-1538`
+- Test: both modified platform modules
+
+**Interfaces:**
+- Consumes: Task 5 secure inventory traversal.
+- Produces a Windows `ImmutablePlatformTrustSnapshot::capture` that proves the
+  installation is not mutable by an untrusted principal before executing the
+  platform.
+
+- [ ] **Step 1: Add failing trust-policy tests**
+
+Build security descriptors from SDDL in tests and prove that the Windows policy:
+
+1. accepts TrustedInstaller, LocalSystem, or built-in Administrators ownership
+   with substitution rights on ancestry and full mutation rights inside the
+   installation limited to those trusted principals, while permitting
+   read/execute access for ordinary users;
+2. rejects an untrusted owner;
+3. rejects an effective allow ACE granting ordinary users `DELETE`,
+   `FILE_DELETE_CHILD`, `WRITE_DAC`, `WRITE_OWNER`, `GENERIC_WRITE`, or
+   `GENERIC_ALL` on an ancestor above the install root;
+4. rejects any effective allow ACE granting ordinary users file/directory
+   creation, write/append, attribute writes, delete/delete-child, `WRITE_DAC`,
+   or `WRITE_OWNER` on the install root or its inventory;
+5. does not treat an `INHERIT_ONLY` ACE as a capability on the current object;
+6. rejects a null/absent DACL and malformed or unsupported ACEs;
+7. rejects an elevated effective thread token, falls back to the process token
+   only for `ERROR_NO_TOKEN`, and fails closed for other thread-token errors;
+8. rejects UNC/device roots and mapped or remote filesystems using evidence
+   queried from the retained installation handle;
+9. rejects a reparse point or multiply linked file in an installation
+   inventory.
+
+The pure descriptor-policy tests do not require changing machine ownership or
+ACLs. At least one integration test must capture real handles and prove that
+the descriptor and identity used by the policy belong to the opened object.
+
+- [ ] **Step 2: Run the trust tests and verify RED**
+
+```powershell
+cargo test -p unica-coder windows_immutable_platform -- --nocapture
+```
+
+Expected: Windows immutable capture still returns
+`immutable platform trust verification is unavailable on this host`.
+
+- [ ] **Step 3: Implement Windows trust capture**
+
+Reject an elevated effective token and fail closed if elevation state cannot be
+proved. Open the current thread token first and fall back to the process token
+only when `OpenThreadToken` reports `ERROR_NO_TOKEN`.
+
+Accept only normal or verbatim local-disk path prefixes. Query native
+filesystem device information from the retained installation handle and reject
+`FILE_REMOTE_DEVICE`, `FILE_DEVICE_NETWORK_FILE_SYSTEM`, UNC/device roots, and
+mapped remote volumes before trusting their metadata.
+
+Walk the volume-root-to-install ancestry one component at a time and the
+complete install inventory with retained handles. Reject reparse points and
+require one hard link for files.
+
+Read owner and DACL from each opened handle with `GetSecurityInfo`. Require the
+owner SID to equal TrustedInstaller, LocalSystem, or built-in Administrators.
+Enumerate the DACL. For ancestry above the installation root, reject
+substitution-capable effective allow ACEs (`DELETE`, `FILE_DELETE_CHILD`,
+`WRITE_DAC`, `WRITE_OWNER`, `GENERIC_WRITE`, or `GENERIC_ALL`) for every
+untrusted SID; creation of an unrelated sibling alone is permitted. For the
+installation root and inventory, reject the complete mutation mask for every
+untrusted SID. Inherited basic allow ACEs are evaluated by the same profile,
+while `INHERIT_ONLY` ACEs grant no capability on the current object and deny
+ACEs grant none. Object, callback, conditional, or unknown ACE forms that
+cannot be evaluated unambiguously fail closed. Hash the canonical self-relative
+security descriptor and store the digest beside path, kind, and identity in
+`ImmutablePlatformEntry`.
+
+Keep the Unix owner/mode implementation unchanged by making the trust evidence
+platform-specific inside the entry.
+
+- [ ] **Step 4: Run attestation and platform resolver tests**
+
+```powershell
+cargo test -p unica-coder windows_immutable_platform -- --nocapture
+cargo test -p unica-coder platform_attestation -- --nocapture
+cargo test -p unica-coder platform_resolver -- --nocapture
+cargo check -p unica-coder --all-targets
+```
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add -- Cargo.toml Cargo.lock crates/unica-coder/src/infrastructure/platform/filesystem.rs crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+git commit -m "feat(windows): attest immutable platform installs"
+```
+
+### Task 7: Remove the Windows pre-flight guard
+
+**Files:**
+- Modify: `crates/unica-coder/src/infrastructure/platform/filesystem.rs`
+- Modify: `crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs:485-507`
+- Test: `crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs`
+
+**Interfaces:**
+- Consumes: Tasks 1–6 Windows security, inspection, attestation, cleanup, and
+  publication primitives.
+- Produces: one `PreparedDump::prepare` implementation shared by Unix and Windows; unsupported non-Unix/non-Windows hosts remain fail-closed at unavailable platform primitives.
+
+- [ ] **Step 1: Add a failing applied-dump regression**
+
+Extend the real `DumpRunner` fixture test so Windows must reach the runner and
+publish:
+
+```rust
+#[cfg(windows)]
+#[test]
+fn windows_applied_full_dump_reaches_runner_and_commits_validated_tree() {
+    let (root, context, target) = workspace("windows-applied-full-dump");
+    let runner = DumpRunner::valid();
+
+    let result = invoke(&runner, &platform(), FullDumpInvocation::BuildDump, &context)
+        .expect("Windows applied full dump");
+
+    assert!(result.0.ok);
+    assert_eq!(runner.calls.load(Ordering::SeqCst), 1);
+    assert!(target.join("Configuration.xml").is_file());
+    fs::remove_dir_all(root).unwrap();
+}
+```
+
+The production mutation caught is restoring the Windows pre-flight error or
+failing before the platform runner is called.
+
+- [ ] **Step 2: Run the regression and verify RED**
+
+Run:
+
+```powershell
+cargo test -p unica-coder windows_applied_full_dump_reaches_runner_and_commits_validated_tree -- --nocapture
+```
+
+Expected: failure with `verified applied full dump is fail-closed on Windows`.
+
+- [ ] **Step 3: Remove the dedicated Windows prepare implementation**
+
+Delete the `#[cfg(windows)] PreparedDump::prepare` error function and widen the
+real implementation from `#[cfg(not(windows))]` to all supported hosts. Do not
+change argument validation, platform attestation, snapshots, stage validation,
+or publication ordering.
+
+- [ ] **Step 4: Close retained private handles before Windows disposition verification**
+
+Add owner-only boundary regressions for synchronous relative file creation,
+moving a populated child between live owner-only parents, and delete-pending
+cleanup while retained anchors remain open.
+
+Every synchronous `NtCreateFile` access mask must explicitly include
+`SYNCHRONIZE`. After owner-only directory creation and validation, reopen the
+child relative to its retained parent with ordinary inspection rights, compare
+identity, close the DELETE-capable create handle, and return only the
+least-privilege handle.
+
+Make private execution, recovery, and root anchors takeable during cleanup.
+Empty a child through its retained handle, close that handle, perform the
+identity-bound delete through the parent, and then verify the parent. Close the
+private root anchor before deleting and verifying the root. Preserve the
+existing retry, recovery, and identity-mismatch behavior.
+
+- [ ] **Step 5: Run focused and workspace Rust tests**
+
+Run:
+
+```powershell
+cargo test -p unica-coder windows_applied_full_dump_reaches_runner_and_commits_validated_tree -- --nocapture
+cargo test -p unica-coder infrastructure::platform::full_dump_publication -- --test-threads=1
+cargo test --workspace -- --test-threads=1
+```
+
+Expected: the Windows regression and the full workspace pass.
+
+- [ ] **Step 6: Commit or stage the task**
+
+```powershell
+git add -- crates/unica-coder/src/infrastructure/platform/filesystem.rs crates/unica-coder/src/infrastructure/platform/full_dump_publication.rs
+git commit -m "fix(runtime): enable verified Windows full dump"
+```
+
+If Git identity remains unavailable, keep the path staged.
+
+### Task 8: Synchronize user-facing support policy
+
+**Files:**
+- Modify: `tests/ci/test_unica_skills.py:1392-1415`
+- Modify: `plugins/unica/skills/v8-runner/SKILL.md:290-310`
+- Modify: `plugins/unica/skills/v8-runner/references/file-and-artifact-workflows.md:25-45`
+- Modify: `plugins/unica/references/tooling/v8project.md:100-117`
+- Modify: `plugins/unica/references/tooling/runtime-build.md:128-145`
+
+**Interfaces:**
+- Consumes: Task 7 observed Windows support.
+- Produces: documentation that routes applied full dump on Windows through the same verified synchronous operation as macOS and Linux.
+
+- [ ] **Step 1: Replace the old documentation assertion with a behavior contract**
+
+Rename the CI test to
+`test_verified_applied_full_dump_documents_supported_hosts_and_verified_publication`.
+Assert that the combined documentation:
+
+```python
+self.assertRegex(
+    combined,
+    re.compile(
+        r"Windows.{0,240}(?:verified|transactional|no-clobber).{0,240}"
+        r"(?:full dump|mode.?=.?full)",
+        re.IGNORECASE | re.DOTALL,
+    ),
+)
+self.assertNotRegex(
+    combined,
+    re.compile(
+        r"Windows.{0,240}(?:fail-closed|blocked|unsupported).{0,240}"
+        r"(?:full dump|mode.?=.?full)",
+        re.IGNORECASE | re.DOTALL,
+    ),
+)
+```
+
+The production documentation change caught is reintroducing the obsolete claim
+that Windows applied full dump is unavailable.
+
+- [ ] **Step 2: Run the contract test and verify RED**
+
+Run:
+
+```powershell
+python -m unittest discover -s tests/ci -p 'test_unica_skills.py' -k verified_applied_full_dump -v
+```
+
+Expected: failure because the current docs explicitly say Windows is fail-closed.
+
+- [ ] **Step 3: Update the four documentation files**
+
+State that synchronous applied `mode=full` for `CONFIGURATION` and `EXTENSION`
+uses verified transactional publication on Windows, macOS, and Linux. Preserve
+the separate restrictions for:
+
+- incremental/partial dump receipts;
+- external source-set applied dump;
+- applied conversion;
+- asynchronous runtime jobs.
+
+Reference `INV-PLATFORM-OS-BEHIND-FACADE` and the existing publication owner
+instead of adding a second normative rule.
+
+- [ ] **Step 4: Run documentation and architecture checks**
+
+Run:
+
+```powershell
+python -m unittest discover -s tests/ci -p 'test_unica_skills.py' -v
+python -m unittest discover -s tests/ci -p 'test_design_documents.py' -v
+python -m unittest discover -s tests/ci -p 'test_architecture_registry.py' -v
+python scripts/ci/check-rust-platform-boundary.py
+```
+
+Expected: all checks pass.
+
+- [ ] **Step 5: Commit or stage the task**
+
+```powershell
+git add -- tests/ci/test_unica_skills.py plugins/unica/skills/v8-runner/SKILL.md plugins/unica/skills/v8-runner/references/file-and-artifact-workflows.md plugins/unica/references/tooling/v8project.md plugins/unica/references/tooling/runtime-build.md
+git commit -m "docs(runtime): support verified Windows full dump"
+```
+
+If Git identity remains unavailable, keep only these paths staged.
+
+### Task 9: Final verification
+
+**Files:**
+- Verify all modified files.
+
+**Interfaces:**
+- Consumes: completed Tasks 1–8.
+- Produces: evidence that the implementation, platform boundary, docs, and workspace remain green.
+
+- [ ] **Step 1: Format and inspect**
+
+Run:
+
+```powershell
+cargo fmt --all
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors; status contains only files named in this plan.
+
+- [ ] **Step 2: Run Rust quality gates**
+
+Run:
+
+```powershell
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace -- --test-threads=1
+```
+
+Expected: both commands exit zero with no warnings.
+
+- [ ] **Step 3: Run Python source gates**
+
+Run:
+
+```powershell
+python -m unittest discover -s tests/ci --durations 20
+python -m unittest discover -s tests/dev --durations 20
+python -m py_compile scripts/ci/*.py tests/ci/*.py
+python -m py_compile scripts/dev/*.py tests/dev/*.py
+python scripts/ci/check-version-contract.py
+python scripts/ci/check-rust-platform-boundary.py
+```
+
+Expected: all commands exit zero.
+
+- [ ] **Step 4: Run architecture synchronization**
+
+Run:
+
+```powershell
+$base = git merge-base HEAD origin/main
+python scripts/ci/check-architecture-sync.py --base $base
+```
+
+Expected: exit zero; no ADR is required because the design implements ADR-0009
+without changing the public surface or architectural rule ownership.
+
+- [ ] **Step 5: Review the final diff against issue #268**
+
+Confirm from the diff and test output:
+
+- no Windows pre-flight guard remains;
+- applied full dump reaches the runner;
+- private creation uses an explicit protected DACL;
+- directory opens reject reparse points;
+- publication never replaces an occupied destination;
+- rollback preserves a concurrent occupant;
+- docs no longer report Windows full dump as unsupported.
+
+- [ ] **Step 6: Create the final commit if identity is configured**
+
+```powershell
+git add -- docs/design/2026-07-30-windows-applied-full-dump-design.md docs/plans/2026-07-30-windows-applied-full-dump.md
+git commit -m "fix(runtime): support verified Windows full dump"
+```
+
+If task commits were already created, amend neither history nor unrelated user
+changes; commit only the remaining design/plan artifacts.

--- a/plugins/unica/references/tooling/runtime-build.md
+++ b/plugins/unica/references/tooling/runtime-build.md
@@ -129,17 +129,23 @@
 > принадлежащий runtime-слою. Синхронный applied `mode=full` для DESIGNER
 > configuration/extension проходит через внешний private stage Unica:
 > платформа независимо фиксируется на exact 8.3.27.x, XML проверяется на raw
-> `version="2.20"` до целой публикации. Async full и external source-set пока
-> preview-only. Неполные режимы дополнительно не имеют безопасного merge receipt.
-> На Windows applied full dump пока fail-closed: owner-only ACL и handle-safe
-> no-clobber публикация каталогов ещё не реализованы; preview остаётся
-> read-only. Поддерживаемый POSIX-маршрут проверяет физические DESIGNER-маркеры,
-> exact sibling `ibcmd --version` и отделяет secret-bearing effective config от
-> сохраняемого recovery. Установка платформы должна целиком принадлежать root,
-> не иметь group/world write, ACL и ссылок и быть неизменяемой для запускающего
-> non-root пользователя. Пользовательская установка отклоняется до `ibcmd` и
-> `v8-runner`; ACL-доказательство поддержано на macOS/Linux, прочие Unix
-> fail-closed.
+> `version="2.20"` до целой публикации. На Windows, macOS и Linux verified
+> transactional publication поддерживает этот synchronous applied full dump
+> (`mode=full`). Владельцем контракта публикации остаётся ADR-0016;
+> `INV-SOURCE-BOUND-PREIMAGES` и `INV-SOURCE-ROLLBACK-VISIBLE` описывают
+> проверяемую транзакцию, а OS-зависимая реализация остаётся за
+> `INV-PLATFORM-OS-BEHIND-FACADE`.
+>
+> Async full и applied external source-set пока preview-only. Неполные режимы
+> дополнительно не имеют безопасного merge receipt. На Windows Unica через
+> no-follow handles проверяет локальную системную установку: trusted owner и DACL
+> защищают install tree от изменения запускающим non-elevated пользователем, а
+> ancestry — от удаления, замены и перенаправления компонентов пути. На macOS и
+> Linux проверяются физические DESIGNER-маркеры, exact sibling
+> `ibcmd --version` и root-owned, link-free install tree без group/world write и
+> ACL. Secret-bearing effective config отделён от сохраняемого recovery.
+> Пользовательская или изменяемая установка отклоняется до `ibcmd` и
+> `v8-runner`; прочие Unix fail-closed.
 
 **Полная выгрузка** — все объекты конфигурации:
 ```
@@ -413,17 +419,17 @@ Legitimate metadata descriptor (включая external EPF/ERF) объекта 
 
 Платформа предоставляет параметры для использования вспомогательного CDFI при
 сравнении, но управление приватным CDFI для пары `source-set + ИБ` относится к
-runtime-слою. Синхронный applied `mode=full` для DESIGNER
-configuration/extension безопасно оборачивается Unica: выбранный source-set
-перенаправляется во внешний private stage, платформа проверяется как exact
-8.3.27.x, а version-bearing XML roots — как raw `2.20`; только затем целое
-дерево публикуется с проверкой preimage и rollback. До реализации private state
-и shadow publication в `alkoleft/v8-runner-rust#30`
+runtime-слою. На Windows, macOS и Linux синхронный applied `mode=full` для
+DESIGNER configuration/extension выполняется через verified transactional
+publication Unica: выбранный source-set перенаправляется во внешний private
+stage, платформа проверяется как exact 8.3.27.x, а version-bearing XML roots —
+как raw `2.20`; только затем целое дерево публикуется с проверкой preimage и
+rollback (ADR-0016, `INV-PLATFORM-OS-BEHIND-FACADE`). До реализации private
+state и shadow publication в `alkoleft/v8-runner-rust#30`
 `mode=incremental|partial` остаётся preview-only: закреплённый runner не
 возвращает точные processed paths/hashes и не выполняет divergence-safe merge.
-Applied-маршрут принимает только системную root-owned установку платформы,
-неизменяемую для вызывающего non-root пользователя; user-owned install не
-исполняется.
+Applied-маршрут принимает только системную установку платформы, неизменяемую для
+вызывающего пользователя; user-owned install не исполняется.
 
 ## Переменные окружения
 

--- a/plugins/unica/references/tooling/runtime-build.md
+++ b/plugins/unica/references/tooling/runtime-build.md
@@ -127,7 +127,7 @@
 > Unica. Не направляй incremental/partial/CDFI-only команды прямо в
 > Git-visible source root: они допустимы только во временный private staging,
 > принадлежащий runtime-слою. Синхронный applied `mode=full` для DESIGNER
-> configuration/extension проходит через внешний private stage Unica:
+> `CONFIGURATION`/`EXTENSION` проходит через внешний private stage Unica:
 > платформа независимо фиксируется на exact 8.3.27.x, XML проверяется на raw
 > `version="2.20"` до целой публикации. На Windows, macOS и Linux verified
 > transactional publication поддерживает этот synchronous applied full dump
@@ -420,7 +420,7 @@ Legitimate metadata descriptor (включая external EPF/ERF) объекта 
 Платформа предоставляет параметры для использования вспомогательного CDFI при
 сравнении, но управление приватным CDFI для пары `source-set + ИБ` относится к
 runtime-слою. На Windows, macOS и Linux синхронный applied `mode=full` для
-DESIGNER configuration/extension выполняется через verified transactional
+DESIGNER `CONFIGURATION`/`EXTENSION` выполняется через verified transactional
 publication Unica: выбранный source-set перенаправляется во внешний private
 stage, платформа проверяется как exact 8.3.27.x, а version-bearing XML roots —
 как raw `2.20`; только затем целое дерево публикуется с проверкой preimage и

--- a/plugins/unica/references/tooling/v8project.md
+++ b/plugins/unica/references/tooling/v8project.md
@@ -102,17 +102,22 @@ Use the `v8-runner` skill and MCP `unica.runtime.execute` for runtime operations
 | Run tests | `operation=test`, `testRunner=yaxunit|va` |
 | Download configured tools | `operation=tools-download`, `tool=yaxunit|vanessa|client-mcp` |
 
-Windows applied full dump is currently fail-closed until owner-only ACL
-enforcement and handle-safe no-clobber directory publication are implemented;
-preview remains read-only. The supported POSIX route validates physical
-DESIGNER markers, attests the exact installation with sibling
-`ibcmd --version`, and never retains effective configuration or credentials in
-recovery.
-The installation must be immutable to the invoking non-root user: its complete
-tree and ancestry are root-owned, not group/world writable, link-free, and
-ACL-free. User-owned platform installs are rejected before `ibcmd` or
-`v8-runner` executes. ACL verification is supported on macOS/Linux; other Unix
-hosts fail closed.
+On Windows, macOS, and Linux, verified transactional publication supports
+synchronous applied `mode=full` for DESIGNER `CONFIGURATION` and `EXTENSION`
+source-sets. ADR-0016 owns the publication contract;
+`INV-SOURCE-BOUND-PREIMAGES` and `INV-SOURCE-ROLLBACK-VISIBLE` describe its
+preimage and rollback guarantees, while OS-specific mechanics stay behind
+`INV-PLATFORM-OS-BEHIND-FACADE`.
+
+On Windows, Unica attests a local system installation through no-follow handles:
+its trusted owner and DACL must prevent mutation of the install tree by the
+invoking non-elevated user, while the ancestry must prevent deletion,
+replacement, or retargeting of path components. On macOS and Linux, Unica
+validates physical DESIGNER markers, attests the exact installation with sibling
+`ibcmd --version`, and requires a root-owned, link-free install tree without
+group/world write or ACLs. Effective configuration and credentials are never
+retained in recovery. User-owned platform installs are rejected before `ibcmd`
+or `v8-runner` executes; other Unix hosts fail closed.
 
 ## Skill Rules
 

--- a/plugins/unica/skills/v8-runner/SKILL.md
+++ b/plugins/unica/skills/v8-runner/SKILL.md
@@ -286,25 +286,30 @@ preview-only. Если исходники уже есть, не выполняй
 и не используй как XML-исходник. Это правило не относится к metadata-файлу
 реального объекта: legitimate metadata descriptor (включая external EPF/ERF)
 с именем `ConfigDumpInfo.xml` remains source и должен храниться в Git.
-Синхронный applied `mode=full` разрешён только для DESIGNER source-set типа
-`CONFIGURATION` или `EXTENSION`: Unica независимо проверяет установленную
+На Windows, macOS и Linux verified transactional publication поддерживает
+синхронный applied full dump (`mode=full`) только для DESIGNER source-set типа
+`CONFIGURATION` или `EXTENSION`. Unica независимо проверяет установленную
 платформу 8.3.27, подменяет выбранный target на private staging, проверяет
-владелец и все XML version-bearing roots на exact raw `2.20`, затем атомарно с
-rollback публикует целое дерево. Асинхронный full dump и external source-set
-пока доступны только как preview. `incremental` и `partial` также preview-only:
-до private CDFI, точного receipt и divergence-safe merge
-(alkoleft/v8-runner-rust#30) им нельзя писать в Git-visible root.
+владельца и все XML version-bearing roots на exact raw `2.20`, затем атомарно с
+rollback публикует целое дерево. Контракт публикации принадлежит ADR-0016:
+привязку preimage и обязательный видимый отказ rollback уточняют
+`INV-SOURCE-BOUND-PREIMAGES` и `INV-SOURCE-ROLLBACK-VISIBLE`, а OS-зависимая
+реализация остаётся за `INV-PLATFORM-OS-BEHIND-FACADE`.
 
-На Windows synchronous applied full dump сейчас fail-closed: owner-only ACL и
-handle-safe no-clobber публикация каталогов ещё не реализованы. Preview остаётся
-read-only. На поддерживаемой POSIX-ветке Unica сверяет физические маркеры
-DESIGNER, получает exact 8.3.27.x через sibling `ibcmd --version`, а recovery
+Асинхронный full dump и applied dump для external source-set пока доступны
+только как preview. `incremental` и `partial` также preview-only: до private
+CDFI, точного receipt и divergence-safe merge (alkoleft/v8-runner-rust#30) им
+нельзя писать в Git-visible root.
+
+На Windows Unica проверяет локальную системную установку через no-follow
+handles: доверенный владелец и DACL должны защищать install tree от изменения
+вызывающим non-elevated пользователем, а ancestry — от удаления, замены или
+перенаправления компонентов пути. На macOS и Linux Unica сверяет физические
+маркеры DESIGNER, получает exact 8.3.27.x через sibling `ibcmd --version` и
+требует root-owned, link-free install tree без group/world write и ACL; recovery
 хранится отдельно от effective config и не содержит credentials.
-Установка платформы должна быть системной и неизменяемой вызывающим
-пользователем: весь install tree и его предки принадлежат root, не имеют
-group/world write, ACL и ссылок; сам Unica запускается не от root. Пользовательская
-или изменяемая установка отклоняется до запуска `ibcmd`/`v8-runner`. Проверка
-ACL реализована для macOS и Linux; остальные Unix пока fail-closed.
+Пользовательская или изменяемая установка отклоняется до запуска
+`ibcmd`/`v8-runner`; остальные Unix пока fail-closed.
 
 ### Incremental dump
 

--- a/plugins/unica/skills/v8-runner/references/file-and-artifact-workflows.md
+++ b/plugins/unica/skills/v8-runner/references/file-and-artifact-workflows.md
@@ -8,11 +8,12 @@ For an applied dump:
 - select an extension with matching `sourceSet` and `extension` names.
 
 On Windows, macOS, and Linux, verified transactional publication supports the
-synchronous applied full dump (`mode=full`) described above. Unica independently
-resolves an exact 8.3.27 installation, redirects the selected source-set to a
-private stage, validates the required owner and every XML version-bearing root
-as the raw literal 2.20, then publishes the complete tree with preimage checks
-and rollback. ADR-0016 owns this publication contract;
+synchronous applied full dump (`mode=full`) for a DESIGNER `CONFIGURATION` or
+`EXTENSION` source-set. Unica independently resolves an exact 8.3.27
+installation, redirects the selected source-set to a private stage, validates
+the required owner and every XML version-bearing root as the raw literal 2.20,
+then publishes the complete tree with preimage checks and rollback. ADR-0016
+owns this publication contract;
 `INV-SOURCE-BOUND-PREIMAGES` and `INV-SOURCE-ROLLBACK-VISIBLE` describe its
 verified transaction behavior, while OS-specific mechanics stay behind
 `INV-PLATFORM-OS-BEHIND-FACADE`.

--- a/plugins/unica/skills/v8-runner/references/file-and-artifact-workflows.md
+++ b/plugins/unica/skills/v8-runner/references/file-and-artifact-workflows.md
@@ -7,13 +7,20 @@ For an applied dump:
 - use synchronous `mode=full` for a DESIGNER `CONFIGURATION` or `EXTENSION`;
 - select an extension with matching `sourceSet` and `extension` names.
 
-Unica independently resolves an exact 8.3.27 installation, redirects the
-selected source-set to a private stage, validates the required owner and every
-XML version-bearing root as the raw literal 2.20, then publishes the complete
-tree with preimage checks and rollback. Async full dumps and external
-source-sets remain preview-only. `mode=incremental` and `mode=partial` are also
-available only as read-only previews with `dryRun=true`; they need
-shadow/staging publication with exact path/hash receipts.
+On Windows, macOS, and Linux, verified transactional publication supports the
+synchronous applied full dump (`mode=full`) described above. Unica independently
+resolves an exact 8.3.27 installation, redirects the selected source-set to a
+private stage, validates the required owner and every XML version-bearing root
+as the raw literal 2.20, then publishes the complete tree with preimage checks
+and rollback. ADR-0016 owns this publication contract;
+`INV-SOURCE-BOUND-PREIMAGES` and `INV-SOURCE-ROLLBACK-VISIBLE` describe its
+verified transaction behavior, while OS-specific mechanics stay behind
+`INV-PLATFORM-OS-BEHIND-FACADE`.
+
+Async full dumps and applied dumps for external source-sets remain preview-only.
+`mode=incremental` and `mode=partial` are also available only as read-only
+previews with `dryRun=true`; they need shadow/staging publication with exact
+path/hash receipts.
 Partial preview also requires `object` or `objects`.
 
 The final stage-to-target move is tentative, not a source-identity CAS. Unica
@@ -28,16 +35,15 @@ continuously hostile same-UID process can still race pathname cleanup;
 excluding that actor requires a stronger OS trust boundary, such as a separate
 identity or immutable parent directory.
 
-On Windows, synchronous applied full dump is fail-closed until owner-only ACL
-enforcement and handle-safe no-clobber directory publication are implemented;
-preview remains read-only. On the supported POSIX path, Unica verifies physical
-DESIGNER markers, probes the exact sibling `ibcmd --version`, and keeps
-secret-bearing effective configuration outside retained recovery.
-The platform install must be system-owned and immutable to the invoking
-non-root user: every install entry and ancestor is root-owned, not group/world
-writable, link-free, and ACL-free. User-owned or otherwise mutable installs are
-rejected before `ibcmd` or `v8-runner` starts. ACL proof is implemented on
-macOS and Linux; other Unix hosts fail closed.
+On Windows, Unica verifies a local system installation through no-follow
+handles: its trusted owner and DACL must prevent the invoking non-elevated user
+from mutating the install tree, while the ancestry must prevent deletion,
+replacement, or retargeting of path components. On macOS and Linux, Unica
+verifies physical DESIGNER markers, probes the exact sibling `ibcmd --version`,
+and requires a root-owned, link-free install tree without group/world write or
+ACLs. Secret-bearing effective configuration stays outside retained recovery.
+User-owned or otherwise mutable installs are rejected before `ibcmd` or
+`v8-runner` starts; other Unix hosts fail closed.
 
 `convert` is repository-aware and does not require an infobase, but applied
 conversion is currently fail-closed because it can publish Designer XML outside

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -1455,14 +1455,15 @@ class UnicaSkillRoutingTests(unittest.TestCase):
             if not support_paragraphs(text):
                 errors.append("missing complete applied full dump support paragraph")
             for paragraph in markdown_paragraphs(text):
-                if (
-                    required["Windows"].search(paragraph)
-                    and required["full dump"].search(paragraph)
-                    and stale_restriction.search(paragraph)
-                ):
-                    errors.append(
-                        "Windows applied full dump is documented as restricted"
-                    )
+                for sentence in re.split(r"(?<=[.!?])\s+", paragraph):
+                    if (
+                        required["Windows"].search(sentence)
+                        and required["full dump"].search(sentence)
+                        and stale_restriction.search(sentence)
+                    ):
+                        errors.append(
+                            "Windows applied full dump is documented as restricted"
+                        )
             return errors
 
         document_texts = {
@@ -1472,6 +1473,18 @@ class UnicaSkillRoutingTests(unittest.TestCase):
         for path in docs:
             with self.subTest(document=path.name):
                 self.assertEqual([], contract_errors(document_texts[path]))
+
+        mixed_claims = (
+            "Windows, macOS, and Linux support synchronous applied full dump "
+            "for CONFIGURATION and EXTENSION through verified transactional "
+            "publication. Incremental dump without receipts remains fail-closed "
+            "on Linux."
+        )
+        self.assertEqual(
+            [],
+            contract_errors(mixed_claims),
+            "a restriction on a different operation is not a Windows full-dump restriction",
+        )
 
         for path, text in document_texts.items():
             complete_paragraphs = support_paragraphs(text)

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -1403,10 +1403,10 @@ class UnicaSkillRoutingTests(unittest.TestCase):
         self.assertNotRegex(v8project, r"(?m)^connection:")
         self.assertNotIn("mode=load|merge|update", v8project)
 
-    def test_verified_applied_full_dump_documents_windows_fail_closed_policy(
+    def test_verified_applied_full_dump_documents_supported_hosts_and_verified_publication(
         self,
     ) -> None:
-        docs = "\n".join(
+        combined = "\n".join(
             path.read_text(encoding="utf-8")
             for path in [
                 self.skill_root() / "v8-runner" / "SKILL.md",
@@ -1420,16 +1420,18 @@ class UnicaSkillRoutingTests(unittest.TestCase):
         )
 
         self.assertRegex(
-            docs,
+            combined,
             re.compile(
-                r"Windows.{0,240}(?:fail-closed|blocked|unsupported)",
+                r"Windows.{0,240}(?:verified|transactional|no-clobber).{0,240}"
+                r"(?:full dump|mode.?=.?full)",
                 re.IGNORECASE | re.DOTALL,
             ),
         )
-        self.assertRegex(
-            docs,
+        self.assertNotRegex(
+            combined,
             re.compile(
-                r"(?:ACL|access control).{0,240}(?:implemented|available|support)",
+                r"Windows.{0,240}(?:fail-closed|blocked|unsupported).{0,240}"
+                r"(?:full dump|mode.?=.?full)",
                 re.IGNORECASE | re.DOTALL,
             ),
         )

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -1440,13 +1440,21 @@ class UnicaSkillRoutingTests(unittest.TestCase):
             re.IGNORECASE,
         )
 
-        def contract_errors(text: str) -> list[str]:
-            errors = [
-                f"missing {label}"
-                for label, pattern in required.items()
-                if pattern.search(text) is None
+        def markdown_paragraphs(text: str) -> list[str]:
+            return re.split(r"\n(?:[ \t]*|>[ \t]*)\n", text)
+
+        def support_paragraphs(text: str) -> list[str]:
+            return [
+                paragraph
+                for paragraph in markdown_paragraphs(text)
+                if all(pattern.search(paragraph) for pattern in required.values())
             ]
-            for paragraph in re.split(r"\n(?:[ \t]*|>[ \t]*)\n", text):
+
+        def contract_errors(text: str) -> list[str]:
+            errors = []
+            if not support_paragraphs(text):
+                errors.append("missing complete applied full dump support paragraph")
+            for paragraph in markdown_paragraphs(text):
                 if (
                     required["Windows"].search(paragraph)
                     and required["full dump"].search(paragraph)
@@ -1457,45 +1465,41 @@ class UnicaSkillRoutingTests(unittest.TestCase):
                     )
             return errors
 
+        document_texts = {
+            path: path.read_text(encoding="utf-8")
+            for path in docs
+        }
         for path in docs:
             with self.subTest(document=path.name):
-                self.assertEqual([], contract_errors(path.read_text(encoding="utf-8")))
+                self.assertEqual([], contract_errors(document_texts[path]))
 
-        valid_contract = (
-            "Windows, macOS, and Linux verified transactional publication "
-            "supports synchronous applied full dump (mode=full) for "
-            "CONFIGURATION and EXTENSION."
-        )
-        mutations = {
-            "drop Windows": valid_contract.replace("Windows, ", ""),
-            "drop macOS": valid_contract.replace("macOS, and ", ""),
-            "drop Linux": valid_contract.replace("Linux ", ""),
-            "drop CONFIGURATION": valid_contract.replace("CONFIGURATION", "CONFIG"),
-            "drop EXTENSION": valid_contract.replace("EXTENSION", "EXT"),
-            "drop synchronous": valid_contract.replace("synchronous ", ""),
-            "drop applied": valid_contract.replace("applied ", ""),
-            "drop full mode": valid_contract.replace(
-                "full dump (mode=full)",
-                "dump",
-            ),
-            "drop verified publication": valid_contract.replace(
-                "verified transactional publication",
-                "publication",
-            ),
+        for path, text in document_texts.items():
+            complete_paragraphs = support_paragraphs(text)
+            for missing, pattern in required.items():
+                mutated = text
+                for paragraph in complete_paragraphs:
+                    mutated_paragraph = pattern.sub("", paragraph)
+                    mutated = mutated.replace(paragraph, mutated_paragraph, 1)
+                with self.subTest(document=path.name, missing=missing):
+                    self.assertTrue(contract_errors(mutated), missing)
+
+        stale_mutations = {
             "natural fail-closed wording": (
-                valid_contract
-                + "\n\nWindows applied full dump is currently fail-closed."
+                "Windows applied full dump is currently fail-closed."
             ),
-            "unsupported wording": (
-                valid_contract + "\n\nWindows full dump is unsupported."
-            ),
-            "blocked mode wording": (
-                valid_contract + "\n\nWindows mode=full is blocked."
+            "unsupported wording": "Windows full dump is unsupported.",
+            "blocked mode wording": "Windows mode=full is blocked.",
+            "reversed fail-closed wording": (
+                "Fail-closed: Windows applied full dump."
             ),
         }
-        for mutation, text in mutations.items():
-            with self.subTest(mutation=mutation):
-                self.assertTrue(contract_errors(text), mutation)
+        for path, text in document_texts.items():
+            for mutation, stale_claim in stale_mutations.items():
+                with self.subTest(document=path.name, mutation=mutation):
+                    self.assertTrue(
+                        contract_errors(f"{text}\n\n{stale_claim}\n"),
+                        mutation,
+                    )
 
     def test_code_patch_skill_uses_only_logical_configuration_and_extension_targets(
         self,

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -1406,35 +1406,96 @@ class UnicaSkillRoutingTests(unittest.TestCase):
     def test_verified_applied_full_dump_documents_supported_hosts_and_verified_publication(
         self,
     ) -> None:
-        combined = "\n".join(
-            path.read_text(encoding="utf-8")
-            for path in [
-                self.skill_root() / "v8-runner" / "SKILL.md",
-                self.skill_root()
-                / "v8-runner"
-                / "references"
-                / "file-and-artifact-workflows.md",
-                self.reference_root() / "tooling" / "runtime-build.md",
-                self.reference_root() / "tooling" / "v8project.md",
-            ]
+        docs = [
+            self.skill_root() / "v8-runner" / "SKILL.md",
+            self.skill_root()
+            / "v8-runner"
+            / "references"
+            / "file-and-artifact-workflows.md",
+            self.reference_root() / "tooling" / "runtime-build.md",
+            self.reference_root() / "tooling" / "v8project.md",
+        ]
+        required = {
+            "Windows": re.compile(r"\bWindows\b", re.IGNORECASE),
+            "macOS": re.compile(r"\bmacOS\b", re.IGNORECASE),
+            "Linux": re.compile(r"\bLinux\b", re.IGNORECASE),
+            "synchronous": re.compile(
+                r"\b(?:synchronous|синхронн\w*)\b",
+                re.IGNORECASE,
+            ),
+            "applied": re.compile(r"\bapplied\b", re.IGNORECASE),
+            "full dump": re.compile(
+                r"(?:\bfull\s+dump\b|\bmode\s*=\s*full\b)",
+                re.IGNORECASE,
+            ),
+            "CONFIGURATION": re.compile(r"\bCONFIGURATION\b"),
+            "EXTENSION": re.compile(r"\bEXTENSION\b"),
+            "verified transactional publication": re.compile(
+                r"\bverified\s+transactional\s+publication\b",
+                re.IGNORECASE,
+            ),
+        }
+        stale_restriction = re.compile(
+            r"(?:fail(?:ed)?[- ]closed|blocked|unsupported)",
+            re.IGNORECASE,
         )
 
-        self.assertRegex(
-            combined,
-            re.compile(
-                r"Windows.{0,240}(?:verified|transactional|no-clobber).{0,240}"
-                r"(?:full dump|mode.?=.?full)",
-                re.IGNORECASE | re.DOTALL,
-            ),
+        def contract_errors(text: str) -> list[str]:
+            errors = [
+                f"missing {label}"
+                for label, pattern in required.items()
+                if pattern.search(text) is None
+            ]
+            for paragraph in re.split(r"\n(?:[ \t]*|>[ \t]*)\n", text):
+                if (
+                    required["Windows"].search(paragraph)
+                    and required["full dump"].search(paragraph)
+                    and stale_restriction.search(paragraph)
+                ):
+                    errors.append(
+                        "Windows applied full dump is documented as restricted"
+                    )
+            return errors
+
+        for path in docs:
+            with self.subTest(document=path.name):
+                self.assertEqual([], contract_errors(path.read_text(encoding="utf-8")))
+
+        valid_contract = (
+            "Windows, macOS, and Linux verified transactional publication "
+            "supports synchronous applied full dump (mode=full) for "
+            "CONFIGURATION and EXTENSION."
         )
-        self.assertNotRegex(
-            combined,
-            re.compile(
-                r"Windows.{0,240}(?:fail-closed|blocked|unsupported).{0,240}"
-                r"(?:full dump|mode.?=.?full)",
-                re.IGNORECASE | re.DOTALL,
+        mutations = {
+            "drop Windows": valid_contract.replace("Windows, ", ""),
+            "drop macOS": valid_contract.replace("macOS, and ", ""),
+            "drop Linux": valid_contract.replace("Linux ", ""),
+            "drop CONFIGURATION": valid_contract.replace("CONFIGURATION", "CONFIG"),
+            "drop EXTENSION": valid_contract.replace("EXTENSION", "EXT"),
+            "drop synchronous": valid_contract.replace("synchronous ", ""),
+            "drop applied": valid_contract.replace("applied ", ""),
+            "drop full mode": valid_contract.replace(
+                "full dump (mode=full)",
+                "dump",
             ),
-        )
+            "drop verified publication": valid_contract.replace(
+                "verified transactional publication",
+                "publication",
+            ),
+            "natural fail-closed wording": (
+                valid_contract
+                + "\n\nWindows applied full dump is currently fail-closed."
+            ),
+            "unsupported wording": (
+                valid_contract + "\n\nWindows full dump is unsupported."
+            ),
+            "blocked mode wording": (
+                valid_contract + "\n\nWindows mode=full is blocked."
+            ),
+        }
+        for mutation, text in mutations.items():
+            with self.subTest(mutation=mutation):
+                self.assertTrue(contract_errors(text), mutation)
 
     def test_code_patch_skill_uses_only_logical_configuration_and_extension_targets(
         self,


### PR DESCRIPTION
## Что изменено

- включён синхронный applied `mode=full` для source-set типов `CONFIGURATION` и `EXTENSION` на Windows;
- добавлены защищённые owner-only ACL, привязка файлов и каталогов через удерживаемые handle без следования по reparse point, проверка неизменяемой локальной установки платформы и fail-closed обработка неоднозначных состояний;
- реализована транзакционная no-clobber публикация дерева с проверкой идентичности, rollback и безопасной очисткой;
- обновлены документация `v8-runner`, проектная записка и контрактные тесты поддерживаемых хостов.

## Причина

Windows-вариант был намеренно закрыт на pre-flight: отсутствовали проверяемое owner-only ACL enforcement и handle-safe публикация каталогов без перезаписи конкурентного назначения. Поэтому runner не запускался даже для корректного applied full dump.

## Влияние

`unica.runtime.execute` и `unica.build.dump` теперь могут выполнить проверенную полную выгрузку конфигурации или расширения на Windows и атомарно опубликовать валидированное дерево. Контракты incremental dump и асинхронных runtime jobs не меняются.

## Проверки

- `cargo test --workspace --quiet -- --test-threads=1` — основной набор: 1763 passed, 2 ignored; все остальные workspace-наборы прошли;
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -A unused-imports -A dead-code`;
- `cargo fmt --all -- --check`;
- `git diff --check origin/main...HEAD`;
- `test_design_documents.py` — 8 passed;
- `test_architecture_registry.py` — 35 passed;
- `test_unica_skills.py` — 44 passed;
- version contract, Windows platform boundary и architecture sync — пройдены, публичная MCP-поверхность не изменилась.

Closes #268


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for verified, transactional synchronous full dumps on Windows for Designer configuration and extension source sets.
  - Added secure publication safeguards, including protected staging, trusted installation checks, no-follow file handling, atomic no-clobber publication, and identity-checked cleanup.
  - Preserved fail-closed behavior for unsupported or untrusted environments.

- **Documentation**
  - Updated runtime, command-mapping, and workflow guidance to describe Windows, macOS, and Linux support and platform-specific validation requirements.

- **Tests**
  - Expanded cross-platform coverage for publication security, rollback, cleanup, race conditions, and documentation contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->