### PR TITLE
fix(code): shorten analyzer Unix socket runtime path

### DIFF
--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -29,10 +29,42 @@ fn short_private_runtime_dir_unix() -> io::Result<PathBuf> {
 }
 
 #[cfg(unix)]
+fn runtime_directory_permissions_error(path: &Path) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::PermissionDenied,
+        format!(
+            "short runtime directory {} must be owned by the current user and have mode 0700",
+            path.display()
+        ),
+    )
+}
+
+#[cfg(unix)]
+fn runtime_directory_metadata_is_ready(
+    path: &Path,
+    metadata: &fs::Metadata,
+    uid: libc::uid_t,
+) -> io::Result<bool> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("short runtime path {} is not a directory", path.display()),
+        ));
+    }
+    if metadata.uid() != uid {
+        return Err(runtime_directory_permissions_error(path));
+    }
+
+    Ok(metadata.permissions().mode() & 0o777 == 0o700)
+}
+
+#[cfg(unix)]
 fn ensure_short_private_runtime_dir_unix(path: &Path, uid: libc::uid_t) -> io::Result<PathBuf> {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
-    use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
+    use std::os::unix::fs::{DirBuilderExt, PermissionsExt};
     use std::os::unix::io::FromRawFd;
     use std::time::Duration;
 
@@ -42,23 +74,7 @@ fn ensure_short_private_runtime_dir_unix(path: &Path, uid: libc::uid_t) -> io::R
     for _ in 0..SETUP_ATTEMPTS {
         match fs::symlink_metadata(path) {
             Ok(metadata) => {
-                let mode = metadata.permissions().mode() & 0o777;
-                if !metadata.is_dir() || metadata.file_type().is_symlink() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        format!("short runtime path {} is not a directory", path.display()),
-                    ));
-                }
-                if metadata.uid() != uid {
-                    return Err(io::Error::new(
-                        io::ErrorKind::PermissionDenied,
-                        format!(
-                            "short runtime directory {} must be owned by the current user and have mode 0700",
-                            path.display()
-                        ),
-                    ));
-                }
-                if mode == 0o700 {
+                if runtime_directory_metadata_is_ready(path, &metadata, uid)? {
                     return Ok(path.to_path_buf());
                 }
 
@@ -113,27 +129,10 @@ fn ensure_short_private_runtime_dir_unix(path: &Path, uid: libc::uid_t) -> io::R
     // Always validate once after the retry budget. In particular, a successful
     // creation on the last iteration must not be reported as disappeared.
     match fs::symlink_metadata(path) {
-        Ok(metadata)
-            if metadata.is_dir()
-                && !metadata.file_type().is_symlink()
-                && metadata.uid() == uid
-                && metadata.permissions().mode() & 0o777 == 0o700 =>
-        {
+        Ok(metadata) if runtime_directory_metadata_is_ready(path, &metadata, uid)? => {
             Ok(path.to_path_buf())
         }
-        Ok(metadata) if !metadata.is_dir() || metadata.file_type().is_symlink() => {
-            Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("short runtime path {} is not a directory", path.display()),
-            ))
-        }
-        Ok(_) => Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            format!(
-                "short runtime directory {} must be owned by the current user and have mode 0700",
-                path.display()
-            ),
-        )),
+        Ok(_) => Err(runtime_directory_permissions_error(path)),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Err(io::Error::new(
             io::ErrorKind::NotFound,
             format!(

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -21,18 +21,26 @@ pub(crate) fn short_private_runtime_dir() -> io::Result<Option<PathBuf>> {
 
 #[cfg(unix)]
 fn short_private_runtime_dir_unix() -> io::Result<PathBuf> {
-    use std::ffi::CString;
-    use std::os::unix::ffi::OsStrExt;
-    use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
-    use std::os::unix::io::FromRawFd;
-
     // SAFETY: `geteuid` has no preconditions and only reads the effective UID
     // of this process.
     let uid = unsafe { libc::geteuid() };
     let path = PathBuf::from("/tmp").join(format!("unica-bsl-{uid}"));
+    ensure_short_private_runtime_dir_unix(&path, uid)
+}
 
-    for _ in 0..2 {
-        match fs::symlink_metadata(&path) {
+#[cfg(unix)]
+fn ensure_short_private_runtime_dir_unix(path: &Path, uid: libc::uid_t) -> io::Result<PathBuf> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
+    use std::os::unix::io::FromRawFd;
+    use std::time::Duration;
+
+    const SETUP_ATTEMPTS: usize = 8;
+    const RETRY_DELAY: Duration = Duration::from_millis(1);
+
+    for _ in 0..SETUP_ATTEMPTS {
+        match fs::symlink_metadata(path) {
             Ok(metadata) => {
                 let mode = metadata.permissions().mode() & 0o777;
                 if !metadata.is_dir() || metadata.file_type().is_symlink() {
@@ -41,7 +49,7 @@ fn short_private_runtime_dir_unix() -> io::Result<PathBuf> {
                         format!("short runtime path {} is not a directory", path.display()),
                     ));
                 }
-                if metadata.uid() != uid || mode != 0o700 {
+                if metadata.uid() != uid {
                     return Err(io::Error::new(
                         io::ErrorKind::PermissionDenied,
                         format!(
@@ -50,10 +58,17 @@ fn short_private_runtime_dir_unix() -> io::Result<PathBuf> {
                         ),
                     ));
                 }
-                return Ok(path);
+                if mode == 0o700 {
+                    return Ok(path.to_path_buf());
+                }
+
+                // Another process with the same UID can observe a directory
+                // between its creation and the creator's permission
+                // normalization. Give that bounded race time to settle.
+                std::thread::sleep(RETRY_DELAY);
             }
             Err(error) if error.kind() == io::ErrorKind::NotFound => {
-                match fs::DirBuilder::new().mode(0o700).create(&path) {
+                match fs::DirBuilder::new().mode(0o700).create(path) {
                     Ok(()) => {
                         // `DirBuilder::mode` is filtered through the caller's
                         // umask. The directory is part of an authentication
@@ -84,9 +99,10 @@ fn short_private_runtime_dir_unix() -> io::Result<PathBuf> {
                         // SAFETY: `open` returned a new owned descriptor.
                         let directory = unsafe { File::from_raw_fd(descriptor) };
                         directory.set_permissions(fs::Permissions::from_mode(0o700))?;
-                        continue;
                     }
-                    Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                    Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                        std::thread::sleep(RETRY_DELAY);
+                    }
                     Err(error) => return Err(error),
                 }
             }
@@ -94,13 +110,39 @@ fn short_private_runtime_dir_unix() -> io::Result<PathBuf> {
         }
     }
 
-    Err(io::Error::new(
-        io::ErrorKind::NotFound,
-        format!(
-            "short runtime directory {} disappeared during setup",
-            path.display()
-        ),
-    ))
+    // Always validate once after the retry budget. In particular, a successful
+    // creation on the last iteration must not be reported as disappeared.
+    match fs::symlink_metadata(path) {
+        Ok(metadata)
+            if metadata.is_dir()
+                && !metadata.file_type().is_symlink()
+                && metadata.uid() == uid
+                && metadata.permissions().mode() & 0o777 == 0o700 =>
+        {
+            Ok(path.to_path_buf())
+        }
+        Ok(metadata) if !metadata.is_dir() || metadata.file_type().is_symlink() => {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("short runtime path {} is not a directory", path.display()),
+            ))
+        }
+        Ok(_) => Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "short runtime directory {} must be owned by the current user and have mode 0700",
+                path.display()
+            ),
+        )),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "short runtime directory {} disappeared during setup",
+                path.display()
+            ),
+        )),
+        Err(error) => Err(error),
+    }
 }
 
 #[cfg(all(test, unix))]
@@ -3247,6 +3289,93 @@ mod tests {
             "unica-filesystem-{name}-{}-{nanos}",
             std::process::id()
         ))
+    }
+
+    #[cfg(unix)]
+    mod unix_runtime_directory {
+        use super::{fs, unique_temp_root};
+        use crate::infrastructure::platform::filesystem::ensure_short_private_runtime_dir_unix;
+        use std::io;
+        use std::os::unix::fs::{symlink, MetadataExt, PermissionsExt};
+
+        fn fixture(name: &str) -> (std::path::PathBuf, std::path::PathBuf) {
+            let root = unique_temp_root(name);
+            fs::create_dir_all(&root).unwrap();
+            let runtime = root.join("runtime");
+            (root, runtime)
+        }
+
+        fn effective_uid() -> libc::uid_t {
+            // SAFETY: `geteuid` has no preconditions and only reads the
+            // effective UID of this process.
+            unsafe { libc::geteuid() }
+        }
+
+        #[test]
+        fn creates_owner_only_runtime_directory() {
+            let (root, runtime) = fixture("short-runtime-create");
+
+            let actual = ensure_short_private_runtime_dir_unix(&runtime, effective_uid()).unwrap();
+            let metadata = fs::symlink_metadata(&runtime).unwrap();
+
+            assert_eq!(actual, runtime);
+            assert!(metadata.is_dir());
+            assert_eq!(metadata.permissions().mode() & 0o777, 0o700);
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn rejects_symlink_at_runtime_path() {
+            let (root, runtime) = fixture("short-runtime-symlink");
+            let target = root.join("target");
+            fs::create_dir(&target).unwrap();
+            symlink(&target, &runtime).unwrap();
+
+            let error =
+                ensure_short_private_runtime_dir_unix(&runtime, effective_uid()).unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn rejects_regular_file_at_runtime_path() {
+            let (root, runtime) = fixture("short-runtime-file");
+            fs::write(&runtime, b"not a directory").unwrap();
+
+            let error =
+                ensure_short_private_runtime_dir_unix(&runtime, effective_uid()).unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn rejects_runtime_directory_owned_by_another_uid() {
+            let (root, runtime) = fixture("short-runtime-owner");
+            fs::create_dir(&runtime).unwrap();
+            fs::set_permissions(&runtime, fs::Permissions::from_mode(0o700)).unwrap();
+            let actual_uid = fs::symlink_metadata(&runtime).unwrap().uid();
+
+            let error = ensure_short_private_runtime_dir_unix(&runtime, actual_uid.wrapping_add(1))
+                .unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn rejects_runtime_directory_with_non_private_mode() {
+            let (root, runtime) = fixture("short-runtime-mode");
+            fs::create_dir(&runtime).unwrap();
+            fs::set_permissions(&runtime, fs::Permissions::from_mode(0o755)).unwrap();
+
+            let error =
+                ensure_short_private_runtime_dir_unix(&runtime, effective_uid()).unwrap_err();
+
+            assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+            fs::remove_dir_all(root).unwrap();
+        }
     }
 
     fn windows_api_path_text(path: &str, absolute: bool) -> String {

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -2,7 +2,106 @@ use std::fs;
 #[cfg(unix)]
 use std::fs::File;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+/// Returns a short, private directory suitable as a child process' Unix runtime
+/// directory.  It deliberately lives below `/tmp`: macOS's `TMPDIR` and a
+/// caller's `XDG_RUNTIME_DIR` can both be too long once a Unix socket name is
+/// appended.
+pub(crate) fn short_private_runtime_dir() -> io::Result<Option<PathBuf>> {
+    #[cfg(unix)]
+    {
+        short_private_runtime_dir_unix().map(Some)
+    }
+    #[cfg(not(unix))]
+    {
+        Ok(None)
+    }
+}
+
+#[cfg(unix)]
+fn short_private_runtime_dir_unix() -> io::Result<PathBuf> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
+    use std::os::unix::io::FromRawFd;
+
+    // SAFETY: `geteuid` has no preconditions and only reads the effective UID
+    // of this process.
+    let uid = unsafe { libc::geteuid() };
+    let path = PathBuf::from("/tmp").join(format!("unica-bsl-{uid}"));
+
+    for _ in 0..2 {
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) => {
+                let mode = metadata.permissions().mode() & 0o777;
+                if !metadata.is_dir() || metadata.file_type().is_symlink() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("short runtime path {} is not a directory", path.display()),
+                    ));
+                }
+                if metadata.uid() != uid || mode != 0o700 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        format!(
+                            "short runtime directory {} must be owned by the current user and have mode 0700",
+                            path.display()
+                        ),
+                    ));
+                }
+                return Ok(path);
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                match fs::DirBuilder::new().mode(0o700).create(&path) {
+                    Ok(()) => {
+                        // `DirBuilder::mode` is filtered through the caller's
+                        // umask. The directory is part of an authentication
+                        // boundary for the local socket, so normalize it before
+                        // accepting the newly created path.
+                        let encoded =
+                            CString::new(path.as_os_str().as_bytes()).map_err(|error| {
+                                io::Error::new(
+                                    io::ErrorKind::InvalidInput,
+                                    format!("short runtime path contains an embedded NUL: {error}"),
+                                )
+                            })?;
+                        // SAFETY: `encoded` is NUL-terminated and remains live for
+                        // the call. `O_NOFOLLOW` prevents a raced symlink from being
+                        // opened before the directory descriptor is owned below.
+                        let descriptor = unsafe {
+                            libc::open(
+                                encoded.as_ptr(),
+                                libc::O_RDONLY
+                                    | libc::O_DIRECTORY
+                                    | libc::O_CLOEXEC
+                                    | libc::O_NOFOLLOW,
+                            )
+                        };
+                        if descriptor < 0 {
+                            return Err(io::Error::last_os_error());
+                        }
+                        // SAFETY: `open` returned a new owned descriptor.
+                        let directory = unsafe { File::from_raw_fd(descriptor) };
+                        directory.set_permissions(fs::Permissions::from_mode(0o700))?;
+                        continue;
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                    Err(error) => return Err(error),
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        format!(
+            "short runtime directory {} disappeared during setup",
+            path.display()
+        ),
+    ))
+}
 
 #[cfg(all(test, unix))]
 pub(crate) fn create_test_directory_link(target: &Path, link: &Path) -> io::Result<()> {

--- a/crates/unica-coder/src/infrastructure/platform/mod.rs
+++ b/crates/unica-coder/src/infrastructure/platform/mod.rs
@@ -8,6 +8,7 @@ mod target;
 pub(crate) mod testing;
 
 pub use entrypoint::run_platform_main;
+pub(crate) use filesystem::short_private_runtime_dir;
 pub(crate) use process::{
     cancel_runtime_job_process_tree, configure_runtime_job_command, ensure_truncation_diagnostics,
     ManagedChild, ManagedCommand, ManagedOutput, ManagedStartupChild,

--- a/crates/unica-coder/src/infrastructure/workspace_services.rs
+++ b/crates/unica-coder/src/infrastructure/workspace_services.rs
@@ -2,7 +2,9 @@ use crate::domain::cancellation::{cancelled_error, CancellationToken};
 use crate::domain::events::{DomainEvent, DomainEventKind};
 use crate::domain::workspace::WorkspaceContext;
 use crate::infrastructure::bundled_tools::resolve_bundled_tool;
-use crate::infrastructure::platform::{ManagedChild, ManagedStartupChild};
+use crate::infrastructure::platform::{
+    short_private_runtime_dir, ManagedChild, ManagedStartupChild,
+};
 use crate::infrastructure::plugin_runtime::find_plugin_root;
 use crate::infrastructure::source_roots::normalize_path_identity;
 use crate::infrastructure::workspace_index::{IndexReadiness, WorkspaceIndexService};
@@ -2113,6 +2115,7 @@ impl PersistentMcpSession {
                 "stdio",
             ])
             .current_dir(&context.cwd);
+        configure_bsl_analyzer_runtime_dir(&mut command)?;
         Self::start_with_command(command, cancellation)
     }
 
@@ -2372,6 +2375,15 @@ impl Drop for PersistentMcpSession {
     fn drop(&mut self) {
         self.invalidate();
     }
+}
+
+fn configure_bsl_analyzer_runtime_dir(command: &mut Command) -> Result<(), String> {
+    if let Some(runtime_dir) = short_private_runtime_dir().map_err(|error| {
+        format!("failed to prepare short runtime directory for bsl-analyzer: {error}")
+    })? {
+        command.env("XDG_RUNTIME_DIR", runtime_dir);
+    }
+    Ok(())
 }
 
 struct RlmMcpSession {
@@ -3733,6 +3745,31 @@ mod tests {
                 limit: 7
             }
         );
+    }
+
+    #[test]
+    fn bsl_analyzer_runtime_directory_is_passed_to_the_child_and_fits_socket_budget() {
+        use std::ffi::OsStr;
+
+        let expected = short_private_runtime_dir().unwrap();
+        let mut command = Command::new("bsl-analyzer");
+        configure_bsl_analyzer_runtime_dir(&mut command).unwrap();
+        let actual = command
+            .get_envs()
+            .find(|(key, _)| *key == OsStr::new("XDG_RUNTIME_DIR"))
+            .and_then(|(_, value)| value.map(PathBuf::from));
+
+        assert_eq!(actual, expected);
+        let Some(runtime_dir) = actual else {
+            return;
+        };
+
+        let socket = runtime_dir
+            .join("bsl-mcp")
+            .join("0123456789abcdef0123456789abcdef.sock");
+
+        assert_eq!(runtime_dir.parent(), Some(Path::new("/tmp")));
+        assert!(socket.as_os_str().as_encoded_bytes().len() < 104);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #303.

bsl-analyzer now receives a short, private XDG_RUNTIME_DIR on Unix before its persistent MCP transport starts. The runtime directory is owner-only, rejects symlinks and unsafe ownership or permissions, and stays within the macOS sun_path limit.

Checks:
- cargo test -p unica-coder --lib
- cargo clippy -p unica-coder --all-targets -- -D warnings
- python3.12 scripts/ci/check-rust-platform-boundary.py
- python3.12 -m unittest tests.ci.test_product_contracts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved BSL Analyzer startup reliability by providing a secure, private runtime location when supported.
  - Reduced socket-path length issues, helping analyzer processes start and communicate consistently.
  - Added safeguards to verify runtime-directory ownership, permissions, and directory settings.
  - Runtime directories are created securely and protected against unsafe links or conflicting files.
  - Platforms without supported runtime-directory handling continue to operate without this configuration.
  - Added coverage for runtime-directory setup and analyzer communication scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->