### PR TITLE
fix(meta): отделять цифры в автогенерируемом синониме

### DIFF
--- a/crates/unica-coder/src/infrastructure/native_operations/meta/edit.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta/edit.rs
@@ -4399,6 +4399,37 @@ mod tests {
     }
 
     #[test]
+    fn typed_resource_add_keeps_digits_apart_in_the_generated_synonym() {
+        let mut xml = object_xml("InformationRegister", "PaymentTerms", "");
+        apply_typed_operations(
+            &mut xml,
+            &[MetaEditOperation::add(
+                MetaCollection::Resources,
+                None,
+                vec![
+                    MetaElementInput::named("СуммаЗакупокЗа30Дней"),
+                    MetaElementInput {
+                        name: "СуммаПродажЗа30Дней".into(),
+                        synonym: Some("Сумма продаж за месяц".into()),
+                        ..MetaElementInput::default()
+                    },
+                ],
+            )
+            .unwrap()],
+        )
+        .unwrap();
+
+        assert!(
+            xml.contains("<v8:content>Сумма закупок за 30 дней</v8:content>"),
+            "{xml}"
+        );
+        assert!(
+            xml.contains("<v8:content>Сумма продаж за месяц</v8:content>"),
+            "{xml}"
+        );
+    }
+
+    #[test]
     fn typed_child_tree_rejects_excessive_depth_before_capture() {
         let root = std::env::temp_dir().join(format!(
             "unica-meta-edit-child-depth-{}",

--- a/crates/unica-coder/src/infrastructure/native_operations/meta/template_catalog.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta/template_catalog.rs
@@ -2936,19 +2936,32 @@ pub(super) fn split_meta_camel_case(name: &str) -> String {
         return String::new();
     }
     let mut result = String::new();
-    let mut previous_lower = false;
+    let mut previous: Option<char> = None;
     for ch in name.chars() {
-        if previous_lower && ch.is_uppercase() {
+        if previous.is_some_and(|previous| meta_synonym_word_boundary(previous, ch)) {
             result.push(' ');
         }
         result.push(ch);
-        previous_lower = ch.is_lowercase();
+        previous = Some(ch);
     }
     let mut chars = result.chars();
     match chars.next() {
         Some(first) => format!("{}{}", first, chars.as_str().to_lowercase()),
         None => result,
     }
+}
+
+/// A generated synonym breaks a word where the platform name itself changes
+/// class: after a lowercase letter before an uppercase one, and on both sides of
+/// a digit run. A digit is neither uppercase nor lowercase, so without the
+/// second rule `SumFor30Days` would keep its digits glued to the words around
+/// them once the tail is lowercased.
+fn meta_synonym_word_boundary(previous: char, current: char) -> bool {
+    if previous.is_lowercase() && current.is_uppercase() {
+        return true;
+    }
+    (previous.is_alphabetic() && current.is_ascii_digit())
+        || (previous.is_ascii_digit() && current.is_alphabetic())
 }
 
 #[cfg(test)]

--- a/crates/unica-coder/src/infrastructure/native_operations/meta/template_catalog_tests.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta/template_catalog_tests.rs
@@ -7,6 +7,7 @@ use crate::domain::source_target::{MetadataAddress, PLATFORM_XML_8_3_27_FORMAT_2
 
 use super::template_catalog::{
     metadata_generated_types_8_3_27, minimal_auxiliary_files, minimal_metadata_xml_for_tests,
+    split_meta_camel_case,
 };
 use super::xml_model::{emit_meta_typed_value_type, meta_info_child, meta_info_child_text};
 
@@ -106,6 +107,21 @@ fn typed_minimal_templates_cover_all_public_add_kinds() {
             "{}",
             kind.as_str()
         );
+    }
+}
+
+#[test]
+fn generated_synonym_separates_digits_from_the_words_around_them() {
+    for (name, synonym) in [
+        ("СуммаЗакупокЗа30Дней", "Сумма закупок за 30 дней"),
+        ("SumOfPurchasesFor30Days", "Sum of purchases for 30 days"),
+        ("Строка1", "Строка 1"),
+        ("Версия20250101", "Версия 20250101"),
+        ("ДатаНачала", "Дата начала"),
+        ("Товар", "Товар"),
+        ("", ""),
+    ] {
+        assert_eq!(split_meta_camel_case(name), synonym, "{name}");
     }
 }
 


### PR DESCRIPTION
## Summary

Закрывает оставшуюся половину #322. Первая половина — молчаливая подмена явно переданного `synonym` — уже устранена на `main` вместе с типизированной поверхностью `unica.meta.*` (#309); проверка и разбор — в [комментарии к #350](https://github.com/IngvarConsulting/unica/pull/350#issuecomment-5206512712).

Осталось то, что срабатывает, когда `synonym` не передан: синоним генерируется из имени элемента и склеивает цифры со словами вокруг.

```text
СуммаЗакупокЗа30Дней -> Сумма закупок за30дней   (было)
СуммаЗакупокЗа30Дней -> Сумма закупок за 30 дней (стало)
```

Причина в `split_meta_camel_case`: пробел ставился только на переходе «строчная → прописная». Цифра не является ни строчной, ни прописной, поэтому граница перед ней не срабатывала, а следующая за ней заглавная не считалась началом слова и терялась при приведении хвоста к нижнему регистру.

Правило границы вынесено в `meta_synonym_word_boundary`: прежний переход сохранён и дополнен разрывом с обеих сторон цепочки цифр. Цифры внутри одной цепочки не разделяются (`Версия20250101` → `Версия 20250101`).

Затронуты все места, где генерируется синоним по умолчанию: элементы коллекций (`attributes`, `dimensions`, `resources`, `enumValues`), колонки табличных частей и сами табличные части. Явно переданный `synonym` этой веткой не затрагивается — он и раньше писался дословно, и это закреплено тестом.

## Validation

- `cargo test -p unica-coder --no-fail-fast --tests -- --test-threads=1` — 1935 lib + все интеграционные цели зелёные, включая корпус `format_8_3_27_xml_corpus` (28 тестов), который сверяет генерируемый XML с дампами платформы
- `cargo clippy -p unica-coder --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `python3.12 -m unittest discover -s tests/ci` — 588 тестов; локально падают только 8 в `test_reference_format_profile.py` из-за отсутствующего `lxml` (`Missing Python dependency: lxml`), к изменению отношения не имеют
- `python3.12 scripts/ci/check-architecture-sync.py --base origin/main --strict` — `public MCP surface unchanged`

## Замечено рядом, в этот PR не втянуто

`cargo test -p unica-coder --lib` при параллельном запуске стабильно роняет два теста, и второй из пары меняется от прогона к прогону:

```text
application::metadata::tests::preview_effects_follow_operation_order
application::meta_remove_surface_tests::meta_remove_reauthorizes_* (имя плавает)
```

Диагностика — `invalid publication target: /…/unica-platform-meta-remove-subsystem-support-authorization-drift-…/.build/unica/caches/metadata_graph.json`: тест публикует состояние в чужой временный каталог. С `--test-threads=1` оба проходят, на чистом `origin/main` воспроизводится так же. Дефект существовал до этой ветки, поэтому по правилам топологии PR он выносится отдельно, а не правится здесь.

Fixes #322


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic synonym generation for names containing digits, preserving numeric sequences and separating digit runs into words where appropriate.
  * Enhanced handling of mixed Cyrillic and Latin camel-case names.

* **Tests**
  * Added coverage for numeric names, mixed alphabets, single-word names, empty input, and explicitly provided synonyms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->