### PR TITLE
Научить платформенный гейт приёмки XDTO-домену

### DIFF
--- a/crates/unica-coder/tests/format_8_3_27_xml_corpus.rs
+++ b/crates/unica-coder/tests/format_8_3_27_xml_corpus.rs
@@ -777,9 +777,23 @@ fn sha256_file(path: &Path) -> Result<String, String> {
 }
 
 fn is_xml_payload_path(path: &Path) -> bool {
-    path.extension()
+    if path
+        .extension()
         .is_some_and(|extension| extension.eq_ignore_ascii_case("xml"))
-        || path.file_name().is_some_and(|name| name == "Package.bin")
+    {
+        return true;
+    }
+    // ADR-0024 grants `Package.bin` its XML reading through the XDTO package
+    // layout, not through the file name. Mirrored by `_is_xml_payload_path` in
+    // scripts/dev/verify-8-3-27-platform.py.
+    let components = path
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+    let [.., collection, _package, ext, name] = components.as_slice() else {
+        return false;
+    };
+    collection == "XDTOPackages" && ext == "Ext" && name == "Package.bin"
 }
 
 fn visit_xml_files(
@@ -4830,6 +4844,35 @@ fn cfe_patch_method_corpus_covers_every_supported_module_layout_family() {
             "Constant.ValueManagerModule",
         ]
     );
+}
+
+#[test]
+fn xml_payload_rule_grants_the_bin_exception_only_to_the_xdto_layout() {
+    // ADR-0024 names `XDTOPackages/<Name>/Ext/Package.bin` as text XML. The
+    // exception belongs to that layout, not to the file name, and this rule
+    // mirrors `_is_xml_payload_path` in scripts/dev/verify-8-3-27-platform.py.
+    for granted in [
+        "src/XDTOPackages/CorpusPackage/Ext/Package.bin",
+        "XDTOPackages/CorpusPackage/Ext/Package.bin",
+        "src/Catalogs/CorpusCatalog.xml",
+        "src/Catalogs/CorpusCatalog.XML",
+    ] {
+        assert!(
+            is_xml_payload_path(Path::new(granted)),
+            "expected XML payload: {granted}"
+        );
+    }
+    for refused in [
+        "src/Ext/Package.bin",
+        "src/XDTOPackages/CorpusPackage/Package.bin",
+        "src/XDTOPackages/Ext/Package.bin",
+        "src/Ext/ParentConfigurations.bin",
+    ] {
+        assert!(
+            !is_xml_payload_path(Path::new(refused)),
+            "expected non-XML payload: {refused}"
+        );
+    }
 }
 
 #[test]

--- a/scripts/dev/verify-8-3-27-platform.py
+++ b/scripts/dev/verify-8-3-27-platform.py
@@ -410,11 +410,20 @@ def _is_xml_payload_path(path: PurePath) -> bool:
 
     ADR-0024 records that `XDTOPackages/<Name>/Ext/Package.bin` is text XML
     rooted at `{http://v8.1c.ru/8.1/xdto}package` despite its extension, so the
-    suffix alone does not decide. Any drift between this rule and
-    `is_xml_payload_path` in `crates/unica-coder/tests/format_8_3_27_xml_corpus.rs`
-    makes the corpus declare a file the verifier cannot find.
+    suffix alone does not decide. The exception belongs to that layout and not
+    to the file name, so a `Package.bin` reached any other way stays binary.
+    Any drift between this rule and `is_xml_payload_path` in
+    `crates/unica-coder/tests/format_8_3_27_xml_corpus.rs` makes the corpus
+    declare a file the verifier cannot find.
     """
-    return path.suffix.lower() == ".xml" or path.name == "Package.bin"
+    if path.suffix.lower() == ".xml":
+        return True
+    parts = path.parts
+    return (
+        len(parts) >= 4
+        and parts[-4] == "XDTOPackages"
+        and parts[-2:] == ("Ext", "Package.bin")
+    )
 
 
 def _regular_payloads(

--- a/scripts/dev/verify-8-3-27-platform.py
+++ b/scripts/dev/verify-8-3-27-platform.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePath, PurePosixPath
 
 from lxml import etree
 
@@ -109,6 +109,7 @@ EXPECTED_OWNER_TYPES = {
 }
 XML_FAMILY_BY_ROOT_QNAME = {
     "{http://v8.1c.ru/8.1/data-composition-system/schema}DataCompositionSchema": "dcs",
+    "{http://v8.1c.ru/8.1/xdto}package": "xdto-package",
     "{http://v8.1c.ru/8.2/data/spreadsheet}document": "mxl",
     "{http://v8.1c.ru/8.2/managed-application/core}ClientApplicationInterface": "client-application-interface",
     "{http://v8.1c.ru/8.2/roles}Rights": "roles",
@@ -185,6 +186,7 @@ MANDATORY_CASE_IDS = frozenset(
         "cfe-init-default",
         "cfe-borrow-object",
         "cfe-borrow-managed-form",
+        "xdto-add-nested-property",
     }
 )
 FORBIDDEN_CREDENTIAL_OPTIONS = {
@@ -403,6 +405,18 @@ def _read_regular_payload(path: Path, metadata, label: str) -> bytes:
             os.close(descriptor)
 
 
+def _is_xml_payload_path(path: PurePath) -> bool:
+    """Mirror the generator's XML rule exactly.
+
+    ADR-0024 records that `XDTOPackages/<Name>/Ext/Package.bin` is text XML
+    rooted at `{http://v8.1c.ru/8.1/xdto}package` despite its extension, so the
+    suffix alone does not decide. Any drift between this rule and
+    `is_xml_payload_path` in `crates/unica-coder/tests/format_8_3_27_xml_corpus.rs`
+    makes the corpus declare a file the verifier cannot find.
+    """
+    return path.suffix.lower() == ".xml" or path.name == "Package.bin"
+
+
 def _regular_payloads(
     root: Path,
 ) -> tuple[dict[str, bytes], dict[str, bytes], list[str]]:
@@ -443,7 +457,7 @@ def _regular_payloads(
                     payload = _read_regular_payload(path, metadata, "source")
                     destination = (
                         xml_payloads
-                        if path.suffix.lower() == ".xml"
+                        if _is_xml_payload_path(path)
                         else non_xml_payloads
                     )
                     destination[relative] = payload
@@ -1314,7 +1328,7 @@ def _snapshot_xml_hashes(root: Path) -> dict[str, str]:
                 raise CorpusError(f"symlink is forbidden in workspace: {path}")
             if entry.is_dir(follow_symlinks=False):
                 visit(path)
-            elif entry.is_file(follow_symlinks=False) and path.suffix.lower() == ".xml":
+            elif entry.is_file(follow_symlinks=False) and _is_xml_payload_path(path):
                 try:
                     metadata = entry.stat(follow_symlinks=False)
                     payload = _read_regular_payload(path, metadata, "workspace XML snapshot")
@@ -1415,7 +1429,7 @@ def _validate_non_xml_contract(
         workspace_path = corpus_path[len(prefix) :]
         if not workspace_path:
             raise CorpusError(f"{label} has no workspace-relative path")
-        if PurePosixPath(workspace_path).suffix.lower() == ".xml":
+        if _is_xml_payload_path(PurePosixPath(workspace_path)):
             raise CorpusError(f"{label} must identify a non-XML file")
         if not any(
             _relative_path_is_within(workspace_path, input_root)
@@ -1435,7 +1449,7 @@ def _validate_non_xml_contract(
         workspace_path = corpus_path[len(pre_prefix) :]
         if not workspace_path:
             raise CorpusError(f"{label} has no workspace-relative path")
-        if PurePosixPath(workspace_path).suffix.lower() == ".xml":
+        if _is_xml_payload_path(PurePosixPath(workspace_path)):
             raise CorpusError(f"{label} must identify a non-XML file")
         if not any(
             _relative_path_is_within(workspace_path, input_root)
@@ -1637,7 +1651,7 @@ def _validate_auxiliary_files(
             raise CorpusError(
                 f"case {case_id} auxiliaryFiles path has no workspace-relative path"
             )
-        if PurePosixPath(workspace_path).suffix.lower() == ".xml":
+        if _is_xml_payload_path(PurePosixPath(workspace_path)):
             raise CorpusError(
                 f"case {case_id} auxiliaryFiles must identify non-XML files"
             )

--- a/tests/dev/test_verify_8_3_27_platform.py
+++ b/tests/dev/test_verify_8_3_27_platform.py
@@ -3,6 +3,7 @@ import hashlib
 import importlib.util
 import json
 import os
+import re
 import sys
 import stat
 import subprocess
@@ -580,6 +581,25 @@ class SemanticXmlTests(unittest.TestCase):
 
 
 class SemanticDirectoryTests(unittest.TestCase):
+    def test_xdto_package_is_captured_as_xml_despite_its_bin_extension(self):
+        """ADR-0024 names `XDTOPackages/<Name>/Ext/Package.bin` as text XML with
+        root `{http://v8.1c.ru/8.1/xdto}package`. Classifying sources by suffix
+        alone drops it out of the XML snapshot the corpus declares it in."""
+        verifier = load_verifier()
+        package = (
+            '﻿<package xmlns="http://v8.1c.ru/8.1/xdto" '
+            'targetNamespace="urn:corpus"/>'
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write(root / "Configuration.xml", CONFIG_XML)
+            write(root / "XDTOPackages/Corpus/Ext/Package.bin", package)
+
+            xml_payloads, non_xml_payloads, _ = verifier._regular_payloads(root)
+
+            self.assertIn("XDTOPackages/Corpus/Ext/Package.bin", xml_payloads)
+            self.assertNotIn("XDTOPackages/Corpus/Ext/Package.bin", non_xml_payloads)
+
     def test_snapshot_comparison_detects_added_and_removed_empty_directories(self):
         verifier = load_verifier()
         with tempfile.TemporaryDirectory() as tmp:
@@ -880,10 +900,44 @@ class CorpusAdapterTests(unittest.TestCase):
             }.issubset(verifier.MANDATORY_CASE_IDS)
         )
 
+    def test_mandatory_corpus_matches_the_generator_case_inventory(self):
+        """The pinned inventory is only honest while it names the same cases the
+        generator emits. A hardcoded count cannot notice a case added on the Rust
+        side, so bind the two inventories to each other instead."""
+        verifier = load_verifier()
+        source = (
+            ROOT / "crates/unica-coder/tests/format_8_3_27_xml_corpus.rs"
+        ).read_text(encoding="utf-8")
+        generated = set(
+            re.findall(r"ExecutableCase\s*\{\s*id:\s*\"([^\"]+)\"", source)
+        )
+
+        self.assertTrue(generated, "generator case inventory could not be read")
+        self.assertEqual(generated, set(verifier.MANDATORY_CASE_IDS))
+
+    def test_family_registry_matches_the_generator_root_registry(self):
+        """A root the generator classifies but the verifier does not makes the
+        corpus declare a family the gate reads as `None`."""
+        verifier = load_verifier()
+        source = (
+            ROOT / "crates/unica-coder/tests/format_8_3_27_xml_corpus.rs"
+        ).read_text(encoding="utf-8")
+        body = source.split("fn family_for_root", 1)[1].split("=> {\n            return", 1)[0]
+        generated = {
+            f"{{{namespace}}}{local_name}": family
+            for namespace, local_name, family in re.findall(
+                r'\(\s*"([^"]+)",\s*"([^"]+)"\s*\)\s*=>\s*(?:\{\s*)?"([^"]+)"',
+                body,
+            )
+        }
+
+        self.assertTrue(generated, "generator root registry could not be read")
+        self.assertEqual(generated, verifier.XML_FAMILY_BY_ROOT_QNAME)
+
     def test_mandatory_corpus_includes_every_cfe_patch_module_layout(self):
         verifier = load_verifier()
 
-        self.assertEqual(len(verifier.MANDATORY_CASE_IDS), 63)
+        self.assertEqual(len(verifier.MANDATORY_CASE_IDS), 64)
         self.assertTrue(
             {
                 "cfe-patch-method-bsl-only",

--- a/tests/dev/test_verify_8_3_27_platform.py
+++ b/tests/dev/test_verify_8_3_27_platform.py
@@ -600,6 +600,22 @@ class SemanticDirectoryTests(unittest.TestCase):
             self.assertIn("XDTOPackages/Corpus/Ext/Package.bin", xml_payloads)
             self.assertNotIn("XDTOPackages/Corpus/Ext/Package.bin", non_xml_payloads)
 
+    def test_package_bin_outside_the_xdto_layout_stays_non_xml(self):
+        """ADR-0024 grants the exception to `XDTOPackages/<Name>/Ext/Package.bin`
+        and to nothing else, so a file that merely shares the name keeps its
+        binary classification instead of entering XML validation."""
+        verifier = load_verifier()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write(root / "Configuration.xml", CONFIG_XML)
+            (root / "Ext").mkdir(parents=True, exist_ok=True)
+            (root / "Ext/Package.bin").write_bytes(b"\x00\x01binary")
+
+            xml_payloads, non_xml_payloads, _ = verifier._regular_payloads(root)
+
+            self.assertIn("Ext/Package.bin", non_xml_payloads)
+            self.assertNotIn("Ext/Package.bin", xml_payloads)
+
     def test_snapshot_comparison_detects_added_and_removed_empty_directories(self):
         verifier = load_verifier()
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Что меняется

Верификатор приёмки не знал домен XDTO-пакетов, добавленный в #287, и потому не
мог принять 64-й случай корпуса `xdto-add-nested-property`: гейт падал на чтении
источников, не доходя до платформы. Пробелов было четыре, и они вскрывались по
одному за прогон:

| Пробел | Правка |
| --- | --- |
| `MANDATORY_CASE_IDS` не называл случай | случай добавлен |
| `Package.bin` не считался XML вопреки ADR-0024 §17 | правило сведено с генератором |
| реестр семейств не знал корень `{http://v8.1c.ru/8.1/xdto}package` | запись добавлена |
| суффиксное правило XML-нагрузки дублировалось в 4 местах | сведено в один `_is_xml_payload_path` |

ADR-0024 §17 нормирует `XDTOPackages/<Имя>/Ext/Package.bin` как текстовый XML с
корнем `{http://v8.1c.ru/8.1/xdto}package` «несмотря на расширение». Генератор
это правило соблюдает и кладёт файл в XML-снимок; верификатор решал по суффиксу
и искал его среди не-XML. Общее правило зеркалит `is_xml_payload_path`
генератора и применено во всех четырёх точках, включая три обратных утверждения
«это обязан быть не-XML».

## Архитектурный слой

- Затронутые записи реестра: нет
- Решение (ADR), если публичный или архитектурный контракт меняется: нет

Публичная поверхность `unica.*` не затронута. Изменение приводит инструмент
приёмки в соответствие с уже принятым ADR-0024, а не меняет контракт.

- [x] Пройден [чек-лист изменений](../spec/architecture/change-checklist.md)
      в части, относящейся к этому изменению.

## Почему дрейф был незаметен

Инвентарь случаев держался на захардкоженном `assertEqual(len(...), 63)`,
который просто ждал, что кто-то вспомнит его поднять, а реестр семейств не
сверялся ни с чем. Поэтому #287 добавил случай, и никто не заметил.

Добавлены два стража, читающие обе структуры прямо из исходника генератора и
требующие равенства, плюс тест, закрепляющий `Package.bin` как XML. Каждый
написан до соответствующей правки и падал по причине дефекта:
`'xdto-add-nested-property'` в первом множестве и не во втором;
`{http://v8.1c.ru/8.1/xdto}package` только в реестре генератора;
`Package.bin` не найден в XML-нагрузках.

## Проверка

```sh
python -m unittest discover -s tests/dev
```

190 тестов, зелено. Окружение — как в CI: Python 3.12 и `lxml==6.1.1` из
`tests/ci/requirements.txt`.

Дополнительно прогнан сам гейт против закреплённой установки
`/opt/1cv8/8.3.27.2074`:

```sh
python scripts/dev/verify-8-3-27-platform.py \
  --ibcmd /opt/1cv8/8.3.27.2074/ibcmd \
  --corpus <corpus>/corpus-manifest.json --report <report>.json
```

До этих правок гейт останавливался на чтении корпуса четырьмя разными ошибками
подряд. После — доходит до платформы и обрабатывает все 64 контрольных пункта.

- [x] Новое поведение покрыто тестом, который можно назвать по имени.
- [x] Документация, описывающая изменённое поведение, обновлена в этом же PR
      (изменённого документированного поведения нет: правки приводят инструмент
      к уже записанному ADR-0024).

## Чего этот PR намеренно не делает

Не закрепляет новый дайджест контракта случаев. Пройдя до платформы, гейт даёт
**43 pass и 21 rejected**, тогда как приёмка принимает только полный `pass`.
Закрепить дайджест сейчас значило бы записать в приёмку корпус, который гейт не
проходит. Регрессия эмитера вынесена отдельной задачей.

Сама воспроизводимость дайджеста — третий пункт #357 — при этом подтверждена: два
независимо порождённых 64-case корпуса дали один и тот же нормализованный
`8413d79840a501f015b6bab105fee074f192985c14db858c933e07634f99eb25`. Закрепление
упирается в регрессию, а не в воспроизводимость.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of XML-based package files, including `Package.bin` payloads in supported XDTO package layouts.
  * Added recognition for XDTO package content during verification.
  * Expanded mandatory validation coverage to include nested XDTO properties.
  * Prevented unrelated binary files named `Package.bin` from being misclassified as XML.

* **Tests**
  * Added coverage for supported and unsupported XML package file locations.
  * Strengthened consistency checks between generated test cases and verifier expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->