### PR TITLE
test(cache): наполнить пустую проверку влияния на кеш из приёмки

### DIFF
--- a/crates/unica-coder/src/domain/cache.rs
+++ b/crates/unica-coder/src/domain/cache.rs
@@ -109,4 +109,163 @@ pub fn path_for_report(path: &Path) -> String {
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use super::*;
+
+    /// Every event kind, listed once. `index_of` below is what keeps the list
+    /// honest: it has no wildcard arm, so adding a variant stops compilation
+    /// until the new event is given an invalidation rule and a place here.
+    const ALL_KINDS: [DomainEventKind; 13] = [
+        DomainEventKind::ConfigXmlChanged,
+        DomainEventKind::CfeChanged,
+        DomainEventKind::MetadataChanged,
+        DomainEventKind::FormChanged,
+        DomainEventKind::ModuleChanged,
+        DomainEventKind::RoleChanged,
+        DomainEventKind::DcsChanged,
+        DomainEventKind::MxlChanged,
+        DomainEventKind::SubsystemChanged,
+        DomainEventKind::TemplateChanged,
+        DomainEventKind::SourceSetChanged,
+        DomainEventKind::BuildCompleted,
+        DomainEventKind::SourceResourcesReplaced,
+    ];
+
+    fn index_of(kind: DomainEventKind) -> usize {
+        match kind {
+            DomainEventKind::ConfigXmlChanged => 0,
+            DomainEventKind::CfeChanged => 1,
+            DomainEventKind::MetadataChanged => 2,
+            DomainEventKind::FormChanged => 3,
+            DomainEventKind::ModuleChanged => 4,
+            DomainEventKind::RoleChanged => 5,
+            DomainEventKind::DcsChanged => 6,
+            DomainEventKind::MxlChanged => 7,
+            DomainEventKind::SubsystemChanged => 8,
+            DomainEventKind::TemplateChanged => 9,
+            DomainEventKind::SourceSetChanged => 10,
+            DomainEventKind::BuildCompleted => 11,
+            DomainEventKind::SourceResourcesReplaced => 12,
+        }
+    }
+
+    fn event(kind: DomainEventKind) -> DomainEvent {
+        DomainEvent {
+            kind,
+            artifact: "fixture".to_string(),
+            details: None,
+        }
+    }
+
+    fn names(set: &BTreeSet<String>) -> Vec<&str> {
+        set.iter().map(String::as_str).collect()
+    }
+
+    /// How many variants the enum has. Deriving this from `ALL_KINDS.len()`
+    /// would make the check below a tautology — both sides would shrink
+    /// together and a forgotten kind would pass. Adding a variant forces a new
+    /// arm in `index_of`, and this constant is what then fails until the kind
+    /// reaches `ALL_KINDS` too.
+    const EXPECTED_KIND_COUNT: usize = 13;
+
+    #[test]
+    fn the_kind_list_covers_the_whole_enum() {
+        assert_eq!(ALL_KINDS.len(), EXPECTED_KIND_COUNT);
+        let mut seen = ALL_KINDS.map(index_of).to_vec();
+        seen.sort_unstable();
+        assert_eq!(seen, (0..EXPECTED_KIND_COUNT).collect::<Vec<_>>());
+    }
+
+    /// ADR-0022: the bounded resource writer replaces one proven BSL module, so
+    /// the BSL caches are the only ones that can have gone stale — and nothing
+    /// is rebuilt eagerly, because the caller asked to write, not to warm.
+    #[test]
+    fn replacing_a_source_resource_invalidates_only_the_two_bsl_caches() {
+        let impact = CacheImpact::from_events(&[event(DomainEventKind::SourceResourcesReplaced)]);
+
+        assert_eq!(names(&impact.invalidated), ["bsl_diagnostics", "bsl_index"]);
+        assert!(
+            impact.eager_refresh.is_empty(),
+            "a resource replacement rebuilds nothing eagerly: {:?}",
+            impact.eager_refresh
+        );
+    }
+
+    /// A module edit reaches the same two caches by a different route, so the
+    /// claim above is about the pair, not about one event that happens to
+    /// match it today.
+    #[test]
+    fn a_module_change_invalidates_the_same_two_caches() {
+        let impact = CacheImpact::from_events(&[event(DomainEventKind::ModuleChanged)]);
+
+        assert_eq!(names(&impact.invalidated), ["bsl_diagnostics", "bsl_index"]);
+        assert!(
+            impact.eager_refresh.is_empty(),
+            "{:?}",
+            impact.eager_refresh
+        );
+    }
+
+    /// Refreshing a cache that was never invalidated would rebuild something
+    /// already fresh; the report would then name work that did not need doing.
+    #[test]
+    fn no_event_refreshes_a_cache_it_did_not_invalidate() {
+        for kind in ALL_KINDS {
+            let impact = CacheImpact::from_events(&[event(kind)]);
+            let dangling = impact
+                .eager_refresh
+                .difference(&impact.invalidated)
+                .cloned()
+                .collect::<Vec<_>>();
+            assert!(
+                dangling.is_empty(),
+                "{kind:?} refreshes caches it never invalidated: {dangling:?}"
+            );
+        }
+    }
+
+    /// An event that invalidates nothing would be a change no consumer hears
+    /// about, which is the failure this whole model exists to prevent.
+    #[test]
+    fn every_event_invalidates_at_least_one_cache() {
+        for kind in ALL_KINDS {
+            let impact = CacheImpact::from_events(&[event(kind)]);
+            assert!(
+                !impact.invalidated.is_empty(),
+                "{kind:?} invalidates nothing"
+            );
+        }
+    }
+
+    /// One call reporting several events must answer for all of them: a
+    /// mutation that emits two events cannot leave one of their caches warm.
+    #[test]
+    fn from_events_unions_the_impact_of_every_event() {
+        let combined = CacheImpact::from_events(&[
+            event(DomainEventKind::SourceResourcesReplaced),
+            event(DomainEventKind::RoleChanged),
+        ]);
+
+        assert_eq!(
+            names(&combined.invalidated),
+            [
+                "bsl_diagnostics",
+                "bsl_index",
+                "metadata_graph",
+                "rights_graph"
+            ]
+        );
+        assert_eq!(
+            names(&combined.eager_refresh),
+            ["metadata_graph", "rights_graph"]
+        );
+    }
+
+    #[test]
+    fn no_events_leave_the_impact_empty() {
+        let impact = CacheImpact::from_events(&[]);
+
+        assert!(impact.invalidated.is_empty());
+        assert!(impact.eager_refresh.is_empty());
+    }
+}


### PR DESCRIPTION
## Что меняется

Приёмка ADR-0021/0022 называет проверкой влияния на кеш команду
`cargo test -p unica-coder domain::cache::tests -- --test-threads=1`. Модуль
`domain::cache::tests` существует с [#266](https://github.com/IngvarConsulting/unica/pull/266)
как `mod tests {}` — пустой. Команда выбирает **ноль** тестов, то есть строка
матрицы «Одно событие инвалидирует только `bsl_index` и `bsl_diagnostics`» с
самого начала не удерживалась ничем.

Найдено при сверке команд верификации в [#434](https://github.com/IngvarConsulting/unica/pull/434);
дефект к тому PR отношения не имеет и вынесен отдельно.

Семь тестов закрывают строку и её окрестность:

- `replacing_a_source_resource_invalidates_only_the_two_bsl_caches` — само
  утверждение приёмки: `SourceResourcesReplaced` инвалидирует ровно эту пару и
  **ничего** не обновляет заранее;
- `a_module_change_invalidates_the_same_two_caches` — та же пара по другому
  маршруту, чтобы утверждение было о паре, а не об одном совпавшем событии;
- `no_event_refreshes_a_cache_it_did_not_invalidate` — обновление того, что не
  инвалидировано, перестраивало бы уже свежее и попадало бы в отчёт как
  несделанная работа;
- `every_event_invalidates_at_least_one_cache` — событие, не инвалидирующее
  ничего, это изменение, о котором никто не узнает;
- `from_events_unions_the_impact_of_every_event`, `no_events_leave_the_impact_empty`;
- `the_kind_list_covers_the_whole_enum` — страж полноты.

### Про страж полноты

Список видов событий защищён двумя способами: у `index_of` нет `_`-арма,
поэтому новый вариант останавливает компиляцию, а `EXPECTED_KIND_COUNT` —
литерал, а не `ALL_KINDS.len()`.

Первая редакция как раз выводила счётчик из длины списка, и это была
тавтология: обе стороны сравнения уменьшались вместе. Мутация, убирающая вид из
списка, её проходила. Проверено мутациями — обе падают:

| Мутация | Результат |
| --- | --- |
| Вид убран из `ALL_KINDS` | `the_kind_list_covers_the_whole_enum` падает (`left: 12, right: 13`) |
| `invalidate(["bsl_index", "bsl_diagnostics"])` → `invalidate(["bsl_index"])` | падают оба теста про пару |

## Архитектурный слой

- Затронутые записи реестра: нет новых. Работа не меняет поведение — она
  снабжает проверкой существующее обязательство ADR-0022 о влиянии на кеш.
- Решение (ADR), если публичный или архитектурный контракт меняется: **нет**.
  Публичная поверхность `unica.*` не затронута, поведение домена не изменено.

- [x] Пройден [чек-лист изменений](../spec/architecture/change-checklist.md)
      в части, относящейся к этому изменению.

## Проверка

```sh
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace -- --test-threads=1
python3.12 -m pip install -r tests/ci/requirements.txt
python3.12 -m unittest discover -s tests/ci
git diff --check
```

Прогнано локально: `cargo test -p unica-coder domain::cache::tests` — 7 зелёных
там, где раньше было 0; `cargo test -p unica-coder --lib` — 2672 зелёных;
`tests/ci` — 639; clippy с `-D warnings` и `fmt --check` чисты;
`git diff --check` пуст.

- [x] Новое поведение покрыто тестом, который можно назвать по имени.
- [x] Документация, описывающая изменённое поведение, обновлена в этом же PR —
      строка приёмки не менялась, потому что она была верна; неверна была её
      пустая проверка.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for domain event cache invalidation behavior.
  * Verified handling of all event types, including multiple events, eager refreshes, and empty event lists.
  * Added safeguards to detect newly introduced event variants that lack test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->