### PR TITLE
Не писать ChildObjects видам метаданных, у которых их не бывает

### DIFF
--- a/crates/unica-coder/src/infrastructure/native_operations/meta/template_catalog.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta/template_catalog.rs
@@ -547,6 +547,25 @@ fn emit_meta_catalog_xml(
     Ok((format!("{}\n", lines.join("\n")), obj_uuid))
 }
 
+/// Whether 8.3.27 declares a `ChildObjects` collection for the kind.
+///
+/// The platform refuses the import outright when a childless kind carries the
+/// element: `document format error: unexpected read property. Current property:
+/// ChildObjects, expected property: <Kind>`. The set below is measured against a
+/// real 8.3.27 dump, where the split is total — every kind either always carries
+/// the element or never does — and confirmed by the exact platform gate.
+fn kind_declares_child_objects(kind: crate::domain::metadata::MetadataKind) -> bool {
+    use crate::domain::metadata::MetadataKind;
+    !matches!(
+        kind,
+        MetadataKind::CommonModule
+            | MetadataKind::Constant
+            | MetadataKind::DefinedType
+            | MetadataKind::EventSubscription
+            | MetadataKind::ScheduledJob
+    )
+}
+
 fn minimal_metadata_xml(
     kind: crate::domain::metadata::MetadataKind,
     obj_name: &str,
@@ -681,7 +700,7 @@ fn minimal_metadata_xml(
             &mut next_uuid,
         );
         lines.push("\t\t</ChildObjects>".to_string());
-    } else {
+    } else if kind_declares_child_objects(kind) {
         lines.push("\t\t<ChildObjects/>".to_string());
     }
     lines.push(format!("\t</{object_type}>"));

--- a/crates/unica-coder/src/infrastructure/native_operations/meta/template_catalog_tests.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta/template_catalog_tests.rs
@@ -111,6 +111,41 @@ fn typed_minimal_templates_cover_all_public_add_kinds() {
 }
 
 #[test]
+fn minimal_templates_emit_child_objects_only_where_the_kind_declares_them() {
+    // 8.3.27 refuses to import a descriptor carrying `ChildObjects` for a kind
+    // that has no child collection: `document format error: unexpected read
+    // property. Current property: ChildObjects, expected property: <Kind>`.
+    // The childless set is measured against a real 8.3.27 dump — across 12k
+    // descriptors every kind is all-or-nothing, never mixed — and confirmed by
+    // the exact platform gate, where every other kind imports with the element.
+    const CHILDLESS: &[MetadataKind] = &[
+        MetadataKind::CommonModule,
+        MetadataKind::Constant,
+        MetadataKind::DefinedType,
+        MetadataKind::EventSubscription,
+        MetadataKind::ScheduledJob,
+    ];
+
+    for kind in MetadataKind::ALL {
+        let (xml, _) = minimal_metadata_xml_for_tests(*kind, "Evidence").unwrap();
+        let document = Document::parse(&xml).unwrap();
+        let object = document
+            .root_element()
+            .children()
+            .find(Node::is_element)
+            .unwrap();
+
+        let emitted = meta_info_child(object, "ChildObjects").is_some();
+        assert_eq!(
+            emitted,
+            !CHILDLESS.contains(kind),
+            "{} emitted ChildObjects={emitted}: {xml}",
+            kind.as_str()
+        );
+    }
+}
+
+#[test]
 fn generated_synonym_separates_digits_from_the_words_around_them() {
     for (name, synonym) in [
         ("СуммаЗакупокЗа30Дней", "Сумма закупок за 30 дней"),


### PR DESCRIPTION
## Что меняется

Минимальный шаблон `unica.meta.add` писал `<ChildObjects/>` каждому виду
метаданных, кроме двух регистров. Платформа 8.3.27 отказывает импорту, когда
элемент несёт вид без дочерней коллекции:

```
[ERROR] File: CorpusDefinedType.xml, document format error: unexpected read property.
Current property: ChildObjects, expected property: DefinedType.
```

Бездетных видов среди 23 поддерживаемых пять: `CommonModule`, `Constant`,
`DefinedType`, `EventSubscription`, `ScheduledJob`. Теперь элемент им не
выпускается. Часть #384.

## Откуда взят набор видов

Два независимых источника, и они сходятся.

**Реальная выгрузка 8.3.27.** Из ~12 тысяч дескрипторов разделение оказалось
абсолютным: ни один вид не встречается и с элементом, и без него. Всегда несут —
`AccumulationRegister` (99/99), `Catalog` (471/471), `Document` (280/280),
`Enum` (940/940), `InformationRegister` (773/773), `Report`, `DataProcessor`,
`DocumentJournal`, `ExchangePlan`, `WebService`, `HTTPService`, `Task`,
`BusinessProcess`, `Subsystem`, `ChartOfCharacteristicTypes`. Не несут никогда —
`CommonModule` (0/2712), `Constant` (0/898), `DefinedType` (0/432),
`EventSubscription` (0/305), `ScheduledJob` (0/204) и ещё полтора десятка видов
вне поверхности `meta.add`.

**Сам гейт.** Четыре вида (`AccountingRegister`, `CalculationRegister`,
`ChartOfAccounts`, `ChartOfCalculationTypes`) в выгрузке отсутствуют, но их
контрольные пункты проходят с `ChildObjects` — это прямое свидетельство
платформы, что элемент им положен. Отвергались ровно те пять, что перечислены
выше.

## Архитектурный слой

- Затронутые записи реестра: нет
- Решение (ADR), если публичный или архитектурный контракт меняется: нет

Аргументы и форма результата `unica.meta.add` не меняются. Меняется
порождаемый XML: он приводится к тому, что платформа принимает, — это область
ADR-0016 и `acceptance/format-profile-8-3-27.md`, а не смена контракта.

- [x] Пройден [чек-лист изменений](../spec/architecture/change-checklist.md)
      в части, относящейся к этому изменению.

## Проверка

`minimal_templates_emit_child_objects_only_where_the_kind_declares_them` написан
до правки и падал на `Constant` (`left: true, right: false`).

```sh
cargo fmt --all -- --check
cargo clippy -p unica-coder --all-targets
cargo test --workspace -- --test-threads=1
git diff --check
```

Все четыре — чисто.

Точный платформенный гейт на закреплённой установке `/opt/1cv8/8.3.27.2074`,
397 команд:

| | было | стало |
| --- | --- | --- |
| pass | 43 | **57** |
| rejected | 21 | **7** |

Закрыто 14 контрольных пунктов — ровно те, что падали на `ChildObjects`.

- [x] Новое поведение покрыто тестом, который можно назвать по имени.
- [x] Документация, описывающая изменённое поведение, обновлена в этом же PR
      (изменённого документированного поведения нет).

Прогон гейта требовал двух временных подмен, ни одна не входит в коммит: скрипт
верификатора из #383, без которого гейт не доходит до 64-го случая, и новый
дайджест контракта, потому что правка эмитера его ожидаемо сдвинула. Закрепление
дайджеста и обновление таблицы инвентаря приёмки делаются последним шагом, когда
гейт станет полностью зелёным.

## Что остаётся в #384

Семь отклонённых пунктов — другой корень в другом слое: writer теряет
объявленные определением свойства.

| Определение `meta.add` | Порождённый XML | Реакция платформы |
| --- | --- | --- |
| `"namespace": "urn:corpus"` | `<Namespace/>` | `WebСервис… - Empty name space` |
| `"task": "Task.CorpusTask"` | `<Task/>` | `БизнесПроцесс… - Business process task not selected` |
| `"registeredDocuments": [...]` | `<RegisteredDocuments/>` | `ЖурналДокументов… - No recorded documents specified for log` |

Плюс регистры сведений и накопления не получают ресурсов
(`Register without dimensions, resources, and attributes`), хотя эмитер уже
умеет добавлять ресурс — но только регистрам бухгалтерии и расчёта, — и
`Configuration` в XDTO-случае выпускается без `InternalInfo`.

Это дефекты отображения определения в XML, затрагивающие публичный результат
`unica.meta.add`, а не присутствие одного элемента. Поэтому идут отдельно.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected minimal metadata templates so `ChildObjects` appears only for metadata types that support child collections.
  * Prevented invalid empty `ChildObjects` elements from being included for childless metadata types.

* **Tests**
  * Added regression coverage to verify `ChildObjects` output across supported metadata types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->