### PR TITLE
Адресовать содержимое управляемой формы вместо дескриптора в генераторе corpus

### DIFF
--- a/crates/unica-coder/tests/format_8_3_27_xml_corpus.rs
+++ b/crates/unica-coder/tests/format_8_3_27_xml_corpus.rs
@@ -2248,7 +2248,7 @@ fn prepare_target(case: &ExecutableCase, workspace: &Path) -> Result<Map<String,
         args.insert("JsonPath".to_string(), Value::String(path));
         args.insert(
             "OutputPath".to_string(),
-            Value::String("src/Reports/CorpusReport/Forms/CorpusForm.xml".to_string()),
+            Value::String("src/Reports/CorpusReport/Forms/CorpusForm/Ext/Form.xml".to_string()),
         );
         return Ok(args);
     }
@@ -2259,7 +2259,9 @@ fn prepare_target(case: &ExecutableCase, workspace: &Path) -> Result<Map<String,
         if case.id == "form-edit-managed" {
             args.insert(
                 "FormPath".to_string(),
-                Value::String("src/Catalogs/CorpusCatalog/Forms/CorpusForm.xml".to_string()),
+                Value::String(
+                    "src/Catalogs/CorpusCatalog/Forms/CorpusForm/Ext/Form.xml".to_string(),
+                ),
             );
             args.insert(
                 "definition".to_string(),
@@ -4116,6 +4118,51 @@ fn non_xml_inventory_covers_every_xml_none_impact_case() {
                 .unwrap(),
             );
         }
+        fs::remove_dir_all(root).unwrap();
+    }
+}
+
+#[test]
+fn managed_form_cases_address_logform_content_and_spare_the_descriptor() {
+    let expectations = [
+        ("form-compile-managed", "src/Reports/CorpusReport"),
+        ("form-edit-managed", "src/Catalogs/CorpusCatalog"),
+    ];
+    for (case_id, owner) in expectations {
+        let root = unique_temp_dir(case_id);
+        let case = EXECUTABLE_CASES
+            .iter()
+            .find(|case| case.id == case_id)
+            .unwrap();
+        let mut gate = SequentialCallGate::default();
+
+        let generated = run_corpus_case(&root, case, &mut gate).unwrap();
+
+        let prefix = manifest_case_prefix(case_id);
+        let content = format!("{prefix}/{owner}/Forms/CorpusForm/Ext/Form.xml");
+        let descriptor = format!("{prefix}/{owner}/Forms/CorpusForm.xml");
+        let families = generated
+            .files
+            .iter()
+            .map(|file| (file.path.as_str(), file.family.as_str()))
+            .collect::<BTreeMap<_, _>>();
+        assert_eq!(
+            families.get(descriptor.as_str()).copied(),
+            Some("metadata"),
+            "{case_id} rewrote the managed form descriptor"
+        );
+        let changed = generated
+            .files
+            .iter()
+            .filter(|file| matches!(file.delta.as_str(), "created" | "modified"))
+            .map(|file| (file.path.as_str(), file.family.as_str()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            changed,
+            [(content.as_str(), "managed-form")],
+            "{case_id} did not change exactly the managed form content"
+        );
+
         fs::remove_dir_all(root).unwrap();
     }
 }


### PR DESCRIPTION
## Что меняется

Генератор 64-case Platform XML corpus падал на первом же form-case: harness
передавал `unica.form.compile` путь дескриптора формы
`src/Reports/CorpusReport/Forms/CorpusForm.xml`, а `unica.form.edit` — такой же
дескриптор `src/Catalogs/CorpusCatalog/Forms/CorpusForm.xml`, тогда как оба
инструмента контрактно принимают путь содержимого
`.../Forms/CorpusForm/Ext/Form.xml`. `form.compile` пишет logform-XML буквально
по `OutputPath`, поэтому дескриптор был бы перезаписан корнем
`{http://v8.1c.ru/8.3/xcf/logform}Form`; format guard корректно блокировал
вызов. `form.edit` требует тот же корень через `require_form_root`.
Оба маршрута разведены на content-путь. Закрывает #357.

`git log -L` по обеим строкам называет один источник: до #266 пути были
правильными, и именно тот PR заменил их на дескрипторы. Дефект существовал до
#352 и правится независимо от него.

## Архитектурный слой

- Затронутые записи реестра: нет
- Решение (ADR), если публичный или архитектурный контракт меняется: нет

Изменение целиком лежит в тестовом харнессе
`crates/unica-coder/tests/format_8_3_27_xml_corpus.rs`. Публичная поверхность
`unica.*`, схемы, обработчики и упаковка не затронуты: харнесс приведён в
соответствие с действующим контрактом инструментов, а не наоборот.

- [x] Пройден [чек-лист изменений](../spec/architecture/change-checklist.md)
      в части, относящейся к этому изменению.

## Проверка

Порядок соблюдён по правилу «сначала падающий тест, потом исправление»:
`managed_form_cases_address_logform_content_and_spare_the_descriptor` написан
первым и падал ровно по причине дефекта —
`declared platform XML target root is {…MDClasses}MetaDataObject, expected
{…xcf/logform}Form`, — и только после этого разведены маршруты. Тест прогоняет
оба case через `run_corpus_case` и проверяет семейство каждого изменённого XML:
меняется ровно содержимое формы с семейством `managed-form`, дескриптор
остаётся `metadata`.

```sh
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace -- --test-threads=1
git diff --check
```

Все четыре — чисто. `python3 -m unittest discover -s tests/ci` на этой машине
даёт 46 записей FAIL/ERROR (554 теста, 14 failures + 32 errors) — ровно тот же
фон окружения, что и на `origin/main`: генерируемый `server.py` падает с
`SyntaxError: Non-UTF-8 code … no encoding declared` из-за локали. Ни один тест
`tests/ci` не читает изменённый файл (`rg -l format_8_3_27_xml_corpus tests/
scripts/ .github/` пуст), так что состав падений от этой ветки не зависит.

Дополнительно прогнана полная генерация корпуса, дважды в разные каталоги:

```sh
UNICA_XML_CORPUS_DIR=<new-dir> cargo test -p unica-coder \
  --test format_8_3_27_xml_corpus generate_platform_xml_corpus \
  -- --exact --ignored --nocapture --test-threads=1
```

64/64 case, оба прогона зелёные.

- [x] Новое поведение покрыто тестом, который можно назвать по имени.
- [x] Документация, описывающая изменённое поведение, обновлена в этом же PR
      (изменённого документированного поведения нет).

## Что этот PR не закрывает

Третий пункт #357 требует, чтобы два независимых 64-case corpus дали одинаковый
contract digest. Сейчас не дадут, и это не связано с этой правкой: сравнение
двух прогонов показывает совпадающий набор из 970 файлов и **побайтово
одинаковый структурный digest** манифеста без полей `sha256`
(`351dd013d8ee68c9…` в обоих), но расходящиеся хеши содержимого — Unica
генерирует свежие 1С-овские UUID через `Uuid::new_v4()`, детерминированного
seed нет. После маскирования UUID расходятся только `case-report.json`, и
исключительно в полях хешей.

То есть закреплять нужно digest формы контракта — пути, семейства, delta,
owner-связи, версии, — либо сначала делать генерацию UUID детерминированной.
Это самостоятельный блокер точного gate ADR-0016, отдельный от этой правки.

Архитектурная причина того, что вызывающий вообще обязан знать файловую
раскладку формы, вынесена в #371.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated managed-form operations to use the correct form content file for report compilation and catalog editing.
  * Added validation to ensure operations modify only form content while preserving metadata descriptors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->