### PR TITLE
fix(meta.edit): отклонять неоднозначный mixed EOL

### DIFF
--- a/crates/unica-coder/src/infrastructure/metadata_operations.rs
+++ b/crates/unica-coder/src/infrastructure/metadata_operations.rs
@@ -662,7 +662,7 @@ mod tests {
                         .and_then(|items| items.first())
                         .and_then(|item| item.get("code"))
                         .and_then(serde_json::Value::as_str),
-                    Some("provider_unavailable"),
+                    Some("validation_failed"),
                     "{label} dryRun={dry_run}: {:?}",
                     result.diagnostics
                 );
@@ -839,6 +839,54 @@ mod tests {
             prepared.publish(&cancellation).unwrap();
             assert_eq!(fs::read(&fixture.descriptor).unwrap(), post_image);
         }
+    }
+
+    #[test]
+    fn typed_edit_republishes_double_bom_preamble_as_single_bom() {
+        // Патологическая двойная преамбула чинится до одной, и больше ничего
+        // не сдвигается: пост-образ от двух-BOM источника побайтово равен
+        // пост-образу той же правки над одно-BOM источником.
+        let fixture = Fixture::new("double-bom");
+        let body = String::from_utf8(fs::read(&fixture.descriptor).unwrap())
+            .unwrap()
+            .trim_start_matches('\u{feff}')
+            .to_string();
+        let cancellation = CancellationToken::new();
+
+        let mut post_images = Vec::new();
+        let mut prepared_double = None;
+        for bom_count in [1usize, 2] {
+            let mut source = Vec::new();
+            for _ in 0..bom_count {
+                source.extend_from_slice(b"\xef\xbb\xbf");
+            }
+            source.extend_from_slice(body.as_bytes());
+            fs::write(&fixture.descriptor, source).unwrap();
+            let request = fixture.edit(
+                "Comment",
+                MetaPropertyValue::String("single bom preamble".into()),
+            );
+            let prepared =
+                MetadataOperations::prepare_mutation(&request, &fixture.context, &cancellation)
+                    .unwrap();
+            post_images.push(
+                prepared
+                    .validation_subject()
+                    .resources
+                    .iter()
+                    .find(|resource| matches!(resource.role, MetadataResourceRole::Descriptor))
+                    .unwrap()
+                    .bytes
+                    .clone(),
+            );
+            prepared_double = Some(prepared);
+        }
+
+        assert_eq!(post_images[0], post_images[1]);
+        assert!(post_images[1].starts_with(b"\xef\xbb\xbf"));
+        assert!(!post_images[1].starts_with(b"\xef\xbb\xbf\xef\xbb\xbf"));
+        prepared_double.unwrap().publish(&cancellation).unwrap();
+        assert_eq!(fs::read(&fixture.descriptor).unwrap(), post_images[1]);
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/metadata_operations.rs
+++ b/crates/unica-coder/src/infrastructure/metadata_operations.rs
@@ -589,6 +589,259 @@ mod tests {
     }
 
     #[test]
+    fn typed_edit_rejects_both_mixed_eol_orders_before_preview_or_apply_side_effects() {
+        fn mixed_eol_source(source: &[u8], first: &str, remaining: &str) -> Vec<u8> {
+            let normalized = String::from_utf8(source.to_vec())
+                .unwrap()
+                .replace("\r\n", "\n")
+                .replace('\r', "\n");
+            let mut output = String::with_capacity(normalized.len() + 64);
+            let mut line_ending_index = 0;
+            for segment in normalized.split_inclusive('\n') {
+                if let Some(body) = segment.strip_suffix('\n') {
+                    output.push_str(body);
+                    output.push_str(if line_ending_index == 0 {
+                        first
+                    } else {
+                        remaining
+                    });
+                    line_ending_index += 1;
+                } else {
+                    output.push_str(segment);
+                }
+            }
+            assert!(line_ending_index > 1, "fixture must contain multiple lines");
+            output.into_bytes()
+        }
+
+        for (label, first, remaining) in [
+            ("lf-then-crlf", "\n", "\r\n"),
+            ("crlf-then-lf", "\r\n", "\n"),
+        ] {
+            let fixture = Fixture::new(label);
+            let original = fs::read(&fixture.descriptor).unwrap();
+            let mixed = mixed_eol_source(&original, first, remaining);
+            let _cwd = crate::test_support::ProcessCwdGuard::enter(&fixture.root).unwrap();
+            let application = UnicaApplication::new();
+            let mut observations = Vec::new();
+
+            for dry_run in [true, false] {
+                fs::write(&fixture.descriptor, &mixed).unwrap();
+                let before = crate::test_support::tree_snapshot(&fixture.root);
+                let result = application
+                    .call_tool(
+                        "unica.meta.edit",
+                        &Map::from_iter([
+                            ("sourceSet".to_string(), json!("main")),
+                            ("metadataPath".to_string(), json!(fixture.target.as_str())),
+                            (
+                                "operations".to_string(),
+                                json!([{
+                                    "op": "setProperties",
+                                    "values": {"Comment": "must not publish"}
+                                }]),
+                            ),
+                            ("dryRun".to_string(), json!(dry_run)),
+                        ]),
+                    )
+                    .expect("public typed meta.edit call");
+                let after = crate::test_support::tree_snapshot(&fixture.root);
+                observations.push((dry_run, result, before, after));
+            }
+
+            for (dry_run, result, before, after) in observations {
+                assert!(
+                    !result.ok,
+                    "{label} dryRun={dry_run} unexpectedly succeeded"
+                );
+                assert_eq!(
+                    result
+                        .diagnostics
+                        .as_ref()
+                        .and_then(serde_json::Value::as_array)
+                        .and_then(|items| items.first())
+                        .and_then(|item| item.get("code"))
+                        .and_then(serde_json::Value::as_str),
+                    Some("provider_unavailable"),
+                    "{label} dryRun={dry_run}: {:?}",
+                    result.diagnostics
+                );
+                let message = result
+                    .diagnostics
+                    .as_ref()
+                    .and_then(serde_json::Value::as_array)
+                    .and_then(|items| items.first())
+                    .and_then(|item| item.get("message"))
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default();
+                assert!(
+                    message.contains("metadata descriptor EOL policy failed")
+                        && message.contains("mixed line endings"),
+                    "{label} dryRun={dry_run}: {message}"
+                );
+                assert!(result.cache.events.is_empty(), "{label} dryRun={dry_run}");
+                assert!(
+                    result.cache.invalidated.is_empty(),
+                    "{label} dryRun={dry_run}"
+                );
+                assert!(
+                    result.cache.refreshed.is_empty(),
+                    "{label} dryRun={dry_run}"
+                );
+                assert_eq!(after, before, "{label} dryRun={dry_run}");
+            }
+        }
+    }
+
+    #[test]
+    fn typed_edit_preserves_uniform_eol_bom_and_terminal_newline_profiles() {
+        fn uniform_source(
+            source: &[u8],
+            eol: &str,
+            has_bom: bool,
+            terminal_newline: bool,
+        ) -> Vec<u8> {
+            let normalized = String::from_utf8(source.to_vec())
+                .unwrap()
+                .trim_start_matches('\u{feff}')
+                .replace("\r\n", "\n")
+                .replace('\r', "\n");
+            let normalized = normalized.trim_end_matches('\n').replace('\n', eol);
+            let mut output = Vec::new();
+            if has_bom {
+                output.extend_from_slice(b"\xef\xbb\xbf");
+            }
+            output.extend_from_slice(normalized.as_bytes());
+            if terminal_newline {
+                output.extend_from_slice(eol.as_bytes());
+            }
+            output
+        }
+
+        for (eol_label, eol) in [("lf", "\n"), ("crlf", "\r\n"), ("cr", "\r")] {
+            for (has_bom, terminal_newline) in
+                [(false, false), (false, true), (true, false), (true, true)]
+            {
+                let label = format!(
+                    "{eol_label}-{}-{}",
+                    if has_bom { "bom" } else { "no-bom" },
+                    if terminal_newline {
+                        "terminal"
+                    } else {
+                        "no-terminal"
+                    }
+                );
+                let fixture = Fixture::new(&label);
+                let source = uniform_source(
+                    &fs::read(&fixture.descriptor).unwrap(),
+                    eol,
+                    has_bom,
+                    terminal_newline,
+                );
+                fs::write(&fixture.descriptor, &source).unwrap();
+                let request = fixture.edit(
+                    "Comment",
+                    MetaPropertyValue::String("uniform source edit".into()),
+                );
+                let cancellation = CancellationToken::new();
+
+                let prepared =
+                    MetadataOperations::prepare_mutation(&request, &fixture.context, &cancellation)
+                        .unwrap();
+                let post_image = prepared
+                    .validation_subject()
+                    .resources
+                    .iter()
+                    .find(|resource| matches!(resource.role, MetadataResourceRole::Descriptor))
+                    .unwrap()
+                    .bytes
+                    .clone();
+                let body = if has_bom {
+                    assert!(post_image.starts_with(b"\xef\xbb\xbf"), "{label}");
+                    &post_image[3..]
+                } else {
+                    assert!(!post_image.starts_with(b"\xef\xbb\xbf"), "{label}");
+                    post_image.as_slice()
+                };
+                let without_eol = body
+                    .split(|byte| *byte == b'\n' || *byte == b'\r')
+                    .collect::<Vec<_>>();
+                assert!(without_eol.len() > 1, "{label}");
+                match eol {
+                    "\n" => assert!(!body.contains(&b'\r'), "{label}"),
+                    "\r\n" => {
+                        let stripped = body.windows(2).filter(|pair| *pair == b"\r\n").count();
+                        assert_eq!(stripped, body.iter().filter(|byte| **byte == b'\n').count());
+                        assert_eq!(stripped, body.iter().filter(|byte| **byte == b'\r').count());
+                    }
+                    "\r" => assert!(!body.contains(&b'\n'), "{label}"),
+                    _ => unreachable!(),
+                }
+                assert_eq!(body.ends_with(eol.as_bytes()), terminal_newline, "{label}");
+
+                prepared.publish(&cancellation).unwrap();
+                assert_eq!(
+                    fs::read(&fixture.descriptor).unwrap(),
+                    post_image,
+                    "{label}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn typed_edit_uses_explicit_lf_policy_when_source_has_no_line_endings() {
+        for has_bom in [false, true] {
+            let label = if has_bom {
+                "no-eol-explicit-lf-bom"
+            } else {
+                "no-eol-explicit-lf-no-bom"
+            };
+            let fixture = Fixture::new(label);
+            let normalized = String::from_utf8(fs::read(&fixture.descriptor).unwrap())
+                .unwrap()
+                .trim_start_matches('\u{feff}')
+                .replace("\r\n", "")
+                .replace(['\r', '\n'], "");
+            let mut source = Vec::new();
+            if has_bom {
+                source.extend_from_slice(b"\xef\xbb\xbf");
+            }
+            source.extend_from_slice(normalized.as_bytes());
+            fs::write(&fixture.descriptor, source).unwrap();
+            let request = fixture.edit(
+                "Synonym",
+                MetaPropertyValue::String("explicit LF policy".into()),
+            );
+            let cancellation = CancellationToken::new();
+
+            let prepared =
+                MetadataOperations::prepare_mutation(&request, &fixture.context, &cancellation)
+                    .unwrap();
+            let post_image = prepared
+                .validation_subject()
+                .resources
+                .iter()
+                .find(|resource| matches!(resource.role, MetadataResourceRole::Descriptor))
+                .unwrap()
+                .bytes
+                .clone();
+
+            assert_eq!(post_image.starts_with(b"\xef\xbb\xbf"), has_bom);
+            let body = if has_bom {
+                &post_image[3..]
+            } else {
+                post_image.as_slice()
+            };
+            assert!(body.contains(&b'\n'));
+            assert!(!body.contains(&b'\r'));
+            assert!(!body.ends_with(b"\n"));
+            prepared.publish(&cancellation).unwrap();
+            assert_eq!(fs::read(&fixture.descriptor).unwrap(), post_image);
+        }
+    }
+
+    #[test]
     fn typed_edit_semantic_noop_has_no_publication_plan_and_writes_nothing() {
         let fixture = Fixture::new("noop");
         let cancellation = CancellationToken::new();

--- a/crates/unica-coder/src/infrastructure/native_operations/code.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/code.rs
@@ -23,7 +23,7 @@ use crate::infrastructure::platform_xml_source_targets::platform_xml_module_iden
 use super::common::{code_patch_source_target, guard_code_patch_resolved_target};
 use super::compile_transaction::CompileTransaction;
 use super::text_snapshot::{
-    resolve_line_ending, EolPolicy, LineEnding, LineEndingProfile, SourceTextSnapshot,
+    resolve_observed_line_ending, LineEnding, LineEndingProfile, SourceTextSnapshot,
 };
 
 pub(crate) fn apply_with_data(
@@ -652,11 +652,7 @@ fn locate_selector(
         }
     };
     let local = local_line_ending_at(text, offset, position);
-    let policy = match snapshot.line_endings() {
-        LineEndingProfile::None => EolPolicy::Lf,
-        LineEndingProfile::Uniform(_) | LineEndingProfile::Mixed { .. } => EolPolicy::Preserve,
-    };
-    let eol = resolve_line_ending(policy, snapshot, local)
+    let eol = resolve_observed_line_ending(snapshot, local)
         .map_err(|error| format!("resolve code.patch EOL: {error}"))?;
     let leading_separator = if position == Position::After
         && offset == text.len()
@@ -690,11 +686,7 @@ fn locate_module_tail(snapshot: &SourceTextSnapshot) -> Result<InsertionSite, St
     let text = snapshot.decoded_text();
     let offset = text.len();
     let local = local_line_ending_at(text, offset, Position::Before);
-    let policy = match snapshot.line_endings() {
-        LineEndingProfile::None => EolPolicy::Lf,
-        LineEndingProfile::Uniform(_) | LineEndingProfile::Mixed { .. } => EolPolicy::Preserve,
-    };
-    let eol = resolve_line_ending(policy, snapshot, local)
+    let eol = resolve_observed_line_ending(snapshot, local)
         .map_err(|error| format!("resolve code.patch EOL: {error}"))?;
     // The separator question is about content, not bytes: a module holding only
     // a byte order mark has nothing to be separated from, so it owes no blank
@@ -752,12 +744,8 @@ fn locate_replacement(
             (selected.start, selected.end)
         }
     };
-    let policy = match snapshot.line_endings() {
-        LineEndingProfile::None => EolPolicy::Lf,
-        LineEndingProfile::Uniform(_) | LineEndingProfile::Mixed { .. } => EolPolicy::Preserve,
-    };
     let local = local_line_ending_at(text, start, Position::Before);
-    let eol = resolve_line_ending(policy, snapshot, local)
+    let eol = resolve_observed_line_ending(snapshot, local)
         .map_err(|error| format!("resolve code.patch EOL: {error}"))?;
     // The replacement keeps a trailing newline only where the span it overwrites
     // had one, so replacing an inline anchor does not break the line.

--- a/crates/unica-coder/src/infrastructure/native_operations/meta/edit.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta/edit.rs
@@ -40,7 +40,7 @@ use super::super::compile_transaction::{
     snapshot_directory_membership, DirectoryMembershipSelector, DirectoryMembershipSnapshot,
 };
 use super::super::text_snapshot::{
-    resolve_line_ending, EolPolicy, LineEnding, LineEndingProfile, SourceTextSnapshot, Utf8Bom,
+    resolve_observed_line_ending, LineEnding, SourceTextSnapshot, Utf8Bom,
 };
 use super::format_contract::{
     validate_metadata_8_3_27_boolean_contract, validate_metadata_8_3_27_enum_contract,
@@ -687,14 +687,13 @@ pub(super) fn build_typed_operation_post_image(
             .with_metadata_path(target.clone()),
         )
     })?;
-    let eol_policy = match snapshot.line_endings() {
-        LineEndingProfile::None => EolPolicy::Lf,
-        LineEndingProfile::Uniform(_) | LineEndingProfile::Mixed { .. } => EolPolicy::Preserve,
-    };
-    let eol = resolve_line_ending(eol_policy, &snapshot, None).map_err(|error| {
+    // Смешанный профиль — дефект содержимого источника, а не отказ провайдера:
+    // байты прочитаны и декодированы, но их вид не проходит проверку writer-а,
+    // как и неканоничные fill-значения ниже по файлу.
+    let eol = resolve_observed_line_ending(&snapshot, None).map_err(|error| {
         MetaFailure::from(
             typed_diagnostic(
-                MetaDiagnosticCode::ProviderUnavailable,
+                MetaDiagnosticCode::ValidationFailed,
                 format!("metadata descriptor EOL policy failed: {error}"),
                 None,
             )

--- a/crates/unica-coder/src/infrastructure/native_operations/meta/edit.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta/edit.rs
@@ -39,6 +39,9 @@ use super::super::common::{escape_xml, is_1c_identifier};
 use super::super::compile_transaction::{
     snapshot_directory_membership, DirectoryMembershipSelector, DirectoryMembershipSnapshot,
 };
+use super::super::text_snapshot::{
+    resolve_line_ending, EolPolicy, LineEnding, LineEndingProfile, SourceTextSnapshot, Utf8Bom,
+};
 use super::format_contract::{
     validate_metadata_8_3_27_boolean_contract, validate_metadata_8_3_27_enum_contract,
 };
@@ -62,32 +65,9 @@ pub(super) struct MetaEditCounts {
 }
 
 #[derive(Clone, Copy)]
-enum MetaEditEol {
-    Lf,
-    CrLf,
-    Cr,
-}
-
-#[derive(Clone, Copy)]
 struct MetaEditSourceFormat {
     has_bom: bool,
-    eol: MetaEditEol,
-}
-
-fn meta_edit_source_eol(text: &str) -> MetaEditEol {
-    let bytes = text.as_bytes();
-    if let Some(index) = bytes.iter().position(|byte| *byte == b'\n') {
-        return if index > 0 && bytes[index - 1] == b'\r' {
-            MetaEditEol::CrLf
-        } else {
-            MetaEditEol::Lf
-        };
-    }
-    if bytes.contains(&b'\r') {
-        MetaEditEol::Cr
-    } else {
-        MetaEditEol::Lf
-    }
+    eol: LineEnding,
 }
 
 fn meta_edit_preserve_source_format(text: &str, format: MetaEditSourceFormat) -> Vec<u8> {
@@ -95,11 +75,7 @@ fn meta_edit_preserve_source_format(text: &str, format: MetaEditSourceFormat) ->
         .trim_start_matches('\u{feff}')
         .replace("\r\n", "\n")
         .replace('\r', "\n");
-    let serialized = match format.eol {
-        MetaEditEol::Lf => normalized,
-        MetaEditEol::CrLf => normalized.replace('\n', "\r\n"),
-        MetaEditEol::Cr => normalized.replace('\n', "\r"),
-    };
+    let serialized = normalized.replace('\n', format.eol.as_str());
     let mut bytes = Vec::with_capacity(serialized.len() + usize::from(format.has_bom) * 3);
     if format.has_bom {
         bytes.extend_from_slice(b"\xef\xbb\xbf");
@@ -701,23 +677,35 @@ pub(super) fn build_typed_operation_post_image(
     operations: &[MetaEditOperation],
     context: &WorkspaceContext,
 ) -> Result<TypedOperationPostImage, MetaFailure> {
-    let mut xml = String::from_utf8(descriptor_preimage.to_vec()).map_err(|_| {
+    let snapshot = SourceTextSnapshot::from_bytes(descriptor_preimage).map_err(|error| {
         MetaFailure::from(
             typed_diagnostic(
                 MetaDiagnosticCode::ProviderUnavailable,
-                "metadata descriptor image is not UTF-8",
+                format!("metadata descriptor snapshot failed: {error}"),
+                None,
+            )
+            .with_metadata_path(target.clone()),
+        )
+    })?;
+    let eol_policy = match snapshot.line_endings() {
+        LineEndingProfile::None => EolPolicy::Lf,
+        LineEndingProfile::Uniform(_) | LineEndingProfile::Mixed { .. } => EolPolicy::Preserve,
+    };
+    let eol = resolve_line_ending(eol_policy, &snapshot, None).map_err(|error| {
+        MetaFailure::from(
+            typed_diagnostic(
+                MetaDiagnosticCode::ProviderUnavailable,
+                format!("metadata descriptor EOL policy failed: {error}"),
                 None,
             )
             .with_metadata_path(target.clone()),
         )
     })?;
     let source_format = MetaEditSourceFormat {
-        has_bom: descriptor_preimage.starts_with(b"\xef\xbb\xbf"),
-        eol: meta_edit_source_eol(&xml),
+        has_bom: snapshot.bom() == Utf8Bom::Present,
+        eol,
     };
-    if xml.starts_with('\u{feff}') {
-        xml = xml.trim_start_matches('\u{feff}').to_string();
-    }
+    let mut xml = snapshot.text().to_string();
     let normalized_preimage = xml.clone();
     let applied = apply_typed_operations(&mut xml, operations).map_err(|mut failure| {
         for diagnostic in &mut failure.diagnostics {

--- a/crates/unica-coder/src/infrastructure/native_operations/text_snapshot.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/text_snapshot.rs
@@ -51,9 +51,6 @@ impl SourceTextSnapshot {
         &self.decoded_text
     }
 
-    // Part of the shared writer contract; code.patch is intentionally the first
-    // consumer and does not need every observation yet.
-    #[allow(dead_code)]
     pub(crate) fn bom(&self) -> Utf8Bom {
         self.bom
     }

--- a/crates/unica-coder/src/infrastructure/native_operations/text_snapshot.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/text_snapshot.rs
@@ -140,6 +140,21 @@ impl fmt::Display for EolPolicyError {
     }
 }
 
+/// Писательский контракт INV-SOURCE-OBSERVED-EOL в одной точке: источник без
+/// переводов строк обслуживается явной политикой `Lf`, любой наблюдённый
+/// профиль — политикой `Preserve` (для смешанного без локального контекста это
+/// отказ, а не выбор за автора файла).
+pub(crate) fn resolve_observed_line_ending(
+    snapshot: &SourceTextSnapshot,
+    local: Option<LineEnding>,
+) -> Result<LineEnding, EolPolicyError> {
+    let policy = match snapshot.line_endings() {
+        LineEndingProfile::None => EolPolicy::Lf,
+        LineEndingProfile::Uniform(_) | LineEndingProfile::Mixed { .. } => EolPolicy::Preserve,
+    };
+    resolve_line_ending(policy, snapshot, local)
+}
+
 pub(crate) fn resolve_line_ending(
     policy: EolPolicy,
     snapshot: &SourceTextSnapshot,
@@ -206,8 +221,8 @@ fn classify_line_endings(text: &str) -> (LineEndingProfile, Option<LineEnding>) 
 #[cfg(test)]
 mod tests {
     use super::{
-        resolve_line_ending, EolPolicy, EolPolicyError, LineEnding, LineEndingProfile,
-        SnapshotError, SourceTextSnapshot, Utf8Bom,
+        resolve_line_ending, resolve_observed_line_ending, EolPolicy, EolPolicyError, LineEnding,
+        LineEndingProfile, SnapshotError, SourceTextSnapshot, Utf8Bom,
     };
 
     #[test]
@@ -350,6 +365,41 @@ mod tests {
         assert_eq!(
             resolve_line_ending(EolPolicy::Preserve, &empty, None),
             Err(EolPolicyError::MissingPreserveContext)
+        );
+    }
+
+    #[test]
+    fn observed_resolution_serves_no_eol_source_with_explicit_lf() {
+        let snapshot = SourceTextSnapshot::from_bytes(b"A").unwrap();
+
+        assert_eq!(
+            resolve_observed_line_ending(&snapshot, None),
+            Ok(LineEnding::Lf)
+        );
+    }
+
+    #[test]
+    fn observed_resolution_preserves_uniform_profile_and_prefers_local() {
+        let uniform = SourceTextSnapshot::from_bytes(b"A\r\nB\r\n").unwrap();
+        assert_eq!(
+            resolve_observed_line_ending(&uniform, None),
+            Ok(LineEnding::CrLf)
+        );
+
+        let mixed = SourceTextSnapshot::from_bytes(b"A\r\nB\n").unwrap();
+        assert_eq!(
+            resolve_observed_line_ending(&mixed, Some(LineEnding::Lf)),
+            Ok(LineEnding::Lf)
+        );
+    }
+
+    #[test]
+    fn observed_resolution_rejects_mixed_profile_without_local_context() {
+        let mixed = SourceTextSnapshot::from_bytes(b"A\r\nB\n").unwrap();
+
+        assert_eq!(
+            resolve_observed_line_ending(&mixed, None),
+            Err(EolPolicyError::AmbiguousPreservePolicy)
         );
     }
 

--- a/spec/architecture/invariants.md
+++ b/spec/architecture/invariants.md
@@ -723,6 +723,8 @@ Unica. Каждая запись формулирует одно нормати�
 - **Decision:** n/a
 - **Check:** `ci-test` — `crates/unica-coder/src/infrastructure/native_operations/text_snapshot.rs`
 - **Check:** `ci-test` — `crates/unica-coder/src/infrastructure/native_operations/code.rs`
+- **Check:** `ci-test` — `crates/unica-coder/src/infrastructure/native_operations/meta/edit.rs`
+- **Check:** `ci-test` — `crates/unica-coder/src/infrastructure/metadata_operations.rs`
 - **Check:** `ci-test` — `crates/unica-coder/src/infrastructure/platform_xml_resources.rs`
 - **Scope:** runtime
 


### PR DESCRIPTION
Closes #366

## Что изменено

- unica.meta.edit теперь строит SourceTextSnapshot и разрешает EOL через общую EolPolicy вместо классификации по первому переводу строки.
- Mixed LF/CRLF отклоняется до построения плана публикации одинаково для preview и apply.
- Uniform LF, CRLF и CR сохраняют BOM и terminal newline независимо друг от друга; источник без EOL использует явную внутреннюю Lf policy.
- Check INV-SOURCE-OBSERVED-EOL связан с meta/edit.rs и реальным regression target metadata_operations.rs.

## Архитектурный контракт

- Владелец: INV-SOURCE-OBSERVED-EOL.
- ADR: none — восстановлено уже принятое правило, публичная MCP-схема и payload не менялись.
- Cache/events: отказ происходит до публикации; тест доказывает отсутствие изменений source tree, cache state и событий.

## TDD

На baseline c1503437 тест typed_edit_rejects_both_mixed_eol_orders_before_preview_or_apply_side_effects сначала упал по дефекту: lf-then-crlf dryRun=true unexpectedly succeeded. Production-код менялся только после этого воспроизведения.

Именованные проверки:

- typed_edit_rejects_both_mixed_eol_orders_before_preview_or_apply_side_effects;
- typed_edit_preserves_uniform_eol_bom_and_terminal_newline_profiles;
- typed_edit_uses_explicit_lf_policy_when_source_has_no_line_endings.

## Gate после rebase на main 37c4fc96

- cargo test --workspace -- --test-threads=1: PASS, 1992 lib tests и все integration/doc tests;
- cargo clippy --workspace --all-targets --all-features -- -D warnings: PASS;
- cargo fmt --all -- --check: PASS;
- tests/ci: 593 PASS, 3 skipped;
- tests/dev: 197 PASS;
- py_compile scripts/ci, tests/ci, scripts/dev, tests/dev: PASS;
- check-version-contract.py: PASS;
- check-architecture-sync.py --base upstream/main --strict: PASS;
- git diff --check: PASS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Metadata and code edits now preserve source line-ending styles, including CRLF and LF.
  * UTF-8 byte-order marks and terminal-newline settings are preserved during previews and published edits.
  * Files without existing line endings use LF without adding a terminal newline.
  * Mixed line-ending files are safely rejected with clear diagnostics and no file or cache changes.
  * Duplicate byte-order marks are normalized to one.

* **Quality Improvements**
  * Added safeguards for consistent text-editing behavior across supported workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->