### PR TITLE
fix(code.graph): сообщать об отсутствующем анализаторе вместо отказа вызова

### DIFF
--- a/crates/unica-coder/src/infrastructure/code_intelligence.rs
+++ b/crates/unica-coder/src/infrastructure/code_intelligence.rs
@@ -848,7 +848,11 @@ fn parse_git_grep_line(line: &str) -> Option<ProviderSearchHit> {
     })
 }
 
-fn is_provider_unavailable_error(error: &str) -> bool {
+/// Causes that mean "this provider is not present here", as opposed to "this
+/// provider ran and failed". `code.search` degrades on them and `code.graph`
+/// reports them instead of failing the call, so the classification stays in one
+/// place rather than being restated per caller.
+pub(crate) fn is_provider_unavailable_error(error: &str) -> bool {
     [
         "could not locate Unica plugin root",
         "Unica third-party manifest not found",

--- a/crates/unica-coder/src/infrastructure/internal_adapters.rs
+++ b/crates/unica-coder/src/infrastructure/internal_adapters.rs
@@ -7,6 +7,7 @@ use crate::domain::operational_config::OperationalConfig;
 use crate::domain::project_sources::{config_dump_info_xml_kind, ConfigDumpInfoXmlKind};
 use crate::domain::workspace::WorkspaceContext;
 use crate::infrastructure::bundled_tools::resolve_bundled_tool;
+use crate::infrastructure::code_intelligence::is_provider_unavailable_error;
 use crate::infrastructure::diagnostics_jsonl::{
     DiagnosticsJsonlParser, MAX_DIAGNOSTICS_JSONL_LINE_BYTES,
 };
@@ -1616,15 +1617,33 @@ impl<'a> BslAnalyzerMcpAdapter<'a> {
             );
         }
 
-        let plugin_root = find_plugin_root(&context.cwd).ok_or_else(|| {
-            "could not locate Unica plugin root for bsl-analyzer MCP adapter lookup".to_string()
-        })?;
+        let plugin_root = match find_plugin_root(&context.cwd) {
+            Some(plugin_root) => plugin_root,
+            None => {
+                return Ok(provider_unavailable_outcome(
+                    tool_name,
+                    "could not locate Unica plugin root for bsl-analyzer MCP adapter lookup"
+                        .to_string(),
+                ))
+            }
+        };
         let source_dir = resolve_source_dir(context, args)?;
         if let Some(path) = diagnostics_path {
             validate_diagnostics_path(&source_dir, path)?;
         }
         let (remote_tool, tool_args) = bsl_mcp_tool_request(tool_name, args)?;
-        let bundled_tool = resolve_bundled_tool(&plugin_root, "bsl-analyzer", !dry_run)?;
+        // A workspace that has not downloaded the tools has no analyzer in its
+        // manifest. `code.search` already answers that state with an
+        // unavailable section and a working result (ADR-0017); answering it
+        // here with a failed call made the same workstation look broken (#275).
+        // A provider that ran and failed is a different case and still fails.
+        let bundled_tool = match resolve_bundled_tool(&plugin_root, "bsl-analyzer", !dry_run) {
+            Ok(bundled_tool) => bundled_tool,
+            Err(error) if is_provider_unavailable_error(&error) => {
+                return Ok(provider_unavailable_outcome(tool_name, error))
+            }
+            Err(error) => return Err(error),
+        };
         let command = bsl_mcp_command(
             &source_dir,
             context,
@@ -1874,6 +1893,27 @@ impl BslAnalyzerOutcome {
             data: None,
         }
     }
+}
+
+/// The answer for a provider that is not present in this workspace: a normal
+/// tool result that states the cause, not a failed call. The
+/// `provider_unavailable:` prefix is the machine-readable part — it separates
+/// "the analyzer is not here" from "the analyzer ran and failed", which the
+/// caller has to tell apart to decide whether retrying is worth anything.
+fn provider_unavailable_outcome(tool_name: &str, error: String) -> BslAnalyzerOutcome {
+    BslAnalyzerOutcome::plain(AdapterOutcome {
+        ok: false,
+        summary: format!(
+            "{tool_name} is unavailable: bsl-analyzer is not bundled in this workspace"
+        ),
+        changes: Vec::new(),
+        warnings: Vec::new(),
+        errors: vec![format!("provider_unavailable: {error}")],
+        artifacts: Vec::new(),
+        stdout: None,
+        stderr: None,
+        command: None,
+    })
 }
 
 impl Default for BslAnalyzerMcpAdapter<'_> {
@@ -4655,6 +4695,55 @@ analyze_timeout_seconds = 900
         cleanup_context(&context);
     }
 
+    /// #275. A checkout that has not downloaded the tools has no
+    /// `bsl-analyzer` in its manifest. `code.search` already answers that
+    /// workstation state with an unavailable section and a working result;
+    /// `code.graph` must not turn the same cause into a failed call.
+    #[test]
+    fn bsl_graph_adapter_degrades_when_the_analyzer_is_not_bundled() {
+        let context = temp_context("graph-missing-analyzer");
+        drop_tool_from_fake_manifest(&context.cwd, "bsl-analyzer");
+        let runner = RecordingBslMcpRunner {
+            commands: RefCell::new(Vec::new()),
+            output: BslMcpOutput {
+                result_text: String::new(),
+                stderr: String::new(),
+            },
+        };
+        let mut args = Map::new();
+        args.insert("mode".to_string(), json!("resolve"));
+        args.insert("query".to_string(), json!("ВидыНоменклатуры"));
+
+        let analyzer = BslAnalyzerMcpAdapter::with_runner(&runner)
+            .invoke("unica.code.graph", &args, &context, false)
+            .expect("an absent provider is a reportable state, not a failed call");
+
+        assert!(!analyzer.outcome.ok, "{:?}", analyzer.outcome);
+        assert!(
+            analyzer
+                .outcome
+                .errors
+                .iter()
+                .any(|error| error.starts_with("provider_unavailable:")),
+            "the answer names the cause in a machine-readable form: {:?}",
+            analyzer.outcome.errors
+        );
+        assert!(
+            analyzer
+                .outcome
+                .errors
+                .iter()
+                .any(|error| error.contains("bsl-analyzer")),
+            "{:?}",
+            analyzer.outcome.errors
+        );
+        assert!(
+            runner.commands.borrow().is_empty(),
+            "an absent provider is never invoked"
+        );
+        cleanup_context(&context);
+    }
+
     #[test]
     fn bsl_graph_adapter_maps_typed_args_to_allowlisted_mcp_call() {
         let context = temp_context("graph-mcp");
@@ -5814,6 +5903,21 @@ analyze_timeout_seconds = 900
             cache_root: root.join(".build").join("unica"),
             workspace_epoch: 1,
         }
+    }
+
+    /// Rewrites the fake manifest without `tool_name`, the way a checkout that
+    /// has not run the tools download looks.
+    fn drop_tool_from_fake_manifest(root: &Path, tool_name: &str) {
+        let manifest_path = root
+            .join("plugins")
+            .join("unica")
+            .join("third-party")
+            .join("manifest.json");
+        let mut manifest: Value =
+            serde_json::from_str(&fs::read_to_string(&manifest_path).unwrap()).unwrap();
+        let tools = manifest["tools"].as_array_mut().unwrap();
+        tools.retain(|tool| tool["name"] != json!(tool_name));
+        fs::write(&manifest_path, serde_json::to_string(&manifest).unwrap()).unwrap();
     }
 
     fn create_fake_plugin_root(root: &Path) {


### PR DESCRIPTION
Часть [#275](https://github.com/IngvarConsulting/unica/issues/275) — та её часть, которая воспроизводится и имеет заданный тикетом критерий. Оставшееся перечислено ниже, поэтому PR не закрывает задачу.

## Ответ на вопрос тикета

Тикет спрашивал: ожидаемо ли отсутствие инструментов в манифесте на рабочей станции, или это дефект упаковки. Ответ по коду — **ожидаемо**:

- инструменты приезжают в `plugins/unica/third-party/manifest.json` отдельным скачиванием, а исходный checkout запускается как `claude --plugin-dir ./plugins/unica` без него;
- `resolve_bundled_tool` для этого случая имеет ветку `resolve_from_lock_for_dry_run`, то есть отсутствие манифеста заранее считается штатным;
- `code.search` уже сейчас отвечает на эту причину секцией `unavailable`, а не отказом.

Значит, действует условие из тикета: «если инструменты опциональны — `code.graph` не должен падать целиком, а должен деградировать так же».

## Дефект

`invoke_cancellable_with_operational_config` пробрасывал ошибку разрешения инструмента через `?`:

```rust
let bundled_tool = resolve_bundled_tool(&plugin_root, "bsl-analyzer", !dry_run)?;
```

Поэтому `unica.code.graph` отвечал отказом вызова с текстом `tool not found in manifest: bsl-analyzer`, тогда как `unica.code.search` на ту же причину отвечал рабочим результатом с секцией `unavailable`. Одно и то же состояние рабочего места читалось у двух инструментов по-разному.

Воспроизведение: `bsl_graph_adapter_degrades_when_the_analyzer_is_not_bundled` на коде до правки падает ровно так:

```
an absent provider is a reportable state, not a failed call: "tool not found in manifest: bsl-analyzer"
```

## Исправление

Адаптер различает «поставщика здесь нет» и «поставщик отработал и упал»:

- первое — обычный типизированный результат с `ok=false` и ошибкой с префиксом `provider_unavailable:`, по которому вызывающий понимает, что повтор бесполезен, пока инструменты не скачаны;
- второе по-прежнему отказ вызова.

Классификация причин не переписана заново: `is_provider_unavailable_error` из `code_intelligence` стал общим для обоих потребителей, поэтому список причин живёт в одном месте. Отсутствующий корень плагина обрабатывается так же.

## Проверка

- `bsl_graph_adapter_degrades_when_the_analyzer_is_not_bundled` — падал до правки, проходит после; отсутствующий поставщик при этом ни разу не вызывается.
- `bsl_graph_adapter_maps_typed_args_to_allowlisted_mcp_call` — рабочий путь не изменился.
- `cargo test --package unica-coder --lib` — 2713 passed, 1 failed: единственное падение — известный флейк #432, чей фикс идёт отдельным PR #439.
- `python -m unittest discover -s tests/ci` — 644 passed, 3 skipped, 0 failed.
- `cargo fmt --check` — чисто.

## Что осталось в #275

1. **Производительность `code.search`** — 3.4–4.4 с против медианы 0.07 с. Отдельная работа, к деградации отношения не имеет.
2. **Шум выдачи git-grep** — `symbol`/`kind`/`providerScore` пустые, когда семантических поставщиков нет. Это следствие отсутствия инструментов, а не дефект самой деградации.