### PR TITLE
test(meta): remove the process-cwd race from the preview effects test

### DIFF
--- a/crates/unica-coder/src/application/metadata.rs
+++ b/crates/unica-coder/src/application/metadata.rs
@@ -2347,8 +2347,7 @@ mod tests {
             "format: DESIGNER\nsource-set:\n  - name: main\n    type: CONFIGURATION\n    path: src\n",
         )
         .unwrap();
-        let previous = std::env::current_dir().unwrap();
-        std::env::set_current_dir(&workspace).unwrap();
+        let cwd = crate::test_support::ProcessCwdGuard::enter(&workspace).unwrap();
         let application = crate::application::UnicaApplication::new();
         for name in ["Owner", "Subject"] {
             let added = application
@@ -2425,7 +2424,7 @@ mod tests {
                 })),
             )
             .unwrap();
-        std::env::set_current_dir(previous).unwrap();
+        drop(cwd);
         let _ = std::fs::remove_dir_all(&workspace);
 
         assert!(preview.ok, "{:?}", preview.errors);


### PR DESCRIPTION
## Что меняется

`application::metadata::tests::preview_effects_follow_operation_order` менял
рабочий каталог процесса голым `std::env::set_current_dir`, минуя уже
существующий `crate::test_support::ProcessCwdGuard`. Guard владеет
process-wide мьютексом cwd и восстанавливает каталог в `Drop`, поэтому обход
дал сразу два дефекта:

1. **Гонка.** Тест не брал мьютекс и двигал cwd процесса, пока работали
   тринадцать тестов, которые guard используют правильно
   (`meta_add_surface_tests`, `meta_info_surface_tests`,
   `meta_remove_surface_tests`, `application/mod.rs`, `interfaces/mcp.rs`), —
   и они двигали cwd из-под него.
2. **Отсутствие восстановления при панике.** Ручной возврат стоял на
   success-пути, после всех `.unwrap()`. Любая паника раньше него оставляла
   весь процесс с cwd во временном каталоге, который тест затем удалял.

Тест переведён на `ProcessCwdGuard::enter`; явный `drop(cwd)` перед удалением
временного дерева сохраняет тот порядок очистки, на который тест уже
опирался. Это тот же паттерн, что в `interfaces/mcp.rs:575` и `:670`.

Правка только тестовая: продуктовый код не затронут.

## Как проявлялось

Недетерминированно, только в полном параллельном прогоне `--lib`; изолированно
тест всегда проходил. Два наблюдённых исхода на одном и том же коммите
`a222c7b1`:

```
test result: FAILED. 1932 passed; 1 failed
    application::metadata::tests::preview_effects_follow_operation_order
    → panicked: ["metadata target was not found"]

test result: FAILED. 1931 passed; 2 failed
    application::metadata::tests::preview_effects_follow_operation_order
    application::meta_remove_surface_tests::meta_remove_private_coordinator_preview_and_apply_publish_events_cache_and_files
    → assertion `left == right` failed (дескриптор прочитан не из того каталога)
```

Второй тест — симметричный симптом той же причины: он берёт guard корректно,
но незащищённый вызов уводил cwd у него под ногами.

Дефект приехал с #309 и к четырём PR, влитым после него (#306, #308, #314,
#348), отношения не имеет — воспроизводится на чистом `a12ea328`.

## Архитектурный слой

- Затронутые записи реестра: нет. Изменение целиком в тестовом коде, публичная
  поверхность `unica.*`, контракты инструментов и инварианты не меняются.
- Решение (ADR), если публичный или архитектурный контракт меняется: нет.

- [x] Пройден [чек-лист изменений](../spec/architecture/change-checklist.md)
      в части, относящейся к этому изменению.

## Проверка

```sh
cargo test -p unica-coder --lib
cargo clippy -p unica-coder --lib --tests -- -D warnings
cargo fmt --all -- --check
git diff --check
```

Полный `--lib` прогнан **три раза подряд** — именно потому, что дефект
недетерминированный:

```
test result: ok. 1933 passed; 0 failed; 2 ignored
test result: ok. 1933 passed; 0 failed; 2 ignored
test result: ok. 1933 passed; 0 failed; 2 ignored
```

`cargo clippy --lib --tests -D warnings`, `cargo fmt --all --check` и
`git diff --check` — чисто.

## Что осталось за рамками

`crates/unica-coder/tests/format_8_3_27_xml_corpus.rs:734` держит собственный
`PROCESS_CWD_LOCK` и восстанавливает cwd до проброса ошибки — он корректен, и
это отдельный тестовый бинарь, так что с lib-набором не пересекается. Не трогал.

Рецидив этого класса можно закрыть гардом в «Verify source guardrails»,
запрещающим `std::env::set_current_dir` вне `test_support.rs`. Это отдельный
скрипт плюс обвязка в workflow, поэтому в этот PR не включено.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved temporary working-directory handling in an effect-order test, ensuring the original directory is restored safely after the test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->