### PR TITLE
fix(test): собирать вспомогательный бинарь RLM один раз на процесс тестов

### DIFF
--- a/crates/unica-coder/src/infrastructure/workspace_services.rs
+++ b/crates/unica-coder/src/infrastructure/workspace_services.rs
@@ -3900,6 +3900,7 @@ mod tests {
     use crate::infrastructure::platform::testing;
     use std::fs;
     use std::path::Path;
+    use std::sync::OnceLock;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
@@ -5789,7 +5790,8 @@ fn main() {
         let module = source_root.join("CommonModules/SmokeModule.bsl");
         fs::write(&module, "Процедура Smoke()\nКонецПроцедуры\n").unwrap();
         write_ready_rlm_status_for_current_source(&context, &source_root);
-        let fixture = compile_blocking_rlm_fixture(&context);
+        let fixture = blocking_rlm_fixture();
+        fs::create_dir_all(&context.cache_root).unwrap();
         let execute_started = context.cache_root.join("blocking-rlm-execute-started.txt");
         let execute_release = context.cache_root.join("blocking-rlm-execute-release.txt");
         let identity = WorkspaceServiceIdentity::new(&context, &source_root).unwrap();
@@ -5830,7 +5832,13 @@ fn main() {
             )
         });
 
-        wait_for_file(&execute_started, Duration::from_secs(2));
+        // With the binary already built and validated, this wait measured 12
+        // and 14 ms under the full parallel suite, against 1822 to 2243 ms
+        // before. Five seconds is the bound the sibling terminal-marker wait
+        // already uses, and over that distribution it is headroom of two and a
+        // half orders of magnitude instead of the margin of tens of
+        // milliseconds the previous two seconds left.
+        wait_for_file(&execute_started, Duration::from_secs(5));
         during_execute(&context, &source_root, &module);
         fs::write(&execute_release, "release").unwrap();
         let response = caller.join().unwrap();
@@ -5849,11 +5857,49 @@ fn main() {
         }
     }
 
-    fn compile_blocking_rlm_fixture(context: &WorkspaceContext) -> PathBuf {
-        let source = context.cache_root.join("blocking-rlm-fixture.rs");
-        let executable =
-            testing::fixture_executable_path(&context.cache_root, "blocking-rlm-fixture");
-        fs::create_dir_all(&context.cache_root).unwrap();
+    /// The helper binary is built and first run once per test process, before
+    /// any test starts timing a spawn.
+    ///
+    /// Measured on this fixture under the full parallel suite: `rustc` costs
+    /// ~100 ms, the JSON-RPC handshake to the first marker costs 0-1 ms, and
+    /// everything else — 1.8 to 2.2 s — was the child getting from `spawn` to
+    /// the first line of `main`. That gap is the first execution of a
+    /// freshly written binary: macOS validates its code signature through a
+    /// shared system service, and a suite that writes a new binary per call
+    /// pays that serialized validation every time. Idle, the same binary needs
+    /// ~300 ms on its first run and ~20 ms on every later one.
+    ///
+    /// Building once per process leaves exactly one validation, and running it
+    /// here moves that validation out of the timed section. What a test waits
+    /// on afterwards is the fixture's own progress, which is what the deadline
+    /// is meant to bound.
+    fn blocking_rlm_fixture() -> PathBuf {
+        static FIXTURE: OnceLock<PathBuf> = OnceLock::new();
+        FIXTURE
+            .get_or_init(|| {
+                let directory = std::env::temp_dir()
+                    .join(format!("unica-blocking-rlm-fixture-{}", std::process::id()));
+                let executable = compile_blocking_rlm_fixture(&directory);
+                // The first run pays the code-signature validation; the fixture
+                // exits on its own once stdin closes, so no marker is needed.
+                let mut warmup = Command::new(&executable)
+                    .arg(directory.join("warmup-started.txt"))
+                    .arg(directory.join("warmup-release.txt"))
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn()
+                    .unwrap();
+                warmup.wait().unwrap();
+                executable
+            })
+            .clone()
+    }
+
+    fn compile_blocking_rlm_fixture(directory: &Path) -> PathBuf {
+        let source = directory.join("blocking-rlm-fixture.rs");
+        let executable = testing::fixture_executable_path(directory, "blocking-rlm-fixture");
+        fs::create_dir_all(directory).unwrap();
         fs::write(
             &source,
             r##"use std::{env, fs, io::{self, BufRead, Write}, thread, time::{Duration, Instant}};


### PR DESCRIPTION
Closes #432.

## Измерение, а не подбор дедлайна

Тикет требовал сначала установить причину. Инструментированный полный прогон развёл три составляющих ожидания:

| Составляющая | Время |
| --- | --- |
| `rustc` вспомогательного бинаря | ~100 мс, и завершается **до** начала ожидания |
| Рукопожатие JSON-RPC от `spawn` до маркера | **0–1 мс** |
| Путь дочернего процесса от `spawn` до первой строки `main` | **1822–2243 мс** |

Разрез снят прямым замером: в фикстуру добавлен маркер, который она пишет первой же строкой `main`. `spawn_to_process_ms` совпал с `spawn_to_marker_ms` с точностью до миллисекунды (2079/2080, 2243/2243, 1834/1834, 2049/2049). То есть ожидание **целиком** состояло из старта процесса, а дедлайн был 2000 мс — тест сидел ровно на границе распределения, отсюда и «6 падений из 9».

Это опровергает обе гипотезы из тикета: `rustc` с ожиданием не конкурирует, а busy-spin ядро у процесса не отбирает — протокол укладывается в 0–1 мс.

## Причина

Первый запуск только что записанного бинаря. macOS проверяет его подпись через разделяемый системный сервис, и набор, который пишет новый бинарь на каждый вызов помощника, платит эту сериализованную проверку каждый раз. Изолированный замер на этой машине, вне нагрузки:

```
fresh binary first-exec:  434 / 304 / 297 мс
        second-exec:       26 /  20 /  21 мс
```

Под полным параллельным набором тот же путь растягивается до 1.8–2.2 с.

## Исправление

Первый кандидат из тикета: бинарь собирается и **первый раз запускается** один раз на процесс тестов (`OnceLock`), до того как хоть один тест начнёт отсчёт. Остаётся ровно одна проверка подписи, и она вынесена из измеряемого участка.

Дедлайн выбран из измеренного распределения: после правки то же ожидание под полным набором — **12 и 14 мс**. 5 с — та же граница, что у соседнего ожидания терминального маркера, и это запас в два с половиной порядка вместо прежних десятков миллисекунд. Величина объяснена комментарием у самого ожидания.

## Проверка

- `cargo test --package unica-coder --lib` — **5 полных прогонов подряд**, все `2672 passed; 0 failed`.
- Оба теста, использующих `run_blocking_rlm_execute`, проходят в изоляции и в полном наборе.
- Независимость от числа потоков: `--test-threads=1`, `=4`, `=32` — по 4 passed, 0 failed.

## Что не тронуто

Утверждения тестов — приоритет активной блокировки индекса, `index_status`, `session_retired`, `maintenance_requests`, `teardown_drained` — не ослаблены: правится синхронизация фикстуры. `#[ignore]` не добавлялся.