### PR TITLE
ci: запускать релиз- и publish-воркфлоу только в каноническом репозитории

### DIFF
--- a/.github/workflows/publish-unica-marketplace.yml
+++ b/.github/workflows/publish-unica-marketplace.yml
@@ -29,10 +29,14 @@ permissions:
 
 jobs:
   stage:
+    # Publishing targets the IngvarConsulting marketplace and needs the shared
+    # credential, so a fork must never run it — its workflow_run trigger fires
+    # automatically after the fork's own build.
     if: >-
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' &&
+      github.repository == 'IngvarConsulting/unica' &&
+      ((github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push') ||
-      (github.event_name == 'workflow_dispatch' && inputs.mode == 'stage')
+      (github.event_name == 'workflow_dispatch' && inputs.mode == 'stage'))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -78,7 +82,9 @@ jobs:
             --body "Stages the verified thin payload from IngvarConsulting/unica run ${SOURCE_RUN_ID}. The stable catalog is unchanged."
 
   promote:
-    if: github.event_name == 'workflow_dispatch' && inputs.mode == 'promote'
+    if: >-
+      github.repository == 'IngvarConsulting/unica' &&
+      github.event_name == 'workflow_dispatch' && inputs.mode == 'promote'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:

--- a/.github/workflows/release-warden.yml
+++ b/.github/workflows/release-warden.yml
@@ -25,6 +25,10 @@ concurrency:
 
 jobs:
   advance:
+    # The release crosses IngvarConsulting repositories and needs the shared
+    # marketplace credential, which forks do not hold. Guarding the job keeps a
+    # fork's scheduled run green (skipped) instead of failing every 20 minutes.
+    if: github.repository == 'IngvarConsulting/unica'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:


### PR DESCRIPTION
## Что делаем

Ставим на релизные job'ы гвард `if: github.repository == 'IngvarConsulting/unica'`, чтобы они выполнялись только в каноническом репозитории, а в форках скипались.

## Зачем

Форки не держат общий креденшел `UNICA_MARKETPLACE_TOKEN` и не имеют доступа к репозиториям `IngvarConsulting/*`, поэтому:

- **`release-warden.yml`** — запускается по расписанию (`cron */20`) и падает в форке каждые 20 минут на первом же шаге `test -n "$GH_TOKEN"`.
- **`publish-unica-marketplace.yml`** — срабатывает по `workflow_run` автоматически после сборки форка (job'ы `stage`/`promote`) и тоже падает.

После гварда эти job'ы в форках дают **зелёный skip вместо красного fail**.

## Что НЕ трогаем

Основное build-CI (`unica-plugin-release.yml`: rust/python-тесты, сборка) секретов не требует и **продолжает работать на форках** — контрибьюторы валидируют PR до upstream.

## Проверка

- `github.repository == 'IngvarConsulting/unica'` добавлен как job-level `if` в `release-warden` (job `advance`) и в оба job'а `publish-unica-marketplace` (`stage`, `promote`, через `&&` к существующим условиям).
- Локально: `python -m unittest tests.ci.test_unica_workflow tests.ci.test_product_contracts tests.ci.test_release_warden` — 73/73 OK.
- YAML обоих файлов парсится.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow safety by ensuring staging, promotion, and advancement run only from the canonical repository.
  * Prevented fork-triggered workflows from initiating cross-repository releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->