### PR TITLE
fix(dcs.compile): компилировать shorthand dataParameters варианта настроек

### DIFF
--- a/crates/unica-coder/src/infrastructure/native_operations/dcs.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/dcs.rs
@@ -2805,6 +2805,22 @@ pub(crate) fn dcs_check_settings(
             }
         }
     }
+    // A `SettingsParameterValue` without a name is a well-formed element that
+    // names nothing, so the platform reads the variant as having no value for
+    // that parameter. Validation used to pass it (#311).
+    for parameter_item in dcs_find_all_path(
+        settings_node,
+        &[("dataParameters", NS_SETTINGS), ("item", DCS_CORE_NS)],
+    ) {
+        let parameter = dcs_child(parameter_item, "parameter", DCS_CORE_NS)
+            .map(dcs_inner_text)
+            .unwrap_or_default();
+        if parameter.trim().is_empty() {
+            report.error(format!(
+                "Variant '{variant_name}' dataParameters: SettingsParameterValue has empty parameter name"
+            ));
+        }
+    }
     dcs_check_filter_items(report, settings_node, variant_name);
     for order_item in dcs_find_all_path(
         settings_node,
@@ -3342,7 +3358,7 @@ fn dcs_compile_xml_with_inputs(
     dcs_compile_emit_calculated_fields(&mut lines, defn)?;
     dcs_compile_emit_total_fields(&mut lines, defn);
     dcs_compile_emit_parameters(&mut lines, defn)?;
-    dcs_compile_emit_settings_variants(&mut lines, defn);
+    dcs_compile_emit_settings_variants(&mut lines, defn)?;
     lines.push("</DataCompositionSchema>".to_string());
     Ok(format!("{}\n", lines.join("\n")))
 }
@@ -4520,14 +4536,17 @@ pub(crate) fn dcs_compile_emit_parameter_value(
     ));
 }
 
-pub(crate) fn dcs_compile_emit_settings_variants(lines: &mut Vec<String>, defn: &Value) {
+pub(crate) fn dcs_compile_emit_settings_variants(
+    lines: &mut Vec<String>,
+    defn: &Value,
+) -> Result<(), String> {
     let Some(variants) = defn.get("settingsVariants").and_then(Value::as_array) else {
         dcs_compile_emit_default_settings_variant(lines);
-        return;
+        return Ok(());
     };
     if variants.is_empty() {
         dcs_compile_emit_default_settings_variant(lines);
-        return;
+        return Ok(());
     }
     for variant in variants {
         lines.push("\t<settingsVariant>".to_string());
@@ -4549,7 +4568,7 @@ pub(crate) fn dcs_compile_emit_settings_variants(lines: &mut Vec<String>, defn: 
             dcs_compile_emit_filter(lines, filter, "\t\t\t");
         }
         if let Some(data_parameters) = settings.get("dataParameters").and_then(Value::as_array) {
-            dcs_compile_emit_data_parameters(lines, data_parameters, "\t\t\t");
+            dcs_compile_emit_data_parameters(lines, data_parameters, "\t\t\t")?;
         }
         if let Some(order) = settings.get("order").and_then(Value::as_array) {
             dcs_compile_emit_order(lines, order, "\t\t\t");
@@ -4570,6 +4589,7 @@ pub(crate) fn dcs_compile_emit_settings_variants(lines: &mut Vec<String>, defn: 
         lines.push("\t\t</dcsset:settings>".to_string());
         lines.push("\t</settingsVariant>".to_string());
     }
+    Ok(())
 }
 
 pub(crate) fn dcs_compile_emit_selection(lines: &mut Vec<String>, items: &[Value], indent: &str) {
@@ -4901,12 +4921,37 @@ pub(crate) fn dcs_compile_emit_data_parameters(
     lines: &mut Vec<String>,
     items: &[Value],
     indent: &str,
-) {
+) -> Result<(), String> {
     if items.is_empty() {
-        return;
+        return Ok(());
     }
     lines.push(format!("{indent}<dcsset:dataParameters>"));
     for item in items {
+        // `dcs-dsl-spec` publishes a shorthand string here, and `dcs.edit`
+        // already parses and emits it. Reusing both keeps one grammar for the
+        // two tools instead of a second one that silently lost the parameter
+        // name and could not reach the nested value shapes at all.
+        let parsed_from_string;
+        let mut shorthand_value = None;
+        let item = if let Some(text) = item.as_str() {
+            let parsed = dcs_edit_parse_data_parameter(text);
+            let mut object = Map::new();
+            object.insert("parameter".to_string(), json!(parsed.parameter));
+            shorthand_value = parsed.value;
+            if let Some(use_flag) = parsed.use_flag {
+                object.insert("use".to_string(), json!(use_flag));
+            }
+            if let Some(view_mode) = parsed.view_mode {
+                object.insert("viewMode".to_string(), json!(view_mode));
+            }
+            if let Some(user_setting_id) = parsed.user_setting_id {
+                object.insert("userSettingID".to_string(), json!(user_setting_id));
+            }
+            parsed_from_string = Value::Object(object);
+            &parsed_from_string
+        } else {
+            item
+        };
         lines.push(format!(
             "{indent}\t<dcscor:item xsi:type=\"dcsset:SettingsParameterValue\">"
         ));
@@ -4922,7 +4967,16 @@ pub(crate) fn dcs_compile_emit_data_parameters(
             "{indent}\t\t<dcscor:parameter>{}</dcscor:parameter>",
             escape_xml(&parameter)
         ));
-        if item
+        if let Some(value) = &shorthand_value {
+            // The shorthand value goes through the same emitter `dcs.edit`
+            // uses for this element, so a period variant reaches its nested
+            // `v8:StandardPeriod` shape instead of being flattened to text.
+            lines.extend(dcs_edit_settings_value_lines(
+                "dcscor:value",
+                value,
+                &format!("{indent}\t"),
+            )?);
+        } else if item
             .get("nilValue")
             .and_then(Value::as_bool)
             .unwrap_or(false)
@@ -4966,6 +5020,7 @@ pub(crate) fn dcs_compile_emit_data_parameters(
         lines.push(format!("{indent}\t</dcscor:item>"));
     }
     lines.push(format!("{indent}</dcsset:dataParameters>"));
+    Ok(())
 }
 
 pub(crate) fn dcs_compile_emit_structure(lines: &mut Vec<String>, structure: &Value, indent: &str) {
@@ -7012,10 +7067,15 @@ pub(crate) fn dcs_edit_parse_data_parameter(value: &str) -> DcsEditDataParameter
     } else {
         None
     };
+    // `@inaccessible` is published alongside the other view-mode flags. Left
+    // unrecognised it was not stripped either, so it ended up inside the
+    // parameter name.
     let view_mode = if value.contains("@quickAccess") {
         Some("QuickAccess".to_string())
     } else if value.contains("@normal") {
         Some("Normal".to_string())
+    } else if value.contains("@inaccessible") {
+        Some("Inaccessible".to_string())
     } else {
         None
     };
@@ -7024,7 +7084,8 @@ pub(crate) fn dcs_edit_parse_data_parameter(value: &str) -> DcsEditDataParameter
         .replace("@on", "")
         .replace("@user", "")
         .replace("@quickAccess", "")
-        .replace("@normal", "");
+        .replace("@normal", "")
+        .replace("@inaccessible", "");
     let (parameter, val) = cleaned
         .split_once('=')
         .map(|(left, right)| (left.trim().to_string(), Some(right.trim().to_string())))
@@ -11206,6 +11267,75 @@ mod tests {
         let _ = fs::remove_dir_all(&context.cwd);
     }
 
+    /// #311. `dcs-dsl-spec` publishes a shorthand string for `dataParameters`
+    /// — `"<Имя> [= <значение>] [@off] [@user] [@quickAccess]"` — and
+    /// `dcs.edit` already parses it. Compilation read `parameter` only from
+    /// the object form, so a shorthand item compiled to an item with an empty
+    /// name and neither `viewMode` nor `userSettingID`.
+    #[test]
+    fn dcs_compile_variant_data_parameters_accept_the_published_shorthand() {
+        let definition = json!({
+            "settingsVariants": [{
+                "name": "Main",
+                "settings": {
+                    "dataParameters": [
+                        "Period = ThisMonth @user @quickAccess",
+                        "Company @user @quickAccess"
+                    ]
+                }
+            }]
+        });
+
+        let xml = dcs_compile_xml(&definition, Path::new("."), Path::new(".")).unwrap();
+        let document = Document::parse(&xml).unwrap();
+        let data_parameters = document
+            .descendants()
+            .find(|node| role_info_element(*node, "dataParameters", Some(TEST_DCS_SETTINGS_NS)))
+            .expect("the variant publishes its data parameters");
+        let items = dcs_children(data_parameters, "item", TEST_DCS_CORE_NS);
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(
+            items
+                .iter()
+                .map(|item| dcs_child(*item, "parameter", TEST_DCS_CORE_NS)
+                    .and_then(|node| node.text())
+                    .unwrap_or_default())
+                .collect::<Vec<_>>(),
+            ["Period", "Company"],
+            "the shorthand carries the parameter name"
+        );
+        for item in &items {
+            assert_eq!(
+                dcs_child(*item, "viewMode", TEST_DCS_SETTINGS_NS).and_then(|node| node.text()),
+                Some("QuickAccess"),
+                "@quickAccess selects the view mode"
+            );
+            assert!(
+                dcs_child(*item, "userSettingID", TEST_DCS_SETTINGS_NS)
+                    .and_then(|node| node.text())
+                    .is_some_and(|id| !id.is_empty()),
+                "@user issues a user setting id"
+            );
+        }
+        assert!(
+            dcs_child(items[0], "value", TEST_DCS_CORE_NS).is_some(),
+            "the shorthand value reaches the item"
+        );
+        assert_eq!(
+            test_direct_child_names(items[0]),
+            ["parameter", "value", "viewMode", "userSettingID"],
+            "the 8.3.27 child sequence is preserved"
+        );
+        assert_eq!(
+            dcs_child(items[0], "value", TEST_DCS_CORE_NS).and_then(
+                |node| node.attribute(("http://www.w3.org/2001/XMLSchema-instance", "type"))
+            ),
+            Some("v8:StandardPeriod"),
+            "a period variant reaches its nested shape instead of flattening to text"
+        );
+    }
+
     #[test]
     fn dcs_compile_calculated_field_merges_restrictions_in_8_3_27_order() {
         let definition = json!({
@@ -12186,6 +12316,36 @@ mod tests {
             data.items
         );
         assert_eq!(fs::read(&template_path).unwrap(), before);
+
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    /// #311. A `SettingsParameterValue` with an empty `<dcscor:parameter>` is
+    /// well-formed XML that names no parameter, so the variant carries no value
+    /// for it. Validation reported `Validation OK` on exactly that shape.
+    #[test]
+    fn native_dcs_validate_rejects_a_data_parameter_without_a_name() {
+        let context = temp_context("dcs-validate-empty-data-parameter");
+        let template_path = context.cwd.join("Template.xml");
+        fs::write(
+            &template_path,
+            base_dcs_xml().replace(
+                "\t\t\t<dcsset:order>",
+                "\t\t\t<dcsset:dataParameters>\n\t\t\t\t<dcscor:item xsi:type=\"dcsset:SettingsParameterValue\">\n\t\t\t\t\t<dcscor:parameter></dcscor:parameter>\n\t\t\t\t</dcscor:item>\n\t\t\t</dcsset:dataParameters>\n\t\t\t<dcsset:order>",
+            ),
+        )
+        .unwrap();
+
+        let mut args = Map::new();
+        args.insert("TemplatePath".to_string(), json!("Template.xml"));
+        let outcome = validate_dcs(&args, &context);
+
+        let stdout = outcome.stdout.unwrap_or_default();
+        assert!(!outcome.ok, "{stdout}");
+        assert!(
+            stdout.contains("SettingsParameterValue has empty parameter name"),
+            "{stdout}"
+        );
 
         let _ = fs::remove_dir_all(&context.cwd);
     }

--- a/crates/unica-coder/src/infrastructure/native_operations/dcs.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/dcs.rs
@@ -11336,6 +11336,38 @@ mod tests {
         );
     }
 
+    /// Review of #442. The shared parser gained `@inaccessible`: before, the
+    /// published flag was neither recognised nor stripped, so it ended up
+    /// inside the parameter name. The fix reaches both `dcs.compile` and
+    /// `dcs.edit`, so it is proven on the public route.
+    #[test]
+    fn dcs_compile_variant_data_parameters_accept_the_inaccessible_flag() {
+        let definition = json!({
+            "settingsVariants": [{
+                "name": "Main",
+                "settings": { "dataParameters": ["Period @inaccessible"] }
+            }]
+        });
+
+        let xml = dcs_compile_xml(&definition, Path::new("."), Path::new(".")).unwrap();
+        let document = Document::parse(&xml).unwrap();
+        let data_parameters = document
+            .descendants()
+            .find(|node| role_info_element(*node, "dataParameters", Some(TEST_DCS_SETTINGS_NS)))
+            .expect("the variant publishes its data parameters");
+        let item = dcs_child(data_parameters, "item", TEST_DCS_CORE_NS).unwrap();
+
+        assert_eq!(
+            dcs_child(item, "parameter", TEST_DCS_CORE_NS).and_then(|node| node.text()),
+            Some("Period"),
+            "the flag is stripped from the name, not carried into it"
+        );
+        assert_eq!(
+            dcs_child(item, "viewMode", TEST_DCS_SETTINGS_NS).and_then(|node| node.text()),
+            Some("Inaccessible")
+        );
+    }
+
     #[test]
     fn dcs_compile_calculated_field_merges_restrictions_in_8_3_27_order() {
         let definition = json!({

--- a/tests/fixtures/unica_mcp_script_parity/donor-relations.json
+++ b/tests/fixtures/unica_mcp_script_parity/donor-relations.json
@@ -1,4040 +1,4040 @@
 {
- "schemaVersion": 1,
- "upstreamId": "cc-1c-skills",
- "retired": {
-  "cfe-borrow/catalog": "unica.cfe.borrow отвечает типизированным data (ADR-0023): прозы для сравнения со скриптом-донором больше нет",
-  "cfe-borrow/common-module": "unica.cfe.borrow отвечает типизированным data (ADR-0023): прозы для сравнения со скриптом-донором больше нет",
-  "cfe-borrow/document": "unica.cfe.borrow отвечает типизированным data (ADR-0023): прозы для сравнения со скриптом-донором больше нет",
-  "cfe-borrow/enum": "unica.cfe.borrow отвечает типизированным data (ADR-0023): прозы для сравнения со скриптом-донором больше нет",
-  "cfe-borrow/form-bindings": "unica.cfe.borrow отвечает типизированным data (ADR-0023): прозы для сравнения со скриптом-донором больше нет",
-  "cfe-borrow/multiple-objects": "unica.cfe.borrow отвечает типизированным data (ADR-0023): прозы для сравнения со скриптом-донором больше нет"
- },
- "relations": {
-  "form-compile-from-object/accumreg-list-simple": {
-   "caseId": "form-compile-from-object/accumreg-list-simple",
-   "contentDigest": "d8a895672b46c1415ef6642a5d8e71ae0d35e555cc05934d968b080c4f2f1062",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "8d00ebd52146f12a7cbc9100166f5fe73cc055c4ba55c57e29d89ea1732c6c62",
-    "donorWorkspaceSha256": "865388d91e0670ab4999ac58952a4a31622c6ac89866279ce17b24217bbba9d1",
-    "mismatchKind": "unsupported_from_object_type",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "1293d0ec23d81743216cfd31620d0c7cd011b3cd62a73c883cdd387088f2f7af",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "8fa36ba5617671d7340e7032e43a71b001e9259ba0fdbdf9c6e7fab31c0a2e2e"
-   },
-   "observationFingerprint": "0cf9cb3d33757947fb4097fc821d25c6c48a6709efe84a58f3cd5b542efa739a",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile-from-object/catalog-item-simple": {
-   "caseId": "form-compile-from-object/catalog-item-simple",
-   "contentDigest": "39beae436557d28423db7216023f44cc02982ac68694c36bd691233d1ffbcac5",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "375572b562f6a8f3f9bd8fb36a66ff66ab755e7c6c1780ec8b10e60b6e49b189",
-    "donorWorkspaceSha256": "39c40132fa62d1cf0153eae4026b93d07b42393e451b302edc929c43a41a3238",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "375572b562f6a8f3f9bd8fb36a66ff66ab755e7c6c1780ec8b10e60b6e49b189",
-    "unicaWorkspaceSha256": "04836930a5e6649b3a150fbcf1a46df22a5d3b87305c049b2faf1acb802c6935"
-   },
-   "observationFingerprint": "2d88a0a5c0ae602af0665051c65afde6e6493018257d4c6a26f591d33faa3859",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "form-compile-from-object/catalog-list-simple": {
-   "caseId": "form-compile-from-object/catalog-list-simple",
-   "contentDigest": "ba7316ff5f74adcc1c31a45910b9854c1298cff16b7568b56daec648748a6b81",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "0b83d2c5c1f10be3f6c9354aa488155e0911a78244b4f58d7ff793ba6fc16272",
-    "donorWorkspaceSha256": "0203e8f50bde955e7a8fada0b86f1cf9e7f2b3bc7cd445231317d2622060499b",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "0b83d2c5c1f10be3f6c9354aa488155e0911a78244b4f58d7ff793ba6fc16272",
-    "unicaWorkspaceSha256": "50c4c2d2dbf77ae071c494a6fd0f74817fea720273ebe4d8feb56cc9eded41df"
-   },
-   "observationFingerprint": "00ef5dbc93a60b3250576287a46376e53d5453f9b45ba02798d3da5edbf7a5f7",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "form-compile-from-object/ccoct-item-simple": {
-   "caseId": "form-compile-from-object/ccoct-item-simple",
-   "contentDigest": "9d3b60405a8751906271924c3302b3170c57cc037c8a903c6e4cb5c71de47eda",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "0056bb421db3719fff48894728adc31e5a298e7e13ceaf9d3f52a448da5a8c35",
-    "donorWorkspaceSha256": "e3c559fff467bac0a1139bca006d7063ec34d35a1b4c10a5fbe80440f2386aa6",
-    "mismatchKind": "unsupported_from_object_type",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "c3d5fdf0691ab6a3681b055d1b28d93bdcde9e7141c33b65b1ea60c02eec89c6",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "9af036485475bbbd4368506ca159d363a7c2dfa568a7123d77c5d468b4b9d86e"
-   },
-   "observationFingerprint": "5e63dfc33cf645af403ef5201b3a1b5876c2b94c4b2f9fb23a2ed999fed6314b",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile-from-object/chartofaccounts-item-simple": {
-   "caseId": "form-compile-from-object/chartofaccounts-item-simple",
-   "contentDigest": "52d1736b5d4ef1bcf50bfd5a7e55b25b440c5872e5b557f72a4d9a3a8d179b22",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "b44c295bdda4bcae6f16b61243a07c2a96151d9e0e69b2753c40436d8e417253",
-    "donorWorkspaceSha256": "f6e06042bda7c8b5536e78a0fa72cb12bc7d046ba07ac7db9b339db2977ec293",
-    "mismatchKind": "unsupported_from_object_type",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "e7863de9c2477d1a385c19fc057c4dd4a8a0d67cb7ed037b3d96dfda8904f14c",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "954fe593261df78a8eef57fe9b523791e9df529068adeb43fa9d3d1a22c4a956"
-   },
-   "observationFingerprint": "e539471d36a5d477b3a53a8331a1427732d58483083fea3c2b124d8796d4eebc",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile-from-object/chartofaccounts-list-simple": {
-   "caseId": "form-compile-from-object/chartofaccounts-list-simple",
-   "contentDigest": "7924478ce3e8341be0f07fec17d1eb58f34ea76d61f65e80be44585ee45c0e07",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "ad60e804c137d7521b8c149dd136b4a898592f9087fd69637d1128c731044d4d",
-    "donorWorkspaceSha256": "fee789784d53c173ba6f0e8dc74ce5b99b102823fba0643f4977bc3f5e6e1293",
-    "mismatchKind": "unsupported_from_object_type",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "e7863de9c2477d1a385c19fc057c4dd4a8a0d67cb7ed037b3d96dfda8904f14c",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "82f5e20f8ca2fb899a86a6eff51b0804be78be0969e685bfd7f997a5db8ae10f"
-   },
-   "observationFingerprint": "8f52f6d11e908cdd4beb434aafa9aa8c378010cb6eaf73ac212e89b641a7de23",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile-from-object/document-item-medium": {
-   "caseId": "form-compile-from-object/document-item-medium",
-   "contentDigest": "d75bef1a39971e7aafa0ac7a5cbd193cf74c3a1f7f66468f2a7877305194931b",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "d26989bc3d2a3d0e14f3e06489ebcc21ba20789612f244a5429fcd1909fdfdf5",
-    "donorWorkspaceSha256": "cacaa9e6fb13d7e2e97966ac41290b48b7a8b2dddd03bd44b7a633204e8e5cc6",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "d26989bc3d2a3d0e14f3e06489ebcc21ba20789612f244a5429fcd1909fdfdf5",
-    "unicaWorkspaceSha256": "3a044f00eadd5ed31df59c029250ca3d0bf2b21105b5d70864e95efc2fb1d293"
-   },
-   "observationFingerprint": "e51eb61134147ee8e05593aa659eb8b388e6bed733d694f166959153301a0014",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "form-compile-from-object/document-list-medium": {
-   "caseId": "form-compile-from-object/document-list-medium",
-   "contentDigest": "da96e559dc0846e97a5cd136b277bae313f98c90d71d3fb7a523ac49b5029f36",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "e47407b3c36bceccd267e3f5a4a90901823703f3c8ae6eca67a68cdad40f697b",
-    "donorWorkspaceSha256": "6cdede734a8325072dcd95cca2067f81d583394f949408a656e54383975ee7f4",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "e47407b3c36bceccd267e3f5a4a90901823703f3c8ae6eca67a68cdad40f697b",
-    "unicaWorkspaceSha256": "5c481dcec638c9ea359ae2e82ed19afd61505173e7d09d8af947d4c6bd3683d8"
-   },
-   "observationFingerprint": "c6f2bd650ab72535663ec19e57d0e1bb5430fff2cab0826895181906a7901b90",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "form-compile-from-object/exchangeplan-item-simple": {
-   "caseId": "form-compile-from-object/exchangeplan-item-simple",
-   "contentDigest": "75ba8ccda85040291aee6a3cefcf9d04b1a726b0db9551b479c153e28b62bc7e",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "f91c1a96072de616be1c8a24bc285a9d8ac0b9015a4cbb2b5bc67e77dcc4041a",
-    "donorWorkspaceSha256": "25d52be8fb1fece67d850c0042a142e034b84750ead877593fb6100b33e7ea6b",
-    "mismatchKind": "unsupported_from_object_type",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "6a0c52a746abcd4f2d0b09ad96a44bdd5612113108f1481b2cf930a387c60a61",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "f2e15bf4df959f49da7d5748faed1e0c0d573e44ab8fd0551e1fe9d7a9b3c839"
-   },
-   "observationFingerprint": "d0a6c076a07a1e97990af17648f28b1e900e51c3ad88afd4227d146045d4bfdc",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile-from-object/inforeg-list-periodic": {
-   "caseId": "form-compile-from-object/inforeg-list-periodic",
-   "contentDigest": "00510469da82355b0f1e95a3da93ff8a1b16769cc43501d8797ba6b4b613795d",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "543cd30f4697b21df81fa4738e80c2f8ed293ae1a1e6dad7de1e15c6f50e7ad9",
-    "donorWorkspaceSha256": "54151e4df10e2589ca271deb8620a05cfe2acfc613da3391765a78520148b83f",
-    "mismatchKind": "unsupported_from_object_type",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "fd2d284b97d327d1a47794f4b90c9cf967a0b3b931a2667b331b623866afb8d6",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "0acec87636765f09cf0297e75a3c0c2a3f9c8601e56b1631c987a1aadbe94a3a"
-   },
-   "observationFingerprint": "9e27e8980d4debe9184aac8ae141b9bdddb2e5869b630264aaa68023a49aed82",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile-from-object/inforeg-record-nonperiodic": {
-   "caseId": "form-compile-from-object/inforeg-record-nonperiodic",
-   "contentDigest": "12b03c95382217782d0856964c8a9a1f383e4daf552a723d3520f040e5d10f1e",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "ba52c163f4e0c046bf9bf0f26fa103643006d6319c71bd653382939b2d0642bd",
-    "donorWorkspaceSha256": "12ab1d857e9db05a78e9a3c1eca89cff6b7e009a2beb683654a77752b79bc6e8",
-    "mismatchKind": "unsupported_from_object_type",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "fd2d284b97d327d1a47794f4b90c9cf967a0b3b931a2667b331b623866afb8d6",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "f33d5bc3dd72dc461b5fa171ea8ead1b8328b455cd627dfb9929817b18303ff3"
-   },
-   "observationFingerprint": "c704328e8e55e2c119d528b678ba7d28db66f96091a798083baaf56aa83d2107",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile-from-object/inforeg-record-periodic": {
-   "caseId": "form-compile-from-object/inforeg-record-periodic",
-   "contentDigest": "e0dc082d770787b50f96c0fcf4367c13f58c9e0bdd8f186e061d8a0252a5b99f",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "e176ba3c276403a4f8c4e8fd3753a4587485d002fed48a9399df83c84b3fc4cd",
-    "donorWorkspaceSha256": "2417c623ba6f0691c951d504c9c2402b69ca3fdeab51199774b15c9d63047ff3",
-    "mismatchKind": "unsupported_from_object_type",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "fd2d284b97d327d1a47794f4b90c9cf967a0b3b931a2667b331b623866afb8d6",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "c890e64bf6d5474ea1742f7c7e57f2608ef8700692ce3494eeab9ce1a9536c7f"
-   },
-   "observationFingerprint": "a14a9d74161941cec4c8c8d9ec437e951dc31b2e2a6c48835ccadb2a173d9824",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile/additional-columns": {
-   "caseId": "form-compile/additional-columns",
-   "contentDigest": "b9dae507aef8c4a0059d05eb8de530bea66f4ba650c84bf1fbf06f3ad31b973c",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "9ce0d3f89a1f6bb5704e776305f5456801e9463bf48dd2ac3dff30179cbd5e9d",
-    "donorWorkspaceSha256": "7fb0bbc01cf8e153041cfffe8ead2046967c3114379b829ad5e53923ff2d0b16",
-    "mismatchKind": "unsupported_form_element",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "1982f74f27c4891fc5a84fa759013002d37d0545782b748f91f1d77863adac8a",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "cb2ed64d993f9a118a6ffee0564d498e9827e0f0fdbabe929e84e2b610728bc8"
-   },
-   "observationFingerprint": "9ab2490ec6d5f8dbcd38d5e648030a570891e6f927af3e0ac5f1265c35f093e6",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile/attributes-types": {
-   "caseId": "form-compile/attributes-types",
-   "contentDigest": "3579d852ff145af4cc83d6829391c07d5068cdc09b1c16ee80f612000ed9026d",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "544c5499727c7a990bb4f9f8a37b94cd122a7ee37c0d8dc52ed5d1b7e5880274",
-    "donorWorkspaceSha256": "54aff38da96fddbb0195f6c0eb92ac35eec126a36e593386913e68f09fda814a",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "544c5499727c7a990bb4f9f8a37b94cd122a7ee37c0d8dc52ed5d1b7e5880274",
-    "unicaWorkspaceSha256": "970bb8246024d64988bfcdad2e8f5d06fb16f469ae59edbdcea6c383788421e1"
-   },
-   "observationFingerprint": "684d99f2bd2ce9b4915da1a77e6d90029393ae509d43413cb4be99370e16e553",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "form-compile/auto-cmd-bar": {
-   "caseId": "form-compile/auto-cmd-bar",
-   "contentDigest": "b35bb890b9b9098188837d18029a86d799b53541f384ef9c305012cfab63d650",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "d061515127707eefae1764b7043b4f485744d04d25591caac4b483c0449e65e2",
-    "donorWorkspaceSha256": "29f3941eed3eeb182399134bcf35ddc440b3db487d8bcfb09890903c935ff54c",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "ee9aa930f4fec414626c7b65fdf72959301759a49c8e080c54aeab583f24212e",
-    "unicaWorkspaceSha256": "7ef1e411c4c2a99fa3da929787538002ff6bf9a64f2c05815a686b7217a00361"
-   },
-   "observationFingerprint": "63a694d365706184a859e42dcde4f8adb759fe783ecd12d3c5f8bda90f8d5eda",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "form-compile/button-group": {
-   "caseId": "form-compile/button-group",
-   "contentDigest": "bd6bdef8d04b4d8fea62027ea2c5166cc5104fcf138c4078f85db8e1178f4698",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "f066b4c729a4155f1c370c992ee0653ed4e522af39d9e7be3b16f5e55a906384",
-    "donorWorkspaceSha256": "7e8fe406360f4d69c8c6e56e35f53ad273df4a301608054d0526c29def2fe634",
-    "mismatchKind": "unsupported_form_element",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "173be5cd807ee1dbde1363e2cabd115e4e2c1d2bcb8beb8807434ae7ca7d2ab3",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1f9b4b3bf1b43f68fcc1c86960669c1d302d478339ae069533c161854183498c"
-   },
-   "observationFingerprint": "a499723992cc22d2f089e8b454c72f7d57f28ef73471bb33ebb4af05f30079e2",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile/calendar": {
-   "caseId": "form-compile/calendar",
-   "contentDigest": "947fdfb6a73b393308a4c310c443c87a774cea85158377dbde761d899b5948e0",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "5bd01f4578c07b621ce6e2220e8b5ba323f5ea03c010b4893fdb11aa894f081a",
-    "donorWorkspaceSha256": "5ce1fd3e02b2c0a1e01d342f3d6e5ab657b7edc30e6212407faa10fd58f191a3",
-    "mismatchKind": "unsupported_form_element",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "5bc87d80ea90273700e7c34cc7bbf5eddf78102c1880a826d4203b2d613b32d8",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "22d1b5d9d5cab7cdbbdf1fe67252ccca0991ba37b18d854ea4c6ec69fe0e94db"
-   },
-   "observationFingerprint": "d978abad3be61ea08b98eade40e087643a20f3ed9d3738bfa0f8375a6afbe4b1",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile/catalog-form": {
-   "caseId": "form-compile/catalog-form",
-   "contentDigest": "dd93193b18e1eb45de32d2410482e247cece3f07821948478c451403aea7443b",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "5c28e2fe60e66e0fc11af95a2c382dd923c859568a8e7935333ef219479b81a5",
-    "donorWorkspaceSha256": "58bec58b9332211e06e6d0b9da6f211c345cade998efd75e80d42f7a1d41a802",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "5c28e2fe60e66e0fc11af95a2c382dd923c859568a8e7935333ef219479b81a5",
-    "unicaWorkspaceSha256": "317579928e620bf926542d311b482eb2cbbb1783691c103943be1f4e5ed617f3"
-   },
-   "observationFingerprint": "3eb1571383fc581b7d8e8c44c517e77c34b9b95d0b6462eaa587621b239194f7",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "form-compile/chart-fields": {
-   "caseId": "form-compile/chart-fields",
-   "contentDigest": "43244692610809fa07a11b69de3e9ecda4d9bd583378bc29b5272340ec4fa498",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "20939f459c15daf39055516e132b50e8c41e5541c332554234e7de8b0d7e0246",
-    "donorWorkspaceSha256": "67b39b8c31bff1e42cb5620b7d6cd9e3bd8c25857d0c6cc14d5b84dbf5ca56a5",
-    "mismatchKind": "unsupported_form_element",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "28c30e2ddaae9025c82b133b16fc6b4205dbd7ec895adf8f89803f1060849ddc",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "f50f75d9c9953f3b5662d72daefa6cc7c5edb68bf72a4f6028576992ee2b6375"
-   },
-   "observationFingerprint": "50c2adff0b3a0d2215d2b58864865220c8aaa3c9805a3dfe220b039e0f4e0857",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile/chart-gantt-settings": {
-   "caseId": "form-compile/chart-gantt-settings",
-   "contentDigest": "9ea7abd8322f2389afd002a37e3ea29c58299851d9e072c42285cff684c7ac74",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "7b65ca941a59d605163cf53d17be3c8b2e1f171c0d349e1bd67a304d349dc0cb",
-    "donorWorkspaceSha256": "d71fbb56eee1ef50cee5bbb829fc0417a60a85db8796fb5a477a9d0b6a4cbcab",
-    "mismatchKind": "unsupported_form_element",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "1c65501669153fab0888aafaa6462d749527f06ebd8c0453eb9ff206b11cf7f4",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "f07a5a5875b414658b1de212be4ca5e32e4fea89a07a2065241d3342ad6e5096"
-   },
-   "observationFingerprint": "7afe2ec0e2c4bbc6d328b4f95411e7e336aed5bf83154df908fdd34b46f65426",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile/chart-settings": {
-   "caseId": "form-compile/chart-settings",
-   "contentDigest": "8c5201b308fd23b8f0ca15e560fbc81d9486ac5d94110f1340392869f691c0ff",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "a742dfda418db4539a80c0efc072ea649c0b336acfb498144d33ebe106f5d88e",
-    "donorWorkspaceSha256": "1320e772996228b8f69c773d44d5f9a005d78dab7d4d231aba4d32ea86556a50",
-    "mismatchKind": "unsupported_form_element",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "28c30e2ddaae9025c82b133b16fc6b4205dbd7ec895adf8f89803f1060849ddc",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "d3d32dc694dff955e909616aa001ee36a956d50724aa9d8a5575e53c56fba955"
-   },
-   "observationFingerprint": "6773e8428647a6b818312579128a027528b470a6305de8fd4341bc9703dfc055",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile/collapsible-control-representation": {
-   "caseId": "form-compile/collapsible-control-representation",
-   "contentDigest": "7d6b48d6926f3b7968e12cc55a86475c1bbb9430d94501676308df3e54042994",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "9abf9e742ac596c3067acab97a74fcb3d3cf3d07b5e7aa3a8632813e36da47bf",
-    "donorStdoutSha256": "65c1db047e4f12001816654a7e985a1e05ce6c25358624965afc8a9f80b0b100",
-    "donorWorkspaceSha256": "050b6b049a5aa840a40fe2bc97a658d59a3af37b7df1ae02f8a3a6893b7b6bff",
-    "mismatchKind": "stderr_mismatch",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "65c1db047e4f12001816654a7e985a1e05ce6c25358624965afc8a9f80b0b100",
-    "unicaWorkspaceSha256": "3978e9c3a7189f02d7b8f71a800135259f8ba251122a6ba219a85107a9a441cf"
-   },
-   "observationFingerprint": "0a07ec5cb4919e42a2814879c9ab9b03641bf0f49538664397574de74c66e524",
-   "reason": "The reviewed observable outcome is compatible while diagnostics or non-semantic presentation differ; the exact normalized observation is pinned.",
-   "relation": "compatible"
-  },
-  "form-compile/column-group": {
-   "caseId": "form-compile/column-group",
-   "contentDigest": "4cd0f0f67efb8dadbac3ca0ec382d56b1c55b0e31d292f04c4656acce924c391",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "fdd5e1880db38b37f9ff45380b1a5f6057bfef4165424cb09d6a71ed043ae439",
-    "donorWorkspaceSha256": "f378cc2dca76f844610aa7e630630357fba2ff51d269f47733ce50e45905691b",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "801ceea30f3cfac425e8a8d526ca8298cdded90b3dc7163e6cdb5b4c8a512b1c",
-    "unicaWorkspaceSha256": "67e76f8008fc7546414d4c3a6f4ed294de431d20ae077b49ff64b2d9b16830ff"
-   },
-   "observationFingerprint": "9496e25ccb916eb294c4684bae23fb264c30745bd250a472bb4f46734f9e50c0",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "form-compile/commands": {
-   "caseId": "form-compile/commands",
-   "contentDigest": "e86476a3bab9cb2aec205bcfe40a1d29754041bb8bc23462d0810121df8d614c",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "cf137c130f4a587267a882de54a4fddc12f9bd73c08991dc28ccebc3a60e1ccf",
-    "donorStdoutSha256": "a3a427d13f3c354d696e4ae5bb15f53d5b0d09dd0a4a2c18f3f89d79e155d03d",
-    "donorWorkspaceSha256": "f1620e98071c32671b84ef0774d8bff782b6caafd538f5ed399b4bfeba64dc50",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "1f48f6171a78334711f2a676ecb08ec3398d47d7a7141569d9b8b22c04f22fb2",
-    "unicaWorkspaceSha256": "74387daeea7767ab80fb7aeb5be147407f18a73a411cabb966cfd5f7d3ab5db3"
-   },
-   "observationFingerprint": "5fabaae2cc1b40a484cdaa3434748496d59c5ce4112b1c5daebb381727be4a6e",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "form-compile/dup-command-names": {
-   "caseId": "form-compile/dup-command-names",
-   "contentDigest": "3da3dff60876f9cf7ac3605bb2cb09f45de724a126d653670d0c6aaa0d596ce0",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": false,
-    "donorStderrSha256": "a6a11515f324e0411580a8f98f17ed5af5571f7d33e8ae109fc94d550f9c6aa5",
-    "donorStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorWorkspaceSha256": "b5f9864b4cd0fde6942eb34bd74469653cb7ffd924258059f3afa2ee1fc0387e",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "c0dcd7c5a5882a5a583decf975c6553120abdd9ad648544a06152f6e0ec911aa",
-    "unicaWorkspaceSha256": "03168bdb2743dfaabf29c6ede3264cab1d259e60baeccacc44b4ede14bef5112"
-   },
-   "observationFingerprint": "afd10f9cde96b46673269ee456b5e7e54689279d5dbfd6274bec4d94c195ff9a",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile/dup-element-names": {
-   "caseId": "form-compile/dup-element-names",
-   "contentDigest": "6b3af0f3d71ccbf0cbc73e270b2ade7efa8a7a75ec8f0f5fa43a4f8568434c66",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": false,
-    "donorStderrSha256": "2176b70387acf39dbede18e75709899f956c8eaeabc88262f1c5d25a8ac2737c",
-    "donorStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorWorkspaceSha256": "5ecdc133758670f7dd5b77a0247475de5e4bee91c3d59c90c241aaefbd57fb6d",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "ea9862365e2ecdb2cadc62b1fbdd90b80b0d976c6965d462c3f9937cf8400afe",
-    "unicaWorkspaceSha256": "70ba670a3f83086bbc06fc680eea937507c6e8c5944aacbd10e2e076158292bf"
-   },
-   "observationFingerprint": "c2c8bd6f77eed2447d92c689181da0577c0f0eeca904a30ea5547245eddb427d",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile/dynamic-list-form": {
-   "caseId": "form-compile/dynamic-list-form",
-   "contentDigest": "0729b5c126992b33bb335760505b1d9f70794a6acb7613902d127fba84fcc5a6",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "8a594da0dcce4fd737c94ff83fff6bb5b7bcd6b76842195ce581678ad6da04aa",
-    "donorStdoutSha256": "0a52caf8ef7c711567d5abf66723a6ae53e56a1bbe7bb900cc1c74e3c07b2e2d",
-    "donorWorkspaceSha256": "0e8ff13926b95ce757d63abddd1c4eddcba2ddd9b73cc76602a4c137a95911ad",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "f13f93a46816715da9b8db4cc85c51569a824aa211305e4225088d54874c49d0",
-    "unicaWorkspaceSha256": "f715801f537a098fe278fbf3bf439a3e9b467858ab6f9a1eeb5ac8dc8fc77c0d"
-   },
-   "observationFingerprint": "94563b62e734252eaf500e1cfcf7b1dfe2620a47a0cfd7866f66d3c4ed6aae7f",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "form-compile/dynamic-list-parameters": {
-   "caseId": "form-compile/dynamic-list-parameters",
-   "contentDigest": "5368ad39b4325ea4deca462600e3a0ef65bce9f22e3061bab5cbdfb64ffd312c",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "f13f93a46816715da9b8db4cc85c51569a824aa211305e4225088d54874c49d0",
-    "donorWorkspaceSha256": "0ec95d3be6bd48e034acdea5c6b1b8da1275079234cd9f8e8ff4dd1a0739ff5e",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "f13f93a46816715da9b8db4cc85c51569a824aa211305e4225088d54874c49d0",
-    "unicaWorkspaceSha256": "dc84ad4d39ca74a32973e52877043bac89504786231a191fc1f21e0ee1b40e9d"
-   },
-   "observationFingerprint": "ebba820fe3d793a9a0fe4594ecef057c015ce2e2ced084c70050594a853c22ab",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "form-compile/element-appearance": {
-   "caseId": "form-compile/element-appearance",
-   "contentDigest": "e9a501ccf3d65bc462fd5b8973b36286b8c5aa6f889a9261d15fd532e7ca8058",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "8524e598c6e0b2449e67266f6903301d8fa4cd33ba3dada468ee675f980a045f",
-    "donorStdoutSha256": "11d79454a1048222a2e7e2763a339adca0325ae15bec0f9082afa16e5fe1a86b",
-    "donorWorkspaceSha256": "69d59d3f06cc6d047c3abe025dc31de125b7f317d946faa921717ee96048be97",
-    "mismatchKind": "unsupported_form_element",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "c00654f859c6e896059420e59102d049981117e41b90252da8aa39a0114ef3f9",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "6905569628075f99ba247ba569508db45c8f500bc5c656c5aecac22566beabe6"
-   },
-   "observationFingerprint": "c3b8728c1ddac518e2137a68ace41e411d964797ea088952cbdde7e5515b8536",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile/events": {
-   "caseId": "form-compile/events",
-   "contentDigest": "892fbeaa280dcc0d7be43b249007ffb2f90e9943fffd7b0a3205abce8c1293ab",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "8c07b9dae53ec1851f7836a8f8d8ec8d5f9cc3d3f9a24cf885d3f16d3562fd47",
-    "donorWorkspaceSha256": "c5d12993dba182d52dd0e7a364fd992ce2fd55ecf5f056bc93e26b7b11e53e2b",
-    "mismatchKind": "unsupported_form_element",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "98e0d10ef3b9b35c5ca91238642241ff67f163a8282f26b5e1ccaf653feebb32",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "17919d4b1725f875df61ce5d303d5db4a2650430733fdd03dc264c81549602d5"
-   },
-   "observationFingerprint": "989a41b2ae10d720c11c72096a89a3b5d9c3618421b18706cd5d5418cf6f7588",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile/file-dialog": {
-   "caseId": "form-compile/file-dialog",
-   "contentDigest": "59c0f046d4c711b6b3968cb6871c40aa9d42b62ef0379fcae3231b540c281faf",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "d227437f0e32f5221a37c1addde59a0d1f659c2f40a7214c89e591310eb268b1",
-    "donorWorkspaceSha256": "474c4a9710bf3e1b2cbc9fed777ae23538606f69367016ed00d5d829b159eb41",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "6e977c47c670a2a23d03c52d4ff0338c800b0941b3686c231b08e9cbd9266656",
-    "unicaWorkspaceSha256": "ec89b36e96e209916840b3662853b6c3c133bd9844630c472f170ba7b6151c81"
-   },
-   "observationFingerprint": "eb841e0e0db70ac126140ead71f61c007c538831bb311f7f11545cbc890bc255",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "form-compile/groups": {
-   "caseId": "form-compile/groups",
-   "contentDigest": "9cf13c566ef57651dfe99d5e84f159c84376e222c6f40e22edcaae1dadc58a38",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "07b436720070fa5b955b2a1e68e2211237fb3f358eb2f12354768aeb758f73bb",
-    "donorStdoutSha256": "33ec0a14806f1491e75378c6d50ab669dbdf97370762be8b2a5d5a856e0397c6",
-    "donorWorkspaceSha256": "5795ed357bf099394527314e3a28de62d24101205d5e00360d53271f8ea953bc",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "2b224f3463cafa8fe4ad3624137ca94ebc7b35e087ced1cf9841d5843ce84e97",
-    "unicaWorkspaceSha256": "8ede9ee0fc1d7d623b288662537eef8046372605518557c3558fb70cacdd7e42"
-   },
-   "observationFingerprint": "4e333168b120ee38539797ed92a521ebdcf2002eb4181b3600daf45c8cfb0250",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "form-compile/guard-deny": {
-   "caseId": "form-compile/guard-deny",
-   "contentDigest": "4af67e6f96af1189a3259d702362d658739d568132f3437fdc02e2e9880feb41",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": false,
-    "donorStderrSha256": "a34c7937455b4f13909ab0a9aa03e61f6b9cc2ad4e7d8c9c3bbd8ab8cefddfa7",
-    "donorStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorWorkspaceSha256": "dbc23bd1ff8e1bb20284a2deb4e531ff680e2429b556de2158e7b6639308fd2f",
-    "mismatchKind": "stderr_mismatch",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "cc24290fdea08afccc53ac3a547e3d2bf07dff6d9117dfc161864e135ce197b5",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "dbc23bd1ff8e1bb20284a2deb4e531ff680e2429b556de2158e7b6639308fd2f"
-   },
-   "observationFingerprint": "679da402f185a521eddf81845c50fe8b22bb19b2581ac8929c3c3f783d1220d1",
-   "reason": "The reviewed observable outcome is compatible while diagnostics or non-semantic presentation differ; the exact normalized observation is pinned.",
-   "relation": "compatible"
-  },
-  "form-compile/input-fields": {
-   "caseId": "form-compile/input-fields",
-   "contentDigest": "3d64378ff1014d82bcb53df51d18a0359043291031843f50f8df1d88535e6692",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "c3475f52c5d045b95ea9f80dad63c6832e25adc4e3b75f5e2930b806ec564cd5",
-    "donorStdoutSha256": "cd2256c006526bb0f9e170a0af98000da31f8ae7fb0ba69f7a1d739559380045",
-    "donorWorkspaceSha256": "7ea4ae002f66a5eb712cdb752b6448152c8e157029da2ca6b669ca4e2d46ee22",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "c7be625b48eadc66973c9c6f594c3ed290b563b534c137904fe052a0292ce686",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "3a200d4ce30e3972a42eababe6d2eab8472130af7de2dacac5ff34e447322403"
-   },
-   "observationFingerprint": "4cf260c48d1d80d1e68be72fe8e5c17816d8ccf49b48fd59b24b3dff8ffa6f29",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile/minimal": {
-   "caseId": "form-compile/minimal",
-   "contentDigest": "38d395dbd87898a4131f9db06efff7fe03fe15347490cd30c4c8200898448f33",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "5b1768d002a8b221f08da0dddc72346822bfce7fd25aaa754ee13de2e017b2f5",
-    "donorWorkspaceSha256": "db65065768df1f9eb034eef3a1f8827bb2a82ab6c9b3b34656f3289e1b327e4e",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "5b1768d002a8b221f08da0dddc72346822bfce7fd25aaa754ee13de2e017b2f5",
-    "unicaWorkspaceSha256": "b51b5e735c7499f925980bd90a5b47b0b04adee89c4abc1bf1d8b162e43be140"
-   },
-   "observationFingerprint": "3360bef21c73752875bcf16adbd03ea921e5754ab907d12d736153790e16d3ae",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "form-compile/namespace-collision-ok": {
-   "caseId": "form-compile/namespace-collision-ok",
-   "contentDigest": "a2fa5c12569984cd8383b00a5d01681e43a1f8c32d4a96359c326e740e5ab641",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "2481365fb36cffdf05ce27152a3a2b34f064e903b750491f76b95251f7f56d2c",
-    "donorWorkspaceSha256": "4f9b137c36b1dd8160f302fcafa820d056fbdd13dd162670bf084da144228b90",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "2481365fb36cffdf05ce27152a3a2b34f064e903b750491f76b95251f7f56d2c",
-    "unicaWorkspaceSha256": "a467545e5f322ef8f6dcf7ed51d1ee16dd26bf70cec9e72c32e160189b0bbcc0"
-   },
-   "observationFingerprint": "2de98774e9d42998f5bee288b93ccce89d2597fc89c1a534e3e6062c4d98be6c",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "form-compile/pages": {
-   "caseId": "form-compile/pages",
-   "contentDigest": "6008711e1c4934b0d32c3e7f2d3a6f25f75491ab182805876d5384e604732605",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "8f9cf11cef0eec28ded3453580662bf63a790fb7e387320d7dc5bd476889b070",
-    "donorWorkspaceSha256": "2e9d2357086bb8110d307eb88bcde8cb4018757c16e3cd519e619e92cbb25b4c",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "8f9cf11cef0eec28ded3453580662bf63a790fb7e387320d7dc5bd476889b070",
-    "unicaWorkspaceSha256": "77ca2ea81cafa335a3789d58e5299b4e69020973ddb21a64dc0b5a7540850289"
-   },
-   "observationFingerprint": "0076753222be56701e24961d62f94880f65159ee52722659a75d7b8eaf377a9e",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "form-compile/picture-field": {
-   "caseId": "form-compile/picture-field",
-   "contentDigest": "5fd95305510953a7ae8ce7c373fc5d97f66396e3564882d85f92b781ac5c8e9e",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "50e6b76c46d96b3b9e0d651617b4c91d162d631a585c88b90f6854a268187375",
-    "donorWorkspaceSha256": "0a93fa06654e07ea22319d75c2baaf70b0d5c5aa43bf1e2b615058650bcc7ee4",
-    "mismatchKind": "unsupported_form_element",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "880e0d4ca6157aa6536fddb5d78ac82613a27f03460a58a8a22487dc38ef2b40",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "19e4d7eb4ee95a13d32dcfd3925400ce5a41f2313b07b21b942b6950fce17f1b"
-   },
-   "observationFingerprint": "c85ea828bb66a91a1ec5d359657654553a6456bffc7d5f3b7202be2ce05c967c",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile/radio-auto-enum": {
-   "caseId": "form-compile/radio-auto-enum",
-   "contentDigest": "01b46d9de6813f369d7c3f12a1c730e4557e0daea1cc0882fbae7f0b791d0d5f",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "38e5874f539af7ef627ca9d7885858741ae42ef60fdeadd70284c0c3fc6f2eee",
-    "donorStdoutSha256": "0719f3e2dffa67e5283e986ad4db1a8197c3cf02c593b4087cbd8a20a8655ddc",
-    "donorWorkspaceSha256": "1aec2aeacc4ac2da6eca08737d475acf23ca6127d39887dc9b26e87119134dd9",
-    "mismatchKind": "unsupported_form_element",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "f25d91a23c2cd1996f1c92a00d162ab4300b8649b517e8a84e93bfb51acf0b07",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "467415faafea8582c3e4e1c2d65b59211e1ae4e7cac678a608431aa206e71a6b"
-   },
-   "observationFingerprint": "fc118030db9bc2e7887cf08aa95b7d5325129d359f64624137189a80a2075ae1",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile/radio-synonyms": {
-   "caseId": "form-compile/radio-synonyms",
-   "contentDigest": "2eda14339ae3474d659a0b44065dfc4787242cc6dc78f5c1cb7d6404c0bcaa02",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "bad278cf6bebc36ec645acdd96da0f57ef3c46df810fbcf9bc9c5ddbe4a27ff5",
-    "donorWorkspaceSha256": "5c8e7e714bc2f051a83f0d71ee34cad3afd544f3e112f6d794082f35b27dc63f",
-    "mismatchKind": "unsupported_form_element",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "f663e990726dc8c48200355c7abd1ca782f6ba32e0422afa1bcecbd8c0e04033",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "070f04d9b3bc3e72379b7759df98bde87092e9fc8f3d3470072a2ee2ab362813"
-   },
-   "observationFingerprint": "8212e251496872fda3d90794a4d26a90becd795b418a977d86cc265d60b6716f",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile/radio-tumbler-strings": {
-   "caseId": "form-compile/radio-tumbler-strings",
-   "contentDigest": "514042ac652d9974d70e4af78a987d1c7e3bfe2375f3cd32360662b1e28b3225",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "e4e8a5c601380b913124fb69be09717b0f33b01be811c96895c46b15f67ee084",
-    "donorStdoutSha256": "c24bf604e91c9c75212e9ba9ac15395df94aded1a196c8588a0f091bd88883d0",
-    "donorWorkspaceSha256": "d2f2b51016943aabd4510925773a082eda96f3fd889152f0f9d696606e10e60d",
-    "mismatchKind": "unsupported_form_element",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "1296a328ee7eaabeaceee098ac2d1af2d7b45f0fd2c11b32cd38a710a02ad2ab",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "51fad90d26e9be8f7aa02b4a9f419fa6f355a42721311b26eeffc6663856ea08"
-   },
-   "observationFingerprint": "c63c53a7edcd20e2fc6a53ba35bee5de74c70faa158d07f5d44d3e04c38b5a9a",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile/special-fields": {
-   "caseId": "form-compile/special-fields",
-   "contentDigest": "e66a534fe5b3c8c77b2aa22995ad655f3160d7fe5f60151ba0691dc9d1ae8946",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "1db679be7fe33712f8566c7756b49e2b7ab16df17ff19d05ad6cbd17fa16bcef",
-    "donorWorkspaceSha256": "d6e999c9b7473383e6d646e38629a6655eefe6f3d5527f3e73c313a9311ab6f8",
-    "mismatchKind": "unsupported_form_element",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "7d59ad0e7aa7283abafecf29b4210fc30e002ad9f01376bd938da9a9f1c4178b",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "ecf2521c64fc56fcb42b0f7a96a52b010f09986b8241b17cca346f7e5a2bcdad"
-   },
-   "observationFingerprint": "a84d8fab1801f7a0a16c3a6c96c1673a5f5330775cf3ae06ed63bdae3bbd99ab",
-   "owner": "unica-maintainers/form",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "form-compile/synonyms": {
-   "caseId": "form-compile/synonyms",
-   "contentDigest": "2634e123e3416ae3e97972d81bb024d92c9b49f0c3a80b63f6f2adf8d19ca17a",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "6cccc0b4d8b01012ff93e8eea26f781c125d9bc523382f1d4d76f9c09a0d5d7a",
-    "donorWorkspaceSha256": "1627d8a0e71be8284dd1911f6bf1db5292b01fbed1d6532a811a73c8b72c500f",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "bc187ac5ab5b9683e322057b1bbde9ab37f9ecc653037762b6ad07848bec5d4d",
-    "unicaWorkspaceSha256": "4ecd180cf1327ed9e862497d482888ece31f2b21d2b407e3127997476f16279e"
-   },
-   "observationFingerprint": "9e5e186003dddca0a9d2448a03765b14289a14ec9b1f0f6f74d79a890144ba1f",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "form-compile/table": {
-   "caseId": "form-compile/table",
-   "contentDigest": "cf8c0c42326cddc02d51ba729b4a254f2a080c7f035890d548547f185c10059b",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "a3a26d06c6606fbf216870dc8329cd875e296057a8a9697797e75b202b25783b",
-    "donorStdoutSha256": "371bd1ad3fa3a8ab68ff5a54fa09a9f96dcbd86b9aa840db2b7c7639713a0394",
-    "donorWorkspaceSha256": "6b1834b1e5a312c88165139e2634ed877bc8a444dca250afd8a13f5c689e9efe",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "80ac45d1647e1c397cf3b942eef44ee089122a9f2785000dc46e130fdf84b0b5",
-    "unicaWorkspaceSha256": "1b0eb10004e5335be2c0cbb23394b3f60e52600c9d4d3cf8f1d508ca11196a7e"
-   },
-   "observationFingerprint": "a9986d574706688c97cbab6ea80711b0c9ad414470d928a06615eaeed3f792db",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "form-compile/text-edit-flag": {
-   "caseId": "form-compile/text-edit-flag",
-   "contentDigest": "8ad278a4cd9ea0245acedfb94f3624ad19be92e434a096f0d5c0900656f8dff2",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/form.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "212c99c4ccef3a93844a6e8e21e1e472ed2e7b341ac6db687039cef93ea70b03",
-    "donorWorkspaceSha256": "649fc0e539c91574f5d603d07bc3b57790df84b065103067ee5a25a3334af493",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "212c99c4ccef3a93844a6e8e21e1e472ed2e7b341ac6db687039cef93ea70b03",
-    "unicaWorkspaceSha256": "7a11dd0b16c38a915382e2cf8ea76cd91d6cab909fc93034017b4135b24ea807"
-   },
-   "observationFingerprint": "2bb1721e2791e97c9661c7459cff61a950245cf21f39833b2e4bc121d465dddd",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/accounting-register": {
-   "caseId": "meta-compile/accounting-register",
-   "contentDigest": "f4cd2fceaea801de978e8edfb7b1cb679ba7b1b8b23ff8ce97e904852a5a0dff",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "AccountingRegisters/Хозрасчетный.xml": true,
-     "AccountingRegisters/Хозрасчетный/Ext/RecordSetModule.bsl": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "beb582f4dba164f17c521c86dc26556adfc0b817fca0c215d9151381bfdfebca",
-    "donorWorkspaceSha256": "68612f80ec6338d7613afb5ca15baf7a41d263754458866ebc0079ad8013bb17",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "AccountingRegisters/Хозрасчетный.xml": true,
-     "AccountingRegisters/Хозрасчетный/Ext/RecordSetModule.bsl": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "beb582f4dba164f17c521c86dc26556adfc0b817fca0c215d9151381bfdfebca",
-    "unicaWorkspaceSha256": "30c58f118363e6fb94ee1bf60c661585e7b1f1110ec217e1ffe287d9d08b6bf8"
-   },
-   "observationFingerprint": "bcf2114d275c8c3fa1d507868b3e95649c4f938df5ccf1c7d7a77216b09be6f9",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/accumulation-register": {
-   "caseId": "meta-compile/accumulation-register",
-   "contentDigest": "bc7b073133696d07b6cb01910a4e4558743440278bbc8b1437a5ed58110e0f0f",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "AccumulationRegisters/ОстаткиТоваров.xml": true,
-     "AccumulationRegisters/ОстаткиТоваров/Ext/RecordSetModule.bsl": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "a4d1881c39593c3909429dc61bee9fd4bd00af7bd28ea2b40888420fa8a35773",
-    "donorWorkspaceSha256": "466eaee384620c693b9d16ac83bfb9616201072fdb6f42252522098dbdacd87a",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "AccumulationRegisters/ОстаткиТоваров.xml": true,
-     "AccumulationRegisters/ОстаткиТоваров/Ext/RecordSetModule.bsl": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "a4d1881c39593c3909429dc61bee9fd4bd00af7bd28ea2b40888420fa8a35773",
-    "unicaWorkspaceSha256": "3ba0d5ea16c95fd1576e5ab97914915cecb4d1a5ce832f9c1468f93dc9b75590"
-   },
-   "observationFingerprint": "28dbeee8fa60c76bb1e4335cba4f09120a8d7a0db109fdb9803dd8fb36050f35",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/batch": {
-   "caseId": "meta-compile/batch",
-   "contentDigest": "8696daab0fc4b4ac2a816e95e6b50c8b75a0208e117fd3cc6215637e0004f3df",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/Валюты.xml": true,
-     "Constants/ОсновнаяВалюта.xml": true,
-     "Enums/Статусы.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "e9ebe1a11ff4b475429e2139bd32774f1d87a28f8f97a184736110786ec738b3",
-    "donorWorkspaceSha256": "11e1147613caa8775ba8c2bd3aeaea28c30df206e7778de9813c44117ff0e0fd",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Catalogs/Валюты.xml": true,
-     "Constants/ОсновнаяВалюта.xml": true,
-     "Enums/Статусы.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "e9ebe1a11ff4b475429e2139bd32774f1d87a28f8f97a184736110786ec738b3",
-    "unicaWorkspaceSha256": "a6229e168ed9eef218ef7b2e6843d3442612da726af43e72505b30e8615ad204"
-   },
-   "observationFingerprint": "1e7c2bffe31b2606e966fc571b6af79d3f178d39eda393ed36e32c7db0264526",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/business-process": {
-   "caseId": "meta-compile/business-process",
-   "contentDigest": "35027db2bbfed09bd34272919d24b12851fd18df1e28343f74da23cff1cecf19",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "BusinessProcesses/СогласованиеДокумента.xml": true,
-     "BusinessProcesses/СогласованиеДокумента/Ext/Flowchart.xml": true,
-     "BusinessProcesses/СогласованиеДокумента/Ext/ObjectModule.bsl": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "56b3e78a062043b7cbd0c40c1c1110a136b957f69f6e960b0eb06ea88d471bd3",
-    "donorWorkspaceSha256": "2a668b7b2866084782d2ad72aaa792f4bbf1d4c2dc9ad2d55223091ac470d683",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "BusinessProcesses/СогласованиеДокумента.xml": true,
-     "BusinessProcesses/СогласованиеДокумента/Ext/Flowchart.xml": true,
-     "BusinessProcesses/СогласованиеДокумента/Ext/ObjectModule.bsl": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "56b3e78a062043b7cbd0c40c1c1110a136b957f69f6e960b0eb06ea88d471bd3",
-    "unicaWorkspaceSha256": "2186c17d68e395a3926db49153e557c993227ea8bab2635e1b4e75b4436f6f53"
-   },
-   "observationFingerprint": "b299bf3216cd4e1d9284702893b2d3d9c8d5e6b1591705cad15edf7f77776102",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/calculation-register": {
-   "caseId": "meta-compile/calculation-register",
-   "contentDigest": "461b3502413d4ae18bb275f44e06c9a3d37cea1faa0df5fdea59b09c19c98b44",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "CalculationRegisters/Начисления.xml": true,
-     "CalculationRegisters/Начисления/Ext/RecordSetModule.bsl": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "5c6ceaa4f6969c0399af11649d444920d3d3fe72b748cf2084d91931ac71e493",
-    "donorWorkspaceSha256": "a840ef24fccfb9efaa48d35f0029a38bfde5bf78a7aa203c560bb4670bffdad9",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "CalculationRegisters/Начисления.xml": true,
-     "CalculationRegisters/Начисления/Ext/RecordSetModule.bsl": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "5c6ceaa4f6969c0399af11649d444920d3d3fe72b748cf2084d91931ac71e493",
-    "unicaWorkspaceSha256": "d3c0960d99b3f701262e66dfee97f3ee58245fcc7069c669565df5551ae2bb86"
-   },
-   "observationFingerprint": "fb8a968b45c98eb5f88502dc5737ccb03dfc1d81c9c6c1350145ac8a5e381560",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/catalog-attr-choice-params": {
-   "caseId": "meta-compile/catalog-attr-choice-params",
-   "contentDigest": "42fd5f778f3a50a9834ea361b434709a767cf4e47b2900dc42b0de71692cf88b",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/ТестВыбора.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "3c4f00a2eb39c8f00df6cc165fe916f573298a2ee6bed097f87f78756f61b907",
-    "donorWorkspaceSha256": "10243b7f53974ff4436ddcc06bd506ca04a6a28dd6945474a91a6bb486cd6580",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Catalogs/ТестВыбора.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "3c4f00a2eb39c8f00df6cc165fe916f573298a2ee6bed097f87f78756f61b907",
-    "unicaWorkspaceSha256": "4bbb9c584dfcd11846e6c82fb0332ccc22d7a6ef2b77e8e055121db26c232337"
-   },
-   "observationFingerprint": "7570752c2bf245f04631664ef27e77cab05f43e9a9c44188f104dd41cb1d98df",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/catalog-attr-fillvalue": {
-   "caseId": "meta-compile/catalog-attr-fillvalue",
-   "contentDigest": "5b1cd315be270394e9c74ec9329999589e3ab3ae2731886a84887387968f4051",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/ТестЗаполнения.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "6b2f74856fe23cf3b00bde7abf6d5d2a2be2ce35e309861ba14f5ba04821290d",
-    "donorWorkspaceSha256": "d82911ab5edac8164a327a30f632e730c280a35b6f1beb97e2b8fb3860afde95",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Catalogs/ТестЗаполнения.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "6b2f74856fe23cf3b00bde7abf6d5d2a2be2ce35e309861ba14f5ba04821290d",
-    "unicaWorkspaceSha256": "a2dae8a9910d30bc6b7b29c47537800182d13e3f14f05797fb0a3f07be910bcb"
-   },
-   "observationFingerprint": "1c5cf22c77879967ecfca9aad605fa0c7bce0084b28c2bdebdad134a92bcced0",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/catalog-attr-ml": {
-   "caseId": "meta-compile/catalog-attr-ml",
-   "contentDigest": "7c7d62a191cf0119195838b247c07bb97e6b74e3e108374c2f6c92333fba9ecb",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/Контрагенты.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "28b74e689cc93c841150a9d49b64acc48c0047fb585cddecd8c5068237a7f553",
-    "donorWorkspaceSha256": "24fe1e87dc71ab3594c2e51cb78d925ca952382a521b95d7765996386077f538",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Catalogs/Контрагенты.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "28b74e689cc93c841150a9d49b64acc48c0047fb585cddecd8c5068237a7f553",
-    "unicaWorkspaceSha256": "036bad39029494296084a8cdb105f842cc4c34785bc8c0f5ff5946ccfc70cfe6"
-   },
-   "observationFingerprint": "018737a7f7c273db22e463d20fbc896dfe2cab0a945159f646327847efaead36",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/catalog-attr-props": {
-   "caseId": "meta-compile/catalog-attr-props",
-   "contentDigest": "b0470013c313ad709579d236833d8ad3ee9a33d068ede7af075ec51f96e2b36d",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/Контрагенты.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "6ded2183ed2029bc9ba79dcc1acc9a2eeaea0faca11b41906b7ee0f5fa2d640a",
-    "donorWorkspaceSha256": "e8d17378c5562efbdd07cca40f0b4d50114e01b2876ecf8bf1307e9ee1e049c2",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "Catalogs/Контрагенты.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "df558af837884dc90cb1b8a176a95fbb74eedd4626313eea5494adde24d1a25f",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "ef8a28ca29f9a856320213aaeea2ae3350298034d1655d0a697081f014cc3cd6",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/catalog-attr-reserved-name": {
-   "caseId": "meta-compile/catalog-attr-reserved-name",
-   "contentDigest": "2d9f2724458598df51072b488350248f80cbaa7662c18a701415255f2b466654",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": false,
-    "donorStderrSha256": "4ac1b0081583599840939c4223cb10b47fb0284906c493665cf371eb2b692e50",
-    "donorStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "6231e4a7c8a23f2b3a6abd4eee9faa3bee8b1e5e7f4af679a1086a7910ad739b",
-    "unicaWorkspaceSha256": "68419e598482e1415052a62942475e0351f2b3e3c52821514faa2bba143fe2d7"
-   },
-   "observationFingerprint": "ef8b62e0c5612fb3d92194303df5969c0ee0499128474188b7c5cd8a58cc46f8",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/catalog-attr-typeset-linkbytype": {
-   "caseId": "meta-compile/catalog-attr-typeset-linkbytype",
-   "contentDigest": "48e74814082e48f5c3e34b1245002838110bbec2435b84072428b4e40119868a",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/ТестХарактеристик.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "235f32bda35672433db372ad4ede0e9d0060cbb0e7c70affbfde9c49f94f9c83",
-    "donorWorkspaceSha256": "4558c6f2760ca439fd0171b64c937fe66371848af8d7a4a9648ff1dbe3cad905",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "Catalogs/ТестХарактеристик.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "05b656d0777c01152e33cc1395df2d01315ebdd9e870e5c42420a17d207837d9",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "da7aefdf7503b1d5858ec8bc35f9bbf088b4a306f2da3125263174ecc03b4aa7",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/catalog-basic": {
-   "caseId": "meta-compile/catalog-basic",
-   "contentDigest": "b134887b66d4cd3a42a5e2f83f7d2e61c5cc2d880d1b85d1ce0cbc99f124381b",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/Валюты.xml": true,
-     "Catalogs/Валюты/Ext/ObjectModule.bsl": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "dc9af2882dc5ab7f8b92a3a5cabb6073ba40f7a3107d63555771a6872fa98738",
-    "donorWorkspaceSha256": "5fd0e6bf1951323b2bf8197479f85ec73b5e8d1f474c7251015b7ff058b23dc7",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Catalogs/Валюты.xml": true,
-     "Catalogs/Валюты/Ext/ObjectModule.bsl": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "dc9af2882dc5ab7f8b92a3a5cabb6073ba40f7a3107d63555771a6872fa98738",
-    "unicaWorkspaceSha256": "987040dbea03558d31ecbf78f4bbd4d4ea079f84bdcb7f242aaf28446de36261"
-   },
-   "observationFingerprint": "ca43be3416541545b337ea704c57c5be8f9746b000a61f3ad0f67cc259f214b8",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/catalog-characteristics": {
-   "caseId": "meta-compile/catalog-characteristics",
-   "contentDigest": "3cad309a5bcd82996377115e797e028cc0600de13eac6692b9064dd81bba58a4",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/Организации.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "4a5acffe0c9c31060a769fdf1352b72d13d0e4fbb8f6ceae0e080175693da7da",
-    "donorWorkspaceSha256": "fd8f7b7182c7dd5334201dcee7f5586aab71a0389a623b3f25a21785327c7604",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "Catalogs/Организации.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "1eb2d6920b6ee1a919e11387a5612684e496d65b7d3a6fc5bbf4276dbb5f9db3",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "7ddd8bf0520885ec117e3dae1d2bd86406c9f60a5c7cb1e57b670089d4526986"
-   },
-   "observationFingerprint": "c68138669f85eba9fb0079daf5b9018952b1541aeffd71190b68140c56895e3f",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/catalog-command": {
-   "caseId": "meta-compile/catalog-command",
-   "contentDigest": "c61146f996288d0dc8c2fbd0fa544e955903a40c74f70c456745f785abc67baf",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/Номенклатура.xml": true,
-     "Catalogs/Номенклатура/Commands/ПечатьЭтикеток/Ext/CommandModule.bsl": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "ab17a05cc87968c66b1e4e399ac532c3db9415d1f457de83535a7d62376dc4f9",
-    "donorWorkspaceSha256": "fa383b4b867c587fa03a1a092df1d11b9ee7fcd108a09663e0dbea0e54705664",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Catalogs/Номенклатура.xml": true,
-     "Catalogs/Номенклатура/Commands/ПечатьЭтикеток/Ext/CommandModule.bsl": false
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "495a71974dce611313860a6bb6097bc2b92c0121fc494a1c793caa651feb64c7",
-    "unicaWorkspaceSha256": "e78ff28693617e05e9f65be3d6ec3942a2e5b420437f488f7238272f66a00d67"
-   },
-   "observationFingerprint": "61c829bfc004c98e35a5c772a51920cd0d85e4d80139dcd31ba8b6addded4256",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/catalog-command-groups": {
-   "caseId": "meta-compile/catalog-command-groups",
-   "contentDigest": "95cf433f3eb638a46dcc48c6c8ebb359c04dd12018c17eadf36337f23dd4419e",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/ТестГруппКоманд.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "8085c122f2e8f43144201c890c48fb47c45e66e1f122b3896efb0707b1d64f17",
-    "donorWorkspaceSha256": "da300c7cfbca2196082fd91a3c31ec3ab8a75ccb0ad992f107cef6388d085fd7",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Catalogs/ТестГруппКоманд.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "0c38b9c9c2cbdbd41ce0ed1566503db6410d973771d417f992ffb989164bba03",
-    "unicaWorkspaceSha256": "5fd7f78df37bc7503e4a18401572cd84f0404e64ab7a3a546d15e760e0ae97b6"
-   },
-   "observationFingerprint": "2b67ab4b1a0472c7c8e49249fb23a0091fba836b7a4a640a103c55e69b9b85df",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/catalog-hierarchical": {
-   "caseId": "meta-compile/catalog-hierarchical",
-   "contentDigest": "c2f624bc115ee482a45bfce66afdb86686c9ee8b4316bf979897d444d422f4d7",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/Подразделения.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "caa312587363b8ae350e6f4f29a1e8fe19346fd81cc1926768cac68543be5d34",
-    "donorWorkspaceSha256": "8cda3fa781779fdba82bdcb809e3c66921f17d76f046678d22f8cc045da34f3f",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Catalogs/Подразделения.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "caa312587363b8ae350e6f4f29a1e8fe19346fd81cc1926768cac68543be5d34",
-    "unicaWorkspaceSha256": "f7212ef7bc37e9414e0446d4688097667be0cc17aa497b1266cb06d88b818786"
-   },
-   "observationFingerprint": "974aa19f166bdbffc38df0fd24e841b4dfa8b389788aaeab630e480f7cb80fc9",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/catalog-inputbystring-datalock": {
-   "caseId": "meta-compile/catalog-inputbystring-datalock",
-   "contentDigest": "3e35c1bf3809604678f53b1e8ad27980d99fa6dca191bfb43aefe45fdd16bee3",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/ДоговорыКонтрагентов.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "2608ee882b40484e2a66459f9cbc0a11f38b7a570440edb02cfeae5e252be0bf",
-    "donorWorkspaceSha256": "0ed3e0e7f8aeee6b8cfcab17d6453b82105a2f1acc5638bd433f141a92418e65",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Catalogs/ДоговорыКонтрагентов.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "2608ee882b40484e2a66459f9cbc0a11f38b7a570440edb02cfeae5e252be0bf",
-    "unicaWorkspaceSha256": "6686a1234ea66e35f57d68f88793c208c62333f3224f6db317dc0d8baf37421b"
-   },
-   "observationFingerprint": "6100925b47f8fc51fcc3ec1365e5ff1f8611a5735d6477defb113cca91d8c9ed",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/catalog-minimal": {
-   "caseId": "meta-compile/catalog-minimal",
-   "contentDigest": "2abad6799d761fbfe8cc544f952d7097944272ae712333e41863cdc8440f3306",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "d09e81e2a0c4903d98051ceb0fcc9699c2f3b070971667825bc1d386ceeddacf",
-    "donorWorkspaceSha256": "c9b88e21b04513ced6f05798e379a62e3d2b342e4ace66ebe7847c428f22d7ce",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "d09e81e2a0c4903d98051ceb0fcc9699c2f3b070971667825bc1d386ceeddacf",
-    "unicaWorkspaceSha256": "114a7edcf92f455ab0c89297ab3a1ee40a8d07f4eafb75c1bc25dd1f0b76102b"
-   },
-   "observationFingerprint": "3e9f65986556ae18f209553503846142eb0c2b41a1c7f6804f277435a1f92b00",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/catalog-mixed-types": {
-   "caseId": "meta-compile/catalog-mixed-types",
-   "contentDigest": "9f71c980c172a6c49e0bca0b58af6d0014cebdb880e5dbe8983acaa1f8c428b8",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/Контрагенты.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "565835c0e8b4b12291afb2ce0901bad77cb44b0d293e68aaacb4a853f360de77",
-    "donorWorkspaceSha256": "456c19f39172bc29b49cf5d543e02fe2a97b582d45b71d43acc7fb8330cb2435",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "Catalogs/Контрагенты.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "cfc73ea9cfcd03e1e61220af99a87eb8b24a2fb57ecbdb8bf08e0c38fbafebe5",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "16f3d6e91bbff70d093b2783d8002ed41648a58dddabd175586d8aa453b9da41",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/catalog-object-props": {
-   "caseId": "meta-compile/catalog-object-props",
-   "contentDigest": "8046493cb059ecab0ef0d37d579eab9fc6d337e5e0db9472a14b213e48eae365",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/НастройкиОбмена.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "7655759667cd9089c1722a59b64a0dbd6990e6bf3f27718c614f8ee01677b904",
-    "donorWorkspaceSha256": "005645365d4360cf3e8a3cbc11048117cb96b43e141bcf7bdb53ebaaf7b72414",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Catalogs/НастройкиОбмена.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "7655759667cd9089c1722a59b64a0dbd6990e6bf3f27718c614f8ee01677b904",
-    "unicaWorkspaceSha256": "b6afa6b9ce43576d5ff27da1c03baa9f03db539a3dc91256c742da4d600cca05"
-   },
-   "observationFingerprint": "a29b3baf2f20d4a9fe8465e5c2312bdc063eebe0d6c50feee30cae60f180fc6e",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/catalog-predefined": {
-   "caseId": "meta-compile/catalog-predefined",
-   "contentDigest": "6684f0da9536687ad2673b9761b0745fec9ad3b5a616c483026e85784719532d",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/ВидыКонтактов.xml": true,
-     "Catalogs/ВидыКонтактов/Ext/Predefined.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "bff7a6cd5238787ffcbc63aec83f653372068e70891106e154861d516433fd44",
-    "donorWorkspaceSha256": "7c2304dc698d175acf99d5e60a9108c8f4a2dbca757671b25ff7fa8f0edc0972",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Catalogs/ВидыКонтактов.xml": true,
-     "Catalogs/ВидыКонтактов/Ext/Predefined.xml": false
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "7ca58db76c97c99e29feb1d18ebffe020ec2130e746e4195c638ad4f5736a0d8",
-    "unicaWorkspaceSha256": "ea81cdfd7574ece19ff3163a0063f5b8107392515c85e8344d6e606767d3cb71"
-   },
-   "observationFingerprint": "5c00fa4d4299e34ddb1aaaff2d9649f9c1f47f2c0e39b14dc06c6e746fde0bc2",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/catalog-standard-attributes": {
-   "caseId": "meta-compile/catalog-standard-attributes",
-   "contentDigest": "e79e46abe551fbdc91dc55350a3a6ba03e8ebcdf5f7565e99feeb203d6216645",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/Контрагенты.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "544b9b3c16b17ef3ead328b63f4667ec223169a2e7913710c0e6df58d02efe32",
-    "donorWorkspaceSha256": "24f0d139eb727a245f66269b392c12414f2b9909a15b97b358f0e5ea27c564e1",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Catalogs/Контрагенты.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "544b9b3c16b17ef3ead328b63f4667ec223169a2e7913710c0e6df58d02efe32",
-    "unicaWorkspaceSha256": "64ce13405392856c0a3488b8330243f80b70eb7acb7de233f35e9fdd16ec9d7a"
-   },
-   "observationFingerprint": "a49ba4c57755b49c7d3c8513916d16f1b64e0067709ddf062183f10d5b4be1d4",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/catalog-stdattr-custom": {
-   "caseId": "meta-compile/catalog-stdattr-custom",
-   "contentDigest": "d6c0c663564cce81ebc83763f3aa3170e664aedc609fb756a09a74b207cd6212",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/Договоры.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "8a6d4ae570b87a9747c29b2efd2851f9be09e4241857c0ddfc3fb779ad16c641",
-    "donorWorkspaceSha256": "1ddc915b5c5c3674174cbe285d148f73c7b0484ce16cba734ef55f804b672748",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Catalogs/Договоры.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "8a6d4ae570b87a9747c29b2efd2851f9be09e4241857c0ddfc3fb779ad16c641",
-    "unicaWorkspaceSha256": "11d474ecae6acfbbfbcea00a2763147b090ac2f427c9f0614b774c31b986c761"
-   },
-   "observationFingerprint": "4bcfcd5daa1895f21fe5b5f5b03fc04afc560e831654685d387f7a073c9c27a8",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/catalog-tabparts": {
-   "caseId": "meta-compile/catalog-tabparts",
-   "contentDigest": "681bd5f867c9d748121fc1006617b97cf06ff56b96062ef4b758e10050646eab",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/Товары.xml": true,
-     "Catalogs/Товары/Ext/ObjectModule.bsl": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "d39d9c6a90466bc5b9d63ae526b5cbddf25f696540580566f87f332b8f7cdcc1",
-    "donorWorkspaceSha256": "ae4b851aad575fe4002641f7e0d5115f14cafb036182f12b08616f6418f287c0",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Catalogs/Товары.xml": true,
-     "Catalogs/Товары/Ext/ObjectModule.bsl": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "d39d9c6a90466bc5b9d63ae526b5cbddf25f696540580566f87f332b8f7cdcc1",
-    "unicaWorkspaceSha256": "6872a8c418ceca5c7ffdb8ef1667af7752ae64a0088a90fcfa72f64fa2edeb66"
-   },
-   "observationFingerprint": "aa5be30933c6c7baf80d4ae7576d9b7f264abd98d4801d596042abb195f34c10",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/catalog-ts-linenumber": {
-   "caseId": "meta-compile/catalog-ts-linenumber",
-   "contentDigest": "a657f7b7251be04602d342291d355c0f7df74005747e5b600cc7b4972ab08959",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Catalogs/Заказы.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "87853d6102939aba4d1471ce4e72e8c041682f886e188787043aebbd4e7f1012",
-    "donorWorkspaceSha256": "30beefd8b6a587dd045d370ab5b23a020f58dc35f79a0ccfa3d93633759a0f06",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "Catalogs/Заказы.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "bc0aee6cc13b49382252cdab5290349a337f97a4bb7e6981f49d3201ab6f0f0d",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "c821b40d080db1fed572ce428868dcb7484c9f19693205a989ad7e43d7b968f2",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/chart-of-accounts": {
-   "caseId": "meta-compile/chart-of-accounts",
-   "contentDigest": "6004fb8c570492bca80869b505c0404188bae729433bbe41ed3be8d09dc61a8f",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "ChartsOfAccounts/Хозрасчетный.xml": true,
-     "ChartsOfAccounts/Хозрасчетный/Ext/Predefined.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "73e47fd33bdb939091b3222708e9104f6ab7b2901edc1b5cdf70e13a1d3f651b",
-    "donorWorkspaceSha256": "8f8bb26602b2f23ec0eff40d5c7092c100244cebc43e4b0e274c619e26058550",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "ChartsOfAccounts/Хозрасчетный.xml": true,
-     "ChartsOfAccounts/Хозрасчетный/Ext/Predefined.xml": false
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "6fa5665f20fa27687012e65fb33ddbbeaf31b7d18661c2cbe58020a69e15d96d",
-    "unicaWorkspaceSha256": "283caeb014b92f788b917306e97e636b2d6fe826003d36bd572c894ad4b4a606"
-   },
-   "observationFingerprint": "0f9f43751151864f6f683993f66cb6fcfbd978df16e0d243379b1e8682b63c1f",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/chart-of-calculation-types": {
-   "caseId": "meta-compile/chart-of-calculation-types",
-   "contentDigest": "b79ade657e5c714453e59578596383a008feb02e2e2a37d4c3393f9e15ee7b0a",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "ChartsOfCalculationTypes/ВидыНачислений.xml": true,
-     "ChartsOfCalculationTypes/ВидыНачислений/Ext/Predefined.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "42577c30c8bebfdaf9990f8df00e98ab6260fd1f5fc58c47e88453da6cbb6d84",
-    "donorWorkspaceSha256": "36db0443ff466daea98db9d39f68c52a11722edc81223cdb94288e0094ad0136",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "ChartsOfCalculationTypes/ВидыНачислений.xml": true,
-     "ChartsOfCalculationTypes/ВидыНачислений/Ext/Predefined.xml": false
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "22ccd0ad4b19982b92c2106449058ebb6c95e2bb00a8746de1e5cf33964d37a7",
-    "unicaWorkspaceSha256": "6ab8e82b4228193ae1893c635f0fcddcf77e3bdb7f794e999cf898e1fe621fe1"
-   },
-   "observationFingerprint": "4ec91b81645370b925e5f7d134c583318fb87fdd07aee38190bea202204ae343",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/chart-of-characteristic-types": {
-   "caseId": "meta-compile/chart-of-characteristic-types",
-   "contentDigest": "825d9dc9fbc97a248907459818f306b48fad94491113cfbcc089c51327ee9569",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения.xml": true,
-     "ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Ext/ObjectModule.bsl": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "caf7901a980b19ca0ad68c718a9c8b09e41db6e96ec4df7dea688a51d31112b3",
-    "donorWorkspaceSha256": "31621dd1fb419e49cd9a676ac657eded5eb15e652ea52d17fddc58c642e177dd",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения.xml": true,
-     "ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Ext/ObjectModule.bsl": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "b2d99a46371c4d98e8629aee26a8dffe3c59f709f9b85104afde4db35da62363",
-    "unicaWorkspaceSha256": "64f687a8361b7caf76b71e761ab4544e946ba40f3c6aea89293ac95fc9a08d13"
-   },
-   "observationFingerprint": "faef5ed261b6129aa4e3f65947c6442bc6001528d6b95a33ff41c76027cefc13",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/command-group": {
-   "caseId": "meta-compile/command-group",
-   "contentDigest": "313b05208b6ae4cccbcfbe752be77927a0efac13bd6c668d915437ec450329fc",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "CommandGroups/МояГруппа.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "eee216710c876852f32f8eda62b07896be9f46f6dc89a456583e8ffa02e6d1e9",
-    "donorWorkspaceSha256": "51dec123b94ea5ea6420c261a512f61e4909660651da2762543d85c6310b9ebd",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "CommandGroups/МояГруппа.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "c2c7ad12b07e8a65c91a4cc8c2a1b775f36b33539d215d980f5995bbdfc050e0",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "c115b6c09bc1655442b21fbcbfd0e30f6cbdd7e7daa5b543a57064253374ece4",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/common-attribute": {
-   "caseId": "meta-compile/common-attribute",
-   "contentDigest": "4f2d41dc1a6d21e3dd57a293a9206395f42c0579fdd8fbed221c96990e726fd9",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "CommonAttributes/Организация.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "57845ce6c1dd6bb159c23af9ea9156d486566ae4fbf44cb599e4ce7484a35b7a",
-    "donorWorkspaceSha256": "55ebc42b6f1898e8419637e5608ce57b151a660feb730937b8b7330d477623f9",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "CommonAttributes/Организация.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "2543d44eeb04b28780311aa4c0a80ada7ddfde64f6f4ef7f9b6ae318d6d9b253",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "8fcbc55fcf3f9d517bb8981342630a67e1d28dcf7b006206c3a602d1d3c244e6",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/common-command": {
-   "caseId": "meta-compile/common-command",
-   "contentDigest": "58991f7937244062e082e4d24a0bf2fd9fba93a42d7fe483ae14521847be8df7",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "CommonCommands/ОткрытьНастройки.xml": true,
-     "CommonCommands/ОткрытьНастройки/Ext/CommandModule.bsl": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "233a21b21b2acb4718734ea16ecc92175e7013d97625113a2107be3f300af41c",
-    "donorWorkspaceSha256": "86179d2faa997bf31e30bf076fd179a091423beb33798988ef7fa7c92e7b24c3",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "CommonCommands/ОткрытьНастройки.xml": false,
-     "CommonCommands/ОткрытьНастройки/Ext/CommandModule.bsl": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "d50bfd4b4d0045598c7c3685eb758d5e2337a9d2419fa944d1a0b50957855c9d",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "f9ec08ac87912bc86fb6e973767840bd3f0665beb64e4fda587dde7bc73cac91",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/common-form": {
-   "caseId": "meta-compile/common-form",
-   "contentDigest": "a6dca6173d91e750729c51aa45f31648961264993d597eb823cdf22f12c0259e",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "CommonForms/НастройкиОбмена.xml": true,
-     "CommonForms/НастройкиОбмена/Ext/Form.xml": true,
-     "CommonForms/НастройкиОбмена/Ext/Form/Module.bsl": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "eca7d760b3957b14b7b451a666471bd3c67c8981632e4e46a76d09d497289e75",
-    "donorWorkspaceSha256": "f9ac0bbcb744eb718118be0d996116ffd19903125970e9572129656eba408973",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "CommonForms/НастройкиОбмена.xml": false,
-     "CommonForms/НастройкиОбмена/Ext/Form.xml": false,
-     "CommonForms/НастройкиОбмена/Ext/Form/Module.bsl": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "a0eb33c57305cd2c1cb9e191537a732579753e3dc024b716755da031c4c05f4a",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "f6e203990ac583b6ce935f79de47d78f56ee594c2dd4b6f3705d2f467bb78fa5",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/common-module": {
-   "caseId": "meta-compile/common-module",
-   "contentDigest": "a6793e2a22646da6cc36d0e2b84070b21bab1823a1be2408d5dcd9c0e24cc19e",
-   "relation": "exact"
-  },
-  "meta-compile/common-module-client": {
-   "caseId": "meta-compile/common-module-client",
-   "contentDigest": "7e6810a408379a5e03c3f234e6782553d58217d6b4a7f17ca4a506d640001949",
-   "relation": "exact"
-  },
-  "meta-compile/common-picture": {
-   "caseId": "meta-compile/common-picture",
-   "contentDigest": "8051b115643a707b41ff1fc09d0cd59cca159806cfc236ed778f5932d9e2590c",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "CommonPictures/Логотип.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "8e2291741dad0cd56a53022981856c761f1d3296de8672617eb2a7eb60e4097e",
-    "donorWorkspaceSha256": "9f67c2a96d8f2f77c34898e40708d6ac32665ebaa43f8d283ee14c894d73105e",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "CommonPictures/Логотип.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "6f9601543a3542af81c75d483c1a1914102dd9fdc2ac20f9f0902a81c6549f84",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "b63f262acb3e79a982c298a3822ab8a2a1d156ff3d1127e834c38ee268723cbb",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/common-template": {
-   "caseId": "meta-compile/common-template",
-   "contentDigest": "f47876e41e0d27d684b0204554532f6caac726b55df4116ea2f9f0db63411e93",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "CommonTemplates/ПечатьЗаказа.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "52ed59a2b82ae046b9ffda02379d70515535b51d0f0c59048ffd6fd147ea0fd3",
-    "donorWorkspaceSha256": "756adfc1d7cad1137de8247f9909921a4840b02957a49cfdb09487675592cf73",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "CommonTemplates/ПечатьЗаказа.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "e643116bd1bd902b626919312dbb8a0951e9e2b5dcc9d26909fe60df6408ca27",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "2a7f65589ae696ed1473226ed6ca49ea0f077ff77eced6a67d2e1e397cf949ab",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/constant": {
-   "caseId": "meta-compile/constant",
-   "contentDigest": "3f38ce1ddbd5aa94ee5a10d55720eba1cdd1ecd8d9e175ea9c42c304464fc65c",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Constants/ОсновнаяВалюта.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "3f1e9258ca655a65472c158b769499937ede5c808e432faa3fe3ff782f91abc9",
-    "donorWorkspaceSha256": "a972f5e1b8e6a673c830cfca53ec5a82056801bc793b038ce87deda0e60a05d0",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Constants/ОсновнаяВалюта.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "3f1e9258ca655a65472c158b769499937ede5c808e432faa3fe3ff782f91abc9",
-    "unicaWorkspaceSha256": "bb61e4bc36f403872710ac85fa8768f4eeac99b7cc68eaba5c99aa075f9fb817"
-   },
-   "observationFingerprint": "407cad9e85331877c3bc7f57412fd1f07269e3e4129ac5d8373b28beb41e7dc4",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/constant-full": {
-   "caseId": "meta-compile/constant-full",
-   "contentDigest": "4b5f104ef2db4051d436f0ed51785939920c3d8305cac14ecb1fa7b732cd0b10",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Constants/СтавкаНДС.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "6e61dfc2025e47a425221d8a4d1f97182fcefbe482af7d26baf6d849ae4e5f4d",
-    "donorWorkspaceSha256": "392f9891527b3888ee8cf6dfb1351651ff5a7eabc74901d7ad60e3550c112d2a",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Constants/СтавкаНДС.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "6e61dfc2025e47a425221d8a4d1f97182fcefbe482af7d26baf6d849ae4e5f4d",
-    "unicaWorkspaceSha256": "3aaf59e69f7348c34d67222838661979a7fde12683aa0b0e1d53c329ad8d256a"
-   },
-   "observationFingerprint": "1a1742503ef78598521d7ae16833af63c68ca8ddc75f1773601edf596235388f",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/data-processor": {
-   "caseId": "meta-compile/data-processor",
-   "contentDigest": "8db80e1572e5aa28e6abbf2e96d8f80d8c52babad50e064b46a8693ac18e3eda",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "DataProcessors/ЗагрузкаДанных.xml": true,
-     "DataProcessors/ЗагрузкаДанных/Ext/ObjectModule.bsl": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "8c9b050f0129ca206e83bd698a43a34739197a616f1549c051c845c1b1d4c559",
-    "donorWorkspaceSha256": "2b41ae0f2640b4c429a1e039fb94ac0792ac2d62728a89b1a0d2557e49ddd0de",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "DataProcessors/ЗагрузкаДанных.xml": true,
-     "DataProcessors/ЗагрузкаДанных/Ext/ObjectModule.bsl": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "8c9b050f0129ca206e83bd698a43a34739197a616f1549c051c845c1b1d4c559",
-    "unicaWorkspaceSha256": "7b5b43a8dc4f26ebfd76507d1a6d476e0a3e8ec43cebace474b354d644a4a2e1"
-   },
-   "observationFingerprint": "134f953d983a10f75a85b85b5273b0261f3a6f70218a8e01caddca83efd46f37",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/data-processor-full": {
-   "caseId": "meta-compile/data-processor-full",
-   "contentDigest": "d0f45d310b234ea8fa0f531ff640a6ef8244fb51cfeb94c2f67b1b42a81dba74",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "DataProcessors/ЗагрузкаТаблиц.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "9b0fec2c271d875864b7d190db8ded3ca3a84ad1dafdd6c67964ca636a19f33e",
-    "donorWorkspaceSha256": "a2e59aa906919f4a3687dd49ceb158a26f0bc0fe3e654857b1c9409f27797072",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "DataProcessors/ЗагрузкаТаблиц.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "7e3ca7eff9473413823c2c0974d27f29f6f39a766dd30e76617c29b0b714a8da",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "8fadbef5b9dec98c446327442d4a6728c52d31690816fc23f93f530b5b64ca64",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/defined-type": {
-   "caseId": "meta-compile/defined-type",
-   "contentDigest": "08b0c1dc3f2492226a4d4fa153f40e1a1220170f0e51c868e358b25637f7f45e",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "DefinedTypes/ДенежныеСредства.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "1a64422219b9860289c984a1008e0b956ec10185fb78f62f6f25e24e8158fd69",
-    "donorWorkspaceSha256": "896a93905d4715abe6218bafdf4231a52f6aafdda92ba60c6d0ff105b863d538",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "DefinedTypes/ДенежныеСредства.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "1a64422219b9860289c984a1008e0b956ec10185fb78f62f6f25e24e8158fd69",
-    "unicaWorkspaceSha256": "e331b7b11030d6423507124082af808bee5dc4e6a27709b8517f592b859ba694"
-   },
-   "observationFingerprint": "5e4c085aed804cb28ad4c49da3f72dad4f3016a6d4d1f1147972d5ad89df235e",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/defined-type-full": {
-   "caseId": "meta-compile/defined-type-full",
-   "contentDigest": "22bcc446cced610e91069e9373fd202379a3001b289357b5ce74a659e914df23",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "DefinedTypes/СсылкаНаКонтрагента.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "7e9717b7557074d8fc05f74d407ab971d30d9de74052e69c5d57381d0e1b11cf",
-    "donorWorkspaceSha256": "7159c3675bd74c61d5373a77c675d9ea28ab39467a9caa0aeb152486e8f94aa3",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "DefinedTypes/СсылкаНаКонтрагента.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "7e9717b7557074d8fc05f74d407ab971d30d9de74052e69c5d57381d0e1b11cf",
-    "unicaWorkspaceSha256": "725e69cf30a7ad10663073a99e390244348156e182caa8b839a9d13283398477"
-   },
-   "observationFingerprint": "b569181e81719a492c4e2646a37102ba78758d19f1f0889bca96e675af20a9ea",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/document-basic": {
-   "caseId": "meta-compile/document-basic",
-   "contentDigest": "cad1e311523633b2cfd2c1f6f2439289864f538ccb8b87e01ebcb1223a7e5f85",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Documents/ПриходнаяНакладная.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "c5839a2dd372f17e717b58699d74924e075ed261b149c92f73f0e3d54b1f7908",
-    "donorWorkspaceSha256": "ef1912391464446003d5fce2248d72c74ac86e234537ae9635b340e08e0dffad",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Documents/ПриходнаяНакладная.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "c5839a2dd372f17e717b58699d74924e075ed261b149c92f73f0e3d54b1f7908",
-    "unicaWorkspaceSha256": "10c413eef588c2c981630bbae7a708e132fee24be099f0e6f6e25b4f27578a8a"
-   },
-   "observationFingerprint": "08c881562dce456b594201ad67aad57148515d72abaadb8ead9b5c7b94b85332",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/document-full": {
-   "caseId": "meta-compile/document-full",
-   "contentDigest": "e50668e058931706b8bc79f75af45263b7b01ffe6ca12f69a7f5bfe9b53e56ea",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Documents/РеализацияУслуг.xml": true,
-     "Documents/РеализацияУслуг/Ext/ObjectModule.bsl": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "42e6640e090825cad6e8112b5fdf4c9319005b465fc2b43b4b86ea5b8fc16c8a",
-    "donorWorkspaceSha256": "025742cc52d55190256307dca31a17480ede6ff3c80f60cf0b0ed0366e277078",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Documents/РеализацияУслуг.xml": true,
-     "Documents/РеализацияУслуг/Ext/ObjectModule.bsl": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "42e6640e090825cad6e8112b5fdf4c9319005b465fc2b43b4b86ea5b8fc16c8a",
-    "unicaWorkspaceSha256": "f2bd2ce6525b196d5d9fbebc6c5b0a43ef32aa9b5400d1fc473a633d9ea6aada"
-   },
-   "observationFingerprint": "14498db3e6be61c39cbe3e0e49474a45c37808b7bee27cdfbbf095b3620abc30",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/document-journal": {
-   "caseId": "meta-compile/document-journal",
-   "contentDigest": "2110bad6523fe15b9c0d054775e12e8ca693a5f003913c4f49881f73d1bf0b20",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "DocumentJournals/ЖурналСкладскихДокументов.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "3723b8031809f071d50aadfc9253a881e3aea1b1e59274f961bc66b8e39e6ec3",
-    "donorWorkspaceSha256": "6623fb4f2747aac9f27d07e899c8d3695b9b05b684bcb7ab58f52318b912cf3c",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "DocumentJournals/ЖурналСкладскихДокументов.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "3723b8031809f071d50aadfc9253a881e3aea1b1e59274f961bc66b8e39e6ec3",
-    "unicaWorkspaceSha256": "71475a02a8d34d064ed9bd1073ca36574239cee292c1eee8c0c2b0d5401aa178"
-   },
-   "observationFingerprint": "21535bf81b2177eb6ca96eae006e062d78c49a8a625a9e370b7c9075bf34e2b9",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/document-journal-full": {
-   "caseId": "meta-compile/document-journal-full",
-   "contentDigest": "ebc208f8a0dca563b47243b9c573d0eb5f676dab980892ea86af54bc4570935a",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "DocumentJournals/ДвиженияДенег.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "f67a43da377db927930501f74423bfd00771954febf9834d7a59e604f59275ac",
-    "donorWorkspaceSha256": "5caeaa5acc4678599b84ebed89a643f91e7438f88b80a37d4ab3b3c0d1fb4149",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "DocumentJournals/ДвиженияДенег.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "f67a43da377db927930501f74423bfd00771954febf9834d7a59e604f59275ac",
-    "unicaWorkspaceSha256": "89a877b8b22607915b20c4c12958e749c78f84fa0d2a4b97f01751b8a4559c4d"
-   },
-   "observationFingerprint": "1412745fd2da98971ffedbbe750415d7f351a21d946fca0658084b07420ebb83",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/document-multiple-tabparts": {
-   "caseId": "meta-compile/document-multiple-tabparts",
-   "contentDigest": "7967c10c51129ba7e85b99ca7abd59f5649423b944ce791cf6d0a7d280d6cbde",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Documents/РеализацияТоваров.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "f413ce2a9391db3780c06bf2e3a84700cc5f9a18de0992669ac46ea152b4a84c",
-    "donorWorkspaceSha256": "460fff8b5bcd2421f8b7c23eab8e62ffefe7c57bae7369a90395947e202430a0",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Documents/РеализацияТоваров.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "f413ce2a9391db3780c06bf2e3a84700cc5f9a18de0992669ac46ea152b4a84c",
-    "unicaWorkspaceSha256": "fff7d79e36d4e0e675e501f30e4bf283d78e9e7e2e53fa72b94fa6aa0c1a793c"
-   },
-   "observationFingerprint": "a9338f77bc468dd51334d889a2949f4986c5ede6c046856c7ebb65ce1c602c5f",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/document-numerator": {
-   "caseId": "meta-compile/document-numerator",
-   "contentDigest": "35f148f94f5e98435e975bb4429c34b1a034bcc6137a2c1d62ba460b486788af",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "DocumentNumerators/ЕдиныйНумератор.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "10b71db852f4b6c091682e8e33ca99e364c18770bded5a3d5b0239d96c78c641",
-    "donorWorkspaceSha256": "00e121ac9ceaf76f8348933b660dea2037a7c5a00f7a31aac934da8bbf8929ac",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "DocumentNumerators/ЕдиныйНумератор.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "54562ee760838e4675cf794486e38d4b9e2c0ac1053b22ac9daf10d1f6db239b",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "f4fc92dd20977dcb440fc267123583d6666216c18b52b2e131ad56398a092c1b",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/enum": {
-   "caseId": "meta-compile/enum",
-   "contentDigest": "d09ad8ed62e7747b21bf8c6f8425c173a61eba1955d73b86fe2cccd30ba6ec93",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Enums/ВидыНоменклатуры.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "1dbd47b9ac16ca11d5de4abcbce0944e1e4fb7d01638c221b001bb819da7236b",
-    "donorWorkspaceSha256": "0a05f364438593f47d35650691848f104b80163563e822002ac7209eb5c059da",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Enums/ВидыНоменклатуры.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "1dbd47b9ac16ca11d5de4abcbce0944e1e4fb7d01638c221b001bb819da7236b",
-    "unicaWorkspaceSha256": "77e62f815c9a019033bf07ffaad9c32c79767d07fa0c41e1c6775770fd8a5e69"
-   },
-   "observationFingerprint": "37ddeb9ad2e268808f1ad60d5086e2fde0118a729bb464f7f7e9c5a5902ff090",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/enum-full": {
-   "caseId": "meta-compile/enum-full",
-   "contentDigest": "e44e55c0728a0748ce6ed0f3164671ac5af3da314ce860008514f89af432df7a",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Enums/СтатусыОбработки.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "989d5db0e23ce7d37b5a82cb13ecf69dda309e42a922f13b19e223a65dd2409e",
-    "donorWorkspaceSha256": "5ed230a4a0ea2b1c052faa9496b3fbc42bd2eb7ade640d9affcf106728e47f4b",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Enums/СтатусыОбработки.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "989d5db0e23ce7d37b5a82cb13ecf69dda309e42a922f13b19e223a65dd2409e",
-    "unicaWorkspaceSha256": "4f033d5f02b9b7129e9cc21357776a66ab2badcf10c315d82cec039dcd9e30d0"
-   },
-   "observationFingerprint": "d43c778712689444a050fc4f2cbf310603c5366762a7a6559d1383f4f5c59db2",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/error-command-nav-param": {
-   "caseId": "meta-compile/error-command-nav-param",
-   "contentDigest": "21af4679d0522a2ab341a8d6c41e946dd58f69371e8ae557427442b7ca466d89",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": false,
-    "donorStderrSha256": "576ac0d54bc7e01753f5ab0227cab2e1db56357629296d5ddbaa1701207b20ec",
-    "donorStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "32116c050ef1b77a5f7f2ef1c33ecd906c73995a4c89d33aaa4f379232b1e7b3",
-    "unicaWorkspaceSha256": "60cead6878615770691cdb68fb416f1dc7017ac1fc88c9a72034971a64997501"
-   },
-   "observationFingerprint": "f6c32950436b18cd7b38acdbd043225563195e53b6285b4c5bc0f70352c890c3",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/error-command-no-group": {
-   "caseId": "meta-compile/error-command-no-group",
-   "contentDigest": "a45a66e7280fe1f25c4f9c5823ab3cb655a191cb0af155fc0fa2027ebe76298f",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": false,
-    "donorStderrSha256": "9b11af377fa36601c4a754df9839b890edeee19bd086930003c5120b59212d87",
-    "donorStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {},
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "77ade498cfcd57961207232841fdc2098b05510c4356b6528511d50256d8182d",
-    "unicaWorkspaceSha256": "1d9b6adeb0c4462e44122de08a3974023665d46140cd476e977cf28d6b270014"
-   },
-   "observationFingerprint": "9deb3a37314942f0f1d19c3194a1b51223c138ba163dc838d73971fbbb7e18af",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/error-empty-name": {
-   "caseId": "meta-compile/error-empty-name",
-   "contentDigest": "a034a2f798cf10c7b432e05abf9cef521eeea462376af7df3d8b24f9ca148863",
-   "relation": "exact"
-  },
-  "meta-compile/error-unknown-type": {
-   "caseId": "meta-compile/error-unknown-type",
-   "contentDigest": "13b107f110073b4c7256fe3d2c9632c673997edcfed2bb17f50358390ce03742",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": false,
-    "donorStderrSha256": "4031643e9173ff5f872bd70879a0869b8220a03ee204f960629a4a3df407a0c7",
-    "donorStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17",
-    "mismatchKind": "stderr_mismatch",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "6dbd1d211b061e026ca65c7353cff9075266c4b1fbb4d1506185beed775845a2",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "73dffef9bafd1a1458c5ca4065feff8f1321751e4c670fd2ccc5bc36d387c5cf",
-   "reason": "The reviewed observable outcome is compatible while diagnostics or non-semantic presentation differ; the exact normalized observation is pinned.",
-   "relation": "compatible"
-  },
-  "meta-compile/event-subscription": {
-   "caseId": "meta-compile/event-subscription",
-   "contentDigest": "47d429529181ae79d2c6996898fad67100bc561abc2c1df19b09331eb0865a93",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "EventSubscriptions/ПриЗаписиДокумента.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "8da3db168ea93f4b5344b1d92503205e69aefdc314c56eb0244d6211ee852817",
-    "donorWorkspaceSha256": "71d73b89e1a022447b132183a3058e49396fbcc2d89030b19c6c729c5cd0c36f",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "EventSubscriptions/ПриЗаписиДокумента.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "ca7df2ea3ea74aedfa455c6192bdeffe3dcc2ee527eef8efceb15e613a559ddd",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "8b8c0c7e9b550c70e758282d1da5cf06f53f6590bf601599e2a6d52e8bba5b0b",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/event-subscription-sources": {
-   "caseId": "meta-compile/event-subscription-sources",
-   "contentDigest": "6493b4f48931b77196238d9bb00b50d352b45921d11fd77b329f4be016729e6b",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "EventSubscriptions/МоиОбработчики.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "f42cbe12a1d6ad4bafa1534f815db16c0404752367d28531e4ee581d0169521a",
-    "donorWorkspaceSha256": "74007c2c0f5a19b994f464e08f753a5d11090495a840a909bc07b4770745e133",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "EventSubscriptions/МоиОбработчики.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "d3766caf8f7b62270c14ed23b92b2b4b14ecd95d62ade9d15cd579767a021a3f",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "e9489ae82662ae24bd52dff8b9c098225ee63fc114e932532fc61cd149a97a55",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/exchange-plan": {
-   "caseId": "meta-compile/exchange-plan",
-   "contentDigest": "59ecae64780166600504631ab011d889c9743081d6ff4460357a1315f59906ef",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "ExchangePlans/ОбменСФилиалами.xml": true,
-     "ExchangePlans/ОбменСФилиалами/Ext/Content.xml": true,
-     "ExchangePlans/ОбменСФилиалами/Ext/ObjectModule.bsl": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "47b1fbd9b2b1794b58e50fea224569bf30ba4f84fd374ab638fe26b71cb2972a",
-    "donorWorkspaceSha256": "4b59e69e1d3e04979f54d9e77563666fc84170372fac253655492074a8746676",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "ExchangePlans/ОбменСФилиалами.xml": true,
-     "ExchangePlans/ОбменСФилиалами/Ext/Content.xml": true,
-     "ExchangePlans/ОбменСФилиалами/Ext/ObjectModule.bsl": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "47b1fbd9b2b1794b58e50fea224569bf30ba4f84fd374ab638fe26b71cb2972a",
-    "unicaWorkspaceSha256": "51b2451d5eb6f27be088352fcd5b733500f927560390441ed4208e6a3e172101"
-   },
-   "observationFingerprint": "99eeb90061b32cc0bed4ab4d97cb9fc4115617cce5052876913e448986caea32",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/exchange-plan-content": {
-   "caseId": "meta-compile/exchange-plan-content",
-   "contentDigest": "dc8d45d38619bdc9fcd10ec792dc19937438fe7c7628f9a51e97a48a6dfb42b8",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "ExchangePlans/ОбменСФилиаламиСоставом.xml": true,
-     "ExchangePlans/ОбменСФилиаламиСоставом/Ext/Content.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "c2b0d68ebee3dc2cf2d37f9ac35f1a3fb78eab0e6a4a7942c74311a79ca47e37",
-    "donorWorkspaceSha256": "69bd7c78bb4c3e0858a0acfadd4c5e791a9abeb3f716ff68b2180887791a627c",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "ExchangePlans/ОбменСФилиаламиСоставом.xml": true,
-     "ExchangePlans/ОбменСФилиаламиСоставом/Ext/Content.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "c2b0d68ebee3dc2cf2d37f9ac35f1a3fb78eab0e6a4a7942c74311a79ca47e37",
-    "unicaWorkspaceSha256": "514255148d87dd06c07e998a6b4aa86ae6572b9f6c517ccb9378fb2722f4267b"
-   },
-   "observationFingerprint": "860cfc0d666306321b99b205b78f37c2c0ef203c813300055006d59fe7ac7de0",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/filter-criterion": {
-   "caseId": "meta-compile/filter-criterion",
-   "contentDigest": "694f8f09d91376cb798549e4b9d8a4632fbdbc0412dd29ee869375588823f746",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "FilterCriteria/ДокументыПоКонтрагенту.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "2a6b35b40214463dec44662ad92f431f56f92d1e8c733aee8ce80e77f1ad5680",
-    "donorWorkspaceSha256": "e5564cf871877dcca37e928b31897c20da7e84baf9b7ad11ec84e9e6b3cf76bd",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "FilterCriteria/ДокументыПоКонтрагенту.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "fc7109916b34de78294929738870a1fc809c3bb3174053e4112d42bc3d7f2eb1",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "915a2dfd4b8e4e613645279dcab37b2f47752afa038c89c22c3a5f4249abff8a",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/functional-option": {
-   "caseId": "meta-compile/functional-option",
-   "contentDigest": "acc60b84585c4cee81c86bbdcfae521e19220b5f1da84715b491dc02ba96f35d",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "FunctionalOptions/ВестиУчетПоСкладам.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "9a46bbeb2a0f91b4c9dec13a85e32e2322b01c4fa2b17a6c8c27d5615510b922",
-    "donorWorkspaceSha256": "750df6b8799be366265129da5d69f05a633ebd5fc903d392698484299e09c7cb",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "FunctionalOptions/ВестиУчетПоСкладам.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "5ebf16505e1acf7d1cf8797a78f9d134515f7c44a3dc6a5473e7f9bc56e82bfd",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "ee9adee1203c31a8052565570a760e6039d9debd37e29526bf089bdce2eecd44",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/functional-options-parameter": {
-   "caseId": "meta-compile/functional-options-parameter",
-   "contentDigest": "dcc3308ea8f3c11063e0180daf7a54445a8ad6f313e313cb5a7d9ab792177828",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "FunctionalOptionsParameters/Организация.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "390064552ecd24586c90261179349b085350399336b5b79ed17bdcfca166774c",
-    "donorWorkspaceSha256": "24f4cf9361bc69fcf0ba8a291669502887e3ac2795b12bf224d05801ddb416a3",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "FunctionalOptionsParameters/Организация.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "ed1428c1c8d41db7b6901e1a4d0b540daa831f9070a092fc6b290cbfa530f4aa",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "37340f2f67c63057f78ad285bf9740cd44742e07ea3104a9b3aa687d89440575",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/guard-deny-root": {
-   "caseId": "meta-compile/guard-deny-root",
-   "contentDigest": "62069bd4b4799ff577d26a6048f09602fe2fb42013758eca6895c7700ce88c86",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": false,
-    "donorStderrSha256": "d8d7f5b65023063858c2d5fe818a28ada949c3334cee7cdc6b5dbe86f3f528b9",
-    "donorStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorWorkspaceSha256": "dbc23bd1ff8e1bb20284a2deb4e531ff680e2429b556de2158e7b6639308fd2f",
-    "mismatchKind": "stderr_mismatch",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "cc24290fdea08afccc53ac3a547e3d2bf07dff6d9117dfc161864e135ce197b5",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "dbc23bd1ff8e1bb20284a2deb4e531ff680e2429b556de2158e7b6639308fd2f"
-   },
-   "observationFingerprint": "5564a1332ba67312e96ea128300737c8087594d41913ed9aa924b50995305f81",
-   "reason": "The reviewed observable outcome is compatible while diagnostics or non-semantic presentation differ; the exact normalized observation is pinned.",
-   "relation": "compatible"
-  },
-  "meta-compile/http-service": {
-   "caseId": "meta-compile/http-service",
-   "contentDigest": "275fbdbf1d6c8f686804bb6372d88d164cec8d3ae8064fce98a0035b43776818",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "HTTPServices/ТоварныйAPI.xml": true,
-     "HTTPServices/ТоварныйAPI/Ext/Module.bsl": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "e7c3973798feb56d95330a45e68aade6decacbfd99c798f95c82aedf78180b07",
-    "donorWorkspaceSha256": "c8d3747ef89d463598246c7290ce6ab52673a7f28ab79b7e527984e4ad1cd73c",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "HTTPServices/ТоварныйAPI.xml": true,
-     "HTTPServices/ТоварныйAPI/Ext/Module.bsl": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "e7c3973798feb56d95330a45e68aade6decacbfd99c798f95c82aedf78180b07",
-    "unicaWorkspaceSha256": "fd67b7ec206fcb3033e1ad011323d1994d88c127f9c41cf6a48e6aa0d32f65cb"
-   },
-   "observationFingerprint": "c30a2081be15208c806b07581a80edd06607323fcd07e29707261cb07e48d114",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/information-register": {
-   "caseId": "meta-compile/information-register",
-   "contentDigest": "9fac75d0db408394c5683795c76468cf4734b988b33b8f7bf172202f0f6f8ef6",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "InformationRegisters/КурсыВалют.xml": true,
-     "InformationRegisters/КурсыВалют/Ext/RecordSetModule.bsl": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "fd2ca9e75faafd8cb2bdaf6c174df23ba2954a7e231bf594117c9006071fcb86",
-    "donorWorkspaceSha256": "1e3f9516a9fb763160b6e1864ab41beafd3f88baf186faba5498c03858d7a69f",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "InformationRegisters/КурсыВалют.xml": true,
-     "InformationRegisters/КурсыВалют/Ext/RecordSetModule.bsl": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "fd2ca9e75faafd8cb2bdaf6c174df23ba2954a7e231bf594117c9006071fcb86",
-    "unicaWorkspaceSha256": "4496ce888a35682d8d436acb09bca5fa09f5a6f6d297bbb984caf9772843f243"
-   },
-   "observationFingerprint": "523c259eb33a5d1f61fa7882e4091349f7ffacf8d17127b4faa107d5c1b8f4d9",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/report": {
-   "caseId": "meta-compile/report",
-   "contentDigest": "efef3a42f0dbaa603223a901ed82ed89319a757ae169cd5000a0e7376c465cf5",
-   "relation": "exact"
-  },
-  "meta-compile/report-full": {
-   "caseId": "meta-compile/report-full",
-   "contentDigest": "3ce23d2a44dcee7860d389456d7cc5b3f9b3c691222f661b6ace180443bec60b",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Reports/АнализПродаж.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "3fa967d3390de40351438c961f69ff117a85bd9fb42d10ac71da2d046b303c48",
-    "donorStdoutSha256": "e56ff97fb772c951406a76d5f2bafc564f3a9d8d6b3682f07ac60a7217be2285",
-    "donorWorkspaceSha256": "e776e6a6dfe3630d59fe00e134f893dc03a1491d39d2f99c9d4ccb6a2cc8ae86",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "Reports/АнализПродаж.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "4de7cdba94b9975ef5c9de6063cac21dfe854c60384a7d7bcbba8d113d7d1ec0",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "e1777ec8fdb12d95d24f4731d95df86bc628b626d43e8ac855e5c9d14c32247b",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/scheduled-job": {
-   "caseId": "meta-compile/scheduled-job",
-   "contentDigest": "09d9eb23d48240e47483bab6edf62accb8a5edf797b2cc3e9ba5e02ba4867b49",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "ScheduledJobs/ОбменДанными.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "e68078c8992363153192848a4fe976376a6b7d9b1ab8fbb3ec400f86d56c6d05",
-    "donorWorkspaceSha256": "bd17fe0ba85ce8c8539df7a49bd142b8a5f1a25a6c59e0d1f312d1045fd40eb7",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "ScheduledJobs/ОбменДанными.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "e68078c8992363153192848a4fe976376a6b7d9b1ab8fbb3ec400f86d56c6d05",
-    "unicaWorkspaceSha256": "0bce0eee93e68605e88ebc93cd35e2344ed83e9c3041969c60ceed120b8c715a"
-   },
-   "observationFingerprint": "1015a436e6191fcf615a59f20ca5bb279b035c22f471bbdf69701d9c06d2c532",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/sequence": {
-   "caseId": "meta-compile/sequence",
-   "contentDigest": "e8a928d942690c8d2a73a76b5be58fb09ac5b7b45d8de1c75153053af29da6e7",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Sequences/ВзаиморасчетыСКонтрагентами.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "9595361fb489b598c8246af99ac01586ee1d8fb7bcae6dc1e303c3263d914fd3",
-    "donorWorkspaceSha256": "ff87cb706fff71c25f5e270bcaf32dd1e360b5b1e2e48b52c08645c73264a111",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "Sequences/ВзаиморасчетыСКонтрагентами.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "40824c87ad7f9160ea4197fb93696929642214fe04ea8086e6b139c394153d16",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "7c5dd600381fec18a9ab0d8f63d479e6948740d923e32106008bebb798db493c",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/session-parameter": {
-   "caseId": "meta-compile/session-parameter",
-   "contentDigest": "e1e984223592041b117784faec4bf72d0fd249a6af457404d47a1f27682d7225",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "SessionParameters/ТекущийПользователь.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "03f7eda9460089e3a891dadfd46494a8197e46723f45766f2f41f44c70f8979f",
-    "donorWorkspaceSha256": "33821aa2bf56993899ee76176055f9c779fce55764f766c4f0bff66224afdbe2",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "SessionParameters/ТекущийПользователь.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "2ef45254e8a3d77ac95c78d7d86db1d4d4766dc43b4e1639ccf2845472e557c2",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "897344ab378b2fa3db3de5e91333ef384609afa380717fed3572dc143e9bc71b",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/settings-storage": {
-   "caseId": "meta-compile/settings-storage",
-   "contentDigest": "783d9fbe3e92b5dcf73ef02f884c1797307d99f6039579e3c4e74bbb28e06564",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "SettingsStorages/ХранилищеОтчетов.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "288fe201cf251dff01c405412c03072e53ea241df2903884b8d448c1e4969ca9",
-    "donorWorkspaceSha256": "900c781bcd5b3eeae72b66f04366235c9e90a8aeb82b6a32ade15380787c2ef5",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "SettingsStorages/ХранилищеОтчетов.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "1ddcd94e74dbb9379c7538f1d461e7e7e38b3e04b3173fff04004a47d71837f6",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "c404931c1b1734214534467929c6b060c7ae959e83597c01f43f6d693edb65ff",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "meta-compile/task": {
-   "caseId": "meta-compile/task",
-   "contentDigest": "09e006032bb95bf19ef87f0dd37e9ef98f5d1c9664ae3633e1b64bd0090259a5",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Tasks/ЗадачаИсполнителя.xml": true,
-     "Tasks/ЗадачаИсполнителя/Ext/ObjectModule.bsl": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "e3d274a8e48e0bdf597173fdec597a076472554cef8b50dc2cea2c259e93f687",
-    "donorWorkspaceSha256": "658de8873139e4cc3096660d6fc241551f4b6243463953f28a6636a6ce60a914",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "Tasks/ЗадачаИсполнителя.xml": true,
-     "Tasks/ЗадачаИсполнителя/Ext/ObjectModule.bsl": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "e3d274a8e48e0bdf597173fdec597a076472554cef8b50dc2cea2c259e93f687",
-    "unicaWorkspaceSha256": "8ea573eea324bace500b27eb3d5befdb848a5cba0dd310def27d162ccb046d49"
-   },
-   "observationFingerprint": "02b90d7f579149e8fc3420157942004bd9639974854e7d646d834a4335e6b4f1",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/web-service": {
-   "caseId": "meta-compile/web-service",
-   "contentDigest": "ae24ff2c48ab7c9f654c9e1af941e934daa8e00f3a84587ef08c1bad07556756",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "WebServices/СервисОбмена.xml": true,
-     "WebServices/СервисОбмена/Ext/Module.bsl": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "4a43463068592db66ffd9af4dd2d22b3cac8e72d56db1cbeb714836d1e3c6d75",
-    "donorWorkspaceSha256": "e366275bda5328ecb0c1a1d885d93c964ac59b98be4ac6d50b59ac7af9962fa1",
-    "mismatchKind": "snapshot_diff",
-    "unicaExpectedFiles": {
-     "WebServices/СервисОбмена.xml": true,
-     "WebServices/СервисОбмена/Ext/Module.bsl": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "4a43463068592db66ffd9af4dd2d22b3cac8e72d56db1cbeb714836d1e3c6d75",
-    "unicaWorkspaceSha256": "cc8c58199d39402e105d24dbacda19732a13ee6f35b041ed39eb9b4dfee2c361"
-   },
-   "observationFingerprint": "a727dafbb68d9ae77df4818ed176b8add5f7a2a7733b601a710c71c7334ca2b9",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "meta-compile/ws-reference": {
-   "caseId": "meta-compile/ws-reference",
-   "contentDigest": "16f1e27bb14b867a06b7dcd07c5b8bca9f962cb65d84898ba6762b6f2955038c",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "WSReferences/ОбменСервис.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "e5b2fa002bcb87fcd973546932c23b542b74cb63d6a8302f971fb2afa3db746d",
-    "donorWorkspaceSha256": "d5589e4e968011eda40f546ae246b6a7bb75000c815d668fe9d8de4b21dbf8fa",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "WSReferences/ОбменСервис.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "a8e4a171ddbb2cc2ae1f8b3d2758658bccf53693fb49c9f645df1d811fd56c08",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
-   },
-   "observationFingerprint": "b22fbe59109bf7bd3f7f2f857cb7507baf3da4035d3a60c467350813d83c686a",
-   "owner": "unica-maintainers/meta",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "skd-compile/auto-data-parameters": {
-   "caseId": "skd-compile/auto-data-parameters",
-   "contentDigest": "7c971493b837ac1da9742962130ae3b9fdfe64e14b8563061b2554c793806103",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "7596b0eced479ba35512537de358fd7d4ab0e23e775c67a324849eea346ce326",
-    "donorWorkspaceSha256": "6ebb0e4d951df4668996da01efa19e2afc969278dc15216d7156d42e818f4239",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "a33127e7bb788d76a0bfcc966d4120f3e3e4dd90863f63aac0b89246711acdbd",
-    "unicaWorkspaceSha256": "9a38baec1c5e028b5f70d286717a5255ecc784dc7c9dad9655e93817547e6e55"
-   },
-   "observationFingerprint": "cb58e1f8d71eca9d4d1d85eb237e7d48da82ef33d6e639b40f93275ebab00aba",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/available-values-and-folders": {
-   "caseId": "skd-compile/available-values-and-folders",
-   "contentDigest": "9b7694c88d2b534a67e6a571b2eaad730d58ec347f3909a8a05514c352e7f1d4",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "41b7cccddecb00d96b6eb7cc135be77726855a81e4e3182d9a398f8b22d4556d",
-    "donorWorkspaceSha256": "2d3ad7a7ef34ce00f8221a6c7376f2ffd8b58ad417bf75b4d17a264324a76c7a",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "5e3fec186bedb713df52cfc5ff4b2ff16180202e8c0f0a6905ec9153a0d4f118",
-    "unicaWorkspaceSha256": "74f4d63f8858ac27bdc8b433dfdda5bd67271d0c807ef38ac71a565287c9e667"
-   },
-   "observationFingerprint": "544893b6820c5270cc1f5478748d68e266e9935ba4109481050208a7f05be84f",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/calc-object-name-restrict-string": {
-   "caseId": "skd-compile/calc-object-name-restrict-string",
-   "contentDigest": "81dc37df58c13db19a05addf6eff206292e233877abc31a8bffb68de972b0c68",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "f8476d3e2f0d4762dc1638224cffa2e6113e852566ccde3f0b79f3942293c9ac",
-    "donorWorkspaceSha256": "194e7b8543766e994fdcbbec4e5a527beebec4b413c97abf803c1a896caf2f4f",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "8dd2a274edad1a99dd784c52e23a6a7e2c28a76c27279538db5308972a3f7fe9",
-    "unicaWorkspaceSha256": "f1a39428b22e746dcdb83ae99a3514128873829c9debf05b7c764c54e8d5dbc8"
-   },
-   "observationFingerprint": "4cb51808adf8f2de3609b6070aa7e8bc4073103fc95efd0efa352d28b97f8131",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/calc-shorthand-extended": {
-   "caseId": "skd-compile/calc-shorthand-extended",
-   "contentDigest": "f0a44227c75c0723606adc1e7e36621cb9d52598c85bc364f34000a745f0a6e6",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "8fd94d67c394a1504a6ded3040707195648f98e035b16bdf4ccd523a0a798a66",
-    "donorWorkspaceSha256": "b42d243eac76dd5a821ecaaccc4a06c0e24e5aa31420aa3c56b16d6e3f6b3851",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "bb4c708dc4861d6ddceeaac20a547c8861c6bae993908c17fbd8d5495e4600dc",
-    "unicaWorkspaceSha256": "c6ae36dd271677143ccc120dc1722535e0c64efb6656fbdbd5ce116ea79d4cda"
-   },
-   "observationFingerprint": "61ad685cbc7c021d96d957ac936148dc8a40b6d5beacf1c6a6b078f55e7960eb",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/calculated-fields": {
-   "caseId": "skd-compile/calculated-fields",
-   "contentDigest": "9cf9895dc643ab5e9ca6f58f95dcd60b92c6b09f990dbad4f58aa552037fdc6b",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "f94635ce2f0d701cd7df91839df963a68037b4bdba3be3e18552ede076ba3590",
-    "donorWorkspaceSha256": "dc7b38585acc3cd05b8cac9396c2f18d26036f917ac8216e45e2bd5459a3460b",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "90c57ea5a786d3b685c8e37e3b9860cf469ba101c59f473e3f6027815681837f",
-    "unicaWorkspaceSha256": "f6fbf76fae945cbe2df91bd9fad336d4efe9a659650921e851bf351becbf2013"
-   },
-   "observationFingerprint": "1be3e2738f2fef834d5420e4625ca1cafb2a8754ac480c7c2062f9b1fd52eacb",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/decimal-qualifier-defaults": {
-   "caseId": "skd-compile/decimal-qualifier-defaults",
-   "contentDigest": "ac940f2e8e1bc1d229cba205460a2ad1e7421171d9cda6140d317f128dfac5a6",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "ed35a647ab736862f1453ddcbf82125e93ae7032cef30468ea156d2fb7f6a30c",
-    "donorWorkspaceSha256": "dd8039f988487511d7250e2a715b0aba9a6aa1732ef94269a9dfe63ec104a690",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "Template.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "906a0979efaba7dacebd69ad48562abf37f2317118eec63abb15bf1cc8aa47e8",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
-   },
-   "observationFingerprint": "ee2ad90f2fe7344b38d8bef25d7d529c84d4e67dac4f5c47312e89314bdd9252",
-   "owner": "unica-maintainers/dcs",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "skd-compile/empty-param-values": {
-   "caseId": "skd-compile/empty-param-values",
-   "contentDigest": "98e177f6fd283a443559bbc2b5fc179d3963d8450158d6f68e37498e14776ab9",
-   "decision": "defer",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "4c10cb7f93975fc9a18097c02869b7f69077c9a07ceafd627ab3df5b3ba244d7",
-    "donorWorkspaceSha256": "11d0e02e59bd3974f23d6173dedad17216afe9b9b7d93b334df5e408a7576708",
-    "mismatchKind": "ok_mismatch",
-    "unicaExpectedFiles": {
-     "Template.xml": false
-    },
-    "unicaOk": false,
-    "unicaStderrSha256": "cbc3465db8d31828e3d327a87751bc1798629115a06cecf5f91db5e1f63aaa6b",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
-   },
-   "observationFingerprint": "caad33f1fb79846dc5f78db400148e546694ae91a724c9c7aefd8711a402f18f",
-   "owner": "unica-maintainers/dcs",
-   "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
-   "relation": "donor_ahead"
-  },
-  "skd-compile/field-appearance-and-presentation": {
-   "caseId": "skd-compile/field-appearance-and-presentation",
-   "contentDigest": "586f6616908ffe08bd251fb0250b5c30078ca9552c9d7bb04754184b58c9f6a0",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "f553072ec32a34c46821390b4d29d241b36599a391986ac97d4ffc1bc59d32d0",
-    "donorWorkspaceSha256": "73ac7d8c17d40a610071c2b6dd8d5d0a0b110038d0980a94fbcb4c532ca0579d",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "6909652f78c510a251681ba33aa2697641832ae5419f010dd68e7381ada03107",
-    "unicaWorkspaceSha256": "9b7c1a1851771a7f2c26208303c7937d8a04b03aec58100fdb58db1d2633b119"
-   },
-   "observationFingerprint": "a1e886f56820de650d63cbe8ceee13cdf33ff76b41c69c8c09fc4dda535cb324",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/field-multi-type": {
-   "caseId": "skd-compile/field-multi-type",
-   "contentDigest": "4b48b6fa1c715fc8a5ca7ed8acfe2caf3e8662b015b6641352ae40598b406ad7",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "25886607f44fd2bb684635f1302091f2ef9b9b68af8f322a6546dad9441cd802",
-    "donorWorkspaceSha256": "ab496f3cbfbc46c69ae538b1d1e8b43c8450655c3cb682fd690d73c30b183e94",
-    "mismatchKind": "stdout_mismatch_snapshot_equal",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "d34fec5162948f0c3b0afaa45899c8d6b58166675d43e6905ecec8f5ae29bcfd",
-    "unicaWorkspaceSha256": "ab496f3cbfbc46c69ae538b1d1e8b43c8450655c3cb682fd690d73c30b183e94"
-   },
-   "observationFingerprint": "c309f6d6336cb3c7769ffabb31cd1491eb3da89a5d5c45399ba4a6454e783801",
-   "reason": "The reviewed observable outcome is compatible while diagnostics or non-semantic presentation differ; the exact normalized observation is pinned.",
-   "relation": "compatible"
-  },
-  "skd-compile/field-restrictions": {
-   "caseId": "skd-compile/field-restrictions",
-   "contentDigest": "1c3271ff4880c090ee17df7318960dd3a04545d2f0dfa78ebe1751da84f0ac12",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "0fcf5e09c6fd521c3a34ab05b848db561fc1a91592c2f65503e5fd7ad5599774",
-    "donorWorkspaceSha256": "087f6c33bf07356750ed56ce8e16217e5bc2f3f5cf7c02965ed5c544528d3fde",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "fb58a517e68f883c4f6c9bbe16693cfee9cc57bd714d0d78111f3f867a28aea1",
-    "unicaWorkspaceSha256": "a3e0d34d9d231b7165fd29b4060183db5b2a9dae273513756dd5d883481f2e78"
-   },
-   "observationFingerprint": "d1e1f1ee6564bc7833eff7c9a1f8224bbb64c356074deef5f6de6a686738a100",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/full-example": {
-   "caseId": "skd-compile/full-example",
-   "contentDigest": "62c494d0f5d7be263aeb113cc00608950375de5b5ce1bd3b42ac667d95137bd4",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "3463f701454f0a70207a299a238c20667874fb5be546e521cc6e17113065b8d9",
-    "donorWorkspaceSha256": "9fa65cd4fc4b61a772d85a396135646e51d2cf5e8a6f4290af4323bfb44a46bd",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "120e66b0783b65ad185bb2a26ba51b37ba928510c7bd6a2a7e613098a835afc6",
-    "unicaWorkspaceSha256": "059cb371b6dbae87dac87cd68660eaddb58f5b233f41df4f77405f53bbd27096"
-   },
-   "observationFingerprint": "c108b0d655e25c81d336a3c5ea154c935642400f794230126d8099f893551972",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/grouping-and-totals": {
-   "caseId": "skd-compile/grouping-and-totals",
-   "contentDigest": "331e9303aa04afcefc0fa9923f0227d504f530731cfec94f4749b4394f851fb5",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "0bd98212666dac059fe89a5e7a8b7bfbc6d2d7593a8cb17bf87252933d63b6cc",
-    "donorWorkspaceSha256": "d4b4b82294bdf3b0db18474e1a1498a2d2ab25c3a3c8940249aee8cbc7ede222",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "0bb3cfd0fb60faa63fd8d503a742288a217ceb455fc3ef9c9fa98c14d1551413",
-    "unicaWorkspaceSha256": "d63729f70c3d09d5754ad011260346afc0141115b512534698912fc35bd53dc5"
-   },
-   "observationFingerprint": "651f19ec9ea689e3758adcd877937c272233770c9bdf8a43b00959aae7c6e157",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/guard-deny": {
-   "caseId": "skd-compile/guard-deny",
-   "contentDigest": "4d6e18e324e00234a9a146a612386c3a3e1b7d35735394b29b506d3a5602b255",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {},
-    "donorOk": false,
-    "donorStderrSha256": "23ffcbf59e531912015832a89140c40be86bcdd082c2ec5f5cf8160f28323ebf",
-    "donorStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorWorkspaceSha256": "dbc23bd1ff8e1bb20284a2deb4e531ff680e2429b556de2158e7b6639308fd2f",
-    "mismatchKind": "stderr_mismatch",
-    "unicaExpectedFiles": {},
-    "unicaOk": false,
-    "unicaStderrSha256": "cc24290fdea08afccc53ac3a547e3d2bf07dff6d9117dfc161864e135ce197b5",
-    "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaWorkspaceSha256": "dbc23bd1ff8e1bb20284a2deb4e531ff680e2429b556de2158e7b6639308fd2f"
-   },
-   "observationFingerprint": "27fb1cfb9aadea63560e2c163fe7040a01523115bd7903f5fcbad396b17dfce3",
-   "reason": "The reviewed observable outcome is compatible while diagnostics or non-semantic presentation differ; the exact normalized observation is pinned.",
-   "relation": "compatible"
-  },
-  "skd-compile/horizontal-merge": {
-   "caseId": "skd-compile/horizontal-merge",
-   "contentDigest": "030c8e1a1b6dfb6fb32d747da505ad48eb0fbe9a43ec0b3710d33b30c3d29c97",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "61ae9b4965549ec2b7f70b117de42885de28341536f03d54a0bb44aa3f9c2142",
-    "donorWorkspaceSha256": "38d8c00912613ab111eb7bab072ce6125dc2dace1358fa52f84166bc5852dfb3",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "07ad2ea37679e95e0a06b8255d4d6258998dcdb5da8bb49eb20bcefce85b8c69",
-    "unicaWorkspaceSha256": "4b7e7bc4ef69ce6dcff609d06dca039be47151cb15847cc95f012da2e7ead579"
-   },
-   "observationFingerprint": "2fd0e7d205fc4d30124e79bf0abeaaa7ea28507c9b9125c69e0c5ec5cb9e1e02",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/minimal": {
-   "caseId": "skd-compile/minimal",
-   "contentDigest": "c8f5d973a0c2277494c20f7c926b10eccfb14c8f0600cf7d32fe90c45f650b3f",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "fc0e7dd216c8acd502b910837eb320accd810fcb825a6759ed0ef8ef17bc47b6",
-    "donorWorkspaceSha256": "eebd3feafd09360aacce75230d778262d3664247c584fc4339e19b1eeda51007",
-    "mismatchKind": "stdout_mismatch_snapshot_equal",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "8be91d4c7f58bb5277755b6c9e5b5a325bc766c0725453d0d1a7bb66f9130b9b",
-    "unicaWorkspaceSha256": "eebd3feafd09360aacce75230d778262d3664247c584fc4339e19b1eeda51007"
-   },
-   "observationFingerprint": "1bbf928f73893e1eee34160fff74f7153e0ca1a4b082d5248c9ca7a2d977460d",
-   "reason": "The reviewed observable outcome is compatible while diagnostics or non-semantic presentation differ; the exact normalized observation is pinned.",
-   "relation": "compatible"
-  },
-  "skd-compile/multi-lang-title": {
-   "caseId": "skd-compile/multi-lang-title",
-   "contentDigest": "6ca53c308dd912efc6479904470bbff889f959718dcf238407e65710d80df730",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "eae32403ea8ed4e9b7454796eb3563e31620cb1e73f007043fc41c0b6dfbbdad",
-    "donorWorkspaceSha256": "393fff3e1fc0f69dc161b59fa93f2e6126e5ebcd83ffea149b086ae69e17de10",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "fdfe0641c5fa58d537e12a872ab0b6150e741980e18e9816080d3dd302a5e4b2",
-    "unicaWorkspaceSha256": "a2e7c8e5213be32fee2d74fbe008f5dbcee00d5c6cf8a14e9e7b589e666fa3be"
-   },
-   "observationFingerprint": "d1e429aa5080920588eddc0e7c426b0afcf31219cad72073cdda014062ef8489",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/multiple-datasets": {
-   "caseId": "skd-compile/multiple-datasets",
-   "contentDigest": "f83f554a10314a649146fbf0f90da0a0f0b9eff21a302f663a09a3df7208ab38",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "841e926bfa5637b267a2abe45291f2f617a8463fd0f98f1345de2f55d39684ea",
-    "donorWorkspaceSha256": "63fe477556fb397e2bb7a9a27b249da6348821556b5a67dd2cf470d64a21f6bb",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "8cdc781ad43b34e06fe686de0a87dda715aed594bcd069f0a90c988abf23572d",
-    "unicaWorkspaceSha256": "181c7ab1423269e0fb371972c28afdabd2cf8cccf7fcde7f0cd7ff2616e3cfda"
-   },
-   "observationFingerprint": "44920b5c573f57418b1caccafcb787917976391a8fd3cb938e7f1b239ab41980",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/orgroup-string-items": {
-   "caseId": "skd-compile/orgroup-string-items",
-   "contentDigest": "a207a4fdaba8c73f072ed60ce29997b82a8a3e3b8310561bc964ccaa9479bf9e",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "9eade7600695a2f27c9ff1c85b70364135b8587b4e88d666de96dd74708a7602",
-    "donorWorkspaceSha256": "d3d9667b0973490559889e84e6d93c2f0201e12463bfa26e39f45a2b6591d731",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "6371e556b5a27bab8849cb4e587514346d800d33c7e19894a9d321db1dd5b892",
-    "unicaWorkspaceSha256": "1c0632210cb3b264fb803c7eeb449a9b82248663be27f2ba58ed8fb1c7a34b27"
-   },
-   "observationFingerprint": "8fabcb064ad47f72873712898e868dffac9c717043f0b8884c5bccfbfcca86f2",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/parameter-title-presentation-synonyms": {
-   "caseId": "skd-compile/parameter-title-presentation-synonyms",
-   "contentDigest": "80a17f63d04d9e64457d41084e5e3104c8f0c80fbaa1d61309cd5bd7fdeb9d92",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "58fcd0a61d657e38892c042ff5c0daaafed7fbc4da7c5db78bb4857226c47d78",
-    "donorWorkspaceSha256": "23f5d4e24e0bca76eaa0d2862cc33a71a674e53d15664b71a1237015dcd80ffc",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "52cc30bb60d1a6259ed0efb084f0c8b62897a2fbb079eaaca7dc2e28f0b0dc55",
-    "unicaWorkspaceSha256": "f2f3bfcf835aaca180d0a3066ee89a3d01b37f03280d911c34dff4d81098e1e4"
-   },
-   "observationFingerprint": "54a9d80031e8f200116ba4d9295b7e04dc116dab297c4962febe26f04aa07fdf",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/parameter-value-list": {
-   "caseId": "skd-compile/parameter-value-list",
-   "contentDigest": "4fa9f6afd0cb85318cd80c7227b398d26ae41543e905552f8be434bdaaa31c09",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "b6e8414dc207f67435bd0f4c05a4d381cc9871029fd01b44cae7d1f9a4505a2e",
-    "donorWorkspaceSha256": "139f421f133c892eb734870f6086113c03018408babce711012d218a619f6c31",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "a7b70e4a60d468a9de1ceb240ba2f7109f4fd357b5b509376eca1c191884d927",
-    "unicaWorkspaceSha256": "3592981c387b63694c3e46a5b4e16fb699197f5f1784c34e6da4bd42ee6db266"
-   },
-   "observationFingerprint": "f1477d03572911d771cd2d06e602130b6306c636e56552eb561b60c41cd68f2c",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/simple-query": {
-   "caseId": "skd-compile/simple-query",
-   "contentDigest": "f982228497b55791d6845b00791f5e6d20ae6fc53ecdaec25926b55109eb47d3",
-   "evidence": [
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "00be28d9d1c963cd727f346d99ea957a032e51c11bfef4fe5348c7ee02e52abd",
-    "donorWorkspaceSha256": "a72853e9b8e86b63b83c0b9aaae0c819a782b443faf3d27981f6180e0766c546",
-    "mismatchKind": "stdout_mismatch_snapshot_equal",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "e4e5357831fbc3e426b8ae4ef3c0db5315dc25fb9849cc27b3671fd490a22808",
-    "unicaWorkspaceSha256": "a72853e9b8e86b63b83c0b9aaae0c819a782b443faf3d27981f6180e0766c546"
-   },
-   "observationFingerprint": "a8c5f408904f8b6875cf8a6941a80030b3bf978dd73db8941900278a12c654de",
-   "reason": "The reviewed observable outcome is compatible while diagnostics or non-semantic presentation differ; the exact normalized observation is pinned.",
-   "relation": "compatible"
-  },
-  "skd-compile/structure-chart": {
-   "caseId": "skd-compile/structure-chart",
-   "contentDigest": "14b5dfafa0122370017597d2bf347599b304c23d2ba554e19e6e9ca0f9027b49",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "ecb07557dae44f35ea0ccfab0702200d2e5ac99a05ac85f223bebbc2fe6214bd",
-    "donorWorkspaceSha256": "5c56d5fd85cb3b87913ca17f39ab453988102b910d1757b836eb21a49fc1f28a",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "1d72941df19afb744f3e15fe90b9348bd0ca61898d2bad388299f09b00c079f2",
-    "unicaWorkspaceSha256": "dc8342c8755bae2ec635b5271f827209847ab659470d926166f4ea249a941c72"
-   },
-   "observationFingerprint": "04911a79334fc9deebfc6f70736246ea0075813cc55fb92ec479448a4444f829",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/structure-object-form": {
-   "caseId": "skd-compile/structure-object-form",
-   "contentDigest": "14667230e3989416ee409523aa6b2c4ed9fa1b3809791d266b457994524db902",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "79392394fea8c08c0a94b0c0060f513f10165502573d02c3523fa6375839d087",
-    "donorWorkspaceSha256": "62ba7dcb8018881b556f528aabff01fdd03100fcc0075a698c33482dd0c32d3c",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "f78174bc485f8934864ef16dc5369a4c76e3f2d65e0a8a5120daba89831ad3f1",
-    "unicaWorkspaceSha256": "332b39cd2ca4031c67852f96552290adafd3962d2fcdc282506cfd801eb482ff"
-   },
-   "observationFingerprint": "397770671a39e1a64a6ff3dc8b07b3bb619ac0fe652f0c81f8f05f3d2e5d5665",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/structure-object-group-no-selection": {
-   "caseId": "skd-compile/structure-object-group-no-selection",
-   "contentDigest": "b7e7dc0160c1bab7308bad6b308f008db9e78c97558543fd9462c46de22eb2bf",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "b0c535c847c3b5868c65c7cc783c04f4b754e8ea5c55691e1fa9d069cce686cb",
-    "donorWorkspaceSha256": "a2c18a87e30fdb891800660ac68ff0a06639a96709c6064a3e1988ce5a21933a",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "8d608fb153f712273b7cc99eb997cd9fb5139568beeff5b03f033beff9ae2a49",
-    "unicaWorkspaceSha256": "395f2e807848156b51a0bed769bb0ff36b1e0e81b8dba5288ed1fa0b64cf987d"
-   },
-   "observationFingerprint": "93e495efb84001259c5769d3d57773211dff199aa3a573dd8e9aec5ab89c17b2",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/structure-table-pivot": {
-   "caseId": "skd-compile/structure-table-pivot",
-   "contentDigest": "9f87bb252f5f87d2971ac8242453fa258ada6a644ea1be6e052665d4834c5fbc",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "5ef340e981026da14e357e219666fffc7e800695aa0e34aadd976c15a9471126",
-    "donorWorkspaceSha256": "8ae95f0d44140b8eff83d4bb21aec89f4044761f26489e021cbd39753525332d",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "d5eb52cf952ca730ce5b0e991062203bf7577bf23e4ae504adb0942f439b1ea7",
-    "unicaWorkspaceSha256": "fb1ab39de4b3c0ac5bc9474216efbe89a4eefc0c93f124f7afa9175effcc0840"
-   },
-   "observationFingerprint": "10b13b7a83ef962e1ec199d952ba5a08164f347e5a205e93959dbf753475422b",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/userestriction-object-form": {
-   "caseId": "skd-compile/userestriction-object-form",
-   "contentDigest": "1ea99bda166de6f5526021a3d963522e4fd870917ca1ae16e4eec7e0cc2f0606",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "f8476d3e2f0d4762dc1638224cffa2e6113e852566ccde3f0b79f3942293c9ac",
-    "donorWorkspaceSha256": "194e7b8543766e994fdcbbec4e5a527beebec4b413c97abf803c1a896caf2f4f",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "8dd2a274edad1a99dd784c52e23a6a7e2c28a76c27279538db5308972a3f7fe9",
-    "unicaWorkspaceSha256": "f1a39428b22e746dcdb83ae99a3514128873829c9debf05b7c764c54e8d5dbc8"
-   },
-   "observationFingerprint": "4cb51808adf8f2de3609b6070aa7e8bc4073103fc95efd0efa352d28b97f8131",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/with-filters": {
-   "caseId": "skd-compile/with-filters",
-   "contentDigest": "52b75e1def962835e8ddb1376e30cc79564148d674c6973dfebc19e7a08b169c",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "53b0942592c634f6b1fa7332b82996564b6538b85210b90865d48756596461cc",
-    "donorWorkspaceSha256": "00a88d0904ed0c23a3de5fe1a81e4380f9a867adf1a92a6304cbb77480a4df88",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "ccb1cbef767d04027e11750a31c39f620be4daadf232d22062f5b6ac97669bdf",
-    "unicaWorkspaceSha256": "02136881c3522e9959f9064648742791d3d44ce473f35c8cf1c3b70b7f2cfaa2"
-   },
-   "observationFingerprint": "2900a31d2416817697d79ba72f8c6a3a62f41eda85ab5047bc163de51883d7ef",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
-  },
-  "skd-compile/with-parameters": {
-   "caseId": "skd-compile/with-parameters",
-   "contentDigest": "556d4c677523fa5d36568df504b0bc2f19a21bd120af86c31fd58853b07ea36d",
-   "evidence": [
-    "spec/acceptance/format-profile-8-3-27.md",
-    "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
-    "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
-   ],
-   "observation": {
-    "donorExpectedFiles": {
-     "Template.xml": true
-    },
-    "donorOk": true,
-    "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "donorStdoutSha256": "67d389c7d1010d52e016d4b1a506f9420943495cea97587f9f20513dfeeb1fd5",
-    "donorWorkspaceSha256": "b5f8ad8dd7884f82efa41fd253fabac50b614574f07996601a5bedea585eeaa1",
-    "mismatchKind": "stdout_mismatch_snapshot_diff",
-    "unicaExpectedFiles": {
-     "Template.xml": true
-    },
-    "unicaOk": true,
-    "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-    "unicaStdoutSha256": "cadf226d3339b9129e17b5a0fefa62af36fa8457f30138d5825ba1ae7c1af4da",
-    "unicaWorkspaceSha256": "a6fc7f9b22759b3cca31bb3bd11a79d4a9f9ddb85ea39783098acda934e7b455"
-   },
-   "observationFingerprint": "22fd761ece4ee3283f2b07464716fc908ab81bc0ef1feebec91f3c8bf6360456",
-   "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
-   "relation": "intentional_divergence"
+  "schemaVersion": 1,
+  "upstreamId": "cc-1c-skills",
+  "retired": {
+    "cfe-borrow/catalog": "unica.cfe.borrow отвечает типизированным data (ADR-0023): прозы для сравнения со скриптом-донором больше нет",
+    "cfe-borrow/common-module": "unica.cfe.borrow отвечает типизированным data (ADR-0023): прозы для сравнения со скриптом-донором больше нет",
+    "cfe-borrow/document": "unica.cfe.borrow отвечает типизированным data (ADR-0023): прозы для сравнения со скриптом-донором больше нет",
+    "cfe-borrow/enum": "unica.cfe.borrow отвечает типизированным data (ADR-0023): прозы для сравнения со скриптом-донором больше нет",
+    "cfe-borrow/form-bindings": "unica.cfe.borrow отвечает типизированным data (ADR-0023): прозы для сравнения со скриптом-донором больше нет",
+    "cfe-borrow/multiple-objects": "unica.cfe.borrow отвечает типизированным data (ADR-0023): прозы для сравнения со скриптом-донором больше нет"
+  },
+  "relations": {
+    "form-compile-from-object/accumreg-list-simple": {
+      "caseId": "form-compile-from-object/accumreg-list-simple",
+      "contentDigest": "d8a895672b46c1415ef6642a5d8e71ae0d35e555cc05934d968b080c4f2f1062",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "8d00ebd52146f12a7cbc9100166f5fe73cc055c4ba55c57e29d89ea1732c6c62",
+        "donorWorkspaceSha256": "865388d91e0670ab4999ac58952a4a31622c6ac89866279ce17b24217bbba9d1",
+        "mismatchKind": "unsupported_from_object_type",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "1293d0ec23d81743216cfd31620d0c7cd011b3cd62a73c883cdd387088f2f7af",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "8fa36ba5617671d7340e7032e43a71b001e9259ba0fdbdf9c6e7fab31c0a2e2e"
+      },
+      "observationFingerprint": "0cf9cb3d33757947fb4097fc821d25c6c48a6709efe84a58f3cd5b542efa739a",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile-from-object/catalog-item-simple": {
+      "caseId": "form-compile-from-object/catalog-item-simple",
+      "contentDigest": "39beae436557d28423db7216023f44cc02982ac68694c36bd691233d1ffbcac5",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "375572b562f6a8f3f9bd8fb36a66ff66ab755e7c6c1780ec8b10e60b6e49b189",
+        "donorWorkspaceSha256": "39c40132fa62d1cf0153eae4026b93d07b42393e451b302edc929c43a41a3238",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "375572b562f6a8f3f9bd8fb36a66ff66ab755e7c6c1780ec8b10e60b6e49b189",
+        "unicaWorkspaceSha256": "04836930a5e6649b3a150fbcf1a46df22a5d3b87305c049b2faf1acb802c6935"
+      },
+      "observationFingerprint": "2d88a0a5c0ae602af0665051c65afde6e6493018257d4c6a26f591d33faa3859",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "form-compile-from-object/catalog-list-simple": {
+      "caseId": "form-compile-from-object/catalog-list-simple",
+      "contentDigest": "ba7316ff5f74adcc1c31a45910b9854c1298cff16b7568b56daec648748a6b81",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "0b83d2c5c1f10be3f6c9354aa488155e0911a78244b4f58d7ff793ba6fc16272",
+        "donorWorkspaceSha256": "0203e8f50bde955e7a8fada0b86f1cf9e7f2b3bc7cd445231317d2622060499b",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "0b83d2c5c1f10be3f6c9354aa488155e0911a78244b4f58d7ff793ba6fc16272",
+        "unicaWorkspaceSha256": "50c4c2d2dbf77ae071c494a6fd0f74817fea720273ebe4d8feb56cc9eded41df"
+      },
+      "observationFingerprint": "00ef5dbc93a60b3250576287a46376e53d5453f9b45ba02798d3da5edbf7a5f7",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "form-compile-from-object/ccoct-item-simple": {
+      "caseId": "form-compile-from-object/ccoct-item-simple",
+      "contentDigest": "9d3b60405a8751906271924c3302b3170c57cc037c8a903c6e4cb5c71de47eda",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "0056bb421db3719fff48894728adc31e5a298e7e13ceaf9d3f52a448da5a8c35",
+        "donorWorkspaceSha256": "e3c559fff467bac0a1139bca006d7063ec34d35a1b4c10a5fbe80440f2386aa6",
+        "mismatchKind": "unsupported_from_object_type",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "c3d5fdf0691ab6a3681b055d1b28d93bdcde9e7141c33b65b1ea60c02eec89c6",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "9af036485475bbbd4368506ca159d363a7c2dfa568a7123d77c5d468b4b9d86e"
+      },
+      "observationFingerprint": "5e63dfc33cf645af403ef5201b3a1b5876c2b94c4b2f9fb23a2ed999fed6314b",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile-from-object/chartofaccounts-item-simple": {
+      "caseId": "form-compile-from-object/chartofaccounts-item-simple",
+      "contentDigest": "52d1736b5d4ef1bcf50bfd5a7e55b25b440c5872e5b557f72a4d9a3a8d179b22",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "b44c295bdda4bcae6f16b61243a07c2a96151d9e0e69b2753c40436d8e417253",
+        "donorWorkspaceSha256": "f6e06042bda7c8b5536e78a0fa72cb12bc7d046ba07ac7db9b339db2977ec293",
+        "mismatchKind": "unsupported_from_object_type",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "e7863de9c2477d1a385c19fc057c4dd4a8a0d67cb7ed037b3d96dfda8904f14c",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "954fe593261df78a8eef57fe9b523791e9df529068adeb43fa9d3d1a22c4a956"
+      },
+      "observationFingerprint": "e539471d36a5d477b3a53a8331a1427732d58483083fea3c2b124d8796d4eebc",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile-from-object/chartofaccounts-list-simple": {
+      "caseId": "form-compile-from-object/chartofaccounts-list-simple",
+      "contentDigest": "7924478ce3e8341be0f07fec17d1eb58f34ea76d61f65e80be44585ee45c0e07",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "ad60e804c137d7521b8c149dd136b4a898592f9087fd69637d1128c731044d4d",
+        "donorWorkspaceSha256": "fee789784d53c173ba6f0e8dc74ce5b99b102823fba0643f4977bc3f5e6e1293",
+        "mismatchKind": "unsupported_from_object_type",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "e7863de9c2477d1a385c19fc057c4dd4a8a0d67cb7ed037b3d96dfda8904f14c",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "82f5e20f8ca2fb899a86a6eff51b0804be78be0969e685bfd7f997a5db8ae10f"
+      },
+      "observationFingerprint": "8f52f6d11e908cdd4beb434aafa9aa8c378010cb6eaf73ac212e89b641a7de23",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile-from-object/document-item-medium": {
+      "caseId": "form-compile-from-object/document-item-medium",
+      "contentDigest": "d75bef1a39971e7aafa0ac7a5cbd193cf74c3a1f7f66468f2a7877305194931b",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "d26989bc3d2a3d0e14f3e06489ebcc21ba20789612f244a5429fcd1909fdfdf5",
+        "donorWorkspaceSha256": "cacaa9e6fb13d7e2e97966ac41290b48b7a8b2dddd03bd44b7a633204e8e5cc6",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "d26989bc3d2a3d0e14f3e06489ebcc21ba20789612f244a5429fcd1909fdfdf5",
+        "unicaWorkspaceSha256": "3a044f00eadd5ed31df59c029250ca3d0bf2b21105b5d70864e95efc2fb1d293"
+      },
+      "observationFingerprint": "e51eb61134147ee8e05593aa659eb8b388e6bed733d694f166959153301a0014",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "form-compile-from-object/document-list-medium": {
+      "caseId": "form-compile-from-object/document-list-medium",
+      "contentDigest": "da96e559dc0846e97a5cd136b277bae313f98c90d71d3fb7a523ac49b5029f36",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "e47407b3c36bceccd267e3f5a4a90901823703f3c8ae6eca67a68cdad40f697b",
+        "donorWorkspaceSha256": "6cdede734a8325072dcd95cca2067f81d583394f949408a656e54383975ee7f4",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "e47407b3c36bceccd267e3f5a4a90901823703f3c8ae6eca67a68cdad40f697b",
+        "unicaWorkspaceSha256": "5c481dcec638c9ea359ae2e82ed19afd61505173e7d09d8af947d4c6bd3683d8"
+      },
+      "observationFingerprint": "c6f2bd650ab72535663ec19e57d0e1bb5430fff2cab0826895181906a7901b90",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "form-compile-from-object/exchangeplan-item-simple": {
+      "caseId": "form-compile-from-object/exchangeplan-item-simple",
+      "contentDigest": "75ba8ccda85040291aee6a3cefcf9d04b1a726b0db9551b479c153e28b62bc7e",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "f91c1a96072de616be1c8a24bc285a9d8ac0b9015a4cbb2b5bc67e77dcc4041a",
+        "donorWorkspaceSha256": "25d52be8fb1fece67d850c0042a142e034b84750ead877593fb6100b33e7ea6b",
+        "mismatchKind": "unsupported_from_object_type",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "6a0c52a746abcd4f2d0b09ad96a44bdd5612113108f1481b2cf930a387c60a61",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "f2e15bf4df959f49da7d5748faed1e0c0d573e44ab8fd0551e1fe9d7a9b3c839"
+      },
+      "observationFingerprint": "d0a6c076a07a1e97990af17648f28b1e900e51c3ad88afd4227d146045d4bfdc",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile-from-object/inforeg-list-periodic": {
+      "caseId": "form-compile-from-object/inforeg-list-periodic",
+      "contentDigest": "00510469da82355b0f1e95a3da93ff8a1b16769cc43501d8797ba6b4b613795d",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "543cd30f4697b21df81fa4738e80c2f8ed293ae1a1e6dad7de1e15c6f50e7ad9",
+        "donorWorkspaceSha256": "54151e4df10e2589ca271deb8620a05cfe2acfc613da3391765a78520148b83f",
+        "mismatchKind": "unsupported_from_object_type",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "fd2d284b97d327d1a47794f4b90c9cf967a0b3b931a2667b331b623866afb8d6",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "0acec87636765f09cf0297e75a3c0c2a3f9c8601e56b1631c987a1aadbe94a3a"
+      },
+      "observationFingerprint": "9e27e8980d4debe9184aac8ae141b9bdddb2e5869b630264aaa68023a49aed82",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile-from-object/inforeg-record-nonperiodic": {
+      "caseId": "form-compile-from-object/inforeg-record-nonperiodic",
+      "contentDigest": "12b03c95382217782d0856964c8a9a1f383e4daf552a723d3520f040e5d10f1e",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "ba52c163f4e0c046bf9bf0f26fa103643006d6319c71bd653382939b2d0642bd",
+        "donorWorkspaceSha256": "12ab1d857e9db05a78e9a3c1eca89cff6b7e009a2beb683654a77752b79bc6e8",
+        "mismatchKind": "unsupported_from_object_type",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "fd2d284b97d327d1a47794f4b90c9cf967a0b3b931a2667b331b623866afb8d6",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "f33d5bc3dd72dc461b5fa171ea8ead1b8328b455cd627dfb9929817b18303ff3"
+      },
+      "observationFingerprint": "c704328e8e55e2c119d528b678ba7d28db66f96091a798083baaf56aa83d2107",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile-from-object/inforeg-record-periodic": {
+      "caseId": "form-compile-from-object/inforeg-record-periodic",
+      "contentDigest": "e0dc082d770787b50f96c0fcf4367c13f58c9e0bdd8f186e061d8a0252a5b99f",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "e176ba3c276403a4f8c4e8fd3753a4587485d002fed48a9399df83c84b3fc4cd",
+        "donorWorkspaceSha256": "2417c623ba6f0691c951d504c9c2402b69ca3fdeab51199774b15c9d63047ff3",
+        "mismatchKind": "unsupported_from_object_type",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "fd2d284b97d327d1a47794f4b90c9cf967a0b3b931a2667b331b623866afb8d6",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "c890e64bf6d5474ea1742f7c7e57f2608ef8700692ce3494eeab9ce1a9536c7f"
+      },
+      "observationFingerprint": "a14a9d74161941cec4c8c8d9ec437e951dc31b2e2a6c48835ccadb2a173d9824",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile/additional-columns": {
+      "caseId": "form-compile/additional-columns",
+      "contentDigest": "b9dae507aef8c4a0059d05eb8de530bea66f4ba650c84bf1fbf06f3ad31b973c",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "9ce0d3f89a1f6bb5704e776305f5456801e9463bf48dd2ac3dff30179cbd5e9d",
+        "donorWorkspaceSha256": "7fb0bbc01cf8e153041cfffe8ead2046967c3114379b829ad5e53923ff2d0b16",
+        "mismatchKind": "unsupported_form_element",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "1982f74f27c4891fc5a84fa759013002d37d0545782b748f91f1d77863adac8a",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "cb2ed64d993f9a118a6ffee0564d498e9827e0f0fdbabe929e84e2b610728bc8"
+      },
+      "observationFingerprint": "9ab2490ec6d5f8dbcd38d5e648030a570891e6f927af3e0ac5f1265c35f093e6",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile/attributes-types": {
+      "caseId": "form-compile/attributes-types",
+      "contentDigest": "3579d852ff145af4cc83d6829391c07d5068cdc09b1c16ee80f612000ed9026d",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "544c5499727c7a990bb4f9f8a37b94cd122a7ee37c0d8dc52ed5d1b7e5880274",
+        "donorWorkspaceSha256": "54aff38da96fddbb0195f6c0eb92ac35eec126a36e593386913e68f09fda814a",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "544c5499727c7a990bb4f9f8a37b94cd122a7ee37c0d8dc52ed5d1b7e5880274",
+        "unicaWorkspaceSha256": "970bb8246024d64988bfcdad2e8f5d06fb16f469ae59edbdcea6c383788421e1"
+      },
+      "observationFingerprint": "684d99f2bd2ce9b4915da1a77e6d90029393ae509d43413cb4be99370e16e553",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "form-compile/auto-cmd-bar": {
+      "caseId": "form-compile/auto-cmd-bar",
+      "contentDigest": "b35bb890b9b9098188837d18029a86d799b53541f384ef9c305012cfab63d650",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "d061515127707eefae1764b7043b4f485744d04d25591caac4b483c0449e65e2",
+        "donorWorkspaceSha256": "29f3941eed3eeb182399134bcf35ddc440b3db487d8bcfb09890903c935ff54c",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "ee9aa930f4fec414626c7b65fdf72959301759a49c8e080c54aeab583f24212e",
+        "unicaWorkspaceSha256": "7ef1e411c4c2a99fa3da929787538002ff6bf9a64f2c05815a686b7217a00361"
+      },
+      "observationFingerprint": "63a694d365706184a859e42dcde4f8adb759fe783ecd12d3c5f8bda90f8d5eda",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "form-compile/button-group": {
+      "caseId": "form-compile/button-group",
+      "contentDigest": "bd6bdef8d04b4d8fea62027ea2c5166cc5104fcf138c4078f85db8e1178f4698",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "f066b4c729a4155f1c370c992ee0653ed4e522af39d9e7be3b16f5e55a906384",
+        "donorWorkspaceSha256": "7e8fe406360f4d69c8c6e56e35f53ad273df4a301608054d0526c29def2fe634",
+        "mismatchKind": "unsupported_form_element",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "173be5cd807ee1dbde1363e2cabd115e4e2c1d2bcb8beb8807434ae7ca7d2ab3",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1f9b4b3bf1b43f68fcc1c86960669c1d302d478339ae069533c161854183498c"
+      },
+      "observationFingerprint": "a499723992cc22d2f089e8b454c72f7d57f28ef73471bb33ebb4af05f30079e2",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile/calendar": {
+      "caseId": "form-compile/calendar",
+      "contentDigest": "947fdfb6a73b393308a4c310c443c87a774cea85158377dbde761d899b5948e0",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "5bd01f4578c07b621ce6e2220e8b5ba323f5ea03c010b4893fdb11aa894f081a",
+        "donorWorkspaceSha256": "5ce1fd3e02b2c0a1e01d342f3d6e5ab657b7edc30e6212407faa10fd58f191a3",
+        "mismatchKind": "unsupported_form_element",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "5bc87d80ea90273700e7c34cc7bbf5eddf78102c1880a826d4203b2d613b32d8",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "22d1b5d9d5cab7cdbbdf1fe67252ccca0991ba37b18d854ea4c6ec69fe0e94db"
+      },
+      "observationFingerprint": "d978abad3be61ea08b98eade40e087643a20f3ed9d3738bfa0f8375a6afbe4b1",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile/catalog-form": {
+      "caseId": "form-compile/catalog-form",
+      "contentDigest": "dd93193b18e1eb45de32d2410482e247cece3f07821948478c451403aea7443b",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "5c28e2fe60e66e0fc11af95a2c382dd923c859568a8e7935333ef219479b81a5",
+        "donorWorkspaceSha256": "58bec58b9332211e06e6d0b9da6f211c345cade998efd75e80d42f7a1d41a802",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "5c28e2fe60e66e0fc11af95a2c382dd923c859568a8e7935333ef219479b81a5",
+        "unicaWorkspaceSha256": "317579928e620bf926542d311b482eb2cbbb1783691c103943be1f4e5ed617f3"
+      },
+      "observationFingerprint": "3eb1571383fc581b7d8e8c44c517e77c34b9b95d0b6462eaa587621b239194f7",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "form-compile/chart-fields": {
+      "caseId": "form-compile/chart-fields",
+      "contentDigest": "43244692610809fa07a11b69de3e9ecda4d9bd583378bc29b5272340ec4fa498",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "20939f459c15daf39055516e132b50e8c41e5541c332554234e7de8b0d7e0246",
+        "donorWorkspaceSha256": "67b39b8c31bff1e42cb5620b7d6cd9e3bd8c25857d0c6cc14d5b84dbf5ca56a5",
+        "mismatchKind": "unsupported_form_element",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "28c30e2ddaae9025c82b133b16fc6b4205dbd7ec895adf8f89803f1060849ddc",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "f50f75d9c9953f3b5662d72daefa6cc7c5edb68bf72a4f6028576992ee2b6375"
+      },
+      "observationFingerprint": "50c2adff0b3a0d2215d2b58864865220c8aaa3c9805a3dfe220b039e0f4e0857",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile/chart-gantt-settings": {
+      "caseId": "form-compile/chart-gantt-settings",
+      "contentDigest": "9ea7abd8322f2389afd002a37e3ea29c58299851d9e072c42285cff684c7ac74",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "7b65ca941a59d605163cf53d17be3c8b2e1f171c0d349e1bd67a304d349dc0cb",
+        "donorWorkspaceSha256": "d71fbb56eee1ef50cee5bbb829fc0417a60a85db8796fb5a477a9d0b6a4cbcab",
+        "mismatchKind": "unsupported_form_element",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "1c65501669153fab0888aafaa6462d749527f06ebd8c0453eb9ff206b11cf7f4",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "f07a5a5875b414658b1de212be4ca5e32e4fea89a07a2065241d3342ad6e5096"
+      },
+      "observationFingerprint": "7afe2ec0e2c4bbc6d328b4f95411e7e336aed5bf83154df908fdd34b46f65426",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile/chart-settings": {
+      "caseId": "form-compile/chart-settings",
+      "contentDigest": "8c5201b308fd23b8f0ca15e560fbc81d9486ac5d94110f1340392869f691c0ff",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "a742dfda418db4539a80c0efc072ea649c0b336acfb498144d33ebe106f5d88e",
+        "donorWorkspaceSha256": "1320e772996228b8f69c773d44d5f9a005d78dab7d4d231aba4d32ea86556a50",
+        "mismatchKind": "unsupported_form_element",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "28c30e2ddaae9025c82b133b16fc6b4205dbd7ec895adf8f89803f1060849ddc",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "d3d32dc694dff955e909616aa001ee36a956d50724aa9d8a5575e53c56fba955"
+      },
+      "observationFingerprint": "6773e8428647a6b818312579128a027528b470a6305de8fd4341bc9703dfc055",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile/collapsible-control-representation": {
+      "caseId": "form-compile/collapsible-control-representation",
+      "contentDigest": "7d6b48d6926f3b7968e12cc55a86475c1bbb9430d94501676308df3e54042994",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "9abf9e742ac596c3067acab97a74fcb3d3cf3d07b5e7aa3a8632813e36da47bf",
+        "donorStdoutSha256": "65c1db047e4f12001816654a7e985a1e05ce6c25358624965afc8a9f80b0b100",
+        "donorWorkspaceSha256": "050b6b049a5aa840a40fe2bc97a658d59a3af37b7df1ae02f8a3a6893b7b6bff",
+        "mismatchKind": "stderr_mismatch",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "65c1db047e4f12001816654a7e985a1e05ce6c25358624965afc8a9f80b0b100",
+        "unicaWorkspaceSha256": "3978e9c3a7189f02d7b8f71a800135259f8ba251122a6ba219a85107a9a441cf"
+      },
+      "observationFingerprint": "0a07ec5cb4919e42a2814879c9ab9b03641bf0f49538664397574de74c66e524",
+      "reason": "The reviewed observable outcome is compatible while diagnostics or non-semantic presentation differ; the exact normalized observation is pinned.",
+      "relation": "compatible"
+    },
+    "form-compile/column-group": {
+      "caseId": "form-compile/column-group",
+      "contentDigest": "4cd0f0f67efb8dadbac3ca0ec382d56b1c55b0e31d292f04c4656acce924c391",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "fdd5e1880db38b37f9ff45380b1a5f6057bfef4165424cb09d6a71ed043ae439",
+        "donorWorkspaceSha256": "f378cc2dca76f844610aa7e630630357fba2ff51d269f47733ce50e45905691b",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "801ceea30f3cfac425e8a8d526ca8298cdded90b3dc7163e6cdb5b4c8a512b1c",
+        "unicaWorkspaceSha256": "67e76f8008fc7546414d4c3a6f4ed294de431d20ae077b49ff64b2d9b16830ff"
+      },
+      "observationFingerprint": "9496e25ccb916eb294c4684bae23fb264c30745bd250a472bb4f46734f9e50c0",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "form-compile/commands": {
+      "caseId": "form-compile/commands",
+      "contentDigest": "e86476a3bab9cb2aec205bcfe40a1d29754041bb8bc23462d0810121df8d614c",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "cf137c130f4a587267a882de54a4fddc12f9bd73c08991dc28ccebc3a60e1ccf",
+        "donorStdoutSha256": "a3a427d13f3c354d696e4ae5bb15f53d5b0d09dd0a4a2c18f3f89d79e155d03d",
+        "donorWorkspaceSha256": "f1620e98071c32671b84ef0774d8bff782b6caafd538f5ed399b4bfeba64dc50",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "1f48f6171a78334711f2a676ecb08ec3398d47d7a7141569d9b8b22c04f22fb2",
+        "unicaWorkspaceSha256": "74387daeea7767ab80fb7aeb5be147407f18a73a411cabb966cfd5f7d3ab5db3"
+      },
+      "observationFingerprint": "5fabaae2cc1b40a484cdaa3434748496d59c5ce4112b1c5daebb381727be4a6e",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "form-compile/dup-command-names": {
+      "caseId": "form-compile/dup-command-names",
+      "contentDigest": "3da3dff60876f9cf7ac3605bb2cb09f45de724a126d653670d0c6aaa0d596ce0",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": false,
+        "donorStderrSha256": "a6a11515f324e0411580a8f98f17ed5af5571f7d33e8ae109fc94d550f9c6aa5",
+        "donorStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorWorkspaceSha256": "b5f9864b4cd0fde6942eb34bd74469653cb7ffd924258059f3afa2ee1fc0387e",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "c0dcd7c5a5882a5a583decf975c6553120abdd9ad648544a06152f6e0ec911aa",
+        "unicaWorkspaceSha256": "03168bdb2743dfaabf29c6ede3264cab1d259e60baeccacc44b4ede14bef5112"
+      },
+      "observationFingerprint": "afd10f9cde96b46673269ee456b5e7e54689279d5dbfd6274bec4d94c195ff9a",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile/dup-element-names": {
+      "caseId": "form-compile/dup-element-names",
+      "contentDigest": "6b3af0f3d71ccbf0cbc73e270b2ade7efa8a7a75ec8f0f5fa43a4f8568434c66",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": false,
+        "donorStderrSha256": "2176b70387acf39dbede18e75709899f956c8eaeabc88262f1c5d25a8ac2737c",
+        "donorStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorWorkspaceSha256": "5ecdc133758670f7dd5b77a0247475de5e4bee91c3d59c90c241aaefbd57fb6d",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "ea9862365e2ecdb2cadc62b1fbdd90b80b0d976c6965d462c3f9937cf8400afe",
+        "unicaWorkspaceSha256": "70ba670a3f83086bbc06fc680eea937507c6e8c5944aacbd10e2e076158292bf"
+      },
+      "observationFingerprint": "c2c8bd6f77eed2447d92c689181da0577c0f0eeca904a30ea5547245eddb427d",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile/dynamic-list-form": {
+      "caseId": "form-compile/dynamic-list-form",
+      "contentDigest": "0729b5c126992b33bb335760505b1d9f70794a6acb7613902d127fba84fcc5a6",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "8a594da0dcce4fd737c94ff83fff6bb5b7bcd6b76842195ce581678ad6da04aa",
+        "donorStdoutSha256": "0a52caf8ef7c711567d5abf66723a6ae53e56a1bbe7bb900cc1c74e3c07b2e2d",
+        "donorWorkspaceSha256": "0e8ff13926b95ce757d63abddd1c4eddcba2ddd9b73cc76602a4c137a95911ad",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "f13f93a46816715da9b8db4cc85c51569a824aa211305e4225088d54874c49d0",
+        "unicaWorkspaceSha256": "f715801f537a098fe278fbf3bf439a3e9b467858ab6f9a1eeb5ac8dc8fc77c0d"
+      },
+      "observationFingerprint": "94563b62e734252eaf500e1cfcf7b1dfe2620a47a0cfd7866f66d3c4ed6aae7f",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "form-compile/dynamic-list-parameters": {
+      "caseId": "form-compile/dynamic-list-parameters",
+      "contentDigest": "5368ad39b4325ea4deca462600e3a0ef65bce9f22e3061bab5cbdfb64ffd312c",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "f13f93a46816715da9b8db4cc85c51569a824aa211305e4225088d54874c49d0",
+        "donorWorkspaceSha256": "0ec95d3be6bd48e034acdea5c6b1b8da1275079234cd9f8e8ff4dd1a0739ff5e",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "f13f93a46816715da9b8db4cc85c51569a824aa211305e4225088d54874c49d0",
+        "unicaWorkspaceSha256": "dc84ad4d39ca74a32973e52877043bac89504786231a191fc1f21e0ee1b40e9d"
+      },
+      "observationFingerprint": "ebba820fe3d793a9a0fe4594ecef057c015ce2e2ced084c70050594a853c22ab",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "form-compile/element-appearance": {
+      "caseId": "form-compile/element-appearance",
+      "contentDigest": "e9a501ccf3d65bc462fd5b8973b36286b8c5aa6f889a9261d15fd532e7ca8058",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "8524e598c6e0b2449e67266f6903301d8fa4cd33ba3dada468ee675f980a045f",
+        "donorStdoutSha256": "11d79454a1048222a2e7e2763a339adca0325ae15bec0f9082afa16e5fe1a86b",
+        "donorWorkspaceSha256": "69d59d3f06cc6d047c3abe025dc31de125b7f317d946faa921717ee96048be97",
+        "mismatchKind": "unsupported_form_element",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "c00654f859c6e896059420e59102d049981117e41b90252da8aa39a0114ef3f9",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "6905569628075f99ba247ba569508db45c8f500bc5c656c5aecac22566beabe6"
+      },
+      "observationFingerprint": "c3b8728c1ddac518e2137a68ace41e411d964797ea088952cbdde7e5515b8536",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile/events": {
+      "caseId": "form-compile/events",
+      "contentDigest": "892fbeaa280dcc0d7be43b249007ffb2f90e9943fffd7b0a3205abce8c1293ab",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "8c07b9dae53ec1851f7836a8f8d8ec8d5f9cc3d3f9a24cf885d3f16d3562fd47",
+        "donorWorkspaceSha256": "c5d12993dba182d52dd0e7a364fd992ce2fd55ecf5f056bc93e26b7b11e53e2b",
+        "mismatchKind": "unsupported_form_element",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "98e0d10ef3b9b35c5ca91238642241ff67f163a8282f26b5e1ccaf653feebb32",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "17919d4b1725f875df61ce5d303d5db4a2650430733fdd03dc264c81549602d5"
+      },
+      "observationFingerprint": "989a41b2ae10d720c11c72096a89a3b5d9c3618421b18706cd5d5418cf6f7588",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile/file-dialog": {
+      "caseId": "form-compile/file-dialog",
+      "contentDigest": "59c0f046d4c711b6b3968cb6871c40aa9d42b62ef0379fcae3231b540c281faf",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "d227437f0e32f5221a37c1addde59a0d1f659c2f40a7214c89e591310eb268b1",
+        "donorWorkspaceSha256": "474c4a9710bf3e1b2cbc9fed777ae23538606f69367016ed00d5d829b159eb41",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "6e977c47c670a2a23d03c52d4ff0338c800b0941b3686c231b08e9cbd9266656",
+        "unicaWorkspaceSha256": "ec89b36e96e209916840b3662853b6c3c133bd9844630c472f170ba7b6151c81"
+      },
+      "observationFingerprint": "eb841e0e0db70ac126140ead71f61c007c538831bb311f7f11545cbc890bc255",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "form-compile/groups": {
+      "caseId": "form-compile/groups",
+      "contentDigest": "9cf13c566ef57651dfe99d5e84f159c84376e222c6f40e22edcaae1dadc58a38",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "07b436720070fa5b955b2a1e68e2211237fb3f358eb2f12354768aeb758f73bb",
+        "donorStdoutSha256": "33ec0a14806f1491e75378c6d50ab669dbdf97370762be8b2a5d5a856e0397c6",
+        "donorWorkspaceSha256": "5795ed357bf099394527314e3a28de62d24101205d5e00360d53271f8ea953bc",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "2b224f3463cafa8fe4ad3624137ca94ebc7b35e087ced1cf9841d5843ce84e97",
+        "unicaWorkspaceSha256": "8ede9ee0fc1d7d623b288662537eef8046372605518557c3558fb70cacdd7e42"
+      },
+      "observationFingerprint": "4e333168b120ee38539797ed92a521ebdcf2002eb4181b3600daf45c8cfb0250",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "form-compile/guard-deny": {
+      "caseId": "form-compile/guard-deny",
+      "contentDigest": "4af67e6f96af1189a3259d702362d658739d568132f3437fdc02e2e9880feb41",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": false,
+        "donorStderrSha256": "a34c7937455b4f13909ab0a9aa03e61f6b9cc2ad4e7d8c9c3bbd8ab8cefddfa7",
+        "donorStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorWorkspaceSha256": "dbc23bd1ff8e1bb20284a2deb4e531ff680e2429b556de2158e7b6639308fd2f",
+        "mismatchKind": "stderr_mismatch",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "cc24290fdea08afccc53ac3a547e3d2bf07dff6d9117dfc161864e135ce197b5",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "dbc23bd1ff8e1bb20284a2deb4e531ff680e2429b556de2158e7b6639308fd2f"
+      },
+      "observationFingerprint": "679da402f185a521eddf81845c50fe8b22bb19b2581ac8929c3c3f783d1220d1",
+      "reason": "The reviewed observable outcome is compatible while diagnostics or non-semantic presentation differ; the exact normalized observation is pinned.",
+      "relation": "compatible"
+    },
+    "form-compile/input-fields": {
+      "caseId": "form-compile/input-fields",
+      "contentDigest": "3d64378ff1014d82bcb53df51d18a0359043291031843f50f8df1d88535e6692",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "c3475f52c5d045b95ea9f80dad63c6832e25adc4e3b75f5e2930b806ec564cd5",
+        "donorStdoutSha256": "cd2256c006526bb0f9e170a0af98000da31f8ae7fb0ba69f7a1d739559380045",
+        "donorWorkspaceSha256": "7ea4ae002f66a5eb712cdb752b6448152c8e157029da2ca6b669ca4e2d46ee22",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "c7be625b48eadc66973c9c6f594c3ed290b563b534c137904fe052a0292ce686",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "3a200d4ce30e3972a42eababe6d2eab8472130af7de2dacac5ff34e447322403"
+      },
+      "observationFingerprint": "4cf260c48d1d80d1e68be72fe8e5c17816d8ccf49b48fd59b24b3dff8ffa6f29",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile/minimal": {
+      "caseId": "form-compile/minimal",
+      "contentDigest": "38d395dbd87898a4131f9db06efff7fe03fe15347490cd30c4c8200898448f33",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "5b1768d002a8b221f08da0dddc72346822bfce7fd25aaa754ee13de2e017b2f5",
+        "donorWorkspaceSha256": "db65065768df1f9eb034eef3a1f8827bb2a82ab6c9b3b34656f3289e1b327e4e",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "5b1768d002a8b221f08da0dddc72346822bfce7fd25aaa754ee13de2e017b2f5",
+        "unicaWorkspaceSha256": "b51b5e735c7499f925980bd90a5b47b0b04adee89c4abc1bf1d8b162e43be140"
+      },
+      "observationFingerprint": "3360bef21c73752875bcf16adbd03ea921e5754ab907d12d736153790e16d3ae",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "form-compile/namespace-collision-ok": {
+      "caseId": "form-compile/namespace-collision-ok",
+      "contentDigest": "a2fa5c12569984cd8383b00a5d01681e43a1f8c32d4a96359c326e740e5ab641",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "2481365fb36cffdf05ce27152a3a2b34f064e903b750491f76b95251f7f56d2c",
+        "donorWorkspaceSha256": "4f9b137c36b1dd8160f302fcafa820d056fbdd13dd162670bf084da144228b90",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "2481365fb36cffdf05ce27152a3a2b34f064e903b750491f76b95251f7f56d2c",
+        "unicaWorkspaceSha256": "a467545e5f322ef8f6dcf7ed51d1ee16dd26bf70cec9e72c32e160189b0bbcc0"
+      },
+      "observationFingerprint": "2de98774e9d42998f5bee288b93ccce89d2597fc89c1a534e3e6062c4d98be6c",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "form-compile/pages": {
+      "caseId": "form-compile/pages",
+      "contentDigest": "6008711e1c4934b0d32c3e7f2d3a6f25f75491ab182805876d5384e604732605",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "8f9cf11cef0eec28ded3453580662bf63a790fb7e387320d7dc5bd476889b070",
+        "donorWorkspaceSha256": "2e9d2357086bb8110d307eb88bcde8cb4018757c16e3cd519e619e92cbb25b4c",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "8f9cf11cef0eec28ded3453580662bf63a790fb7e387320d7dc5bd476889b070",
+        "unicaWorkspaceSha256": "77ca2ea81cafa335a3789d58e5299b4e69020973ddb21a64dc0b5a7540850289"
+      },
+      "observationFingerprint": "0076753222be56701e24961d62f94880f65159ee52722659a75d7b8eaf377a9e",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "form-compile/picture-field": {
+      "caseId": "form-compile/picture-field",
+      "contentDigest": "5fd95305510953a7ae8ce7c373fc5d97f66396e3564882d85f92b781ac5c8e9e",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "50e6b76c46d96b3b9e0d651617b4c91d162d631a585c88b90f6854a268187375",
+        "donorWorkspaceSha256": "0a93fa06654e07ea22319d75c2baaf70b0d5c5aa43bf1e2b615058650bcc7ee4",
+        "mismatchKind": "unsupported_form_element",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "880e0d4ca6157aa6536fddb5d78ac82613a27f03460a58a8a22487dc38ef2b40",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "19e4d7eb4ee95a13d32dcfd3925400ce5a41f2313b07b21b942b6950fce17f1b"
+      },
+      "observationFingerprint": "c85ea828bb66a91a1ec5d359657654553a6456bffc7d5f3b7202be2ce05c967c",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile/radio-auto-enum": {
+      "caseId": "form-compile/radio-auto-enum",
+      "contentDigest": "01b46d9de6813f369d7c3f12a1c730e4557e0daea1cc0882fbae7f0b791d0d5f",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "38e5874f539af7ef627ca9d7885858741ae42ef60fdeadd70284c0c3fc6f2eee",
+        "donorStdoutSha256": "0719f3e2dffa67e5283e986ad4db1a8197c3cf02c593b4087cbd8a20a8655ddc",
+        "donorWorkspaceSha256": "1aec2aeacc4ac2da6eca08737d475acf23ca6127d39887dc9b26e87119134dd9",
+        "mismatchKind": "unsupported_form_element",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "f25d91a23c2cd1996f1c92a00d162ab4300b8649b517e8a84e93bfb51acf0b07",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "467415faafea8582c3e4e1c2d65b59211e1ae4e7cac678a608431aa206e71a6b"
+      },
+      "observationFingerprint": "fc118030db9bc2e7887cf08aa95b7d5325129d359f64624137189a80a2075ae1",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile/radio-synonyms": {
+      "caseId": "form-compile/radio-synonyms",
+      "contentDigest": "2eda14339ae3474d659a0b44065dfc4787242cc6dc78f5c1cb7d6404c0bcaa02",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "bad278cf6bebc36ec645acdd96da0f57ef3c46df810fbcf9bc9c5ddbe4a27ff5",
+        "donorWorkspaceSha256": "5c8e7e714bc2f051a83f0d71ee34cad3afd544f3e112f6d794082f35b27dc63f",
+        "mismatchKind": "unsupported_form_element",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "f663e990726dc8c48200355c7abd1ca782f6ba32e0422afa1bcecbd8c0e04033",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "070f04d9b3bc3e72379b7759df98bde87092e9fc8f3d3470072a2ee2ab362813"
+      },
+      "observationFingerprint": "8212e251496872fda3d90794a4d26a90becd795b418a977d86cc265d60b6716f",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile/radio-tumbler-strings": {
+      "caseId": "form-compile/radio-tumbler-strings",
+      "contentDigest": "514042ac652d9974d70e4af78a987d1c7e3bfe2375f3cd32360662b1e28b3225",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "e4e8a5c601380b913124fb69be09717b0f33b01be811c96895c46b15f67ee084",
+        "donorStdoutSha256": "c24bf604e91c9c75212e9ba9ac15395df94aded1a196c8588a0f091bd88883d0",
+        "donorWorkspaceSha256": "d2f2b51016943aabd4510925773a082eda96f3fd889152f0f9d696606e10e60d",
+        "mismatchKind": "unsupported_form_element",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "1296a328ee7eaabeaceee098ac2d1af2d7b45f0fd2c11b32cd38a710a02ad2ab",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "51fad90d26e9be8f7aa02b4a9f419fa6f355a42721311b26eeffc6663856ea08"
+      },
+      "observationFingerprint": "c63c53a7edcd20e2fc6a53ba35bee5de74c70faa158d07f5d44d3e04c38b5a9a",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile/special-fields": {
+      "caseId": "form-compile/special-fields",
+      "contentDigest": "e66a534fe5b3c8c77b2aa22995ad655f3160d7fe5f60151ba0691dc9d1ae8946",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "1db679be7fe33712f8566c7756b49e2b7ab16df17ff19d05ad6cbd17fa16bcef",
+        "donorWorkspaceSha256": "d6e999c9b7473383e6d646e38629a6655eefe6f3d5527f3e73c313a9311ab6f8",
+        "mismatchKind": "unsupported_form_element",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "7d59ad0e7aa7283abafecf29b4210fc30e002ad9f01376bd938da9a9f1c4178b",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "ecf2521c64fc56fcb42b0f7a96a52b010f09986b8241b17cca346f7e5a2bcdad"
+      },
+      "observationFingerprint": "a84d8fab1801f7a0a16c3a6c96c1673a5f5330775cf3ae06ed63bdae3bbd99ab",
+      "owner": "unica-maintainers/form",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "form-compile/synonyms": {
+      "caseId": "form-compile/synonyms",
+      "contentDigest": "2634e123e3416ae3e97972d81bb024d92c9b49f0c3a80b63f6f2adf8d19ca17a",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "6cccc0b4d8b01012ff93e8eea26f781c125d9bc523382f1d4d76f9c09a0d5d7a",
+        "donorWorkspaceSha256": "1627d8a0e71be8284dd1911f6bf1db5292b01fbed1d6532a811a73c8b72c500f",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "bc187ac5ab5b9683e322057b1bbde9ab37f9ecc653037762b6ad07848bec5d4d",
+        "unicaWorkspaceSha256": "4ecd180cf1327ed9e862497d482888ece31f2b21d2b407e3127997476f16279e"
+      },
+      "observationFingerprint": "9e5e186003dddca0a9d2448a03765b14289a14ec9b1f0f6f74d79a890144ba1f",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "form-compile/table": {
+      "caseId": "form-compile/table",
+      "contentDigest": "cf8c0c42326cddc02d51ba729b4a254f2a080c7f035890d548547f185c10059b",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "a3a26d06c6606fbf216870dc8329cd875e296057a8a9697797e75b202b25783b",
+        "donorStdoutSha256": "371bd1ad3fa3a8ab68ff5a54fa09a9f96dcbd86b9aa840db2b7c7639713a0394",
+        "donorWorkspaceSha256": "6b1834b1e5a312c88165139e2634ed877bc8a444dca250afd8a13f5c689e9efe",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "80ac45d1647e1c397cf3b942eef44ee089122a9f2785000dc46e130fdf84b0b5",
+        "unicaWorkspaceSha256": "1b0eb10004e5335be2c0cbb23394b3f60e52600c9d4d3cf8f1d508ca11196a7e"
+      },
+      "observationFingerprint": "a9986d574706688c97cbab6ea80711b0c9ad414470d928a06615eaeed3f792db",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "form-compile/text-edit-flag": {
+      "caseId": "form-compile/text-edit-flag",
+      "contentDigest": "8ad278a4cd9ea0245acedfb94f3624ad19be92e434a096f0d5c0900656f8dff2",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/form.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "212c99c4ccef3a93844a6e8e21e1e472ed2e7b341ac6db687039cef93ea70b03",
+        "donorWorkspaceSha256": "649fc0e539c91574f5d603d07bc3b57790df84b065103067ee5a25a3334af493",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "212c99c4ccef3a93844a6e8e21e1e472ed2e7b341ac6db687039cef93ea70b03",
+        "unicaWorkspaceSha256": "7a11dd0b16c38a915382e2cf8ea76cd91d6cab909fc93034017b4135b24ea807"
+      },
+      "observationFingerprint": "2bb1721e2791e97c9661c7459cff61a950245cf21f39833b2e4bc121d465dddd",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/accounting-register": {
+      "caseId": "meta-compile/accounting-register",
+      "contentDigest": "f4cd2fceaea801de978e8edfb7b1cb679ba7b1b8b23ff8ce97e904852a5a0dff",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "AccountingRegisters/Хозрасчетный.xml": true,
+          "AccountingRegisters/Хозрасчетный/Ext/RecordSetModule.bsl": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "beb582f4dba164f17c521c86dc26556adfc0b817fca0c215d9151381bfdfebca",
+        "donorWorkspaceSha256": "68612f80ec6338d7613afb5ca15baf7a41d263754458866ebc0079ad8013bb17",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "AccountingRegisters/Хозрасчетный.xml": true,
+          "AccountingRegisters/Хозрасчетный/Ext/RecordSetModule.bsl": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "beb582f4dba164f17c521c86dc26556adfc0b817fca0c215d9151381bfdfebca",
+        "unicaWorkspaceSha256": "30c58f118363e6fb94ee1bf60c661585e7b1f1110ec217e1ffe287d9d08b6bf8"
+      },
+      "observationFingerprint": "bcf2114d275c8c3fa1d507868b3e95649c4f938df5ccf1c7d7a77216b09be6f9",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/accumulation-register": {
+      "caseId": "meta-compile/accumulation-register",
+      "contentDigest": "bc7b073133696d07b6cb01910a4e4558743440278bbc8b1437a5ed58110e0f0f",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "AccumulationRegisters/ОстаткиТоваров.xml": true,
+          "AccumulationRegisters/ОстаткиТоваров/Ext/RecordSetModule.bsl": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "a4d1881c39593c3909429dc61bee9fd4bd00af7bd28ea2b40888420fa8a35773",
+        "donorWorkspaceSha256": "466eaee384620c693b9d16ac83bfb9616201072fdb6f42252522098dbdacd87a",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "AccumulationRegisters/ОстаткиТоваров.xml": true,
+          "AccumulationRegisters/ОстаткиТоваров/Ext/RecordSetModule.bsl": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "a4d1881c39593c3909429dc61bee9fd4bd00af7bd28ea2b40888420fa8a35773",
+        "unicaWorkspaceSha256": "3ba0d5ea16c95fd1576e5ab97914915cecb4d1a5ce832f9c1468f93dc9b75590"
+      },
+      "observationFingerprint": "28dbeee8fa60c76bb1e4335cba4f09120a8d7a0db109fdb9803dd8fb36050f35",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/batch": {
+      "caseId": "meta-compile/batch",
+      "contentDigest": "8696daab0fc4b4ac2a816e95e6b50c8b75a0208e117fd3cc6215637e0004f3df",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/Валюты.xml": true,
+          "Constants/ОсновнаяВалюта.xml": true,
+          "Enums/Статусы.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "e9ebe1a11ff4b475429e2139bd32774f1d87a28f8f97a184736110786ec738b3",
+        "donorWorkspaceSha256": "11e1147613caa8775ba8c2bd3aeaea28c30df206e7778de9813c44117ff0e0fd",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Catalogs/Валюты.xml": true,
+          "Constants/ОсновнаяВалюта.xml": true,
+          "Enums/Статусы.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "e9ebe1a11ff4b475429e2139bd32774f1d87a28f8f97a184736110786ec738b3",
+        "unicaWorkspaceSha256": "a6229e168ed9eef218ef7b2e6843d3442612da726af43e72505b30e8615ad204"
+      },
+      "observationFingerprint": "1e7c2bffe31b2606e966fc571b6af79d3f178d39eda393ed36e32c7db0264526",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/business-process": {
+      "caseId": "meta-compile/business-process",
+      "contentDigest": "35027db2bbfed09bd34272919d24b12851fd18df1e28343f74da23cff1cecf19",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "BusinessProcesses/СогласованиеДокумента.xml": true,
+          "BusinessProcesses/СогласованиеДокумента/Ext/Flowchart.xml": true,
+          "BusinessProcesses/СогласованиеДокумента/Ext/ObjectModule.bsl": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "56b3e78a062043b7cbd0c40c1c1110a136b957f69f6e960b0eb06ea88d471bd3",
+        "donorWorkspaceSha256": "2a668b7b2866084782d2ad72aaa792f4bbf1d4c2dc9ad2d55223091ac470d683",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "BusinessProcesses/СогласованиеДокумента.xml": true,
+          "BusinessProcesses/СогласованиеДокумента/Ext/Flowchart.xml": true,
+          "BusinessProcesses/СогласованиеДокумента/Ext/ObjectModule.bsl": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "56b3e78a062043b7cbd0c40c1c1110a136b957f69f6e960b0eb06ea88d471bd3",
+        "unicaWorkspaceSha256": "2186c17d68e395a3926db49153e557c993227ea8bab2635e1b4e75b4436f6f53"
+      },
+      "observationFingerprint": "b299bf3216cd4e1d9284702893b2d3d9c8d5e6b1591705cad15edf7f77776102",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/calculation-register": {
+      "caseId": "meta-compile/calculation-register",
+      "contentDigest": "461b3502413d4ae18bb275f44e06c9a3d37cea1faa0df5fdea59b09c19c98b44",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "CalculationRegisters/Начисления.xml": true,
+          "CalculationRegisters/Начисления/Ext/RecordSetModule.bsl": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "5c6ceaa4f6969c0399af11649d444920d3d3fe72b748cf2084d91931ac71e493",
+        "donorWorkspaceSha256": "a840ef24fccfb9efaa48d35f0029a38bfde5bf78a7aa203c560bb4670bffdad9",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "CalculationRegisters/Начисления.xml": true,
+          "CalculationRegisters/Начисления/Ext/RecordSetModule.bsl": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "5c6ceaa4f6969c0399af11649d444920d3d3fe72b748cf2084d91931ac71e493",
+        "unicaWorkspaceSha256": "d3c0960d99b3f701262e66dfee97f3ee58245fcc7069c669565df5551ae2bb86"
+      },
+      "observationFingerprint": "fb8a968b45c98eb5f88502dc5737ccb03dfc1d81c9c6c1350145ac8a5e381560",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/catalog-attr-choice-params": {
+      "caseId": "meta-compile/catalog-attr-choice-params",
+      "contentDigest": "42fd5f778f3a50a9834ea361b434709a767cf4e47b2900dc42b0de71692cf88b",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/ТестВыбора.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "3c4f00a2eb39c8f00df6cc165fe916f573298a2ee6bed097f87f78756f61b907",
+        "donorWorkspaceSha256": "10243b7f53974ff4436ddcc06bd506ca04a6a28dd6945474a91a6bb486cd6580",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Catalogs/ТестВыбора.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "3c4f00a2eb39c8f00df6cc165fe916f573298a2ee6bed097f87f78756f61b907",
+        "unicaWorkspaceSha256": "4bbb9c584dfcd11846e6c82fb0332ccc22d7a6ef2b77e8e055121db26c232337"
+      },
+      "observationFingerprint": "7570752c2bf245f04631664ef27e77cab05f43e9a9c44188f104dd41cb1d98df",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/catalog-attr-fillvalue": {
+      "caseId": "meta-compile/catalog-attr-fillvalue",
+      "contentDigest": "5b1cd315be270394e9c74ec9329999589e3ab3ae2731886a84887387968f4051",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/ТестЗаполнения.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "6b2f74856fe23cf3b00bde7abf6d5d2a2be2ce35e309861ba14f5ba04821290d",
+        "donorWorkspaceSha256": "d82911ab5edac8164a327a30f632e730c280a35b6f1beb97e2b8fb3860afde95",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Catalogs/ТестЗаполнения.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "6b2f74856fe23cf3b00bde7abf6d5d2a2be2ce35e309861ba14f5ba04821290d",
+        "unicaWorkspaceSha256": "a2dae8a9910d30bc6b7b29c47537800182d13e3f14f05797fb0a3f07be910bcb"
+      },
+      "observationFingerprint": "1c5cf22c77879967ecfca9aad605fa0c7bce0084b28c2bdebdad134a92bcced0",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/catalog-attr-ml": {
+      "caseId": "meta-compile/catalog-attr-ml",
+      "contentDigest": "7c7d62a191cf0119195838b247c07bb97e6b74e3e108374c2f6c92333fba9ecb",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/Контрагенты.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "28b74e689cc93c841150a9d49b64acc48c0047fb585cddecd8c5068237a7f553",
+        "donorWorkspaceSha256": "24fe1e87dc71ab3594c2e51cb78d925ca952382a521b95d7765996386077f538",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Catalogs/Контрагенты.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "28b74e689cc93c841150a9d49b64acc48c0047fb585cddecd8c5068237a7f553",
+        "unicaWorkspaceSha256": "036bad39029494296084a8cdb105f842cc4c34785bc8c0f5ff5946ccfc70cfe6"
+      },
+      "observationFingerprint": "018737a7f7c273db22e463d20fbc896dfe2cab0a945159f646327847efaead36",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/catalog-attr-props": {
+      "caseId": "meta-compile/catalog-attr-props",
+      "contentDigest": "b0470013c313ad709579d236833d8ad3ee9a33d068ede7af075ec51f96e2b36d",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/Контрагенты.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "6ded2183ed2029bc9ba79dcc1acc9a2eeaea0faca11b41906b7ee0f5fa2d640a",
+        "donorWorkspaceSha256": "e8d17378c5562efbdd07cca40f0b4d50114e01b2876ecf8bf1307e9ee1e049c2",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "Catalogs/Контрагенты.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "df558af837884dc90cb1b8a176a95fbb74eedd4626313eea5494adde24d1a25f",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "ef8a28ca29f9a856320213aaeea2ae3350298034d1655d0a697081f014cc3cd6",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/catalog-attr-reserved-name": {
+      "caseId": "meta-compile/catalog-attr-reserved-name",
+      "contentDigest": "2d9f2724458598df51072b488350248f80cbaa7662c18a701415255f2b466654",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": false,
+        "donorStderrSha256": "4ac1b0081583599840939c4223cb10b47fb0284906c493665cf371eb2b692e50",
+        "donorStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "6231e4a7c8a23f2b3a6abd4eee9faa3bee8b1e5e7f4af679a1086a7910ad739b",
+        "unicaWorkspaceSha256": "68419e598482e1415052a62942475e0351f2b3e3c52821514faa2bba143fe2d7"
+      },
+      "observationFingerprint": "ef8b62e0c5612fb3d92194303df5969c0ee0499128474188b7c5cd8a58cc46f8",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/catalog-attr-typeset-linkbytype": {
+      "caseId": "meta-compile/catalog-attr-typeset-linkbytype",
+      "contentDigest": "48e74814082e48f5c3e34b1245002838110bbec2435b84072428b4e40119868a",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/ТестХарактеристик.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "235f32bda35672433db372ad4ede0e9d0060cbb0e7c70affbfde9c49f94f9c83",
+        "donorWorkspaceSha256": "4558c6f2760ca439fd0171b64c937fe66371848af8d7a4a9648ff1dbe3cad905",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "Catalogs/ТестХарактеристик.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "05b656d0777c01152e33cc1395df2d01315ebdd9e870e5c42420a17d207837d9",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "da7aefdf7503b1d5858ec8bc35f9bbf088b4a306f2da3125263174ecc03b4aa7",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/catalog-basic": {
+      "caseId": "meta-compile/catalog-basic",
+      "contentDigest": "b134887b66d4cd3a42a5e2f83f7d2e61c5cc2d880d1b85d1ce0cbc99f124381b",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/Валюты.xml": true,
+          "Catalogs/Валюты/Ext/ObjectModule.bsl": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "dc9af2882dc5ab7f8b92a3a5cabb6073ba40f7a3107d63555771a6872fa98738",
+        "donorWorkspaceSha256": "5fd0e6bf1951323b2bf8197479f85ec73b5e8d1f474c7251015b7ff058b23dc7",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Catalogs/Валюты.xml": true,
+          "Catalogs/Валюты/Ext/ObjectModule.bsl": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "dc9af2882dc5ab7f8b92a3a5cabb6073ba40f7a3107d63555771a6872fa98738",
+        "unicaWorkspaceSha256": "987040dbea03558d31ecbf78f4bbd4d4ea079f84bdcb7f242aaf28446de36261"
+      },
+      "observationFingerprint": "ca43be3416541545b337ea704c57c5be8f9746b000a61f3ad0f67cc259f214b8",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/catalog-characteristics": {
+      "caseId": "meta-compile/catalog-characteristics",
+      "contentDigest": "3cad309a5bcd82996377115e797e028cc0600de13eac6692b9064dd81bba58a4",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/Организации.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "4a5acffe0c9c31060a769fdf1352b72d13d0e4fbb8f6ceae0e080175693da7da",
+        "donorWorkspaceSha256": "fd8f7b7182c7dd5334201dcee7f5586aab71a0389a623b3f25a21785327c7604",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "Catalogs/Организации.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "1eb2d6920b6ee1a919e11387a5612684e496d65b7d3a6fc5bbf4276dbb5f9db3",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "7ddd8bf0520885ec117e3dae1d2bd86406c9f60a5c7cb1e57b670089d4526986"
+      },
+      "observationFingerprint": "c68138669f85eba9fb0079daf5b9018952b1541aeffd71190b68140c56895e3f",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/catalog-command": {
+      "caseId": "meta-compile/catalog-command",
+      "contentDigest": "c61146f996288d0dc8c2fbd0fa544e955903a40c74f70c456745f785abc67baf",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/Номенклатура.xml": true,
+          "Catalogs/Номенклатура/Commands/ПечатьЭтикеток/Ext/CommandModule.bsl": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "ab17a05cc87968c66b1e4e399ac532c3db9415d1f457de83535a7d62376dc4f9",
+        "donorWorkspaceSha256": "fa383b4b867c587fa03a1a092df1d11b9ee7fcd108a09663e0dbea0e54705664",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Catalogs/Номенклатура.xml": true,
+          "Catalogs/Номенклатура/Commands/ПечатьЭтикеток/Ext/CommandModule.bsl": false
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "495a71974dce611313860a6bb6097bc2b92c0121fc494a1c793caa651feb64c7",
+        "unicaWorkspaceSha256": "e78ff28693617e05e9f65be3d6ec3942a2e5b420437f488f7238272f66a00d67"
+      },
+      "observationFingerprint": "61c829bfc004c98e35a5c772a51920cd0d85e4d80139dcd31ba8b6addded4256",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/catalog-command-groups": {
+      "caseId": "meta-compile/catalog-command-groups",
+      "contentDigest": "95cf433f3eb638a46dcc48c6c8ebb359c04dd12018c17eadf36337f23dd4419e",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/ТестГруппКоманд.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "8085c122f2e8f43144201c890c48fb47c45e66e1f122b3896efb0707b1d64f17",
+        "donorWorkspaceSha256": "da300c7cfbca2196082fd91a3c31ec3ab8a75ccb0ad992f107cef6388d085fd7",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Catalogs/ТестГруппКоманд.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "0c38b9c9c2cbdbd41ce0ed1566503db6410d973771d417f992ffb989164bba03",
+        "unicaWorkspaceSha256": "5fd7f78df37bc7503e4a18401572cd84f0404e64ab7a3a546d15e760e0ae97b6"
+      },
+      "observationFingerprint": "2b67ab4b1a0472c7c8e49249fb23a0091fba836b7a4a640a103c55e69b9b85df",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/catalog-hierarchical": {
+      "caseId": "meta-compile/catalog-hierarchical",
+      "contentDigest": "c2f624bc115ee482a45bfce66afdb86686c9ee8b4316bf979897d444d422f4d7",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/Подразделения.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "caa312587363b8ae350e6f4f29a1e8fe19346fd81cc1926768cac68543be5d34",
+        "donorWorkspaceSha256": "8cda3fa781779fdba82bdcb809e3c66921f17d76f046678d22f8cc045da34f3f",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Catalogs/Подразделения.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "caa312587363b8ae350e6f4f29a1e8fe19346fd81cc1926768cac68543be5d34",
+        "unicaWorkspaceSha256": "f7212ef7bc37e9414e0446d4688097667be0cc17aa497b1266cb06d88b818786"
+      },
+      "observationFingerprint": "974aa19f166bdbffc38df0fd24e841b4dfa8b389788aaeab630e480f7cb80fc9",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/catalog-inputbystring-datalock": {
+      "caseId": "meta-compile/catalog-inputbystring-datalock",
+      "contentDigest": "3e35c1bf3809604678f53b1e8ad27980d99fa6dca191bfb43aefe45fdd16bee3",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/ДоговорыКонтрагентов.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "2608ee882b40484e2a66459f9cbc0a11f38b7a570440edb02cfeae5e252be0bf",
+        "donorWorkspaceSha256": "0ed3e0e7f8aeee6b8cfcab17d6453b82105a2f1acc5638bd433f141a92418e65",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Catalogs/ДоговорыКонтрагентов.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "2608ee882b40484e2a66459f9cbc0a11f38b7a570440edb02cfeae5e252be0bf",
+        "unicaWorkspaceSha256": "6686a1234ea66e35f57d68f88793c208c62333f3224f6db317dc0d8baf37421b"
+      },
+      "observationFingerprint": "6100925b47f8fc51fcc3ec1365e5ff1f8611a5735d6477defb113cca91d8c9ed",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/catalog-minimal": {
+      "caseId": "meta-compile/catalog-minimal",
+      "contentDigest": "2abad6799d761fbfe8cc544f952d7097944272ae712333e41863cdc8440f3306",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "d09e81e2a0c4903d98051ceb0fcc9699c2f3b070971667825bc1d386ceeddacf",
+        "donorWorkspaceSha256": "c9b88e21b04513ced6f05798e379a62e3d2b342e4ace66ebe7847c428f22d7ce",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "d09e81e2a0c4903d98051ceb0fcc9699c2f3b070971667825bc1d386ceeddacf",
+        "unicaWorkspaceSha256": "114a7edcf92f455ab0c89297ab3a1ee40a8d07f4eafb75c1bc25dd1f0b76102b"
+      },
+      "observationFingerprint": "3e9f65986556ae18f209553503846142eb0c2b41a1c7f6804f277435a1f92b00",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/catalog-mixed-types": {
+      "caseId": "meta-compile/catalog-mixed-types",
+      "contentDigest": "9f71c980c172a6c49e0bca0b58af6d0014cebdb880e5dbe8983acaa1f8c428b8",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/Контрагенты.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "565835c0e8b4b12291afb2ce0901bad77cb44b0d293e68aaacb4a853f360de77",
+        "donorWorkspaceSha256": "456c19f39172bc29b49cf5d543e02fe2a97b582d45b71d43acc7fb8330cb2435",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "Catalogs/Контрагенты.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "cfc73ea9cfcd03e1e61220af99a87eb8b24a2fb57ecbdb8bf08e0c38fbafebe5",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "16f3d6e91bbff70d093b2783d8002ed41648a58dddabd175586d8aa453b9da41",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/catalog-object-props": {
+      "caseId": "meta-compile/catalog-object-props",
+      "contentDigest": "8046493cb059ecab0ef0d37d579eab9fc6d337e5e0db9472a14b213e48eae365",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/НастройкиОбмена.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "7655759667cd9089c1722a59b64a0dbd6990e6bf3f27718c614f8ee01677b904",
+        "donorWorkspaceSha256": "005645365d4360cf3e8a3cbc11048117cb96b43e141bcf7bdb53ebaaf7b72414",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Catalogs/НастройкиОбмена.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "7655759667cd9089c1722a59b64a0dbd6990e6bf3f27718c614f8ee01677b904",
+        "unicaWorkspaceSha256": "b6afa6b9ce43576d5ff27da1c03baa9f03db539a3dc91256c742da4d600cca05"
+      },
+      "observationFingerprint": "a29b3baf2f20d4a9fe8465e5c2312bdc063eebe0d6c50feee30cae60f180fc6e",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/catalog-predefined": {
+      "caseId": "meta-compile/catalog-predefined",
+      "contentDigest": "6684f0da9536687ad2673b9761b0745fec9ad3b5a616c483026e85784719532d",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/ВидыКонтактов.xml": true,
+          "Catalogs/ВидыКонтактов/Ext/Predefined.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "bff7a6cd5238787ffcbc63aec83f653372068e70891106e154861d516433fd44",
+        "donorWorkspaceSha256": "7c2304dc698d175acf99d5e60a9108c8f4a2dbca757671b25ff7fa8f0edc0972",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Catalogs/ВидыКонтактов.xml": true,
+          "Catalogs/ВидыКонтактов/Ext/Predefined.xml": false
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "7ca58db76c97c99e29feb1d18ebffe020ec2130e746e4195c638ad4f5736a0d8",
+        "unicaWorkspaceSha256": "ea81cdfd7574ece19ff3163a0063f5b8107392515c85e8344d6e606767d3cb71"
+      },
+      "observationFingerprint": "5c00fa4d4299e34ddb1aaaff2d9649f9c1f47f2c0e39b14dc06c6e746fde0bc2",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/catalog-standard-attributes": {
+      "caseId": "meta-compile/catalog-standard-attributes",
+      "contentDigest": "e79e46abe551fbdc91dc55350a3a6ba03e8ebcdf5f7565e99feeb203d6216645",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/Контрагенты.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "544b9b3c16b17ef3ead328b63f4667ec223169a2e7913710c0e6df58d02efe32",
+        "donorWorkspaceSha256": "24f0d139eb727a245f66269b392c12414f2b9909a15b97b358f0e5ea27c564e1",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Catalogs/Контрагенты.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "544b9b3c16b17ef3ead328b63f4667ec223169a2e7913710c0e6df58d02efe32",
+        "unicaWorkspaceSha256": "64ce13405392856c0a3488b8330243f80b70eb7acb7de233f35e9fdd16ec9d7a"
+      },
+      "observationFingerprint": "a49ba4c57755b49c7d3c8513916d16f1b64e0067709ddf062183f10d5b4be1d4",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/catalog-stdattr-custom": {
+      "caseId": "meta-compile/catalog-stdattr-custom",
+      "contentDigest": "d6c0c663564cce81ebc83763f3aa3170e664aedc609fb756a09a74b207cd6212",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/Договоры.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "8a6d4ae570b87a9747c29b2efd2851f9be09e4241857c0ddfc3fb779ad16c641",
+        "donorWorkspaceSha256": "1ddc915b5c5c3674174cbe285d148f73c7b0484ce16cba734ef55f804b672748",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Catalogs/Договоры.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "8a6d4ae570b87a9747c29b2efd2851f9be09e4241857c0ddfc3fb779ad16c641",
+        "unicaWorkspaceSha256": "11d474ecae6acfbbfbcea00a2763147b090ac2f427c9f0614b774c31b986c761"
+      },
+      "observationFingerprint": "4bcfcd5daa1895f21fe5b5f5b03fc04afc560e831654685d387f7a073c9c27a8",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/catalog-tabparts": {
+      "caseId": "meta-compile/catalog-tabparts",
+      "contentDigest": "681bd5f867c9d748121fc1006617b97cf06ff56b96062ef4b758e10050646eab",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/Товары.xml": true,
+          "Catalogs/Товары/Ext/ObjectModule.bsl": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "d39d9c6a90466bc5b9d63ae526b5cbddf25f696540580566f87f332b8f7cdcc1",
+        "donorWorkspaceSha256": "ae4b851aad575fe4002641f7e0d5115f14cafb036182f12b08616f6418f287c0",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Catalogs/Товары.xml": true,
+          "Catalogs/Товары/Ext/ObjectModule.bsl": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "d39d9c6a90466bc5b9d63ae526b5cbddf25f696540580566f87f332b8f7cdcc1",
+        "unicaWorkspaceSha256": "6872a8c418ceca5c7ffdb8ef1667af7752ae64a0088a90fcfa72f64fa2edeb66"
+      },
+      "observationFingerprint": "aa5be30933c6c7baf80d4ae7576d9b7f264abd98d4801d596042abb195f34c10",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/catalog-ts-linenumber": {
+      "caseId": "meta-compile/catalog-ts-linenumber",
+      "contentDigest": "a657f7b7251be04602d342291d355c0f7df74005747e5b600cc7b4972ab08959",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Catalogs/Заказы.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "87853d6102939aba4d1471ce4e72e8c041682f886e188787043aebbd4e7f1012",
+        "donorWorkspaceSha256": "30beefd8b6a587dd045d370ab5b23a020f58dc35f79a0ccfa3d93633759a0f06",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "Catalogs/Заказы.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "bc0aee6cc13b49382252cdab5290349a337f97a4bb7e6981f49d3201ab6f0f0d",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "c821b40d080db1fed572ce428868dcb7484c9f19693205a989ad7e43d7b968f2",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/chart-of-accounts": {
+      "caseId": "meta-compile/chart-of-accounts",
+      "contentDigest": "6004fb8c570492bca80869b505c0404188bae729433bbe41ed3be8d09dc61a8f",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "ChartsOfAccounts/Хозрасчетный.xml": true,
+          "ChartsOfAccounts/Хозрасчетный/Ext/Predefined.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "73e47fd33bdb939091b3222708e9104f6ab7b2901edc1b5cdf70e13a1d3f651b",
+        "donorWorkspaceSha256": "8f8bb26602b2f23ec0eff40d5c7092c100244cebc43e4b0e274c619e26058550",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "ChartsOfAccounts/Хозрасчетный.xml": true,
+          "ChartsOfAccounts/Хозрасчетный/Ext/Predefined.xml": false
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "6fa5665f20fa27687012e65fb33ddbbeaf31b7d18661c2cbe58020a69e15d96d",
+        "unicaWorkspaceSha256": "283caeb014b92f788b917306e97e636b2d6fe826003d36bd572c894ad4b4a606"
+      },
+      "observationFingerprint": "0f9f43751151864f6f683993f66cb6fcfbd978df16e0d243379b1e8682b63c1f",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/chart-of-calculation-types": {
+      "caseId": "meta-compile/chart-of-calculation-types",
+      "contentDigest": "b79ade657e5c714453e59578596383a008feb02e2e2a37d4c3393f9e15ee7b0a",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "ChartsOfCalculationTypes/ВидыНачислений.xml": true,
+          "ChartsOfCalculationTypes/ВидыНачислений/Ext/Predefined.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "42577c30c8bebfdaf9990f8df00e98ab6260fd1f5fc58c47e88453da6cbb6d84",
+        "donorWorkspaceSha256": "36db0443ff466daea98db9d39f68c52a11722edc81223cdb94288e0094ad0136",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "ChartsOfCalculationTypes/ВидыНачислений.xml": true,
+          "ChartsOfCalculationTypes/ВидыНачислений/Ext/Predefined.xml": false
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "22ccd0ad4b19982b92c2106449058ebb6c95e2bb00a8746de1e5cf33964d37a7",
+        "unicaWorkspaceSha256": "6ab8e82b4228193ae1893c635f0fcddcf77e3bdb7f794e999cf898e1fe621fe1"
+      },
+      "observationFingerprint": "4ec91b81645370b925e5f7d134c583318fb87fdd07aee38190bea202204ae343",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/chart-of-characteristic-types": {
+      "caseId": "meta-compile/chart-of-characteristic-types",
+      "contentDigest": "825d9dc9fbc97a248907459818f306b48fad94491113cfbcc089c51327ee9569",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения.xml": true,
+          "ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Ext/ObjectModule.bsl": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "caf7901a980b19ca0ad68c718a9c8b09e41db6e96ec4df7dea688a51d31112b3",
+        "donorWorkspaceSha256": "31621dd1fb419e49cd9a676ac657eded5eb15e652ea52d17fddc58c642e177dd",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения.xml": true,
+          "ChartsOfCharacteristicTypes/ДополнительныеРеквизитыИСведения/Ext/ObjectModule.bsl": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "b2d99a46371c4d98e8629aee26a8dffe3c59f709f9b85104afde4db35da62363",
+        "unicaWorkspaceSha256": "64f687a8361b7caf76b71e761ab4544e946ba40f3c6aea89293ac95fc9a08d13"
+      },
+      "observationFingerprint": "faef5ed261b6129aa4e3f65947c6442bc6001528d6b95a33ff41c76027cefc13",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/command-group": {
+      "caseId": "meta-compile/command-group",
+      "contentDigest": "313b05208b6ae4cccbcfbe752be77927a0efac13bd6c668d915437ec450329fc",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "CommandGroups/МояГруппа.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "eee216710c876852f32f8eda62b07896be9f46f6dc89a456583e8ffa02e6d1e9",
+        "donorWorkspaceSha256": "51dec123b94ea5ea6420c261a512f61e4909660651da2762543d85c6310b9ebd",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "CommandGroups/МояГруппа.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "c2c7ad12b07e8a65c91a4cc8c2a1b775f36b33539d215d980f5995bbdfc050e0",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "c115b6c09bc1655442b21fbcbfd0e30f6cbdd7e7daa5b543a57064253374ece4",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/common-attribute": {
+      "caseId": "meta-compile/common-attribute",
+      "contentDigest": "4f2d41dc1a6d21e3dd57a293a9206395f42c0579fdd8fbed221c96990e726fd9",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "CommonAttributes/Организация.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "57845ce6c1dd6bb159c23af9ea9156d486566ae4fbf44cb599e4ce7484a35b7a",
+        "donorWorkspaceSha256": "55ebc42b6f1898e8419637e5608ce57b151a660feb730937b8b7330d477623f9",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "CommonAttributes/Организация.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "2543d44eeb04b28780311aa4c0a80ada7ddfde64f6f4ef7f9b6ae318d6d9b253",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "8fcbc55fcf3f9d517bb8981342630a67e1d28dcf7b006206c3a602d1d3c244e6",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/common-command": {
+      "caseId": "meta-compile/common-command",
+      "contentDigest": "58991f7937244062e082e4d24a0bf2fd9fba93a42d7fe483ae14521847be8df7",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "CommonCommands/ОткрытьНастройки.xml": true,
+          "CommonCommands/ОткрытьНастройки/Ext/CommandModule.bsl": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "233a21b21b2acb4718734ea16ecc92175e7013d97625113a2107be3f300af41c",
+        "donorWorkspaceSha256": "86179d2faa997bf31e30bf076fd179a091423beb33798988ef7fa7c92e7b24c3",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "CommonCommands/ОткрытьНастройки.xml": false,
+          "CommonCommands/ОткрытьНастройки/Ext/CommandModule.bsl": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "d50bfd4b4d0045598c7c3685eb758d5e2337a9d2419fa944d1a0b50957855c9d",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "f9ec08ac87912bc86fb6e973767840bd3f0665beb64e4fda587dde7bc73cac91",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/common-form": {
+      "caseId": "meta-compile/common-form",
+      "contentDigest": "a6dca6173d91e750729c51aa45f31648961264993d597eb823cdf22f12c0259e",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "CommonForms/НастройкиОбмена.xml": true,
+          "CommonForms/НастройкиОбмена/Ext/Form.xml": true,
+          "CommonForms/НастройкиОбмена/Ext/Form/Module.bsl": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "eca7d760b3957b14b7b451a666471bd3c67c8981632e4e46a76d09d497289e75",
+        "donorWorkspaceSha256": "f9ac0bbcb744eb718118be0d996116ffd19903125970e9572129656eba408973",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "CommonForms/НастройкиОбмена.xml": false,
+          "CommonForms/НастройкиОбмена/Ext/Form.xml": false,
+          "CommonForms/НастройкиОбмена/Ext/Form/Module.bsl": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "a0eb33c57305cd2c1cb9e191537a732579753e3dc024b716755da031c4c05f4a",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "f6e203990ac583b6ce935f79de47d78f56ee594c2dd4b6f3705d2f467bb78fa5",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/common-module": {
+      "caseId": "meta-compile/common-module",
+      "contentDigest": "a6793e2a22646da6cc36d0e2b84070b21bab1823a1be2408d5dcd9c0e24cc19e",
+      "relation": "exact"
+    },
+    "meta-compile/common-module-client": {
+      "caseId": "meta-compile/common-module-client",
+      "contentDigest": "7e6810a408379a5e03c3f234e6782553d58217d6b4a7f17ca4a506d640001949",
+      "relation": "exact"
+    },
+    "meta-compile/common-picture": {
+      "caseId": "meta-compile/common-picture",
+      "contentDigest": "8051b115643a707b41ff1fc09d0cd59cca159806cfc236ed778f5932d9e2590c",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "CommonPictures/Логотип.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "8e2291741dad0cd56a53022981856c761f1d3296de8672617eb2a7eb60e4097e",
+        "donorWorkspaceSha256": "9f67c2a96d8f2f77c34898e40708d6ac32665ebaa43f8d283ee14c894d73105e",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "CommonPictures/Логотип.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "6f9601543a3542af81c75d483c1a1914102dd9fdc2ac20f9f0902a81c6549f84",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "b63f262acb3e79a982c298a3822ab8a2a1d156ff3d1127e834c38ee268723cbb",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/common-template": {
+      "caseId": "meta-compile/common-template",
+      "contentDigest": "f47876e41e0d27d684b0204554532f6caac726b55df4116ea2f9f0db63411e93",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "CommonTemplates/ПечатьЗаказа.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "52ed59a2b82ae046b9ffda02379d70515535b51d0f0c59048ffd6fd147ea0fd3",
+        "donorWorkspaceSha256": "756adfc1d7cad1137de8247f9909921a4840b02957a49cfdb09487675592cf73",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "CommonTemplates/ПечатьЗаказа.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "e643116bd1bd902b626919312dbb8a0951e9e2b5dcc9d26909fe60df6408ca27",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "2a7f65589ae696ed1473226ed6ca49ea0f077ff77eced6a67d2e1e397cf949ab",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/constant": {
+      "caseId": "meta-compile/constant",
+      "contentDigest": "3f38ce1ddbd5aa94ee5a10d55720eba1cdd1ecd8d9e175ea9c42c304464fc65c",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Constants/ОсновнаяВалюта.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "3f1e9258ca655a65472c158b769499937ede5c808e432faa3fe3ff782f91abc9",
+        "donorWorkspaceSha256": "a972f5e1b8e6a673c830cfca53ec5a82056801bc793b038ce87deda0e60a05d0",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Constants/ОсновнаяВалюта.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "3f1e9258ca655a65472c158b769499937ede5c808e432faa3fe3ff782f91abc9",
+        "unicaWorkspaceSha256": "bb61e4bc36f403872710ac85fa8768f4eeac99b7cc68eaba5c99aa075f9fb817"
+      },
+      "observationFingerprint": "407cad9e85331877c3bc7f57412fd1f07269e3e4129ac5d8373b28beb41e7dc4",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/constant-full": {
+      "caseId": "meta-compile/constant-full",
+      "contentDigest": "4b5f104ef2db4051d436f0ed51785939920c3d8305cac14ecb1fa7b732cd0b10",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Constants/СтавкаНДС.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "6e61dfc2025e47a425221d8a4d1f97182fcefbe482af7d26baf6d849ae4e5f4d",
+        "donorWorkspaceSha256": "392f9891527b3888ee8cf6dfb1351651ff5a7eabc74901d7ad60e3550c112d2a",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Constants/СтавкаНДС.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "6e61dfc2025e47a425221d8a4d1f97182fcefbe482af7d26baf6d849ae4e5f4d",
+        "unicaWorkspaceSha256": "3aaf59e69f7348c34d67222838661979a7fde12683aa0b0e1d53c329ad8d256a"
+      },
+      "observationFingerprint": "1a1742503ef78598521d7ae16833af63c68ca8ddc75f1773601edf596235388f",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/data-processor": {
+      "caseId": "meta-compile/data-processor",
+      "contentDigest": "8db80e1572e5aa28e6abbf2e96d8f80d8c52babad50e064b46a8693ac18e3eda",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "DataProcessors/ЗагрузкаДанных.xml": true,
+          "DataProcessors/ЗагрузкаДанных/Ext/ObjectModule.bsl": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "8c9b050f0129ca206e83bd698a43a34739197a616f1549c051c845c1b1d4c559",
+        "donorWorkspaceSha256": "2b41ae0f2640b4c429a1e039fb94ac0792ac2d62728a89b1a0d2557e49ddd0de",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "DataProcessors/ЗагрузкаДанных.xml": true,
+          "DataProcessors/ЗагрузкаДанных/Ext/ObjectModule.bsl": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "8c9b050f0129ca206e83bd698a43a34739197a616f1549c051c845c1b1d4c559",
+        "unicaWorkspaceSha256": "7b5b43a8dc4f26ebfd76507d1a6d476e0a3e8ec43cebace474b354d644a4a2e1"
+      },
+      "observationFingerprint": "134f953d983a10f75a85b85b5273b0261f3a6f70218a8e01caddca83efd46f37",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/data-processor-full": {
+      "caseId": "meta-compile/data-processor-full",
+      "contentDigest": "d0f45d310b234ea8fa0f531ff640a6ef8244fb51cfeb94c2f67b1b42a81dba74",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "DataProcessors/ЗагрузкаТаблиц.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "9b0fec2c271d875864b7d190db8ded3ca3a84ad1dafdd6c67964ca636a19f33e",
+        "donorWorkspaceSha256": "a2e59aa906919f4a3687dd49ceb158a26f0bc0fe3e654857b1c9409f27797072",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "DataProcessors/ЗагрузкаТаблиц.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "7e3ca7eff9473413823c2c0974d27f29f6f39a766dd30e76617c29b0b714a8da",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "8fadbef5b9dec98c446327442d4a6728c52d31690816fc23f93f530b5b64ca64",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/defined-type": {
+      "caseId": "meta-compile/defined-type",
+      "contentDigest": "08b0c1dc3f2492226a4d4fa153f40e1a1220170f0e51c868e358b25637f7f45e",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "DefinedTypes/ДенежныеСредства.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "1a64422219b9860289c984a1008e0b956ec10185fb78f62f6f25e24e8158fd69",
+        "donorWorkspaceSha256": "896a93905d4715abe6218bafdf4231a52f6aafdda92ba60c6d0ff105b863d538",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "DefinedTypes/ДенежныеСредства.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "1a64422219b9860289c984a1008e0b956ec10185fb78f62f6f25e24e8158fd69",
+        "unicaWorkspaceSha256": "e331b7b11030d6423507124082af808bee5dc4e6a27709b8517f592b859ba694"
+      },
+      "observationFingerprint": "5e4c085aed804cb28ad4c49da3f72dad4f3016a6d4d1f1147972d5ad89df235e",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/defined-type-full": {
+      "caseId": "meta-compile/defined-type-full",
+      "contentDigest": "22bcc446cced610e91069e9373fd202379a3001b289357b5ce74a659e914df23",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "DefinedTypes/СсылкаНаКонтрагента.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "7e9717b7557074d8fc05f74d407ab971d30d9de74052e69c5d57381d0e1b11cf",
+        "donorWorkspaceSha256": "7159c3675bd74c61d5373a77c675d9ea28ab39467a9caa0aeb152486e8f94aa3",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "DefinedTypes/СсылкаНаКонтрагента.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "7e9717b7557074d8fc05f74d407ab971d30d9de74052e69c5d57381d0e1b11cf",
+        "unicaWorkspaceSha256": "725e69cf30a7ad10663073a99e390244348156e182caa8b839a9d13283398477"
+      },
+      "observationFingerprint": "b569181e81719a492c4e2646a37102ba78758d19f1f0889bca96e675af20a9ea",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/document-basic": {
+      "caseId": "meta-compile/document-basic",
+      "contentDigest": "cad1e311523633b2cfd2c1f6f2439289864f538ccb8b87e01ebcb1223a7e5f85",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Documents/ПриходнаяНакладная.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "c5839a2dd372f17e717b58699d74924e075ed261b149c92f73f0e3d54b1f7908",
+        "donorWorkspaceSha256": "ef1912391464446003d5fce2248d72c74ac86e234537ae9635b340e08e0dffad",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Documents/ПриходнаяНакладная.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "c5839a2dd372f17e717b58699d74924e075ed261b149c92f73f0e3d54b1f7908",
+        "unicaWorkspaceSha256": "10c413eef588c2c981630bbae7a708e132fee24be099f0e6f6e25b4f27578a8a"
+      },
+      "observationFingerprint": "08c881562dce456b594201ad67aad57148515d72abaadb8ead9b5c7b94b85332",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/document-full": {
+      "caseId": "meta-compile/document-full",
+      "contentDigest": "e50668e058931706b8bc79f75af45263b7b01ffe6ca12f69a7f5bfe9b53e56ea",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Documents/РеализацияУслуг.xml": true,
+          "Documents/РеализацияУслуг/Ext/ObjectModule.bsl": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "42e6640e090825cad6e8112b5fdf4c9319005b465fc2b43b4b86ea5b8fc16c8a",
+        "donorWorkspaceSha256": "025742cc52d55190256307dca31a17480ede6ff3c80f60cf0b0ed0366e277078",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Documents/РеализацияУслуг.xml": true,
+          "Documents/РеализацияУслуг/Ext/ObjectModule.bsl": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "42e6640e090825cad6e8112b5fdf4c9319005b465fc2b43b4b86ea5b8fc16c8a",
+        "unicaWorkspaceSha256": "f2bd2ce6525b196d5d9fbebc6c5b0a43ef32aa9b5400d1fc473a633d9ea6aada"
+      },
+      "observationFingerprint": "14498db3e6be61c39cbe3e0e49474a45c37808b7bee27cdfbbf095b3620abc30",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/document-journal": {
+      "caseId": "meta-compile/document-journal",
+      "contentDigest": "2110bad6523fe15b9c0d054775e12e8ca693a5f003913c4f49881f73d1bf0b20",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "DocumentJournals/ЖурналСкладскихДокументов.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "3723b8031809f071d50aadfc9253a881e3aea1b1e59274f961bc66b8e39e6ec3",
+        "donorWorkspaceSha256": "6623fb4f2747aac9f27d07e899c8d3695b9b05b684bcb7ab58f52318b912cf3c",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "DocumentJournals/ЖурналСкладскихДокументов.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "3723b8031809f071d50aadfc9253a881e3aea1b1e59274f961bc66b8e39e6ec3",
+        "unicaWorkspaceSha256": "71475a02a8d34d064ed9bd1073ca36574239cee292c1eee8c0c2b0d5401aa178"
+      },
+      "observationFingerprint": "21535bf81b2177eb6ca96eae006e062d78c49a8a625a9e370b7c9075bf34e2b9",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/document-journal-full": {
+      "caseId": "meta-compile/document-journal-full",
+      "contentDigest": "ebc208f8a0dca563b47243b9c573d0eb5f676dab980892ea86af54bc4570935a",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "DocumentJournals/ДвиженияДенег.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "f67a43da377db927930501f74423bfd00771954febf9834d7a59e604f59275ac",
+        "donorWorkspaceSha256": "5caeaa5acc4678599b84ebed89a643f91e7438f88b80a37d4ab3b3c0d1fb4149",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "DocumentJournals/ДвиженияДенег.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "f67a43da377db927930501f74423bfd00771954febf9834d7a59e604f59275ac",
+        "unicaWorkspaceSha256": "89a877b8b22607915b20c4c12958e749c78f84fa0d2a4b97f01751b8a4559c4d"
+      },
+      "observationFingerprint": "1412745fd2da98971ffedbbe750415d7f351a21d946fca0658084b07420ebb83",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/document-multiple-tabparts": {
+      "caseId": "meta-compile/document-multiple-tabparts",
+      "contentDigest": "7967c10c51129ba7e85b99ca7abd59f5649423b944ce791cf6d0a7d280d6cbde",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Documents/РеализацияТоваров.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "f413ce2a9391db3780c06bf2e3a84700cc5f9a18de0992669ac46ea152b4a84c",
+        "donorWorkspaceSha256": "460fff8b5bcd2421f8b7c23eab8e62ffefe7c57bae7369a90395947e202430a0",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Documents/РеализацияТоваров.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "f413ce2a9391db3780c06bf2e3a84700cc5f9a18de0992669ac46ea152b4a84c",
+        "unicaWorkspaceSha256": "fff7d79e36d4e0e675e501f30e4bf283d78e9e7e2e53fa72b94fa6aa0c1a793c"
+      },
+      "observationFingerprint": "a9338f77bc468dd51334d889a2949f4986c5ede6c046856c7ebb65ce1c602c5f",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/document-numerator": {
+      "caseId": "meta-compile/document-numerator",
+      "contentDigest": "35f148f94f5e98435e975bb4429c34b1a034bcc6137a2c1d62ba460b486788af",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "DocumentNumerators/ЕдиныйНумератор.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "10b71db852f4b6c091682e8e33ca99e364c18770bded5a3d5b0239d96c78c641",
+        "donorWorkspaceSha256": "00e121ac9ceaf76f8348933b660dea2037a7c5a00f7a31aac934da8bbf8929ac",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "DocumentNumerators/ЕдиныйНумератор.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "54562ee760838e4675cf794486e38d4b9e2c0ac1053b22ac9daf10d1f6db239b",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "f4fc92dd20977dcb440fc267123583d6666216c18b52b2e131ad56398a092c1b",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/enum": {
+      "caseId": "meta-compile/enum",
+      "contentDigest": "d09ad8ed62e7747b21bf8c6f8425c173a61eba1955d73b86fe2cccd30ba6ec93",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Enums/ВидыНоменклатуры.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "1dbd47b9ac16ca11d5de4abcbce0944e1e4fb7d01638c221b001bb819da7236b",
+        "donorWorkspaceSha256": "0a05f364438593f47d35650691848f104b80163563e822002ac7209eb5c059da",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Enums/ВидыНоменклатуры.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "1dbd47b9ac16ca11d5de4abcbce0944e1e4fb7d01638c221b001bb819da7236b",
+        "unicaWorkspaceSha256": "77e62f815c9a019033bf07ffaad9c32c79767d07fa0c41e1c6775770fd8a5e69"
+      },
+      "observationFingerprint": "37ddeb9ad2e268808f1ad60d5086e2fde0118a729bb464f7f7e9c5a5902ff090",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/enum-full": {
+      "caseId": "meta-compile/enum-full",
+      "contentDigest": "e44e55c0728a0748ce6ed0f3164671ac5af3da314ce860008514f89af432df7a",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Enums/СтатусыОбработки.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "989d5db0e23ce7d37b5a82cb13ecf69dda309e42a922f13b19e223a65dd2409e",
+        "donorWorkspaceSha256": "5ed230a4a0ea2b1c052faa9496b3fbc42bd2eb7ade640d9affcf106728e47f4b",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Enums/СтатусыОбработки.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "989d5db0e23ce7d37b5a82cb13ecf69dda309e42a922f13b19e223a65dd2409e",
+        "unicaWorkspaceSha256": "4f033d5f02b9b7129e9cc21357776a66ab2badcf10c315d82cec039dcd9e30d0"
+      },
+      "observationFingerprint": "d43c778712689444a050fc4f2cbf310603c5366762a7a6559d1383f4f5c59db2",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/error-command-nav-param": {
+      "caseId": "meta-compile/error-command-nav-param",
+      "contentDigest": "21af4679d0522a2ab341a8d6c41e946dd58f69371e8ae557427442b7ca466d89",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": false,
+        "donorStderrSha256": "576ac0d54bc7e01753f5ab0227cab2e1db56357629296d5ddbaa1701207b20ec",
+        "donorStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "32116c050ef1b77a5f7f2ef1c33ecd906c73995a4c89d33aaa4f379232b1e7b3",
+        "unicaWorkspaceSha256": "60cead6878615770691cdb68fb416f1dc7017ac1fc88c9a72034971a64997501"
+      },
+      "observationFingerprint": "f6c32950436b18cd7b38acdbd043225563195e53b6285b4c5bc0f70352c890c3",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/error-command-no-group": {
+      "caseId": "meta-compile/error-command-no-group",
+      "contentDigest": "a45a66e7280fe1f25c4f9c5823ab3cb655a191cb0af155fc0fa2027ebe76298f",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": false,
+        "donorStderrSha256": "9b11af377fa36601c4a754df9839b890edeee19bd086930003c5120b59212d87",
+        "donorStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {},
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "77ade498cfcd57961207232841fdc2098b05510c4356b6528511d50256d8182d",
+        "unicaWorkspaceSha256": "1d9b6adeb0c4462e44122de08a3974023665d46140cd476e977cf28d6b270014"
+      },
+      "observationFingerprint": "9deb3a37314942f0f1d19c3194a1b51223c138ba163dc838d73971fbbb7e18af",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/error-empty-name": {
+      "caseId": "meta-compile/error-empty-name",
+      "contentDigest": "a034a2f798cf10c7b432e05abf9cef521eeea462376af7df3d8b24f9ca148863",
+      "relation": "exact"
+    },
+    "meta-compile/error-unknown-type": {
+      "caseId": "meta-compile/error-unknown-type",
+      "contentDigest": "13b107f110073b4c7256fe3d2c9632c673997edcfed2bb17f50358390ce03742",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": false,
+        "donorStderrSha256": "4031643e9173ff5f872bd70879a0869b8220a03ee204f960629a4a3df407a0c7",
+        "donorStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17",
+        "mismatchKind": "stderr_mismatch",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "6dbd1d211b061e026ca65c7353cff9075266c4b1fbb4d1506185beed775845a2",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "73dffef9bafd1a1458c5ca4065feff8f1321751e4c670fd2ccc5bc36d387c5cf",
+      "reason": "The reviewed observable outcome is compatible while diagnostics or non-semantic presentation differ; the exact normalized observation is pinned.",
+      "relation": "compatible"
+    },
+    "meta-compile/event-subscription": {
+      "caseId": "meta-compile/event-subscription",
+      "contentDigest": "47d429529181ae79d2c6996898fad67100bc561abc2c1df19b09331eb0865a93",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "EventSubscriptions/ПриЗаписиДокумента.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "8da3db168ea93f4b5344b1d92503205e69aefdc314c56eb0244d6211ee852817",
+        "donorWorkspaceSha256": "71d73b89e1a022447b132183a3058e49396fbcc2d89030b19c6c729c5cd0c36f",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "EventSubscriptions/ПриЗаписиДокумента.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "ca7df2ea3ea74aedfa455c6192bdeffe3dcc2ee527eef8efceb15e613a559ddd",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "8b8c0c7e9b550c70e758282d1da5cf06f53f6590bf601599e2a6d52e8bba5b0b",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/event-subscription-sources": {
+      "caseId": "meta-compile/event-subscription-sources",
+      "contentDigest": "6493b4f48931b77196238d9bb00b50d352b45921d11fd77b329f4be016729e6b",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "EventSubscriptions/МоиОбработчики.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "f42cbe12a1d6ad4bafa1534f815db16c0404752367d28531e4ee581d0169521a",
+        "donorWorkspaceSha256": "74007c2c0f5a19b994f464e08f753a5d11090495a840a909bc07b4770745e133",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "EventSubscriptions/МоиОбработчики.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "d3766caf8f7b62270c14ed23b92b2b4b14ecd95d62ade9d15cd579767a021a3f",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "e9489ae82662ae24bd52dff8b9c098225ee63fc114e932532fc61cd149a97a55",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/exchange-plan": {
+      "caseId": "meta-compile/exchange-plan",
+      "contentDigest": "59ecae64780166600504631ab011d889c9743081d6ff4460357a1315f59906ef",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "ExchangePlans/ОбменСФилиалами.xml": true,
+          "ExchangePlans/ОбменСФилиалами/Ext/Content.xml": true,
+          "ExchangePlans/ОбменСФилиалами/Ext/ObjectModule.bsl": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "47b1fbd9b2b1794b58e50fea224569bf30ba4f84fd374ab638fe26b71cb2972a",
+        "donorWorkspaceSha256": "4b59e69e1d3e04979f54d9e77563666fc84170372fac253655492074a8746676",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "ExchangePlans/ОбменСФилиалами.xml": true,
+          "ExchangePlans/ОбменСФилиалами/Ext/Content.xml": true,
+          "ExchangePlans/ОбменСФилиалами/Ext/ObjectModule.bsl": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "47b1fbd9b2b1794b58e50fea224569bf30ba4f84fd374ab638fe26b71cb2972a",
+        "unicaWorkspaceSha256": "51b2451d5eb6f27be088352fcd5b733500f927560390441ed4208e6a3e172101"
+      },
+      "observationFingerprint": "99eeb90061b32cc0bed4ab4d97cb9fc4115617cce5052876913e448986caea32",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/exchange-plan-content": {
+      "caseId": "meta-compile/exchange-plan-content",
+      "contentDigest": "dc8d45d38619bdc9fcd10ec792dc19937438fe7c7628f9a51e97a48a6dfb42b8",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "ExchangePlans/ОбменСФилиаламиСоставом.xml": true,
+          "ExchangePlans/ОбменСФилиаламиСоставом/Ext/Content.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "c2b0d68ebee3dc2cf2d37f9ac35f1a3fb78eab0e6a4a7942c74311a79ca47e37",
+        "donorWorkspaceSha256": "69bd7c78bb4c3e0858a0acfadd4c5e791a9abeb3f716ff68b2180887791a627c",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "ExchangePlans/ОбменСФилиаламиСоставом.xml": true,
+          "ExchangePlans/ОбменСФилиаламиСоставом/Ext/Content.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "c2b0d68ebee3dc2cf2d37f9ac35f1a3fb78eab0e6a4a7942c74311a79ca47e37",
+        "unicaWorkspaceSha256": "514255148d87dd06c07e998a6b4aa86ae6572b9f6c517ccb9378fb2722f4267b"
+      },
+      "observationFingerprint": "860cfc0d666306321b99b205b78f37c2c0ef203c813300055006d59fe7ac7de0",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/filter-criterion": {
+      "caseId": "meta-compile/filter-criterion",
+      "contentDigest": "694f8f09d91376cb798549e4b9d8a4632fbdbc0412dd29ee869375588823f746",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "FilterCriteria/ДокументыПоКонтрагенту.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "2a6b35b40214463dec44662ad92f431f56f92d1e8c733aee8ce80e77f1ad5680",
+        "donorWorkspaceSha256": "e5564cf871877dcca37e928b31897c20da7e84baf9b7ad11ec84e9e6b3cf76bd",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "FilterCriteria/ДокументыПоКонтрагенту.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "fc7109916b34de78294929738870a1fc809c3bb3174053e4112d42bc3d7f2eb1",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "915a2dfd4b8e4e613645279dcab37b2f47752afa038c89c22c3a5f4249abff8a",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/functional-option": {
+      "caseId": "meta-compile/functional-option",
+      "contentDigest": "acc60b84585c4cee81c86bbdcfae521e19220b5f1da84715b491dc02ba96f35d",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "FunctionalOptions/ВестиУчетПоСкладам.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "9a46bbeb2a0f91b4c9dec13a85e32e2322b01c4fa2b17a6c8c27d5615510b922",
+        "donorWorkspaceSha256": "750df6b8799be366265129da5d69f05a633ebd5fc903d392698484299e09c7cb",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "FunctionalOptions/ВестиУчетПоСкладам.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "5ebf16505e1acf7d1cf8797a78f9d134515f7c44a3dc6a5473e7f9bc56e82bfd",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "ee9adee1203c31a8052565570a760e6039d9debd37e29526bf089bdce2eecd44",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/functional-options-parameter": {
+      "caseId": "meta-compile/functional-options-parameter",
+      "contentDigest": "dcc3308ea8f3c11063e0180daf7a54445a8ad6f313e313cb5a7d9ab792177828",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "FunctionalOptionsParameters/Организация.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "390064552ecd24586c90261179349b085350399336b5b79ed17bdcfca166774c",
+        "donorWorkspaceSha256": "24f4cf9361bc69fcf0ba8a291669502887e3ac2795b12bf224d05801ddb416a3",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "FunctionalOptionsParameters/Организация.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "ed1428c1c8d41db7b6901e1a4d0b540daa831f9070a092fc6b290cbfa530f4aa",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "37340f2f67c63057f78ad285bf9740cd44742e07ea3104a9b3aa687d89440575",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/guard-deny-root": {
+      "caseId": "meta-compile/guard-deny-root",
+      "contentDigest": "62069bd4b4799ff577d26a6048f09602fe2fb42013758eca6895c7700ce88c86",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": false,
+        "donorStderrSha256": "d8d7f5b65023063858c2d5fe818a28ada949c3334cee7cdc6b5dbe86f3f528b9",
+        "donorStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorWorkspaceSha256": "dbc23bd1ff8e1bb20284a2deb4e531ff680e2429b556de2158e7b6639308fd2f",
+        "mismatchKind": "stderr_mismatch",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "cc24290fdea08afccc53ac3a547e3d2bf07dff6d9117dfc161864e135ce197b5",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "dbc23bd1ff8e1bb20284a2deb4e531ff680e2429b556de2158e7b6639308fd2f"
+      },
+      "observationFingerprint": "5564a1332ba67312e96ea128300737c8087594d41913ed9aa924b50995305f81",
+      "reason": "The reviewed observable outcome is compatible while diagnostics or non-semantic presentation differ; the exact normalized observation is pinned.",
+      "relation": "compatible"
+    },
+    "meta-compile/http-service": {
+      "caseId": "meta-compile/http-service",
+      "contentDigest": "275fbdbf1d6c8f686804bb6372d88d164cec8d3ae8064fce98a0035b43776818",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "HTTPServices/ТоварныйAPI.xml": true,
+          "HTTPServices/ТоварныйAPI/Ext/Module.bsl": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "e7c3973798feb56d95330a45e68aade6decacbfd99c798f95c82aedf78180b07",
+        "donorWorkspaceSha256": "c8d3747ef89d463598246c7290ce6ab52673a7f28ab79b7e527984e4ad1cd73c",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "HTTPServices/ТоварныйAPI.xml": true,
+          "HTTPServices/ТоварныйAPI/Ext/Module.bsl": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "e7c3973798feb56d95330a45e68aade6decacbfd99c798f95c82aedf78180b07",
+        "unicaWorkspaceSha256": "fd67b7ec206fcb3033e1ad011323d1994d88c127f9c41cf6a48e6aa0d32f65cb"
+      },
+      "observationFingerprint": "c30a2081be15208c806b07581a80edd06607323fcd07e29707261cb07e48d114",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/information-register": {
+      "caseId": "meta-compile/information-register",
+      "contentDigest": "9fac75d0db408394c5683795c76468cf4734b988b33b8f7bf172202f0f6f8ef6",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "InformationRegisters/КурсыВалют.xml": true,
+          "InformationRegisters/КурсыВалют/Ext/RecordSetModule.bsl": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "fd2ca9e75faafd8cb2bdaf6c174df23ba2954a7e231bf594117c9006071fcb86",
+        "donorWorkspaceSha256": "1e3f9516a9fb763160b6e1864ab41beafd3f88baf186faba5498c03858d7a69f",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "InformationRegisters/КурсыВалют.xml": true,
+          "InformationRegisters/КурсыВалют/Ext/RecordSetModule.bsl": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "fd2ca9e75faafd8cb2bdaf6c174df23ba2954a7e231bf594117c9006071fcb86",
+        "unicaWorkspaceSha256": "4496ce888a35682d8d436acb09bca5fa09f5a6f6d297bbb984caf9772843f243"
+      },
+      "observationFingerprint": "523c259eb33a5d1f61fa7882e4091349f7ffacf8d17127b4faa107d5c1b8f4d9",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/report": {
+      "caseId": "meta-compile/report",
+      "contentDigest": "efef3a42f0dbaa603223a901ed82ed89319a757ae169cd5000a0e7376c465cf5",
+      "relation": "exact"
+    },
+    "meta-compile/report-full": {
+      "caseId": "meta-compile/report-full",
+      "contentDigest": "3ce23d2a44dcee7860d389456d7cc5b3f9b3c691222f661b6ace180443bec60b",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Reports/АнализПродаж.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "3fa967d3390de40351438c961f69ff117a85bd9fb42d10ac71da2d046b303c48",
+        "donorStdoutSha256": "e56ff97fb772c951406a76d5f2bafc564f3a9d8d6b3682f07ac60a7217be2285",
+        "donorWorkspaceSha256": "e776e6a6dfe3630d59fe00e134f893dc03a1491d39d2f99c9d4ccb6a2cc8ae86",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "Reports/АнализПродаж.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "4de7cdba94b9975ef5c9de6063cac21dfe854c60384a7d7bcbba8d113d7d1ec0",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "e1777ec8fdb12d95d24f4731d95df86bc628b626d43e8ac855e5c9d14c32247b",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/scheduled-job": {
+      "caseId": "meta-compile/scheduled-job",
+      "contentDigest": "09d9eb23d48240e47483bab6edf62accb8a5edf797b2cc3e9ba5e02ba4867b49",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "ScheduledJobs/ОбменДанными.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "e68078c8992363153192848a4fe976376a6b7d9b1ab8fbb3ec400f86d56c6d05",
+        "donorWorkspaceSha256": "bd17fe0ba85ce8c8539df7a49bd142b8a5f1a25a6c59e0d1f312d1045fd40eb7",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "ScheduledJobs/ОбменДанными.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "e68078c8992363153192848a4fe976376a6b7d9b1ab8fbb3ec400f86d56c6d05",
+        "unicaWorkspaceSha256": "0bce0eee93e68605e88ebc93cd35e2344ed83e9c3041969c60ceed120b8c715a"
+      },
+      "observationFingerprint": "1015a436e6191fcf615a59f20ca5bb279b035c22f471bbdf69701d9c06d2c532",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/sequence": {
+      "caseId": "meta-compile/sequence",
+      "contentDigest": "e8a928d942690c8d2a73a76b5be58fb09ac5b7b45d8de1c75153053af29da6e7",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Sequences/ВзаиморасчетыСКонтрагентами.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "9595361fb489b598c8246af99ac01586ee1d8fb7bcae6dc1e303c3263d914fd3",
+        "donorWorkspaceSha256": "ff87cb706fff71c25f5e270bcaf32dd1e360b5b1e2e48b52c08645c73264a111",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "Sequences/ВзаиморасчетыСКонтрагентами.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "40824c87ad7f9160ea4197fb93696929642214fe04ea8086e6b139c394153d16",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "7c5dd600381fec18a9ab0d8f63d479e6948740d923e32106008bebb798db493c",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/session-parameter": {
+      "caseId": "meta-compile/session-parameter",
+      "contentDigest": "e1e984223592041b117784faec4bf72d0fd249a6af457404d47a1f27682d7225",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "SessionParameters/ТекущийПользователь.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "03f7eda9460089e3a891dadfd46494a8197e46723f45766f2f41f44c70f8979f",
+        "donorWorkspaceSha256": "33821aa2bf56993899ee76176055f9c779fce55764f766c4f0bff66224afdbe2",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "SessionParameters/ТекущийПользователь.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "2ef45254e8a3d77ac95c78d7d86db1d4d4766dc43b4e1639ccf2845472e557c2",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "897344ab378b2fa3db3de5e91333ef384609afa380717fed3572dc143e9bc71b",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/settings-storage": {
+      "caseId": "meta-compile/settings-storage",
+      "contentDigest": "783d9fbe3e92b5dcf73ef02f884c1797307d99f6039579e3c4e74bbb28e06564",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "SettingsStorages/ХранилищеОтчетов.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "288fe201cf251dff01c405412c03072e53ea241df2903884b8d448c1e4969ca9",
+        "donorWorkspaceSha256": "900c781bcd5b3eeae72b66f04366235c9e90a8aeb82b6a32ade15380787c2ef5",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "SettingsStorages/ХранилищеОтчетов.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "1ddcd94e74dbb9379c7538f1d461e7e7e38b3e04b3173fff04004a47d71837f6",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "c404931c1b1734214534467929c6b060c7ae959e83597c01f43f6d693edb65ff",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "meta-compile/task": {
+      "caseId": "meta-compile/task",
+      "contentDigest": "09e006032bb95bf19ef87f0dd37e9ef98f5d1c9664ae3633e1b64bd0090259a5",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Tasks/ЗадачаИсполнителя.xml": true,
+          "Tasks/ЗадачаИсполнителя/Ext/ObjectModule.bsl": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "e3d274a8e48e0bdf597173fdec597a076472554cef8b50dc2cea2c259e93f687",
+        "donorWorkspaceSha256": "658de8873139e4cc3096660d6fc241551f4b6243463953f28a6636a6ce60a914",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "Tasks/ЗадачаИсполнителя.xml": true,
+          "Tasks/ЗадачаИсполнителя/Ext/ObjectModule.bsl": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "e3d274a8e48e0bdf597173fdec597a076472554cef8b50dc2cea2c259e93f687",
+        "unicaWorkspaceSha256": "8ea573eea324bace500b27eb3d5befdb848a5cba0dd310def27d162ccb046d49"
+      },
+      "observationFingerprint": "02b90d7f579149e8fc3420157942004bd9639974854e7d646d834a4335e6b4f1",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/web-service": {
+      "caseId": "meta-compile/web-service",
+      "contentDigest": "ae24ff2c48ab7c9f654c9e1af941e934daa8e00f3a84587ef08c1bad07556756",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "WebServices/СервисОбмена.xml": true,
+          "WebServices/СервисОбмена/Ext/Module.bsl": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "4a43463068592db66ffd9af4dd2d22b3cac8e72d56db1cbeb714836d1e3c6d75",
+        "donorWorkspaceSha256": "e366275bda5328ecb0c1a1d885d93c964ac59b98be4ac6d50b59ac7af9962fa1",
+        "mismatchKind": "snapshot_diff",
+        "unicaExpectedFiles": {
+          "WebServices/СервисОбмена.xml": true,
+          "WebServices/СервисОбмена/Ext/Module.bsl": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "4a43463068592db66ffd9af4dd2d22b3cac8e72d56db1cbeb714836d1e3c6d75",
+        "unicaWorkspaceSha256": "cc8c58199d39402e105d24dbacda19732a13ee6f35b041ed39eb9b4dfee2c361"
+      },
+      "observationFingerprint": "a727dafbb68d9ae77df4818ed176b8add5f7a2a7733b601a710c71c7334ca2b9",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "meta-compile/ws-reference": {
+      "caseId": "meta-compile/ws-reference",
+      "contentDigest": "16f1e27bb14b867a06b7dcd07c5b8bca9f962cb65d84898ba6762b6f2955038c",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "WSReferences/ОбменСервис.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "e5b2fa002bcb87fcd973546932c23b542b74cb63d6a8302f971fb2afa3db746d",
+        "donorWorkspaceSha256": "d5589e4e968011eda40f546ae246b6a7bb75000c815d668fe9d8de4b21dbf8fa",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "WSReferences/ОбменСервис.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "a8e4a171ddbb2cc2ae1f8b3d2758658bccf53693fb49c9f645df1d811fd56c08",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "1841b6d00ee4e69c264b4ff400784052d318d6340bf68f27821e04fae785af17"
+      },
+      "observationFingerprint": "b22fbe59109bf7bd3f7f2f857cb7507baf3da4035d3a60c467350813d83c686a",
+      "owner": "unica-maintainers/meta",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "skd-compile/auto-data-parameters": {
+      "caseId": "skd-compile/auto-data-parameters",
+      "contentDigest": "7c971493b837ac1da9742962130ae3b9fdfe64e14b8563061b2554c793806103",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "7596b0eced479ba35512537de358fd7d4ab0e23e775c67a324849eea346ce326",
+        "donorWorkspaceSha256": "6ebb0e4d951df4668996da01efa19e2afc969278dc15216d7156d42e818f4239",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "a33127e7bb788d76a0bfcc966d4120f3e3e4dd90863f63aac0b89246711acdbd",
+        "unicaWorkspaceSha256": "9a38baec1c5e028b5f70d286717a5255ecc784dc7c9dad9655e93817547e6e55"
+      },
+      "observationFingerprint": "cb58e1f8d71eca9d4d1d85eb237e7d48da82ef33d6e639b40f93275ebab00aba",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/available-values-and-folders": {
+      "caseId": "skd-compile/available-values-and-folders",
+      "contentDigest": "9b7694c88d2b534a67e6a571b2eaad730d58ec347f3909a8a05514c352e7f1d4",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "41b7cccddecb00d96b6eb7cc135be77726855a81e4e3182d9a398f8b22d4556d",
+        "donorWorkspaceSha256": "2d3ad7a7ef34ce00f8221a6c7376f2ffd8b58ad417bf75b4d17a264324a76c7a",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "5e3fec186bedb713df52cfc5ff4b2ff16180202e8c0f0a6905ec9153a0d4f118",
+        "unicaWorkspaceSha256": "74f4d63f8858ac27bdc8b433dfdda5bd67271d0c807ef38ac71a565287c9e667"
+      },
+      "observationFingerprint": "544893b6820c5270cc1f5478748d68e266e9935ba4109481050208a7f05be84f",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/calc-object-name-restrict-string": {
+      "caseId": "skd-compile/calc-object-name-restrict-string",
+      "contentDigest": "81dc37df58c13db19a05addf6eff206292e233877abc31a8bffb68de972b0c68",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "f8476d3e2f0d4762dc1638224cffa2e6113e852566ccde3f0b79f3942293c9ac",
+        "donorWorkspaceSha256": "194e7b8543766e994fdcbbec4e5a527beebec4b413c97abf803c1a896caf2f4f",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "8dd2a274edad1a99dd784c52e23a6a7e2c28a76c27279538db5308972a3f7fe9",
+        "unicaWorkspaceSha256": "f1a39428b22e746dcdb83ae99a3514128873829c9debf05b7c764c54e8d5dbc8"
+      },
+      "observationFingerprint": "4cb51808adf8f2de3609b6070aa7e8bc4073103fc95efd0efa352d28b97f8131",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/calc-shorthand-extended": {
+      "caseId": "skd-compile/calc-shorthand-extended",
+      "contentDigest": "f0a44227c75c0723606adc1e7e36621cb9d52598c85bc364f34000a745f0a6e6",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "8fd94d67c394a1504a6ded3040707195648f98e035b16bdf4ccd523a0a798a66",
+        "donorWorkspaceSha256": "b42d243eac76dd5a821ecaaccc4a06c0e24e5aa31420aa3c56b16d6e3f6b3851",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "bb4c708dc4861d6ddceeaac20a547c8861c6bae993908c17fbd8d5495e4600dc",
+        "unicaWorkspaceSha256": "c6ae36dd271677143ccc120dc1722535e0c64efb6656fbdbd5ce116ea79d4cda"
+      },
+      "observationFingerprint": "61ad685cbc7c021d96d957ac936148dc8a40b6d5beacf1c6a6b078f55e7960eb",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/calculated-fields": {
+      "caseId": "skd-compile/calculated-fields",
+      "contentDigest": "9cf9895dc643ab5e9ca6f58f95dcd60b92c6b09f990dbad4f58aa552037fdc6b",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "f94635ce2f0d701cd7df91839df963a68037b4bdba3be3e18552ede076ba3590",
+        "donorWorkspaceSha256": "dc7b38585acc3cd05b8cac9396c2f18d26036f917ac8216e45e2bd5459a3460b",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "90c57ea5a786d3b685c8e37e3b9860cf469ba101c59f473e3f6027815681837f",
+        "unicaWorkspaceSha256": "f6fbf76fae945cbe2df91bd9fad336d4efe9a659650921e851bf351becbf2013"
+      },
+      "observationFingerprint": "1be3e2738f2fef834d5420e4625ca1cafb2a8754ac480c7c2062f9b1fd52eacb",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/decimal-qualifier-defaults": {
+      "caseId": "skd-compile/decimal-qualifier-defaults",
+      "contentDigest": "ac940f2e8e1bc1d229cba205460a2ad1e7421171d9cda6140d317f128dfac5a6",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "ed35a647ab736862f1453ddcbf82125e93ae7032cef30468ea156d2fb7f6a30c",
+        "donorWorkspaceSha256": "dd8039f988487511d7250e2a715b0aba9a6aa1732ef94269a9dfe63ec104a690",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "Template.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "906a0979efaba7dacebd69ad48562abf37f2317118eec63abb15bf1cc8aa47e8",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+      },
+      "observationFingerprint": "ee2ad90f2fe7344b38d8bef25d7d529c84d4e67dac4f5c47312e89314bdd9252",
+      "owner": "unica-maintainers/dcs",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "skd-compile/empty-param-values": {
+      "caseId": "skd-compile/empty-param-values",
+      "contentDigest": "98e177f6fd283a443559bbc2b5fc179d3963d8450158d6f68e37498e14776ab9",
+      "decision": "defer",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "4c10cb7f93975fc9a18097c02869b7f69077c9a07ceafd627ab3df5b3ba244d7",
+        "donorWorkspaceSha256": "11d0e02e59bd3974f23d6173dedad17216afe9b9b7d93b334df5e408a7576708",
+        "mismatchKind": "ok_mismatch",
+        "unicaExpectedFiles": {
+          "Template.xml": false
+        },
+        "unicaOk": false,
+        "unicaStderrSha256": "cbc3465db8d31828e3d327a87751bc1798629115a06cecf5f91db5e1f63aaa6b",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+      },
+      "observationFingerprint": "caad33f1fb79846dc5f78db400148e546694ae91a724c9c7aefd8711a402f18f",
+      "owner": "unica-maintainers/dcs",
+      "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
+      "relation": "donor_ahead"
+    },
+    "skd-compile/field-appearance-and-presentation": {
+      "caseId": "skd-compile/field-appearance-and-presentation",
+      "contentDigest": "586f6616908ffe08bd251fb0250b5c30078ca9552c9d7bb04754184b58c9f6a0",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "f553072ec32a34c46821390b4d29d241b36599a391986ac97d4ffc1bc59d32d0",
+        "donorWorkspaceSha256": "73ac7d8c17d40a610071c2b6dd8d5d0a0b110038d0980a94fbcb4c532ca0579d",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "6909652f78c510a251681ba33aa2697641832ae5419f010dd68e7381ada03107",
+        "unicaWorkspaceSha256": "9b7c1a1851771a7f2c26208303c7937d8a04b03aec58100fdb58db1d2633b119"
+      },
+      "observationFingerprint": "a1e886f56820de650d63cbe8ceee13cdf33ff76b41c69c8c09fc4dda535cb324",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/field-multi-type": {
+      "caseId": "skd-compile/field-multi-type",
+      "contentDigest": "4b48b6fa1c715fc8a5ca7ed8acfe2caf3e8662b015b6641352ae40598b406ad7",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "25886607f44fd2bb684635f1302091f2ef9b9b68af8f322a6546dad9441cd802",
+        "donorWorkspaceSha256": "ab496f3cbfbc46c69ae538b1d1e8b43c8450655c3cb682fd690d73c30b183e94",
+        "mismatchKind": "stdout_mismatch_snapshot_equal",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "d34fec5162948f0c3b0afaa45899c8d6b58166675d43e6905ecec8f5ae29bcfd",
+        "unicaWorkspaceSha256": "ab496f3cbfbc46c69ae538b1d1e8b43c8450655c3cb682fd690d73c30b183e94"
+      },
+      "observationFingerprint": "c309f6d6336cb3c7769ffabb31cd1491eb3da89a5d5c45399ba4a6454e783801",
+      "reason": "The reviewed observable outcome is compatible while diagnostics or non-semantic presentation differ; the exact normalized observation is pinned.",
+      "relation": "compatible"
+    },
+    "skd-compile/field-restrictions": {
+      "caseId": "skd-compile/field-restrictions",
+      "contentDigest": "1c3271ff4880c090ee17df7318960dd3a04545d2f0dfa78ebe1751da84f0ac12",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "0fcf5e09c6fd521c3a34ab05b848db561fc1a91592c2f65503e5fd7ad5599774",
+        "donorWorkspaceSha256": "087f6c33bf07356750ed56ce8e16217e5bc2f3f5cf7c02965ed5c544528d3fde",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "fb58a517e68f883c4f6c9bbe16693cfee9cc57bd714d0d78111f3f867a28aea1",
+        "unicaWorkspaceSha256": "a3e0d34d9d231b7165fd29b4060183db5b2a9dae273513756dd5d883481f2e78"
+      },
+      "observationFingerprint": "d1e1f1ee6564bc7833eff7c9a1f8224bbb64c356074deef5f6de6a686738a100",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/full-example": {
+      "caseId": "skd-compile/full-example",
+      "contentDigest": "62c494d0f5d7be263aeb113cc00608950375de5b5ce1bd3b42ac667d95137bd4",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorOk": true,
+        "unicaOk": true,
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "donorStdoutSha256": "3463f701454f0a70207a299a238c20667874fb5be546e521cc6e17113065b8d9",
+        "unicaStdoutSha256": "d8cc5b92a2dec26dd220d7da1853428066b9b97d9c064db4b193f153d1ebbfce",
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorWorkspaceSha256": "9fa65cd4fc4b61a772d85a396135646e51d2cf5e8a6f4290af4323bfb44a46bd",
+        "unicaWorkspaceSha256": "1c08493e15b017a3e7b009d17a0c56af99990459b3b824bf6bea563f797e16fd",
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        }
+      },
+      "observationFingerprint": "fc973349266967e5202bc5a2e56b70cf7e7e076898424d16601f356f4ada65d8",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/grouping-and-totals": {
+      "caseId": "skd-compile/grouping-and-totals",
+      "contentDigest": "331e9303aa04afcefc0fa9923f0227d504f530731cfec94f4749b4394f851fb5",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "0bd98212666dac059fe89a5e7a8b7bfbc6d2d7593a8cb17bf87252933d63b6cc",
+        "donorWorkspaceSha256": "d4b4b82294bdf3b0db18474e1a1498a2d2ab25c3a3c8940249aee8cbc7ede222",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "0bb3cfd0fb60faa63fd8d503a742288a217ceb455fc3ef9c9fa98c14d1551413",
+        "unicaWorkspaceSha256": "d63729f70c3d09d5754ad011260346afc0141115b512534698912fc35bd53dc5"
+      },
+      "observationFingerprint": "651f19ec9ea689e3758adcd877937c272233770c9bdf8a43b00959aae7c6e157",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/guard-deny": {
+      "caseId": "skd-compile/guard-deny",
+      "contentDigest": "4d6e18e324e00234a9a146a612386c3a3e1b7d35735394b29b506d3a5602b255",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {},
+        "donorOk": false,
+        "donorStderrSha256": "23ffcbf59e531912015832a89140c40be86bcdd082c2ec5f5cf8160f28323ebf",
+        "donorStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorWorkspaceSha256": "dbc23bd1ff8e1bb20284a2deb4e531ff680e2429b556de2158e7b6639308fd2f",
+        "mismatchKind": "stderr_mismatch",
+        "unicaExpectedFiles": {},
+        "unicaOk": false,
+        "unicaStderrSha256": "cc24290fdea08afccc53ac3a547e3d2bf07dff6d9117dfc161864e135ce197b5",
+        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaWorkspaceSha256": "dbc23bd1ff8e1bb20284a2deb4e531ff680e2429b556de2158e7b6639308fd2f"
+      },
+      "observationFingerprint": "27fb1cfb9aadea63560e2c163fe7040a01523115bd7903f5fcbad396b17dfce3",
+      "reason": "The reviewed observable outcome is compatible while diagnostics or non-semantic presentation differ; the exact normalized observation is pinned.",
+      "relation": "compatible"
+    },
+    "skd-compile/horizontal-merge": {
+      "caseId": "skd-compile/horizontal-merge",
+      "contentDigest": "030c8e1a1b6dfb6fb32d747da505ad48eb0fbe9a43ec0b3710d33b30c3d29c97",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "61ae9b4965549ec2b7f70b117de42885de28341536f03d54a0bb44aa3f9c2142",
+        "donorWorkspaceSha256": "38d8c00912613ab111eb7bab072ce6125dc2dace1358fa52f84166bc5852dfb3",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "07ad2ea37679e95e0a06b8255d4d6258998dcdb5da8bb49eb20bcefce85b8c69",
+        "unicaWorkspaceSha256": "4b7e7bc4ef69ce6dcff609d06dca039be47151cb15847cc95f012da2e7ead579"
+      },
+      "observationFingerprint": "2fd0e7d205fc4d30124e79bf0abeaaa7ea28507c9b9125c69e0c5ec5cb9e1e02",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/minimal": {
+      "caseId": "skd-compile/minimal",
+      "contentDigest": "c8f5d973a0c2277494c20f7c926b10eccfb14c8f0600cf7d32fe90c45f650b3f",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "fc0e7dd216c8acd502b910837eb320accd810fcb825a6759ed0ef8ef17bc47b6",
+        "donorWorkspaceSha256": "eebd3feafd09360aacce75230d778262d3664247c584fc4339e19b1eeda51007",
+        "mismatchKind": "stdout_mismatch_snapshot_equal",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "8be91d4c7f58bb5277755b6c9e5b5a325bc766c0725453d0d1a7bb66f9130b9b",
+        "unicaWorkspaceSha256": "eebd3feafd09360aacce75230d778262d3664247c584fc4339e19b1eeda51007"
+      },
+      "observationFingerprint": "1bbf928f73893e1eee34160fff74f7153e0ca1a4b082d5248c9ca7a2d977460d",
+      "reason": "The reviewed observable outcome is compatible while diagnostics or non-semantic presentation differ; the exact normalized observation is pinned.",
+      "relation": "compatible"
+    },
+    "skd-compile/multi-lang-title": {
+      "caseId": "skd-compile/multi-lang-title",
+      "contentDigest": "6ca53c308dd912efc6479904470bbff889f959718dcf238407e65710d80df730",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "eae32403ea8ed4e9b7454796eb3563e31620cb1e73f007043fc41c0b6dfbbdad",
+        "donorWorkspaceSha256": "393fff3e1fc0f69dc161b59fa93f2e6126e5ebcd83ffea149b086ae69e17de10",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "fdfe0641c5fa58d537e12a872ab0b6150e741980e18e9816080d3dd302a5e4b2",
+        "unicaWorkspaceSha256": "a2e7c8e5213be32fee2d74fbe008f5dbcee00d5c6cf8a14e9e7b589e666fa3be"
+      },
+      "observationFingerprint": "d1e429aa5080920588eddc0e7c426b0afcf31219cad72073cdda014062ef8489",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/multiple-datasets": {
+      "caseId": "skd-compile/multiple-datasets",
+      "contentDigest": "f83f554a10314a649146fbf0f90da0a0f0b9eff21a302f663a09a3df7208ab38",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "841e926bfa5637b267a2abe45291f2f617a8463fd0f98f1345de2f55d39684ea",
+        "donorWorkspaceSha256": "63fe477556fb397e2bb7a9a27b249da6348821556b5a67dd2cf470d64a21f6bb",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "8cdc781ad43b34e06fe686de0a87dda715aed594bcd069f0a90c988abf23572d",
+        "unicaWorkspaceSha256": "181c7ab1423269e0fb371972c28afdabd2cf8cccf7fcde7f0cd7ff2616e3cfda"
+      },
+      "observationFingerprint": "44920b5c573f57418b1caccafcb787917976391a8fd3cb938e7f1b239ab41980",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/orgroup-string-items": {
+      "caseId": "skd-compile/orgroup-string-items",
+      "contentDigest": "a207a4fdaba8c73f072ed60ce29997b82a8a3e3b8310561bc964ccaa9479bf9e",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "9eade7600695a2f27c9ff1c85b70364135b8587b4e88d666de96dd74708a7602",
+        "donorWorkspaceSha256": "d3d9667b0973490559889e84e6d93c2f0201e12463bfa26e39f45a2b6591d731",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "6371e556b5a27bab8849cb4e587514346d800d33c7e19894a9d321db1dd5b892",
+        "unicaWorkspaceSha256": "1c0632210cb3b264fb803c7eeb449a9b82248663be27f2ba58ed8fb1c7a34b27"
+      },
+      "observationFingerprint": "8fabcb064ad47f72873712898e868dffac9c717043f0b8884c5bccfbfcca86f2",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/parameter-title-presentation-synonyms": {
+      "caseId": "skd-compile/parameter-title-presentation-synonyms",
+      "contentDigest": "80a17f63d04d9e64457d41084e5e3104c8f0c80fbaa1d61309cd5bd7fdeb9d92",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "58fcd0a61d657e38892c042ff5c0daaafed7fbc4da7c5db78bb4857226c47d78",
+        "donorWorkspaceSha256": "23f5d4e24e0bca76eaa0d2862cc33a71a674e53d15664b71a1237015dcd80ffc",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "52cc30bb60d1a6259ed0efb084f0c8b62897a2fbb079eaaca7dc2e28f0b0dc55",
+        "unicaWorkspaceSha256": "f2f3bfcf835aaca180d0a3066ee89a3d01b37f03280d911c34dff4d81098e1e4"
+      },
+      "observationFingerprint": "54a9d80031e8f200116ba4d9295b7e04dc116dab297c4962febe26f04aa07fdf",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/parameter-value-list": {
+      "caseId": "skd-compile/parameter-value-list",
+      "contentDigest": "4fa9f6afd0cb85318cd80c7227b398d26ae41543e905552f8be434bdaaa31c09",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "b6e8414dc207f67435bd0f4c05a4d381cc9871029fd01b44cae7d1f9a4505a2e",
+        "donorWorkspaceSha256": "139f421f133c892eb734870f6086113c03018408babce711012d218a619f6c31",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "a7b70e4a60d468a9de1ceb240ba2f7109f4fd357b5b509376eca1c191884d927",
+        "unicaWorkspaceSha256": "3592981c387b63694c3e46a5b4e16fb699197f5f1784c34e6da4bd42ee6db266"
+      },
+      "observationFingerprint": "f1477d03572911d771cd2d06e602130b6306c636e56552eb561b60c41cd68f2c",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/simple-query": {
+      "caseId": "skd-compile/simple-query",
+      "contentDigest": "f982228497b55791d6845b00791f5e6d20ae6fc53ecdaec25926b55109eb47d3",
+      "evidence": [
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "00be28d9d1c963cd727f346d99ea957a032e51c11bfef4fe5348c7ee02e52abd",
+        "donorWorkspaceSha256": "a72853e9b8e86b63b83c0b9aaae0c819a782b443faf3d27981f6180e0766c546",
+        "mismatchKind": "stdout_mismatch_snapshot_equal",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "e4e5357831fbc3e426b8ae4ef3c0db5315dc25fb9849cc27b3671fd490a22808",
+        "unicaWorkspaceSha256": "a72853e9b8e86b63b83c0b9aaae0c819a782b443faf3d27981f6180e0766c546"
+      },
+      "observationFingerprint": "a8c5f408904f8b6875cf8a6941a80030b3bf978dd73db8941900278a12c654de",
+      "reason": "The reviewed observable outcome is compatible while diagnostics or non-semantic presentation differ; the exact normalized observation is pinned.",
+      "relation": "compatible"
+    },
+    "skd-compile/structure-chart": {
+      "caseId": "skd-compile/structure-chart",
+      "contentDigest": "14b5dfafa0122370017597d2bf347599b304c23d2ba554e19e6e9ca0f9027b49",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "ecb07557dae44f35ea0ccfab0702200d2e5ac99a05ac85f223bebbc2fe6214bd",
+        "donorWorkspaceSha256": "5c56d5fd85cb3b87913ca17f39ab453988102b910d1757b836eb21a49fc1f28a",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "1d72941df19afb744f3e15fe90b9348bd0ca61898d2bad388299f09b00c079f2",
+        "unicaWorkspaceSha256": "dc8342c8755bae2ec635b5271f827209847ab659470d926166f4ea249a941c72"
+      },
+      "observationFingerprint": "04911a79334fc9deebfc6f70736246ea0075813cc55fb92ec479448a4444f829",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/structure-object-form": {
+      "caseId": "skd-compile/structure-object-form",
+      "contentDigest": "14667230e3989416ee409523aa6b2c4ed9fa1b3809791d266b457994524db902",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "79392394fea8c08c0a94b0c0060f513f10165502573d02c3523fa6375839d087",
+        "donorWorkspaceSha256": "62ba7dcb8018881b556f528aabff01fdd03100fcc0075a698c33482dd0c32d3c",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "f78174bc485f8934864ef16dc5369a4c76e3f2d65e0a8a5120daba89831ad3f1",
+        "unicaWorkspaceSha256": "332b39cd2ca4031c67852f96552290adafd3962d2fcdc282506cfd801eb482ff"
+      },
+      "observationFingerprint": "397770671a39e1a64a6ff3dc8b07b3bb619ac0fe652f0c81f8f05f3d2e5d5665",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/structure-object-group-no-selection": {
+      "caseId": "skd-compile/structure-object-group-no-selection",
+      "contentDigest": "b7e7dc0160c1bab7308bad6b308f008db9e78c97558543fd9462c46de22eb2bf",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "b0c535c847c3b5868c65c7cc783c04f4b754e8ea5c55691e1fa9d069cce686cb",
+        "donorWorkspaceSha256": "a2c18a87e30fdb891800660ac68ff0a06639a96709c6064a3e1988ce5a21933a",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "8d608fb153f712273b7cc99eb997cd9fb5139568beeff5b03f033beff9ae2a49",
+        "unicaWorkspaceSha256": "395f2e807848156b51a0bed769bb0ff36b1e0e81b8dba5288ed1fa0b64cf987d"
+      },
+      "observationFingerprint": "93e495efb84001259c5769d3d57773211dff199aa3a573dd8e9aec5ab89c17b2",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/structure-table-pivot": {
+      "caseId": "skd-compile/structure-table-pivot",
+      "contentDigest": "9f87bb252f5f87d2971ac8242453fa258ada6a644ea1be6e052665d4834c5fbc",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "5ef340e981026da14e357e219666fffc7e800695aa0e34aadd976c15a9471126",
+        "donorWorkspaceSha256": "8ae95f0d44140b8eff83d4bb21aec89f4044761f26489e021cbd39753525332d",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "d5eb52cf952ca730ce5b0e991062203bf7577bf23e4ae504adb0942f439b1ea7",
+        "unicaWorkspaceSha256": "fb1ab39de4b3c0ac5bc9474216efbe89a4eefc0c93f124f7afa9175effcc0840"
+      },
+      "observationFingerprint": "10b13b7a83ef962e1ec199d952ba5a08164f347e5a205e93959dbf753475422b",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/userestriction-object-form": {
+      "caseId": "skd-compile/userestriction-object-form",
+      "contentDigest": "1ea99bda166de6f5526021a3d963522e4fd870917ca1ae16e4eec7e0cc2f0606",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "f8476d3e2f0d4762dc1638224cffa2e6113e852566ccde3f0b79f3942293c9ac",
+        "donorWorkspaceSha256": "194e7b8543766e994fdcbbec4e5a527beebec4b413c97abf803c1a896caf2f4f",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "8dd2a274edad1a99dd784c52e23a6a7e2c28a76c27279538db5308972a3f7fe9",
+        "unicaWorkspaceSha256": "f1a39428b22e746dcdb83ae99a3514128873829c9debf05b7c764c54e8d5dbc8"
+      },
+      "observationFingerprint": "4cb51808adf8f2de3609b6070aa7e8bc4073103fc95efd0efa352d28b97f8131",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/with-filters": {
+      "caseId": "skd-compile/with-filters",
+      "contentDigest": "52b75e1def962835e8ddb1376e30cc79564148d674c6973dfebc19e7a08b169c",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorOk": true,
+        "unicaOk": true,
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "donorStdoutSha256": "53b0942592c634f6b1fa7332b82996564b6538b85210b90865d48756596461cc",
+        "unicaStdoutSha256": "644ed996e4914d07fedca78c7a8d93d6b7a16cef10dc1addc72f613baa745245",
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorWorkspaceSha256": "00a88d0904ed0c23a3de5fe1a81e4380f9a867adf1a92a6304cbb77480a4df88",
+        "unicaWorkspaceSha256": "abd336769b25511393c14addc3e4847ac30f4da6dafc16cc7a923694838c3082",
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        }
+      },
+      "observationFingerprint": "100a371d4afb386e606d8fdcbc99c818d3bb91c67fe2fc975f108b3ccdf4ce31",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    },
+    "skd-compile/with-parameters": {
+      "caseId": "skd-compile/with-parameters",
+      "contentDigest": "556d4c677523fa5d36568df504b0bc2f19a21bd120af86c31fd58853b07ea36d",
+      "evidence": [
+        "spec/acceptance/format-profile-8-3-27.md",
+        "docs/design/2026-07-24-updatable-donor-parity-relations-design.md",
+        "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
+      ],
+      "observation": {
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "67d389c7d1010d52e016d4b1a506f9420943495cea97587f9f20513dfeeb1fd5",
+        "donorWorkspaceSha256": "b5f8ad8dd7884f82efa41fd253fabac50b614574f07996601a5bedea585eeaa1",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "cadf226d3339b9129e17b5a0fefa62af36fa8457f30138d5825ba1ae7c1af4da",
+        "unicaWorkspaceSha256": "a6fc7f9b22759b3cca31bb3bd11a79d4a9f9ddb85ea39783098acda934e7b455"
+      },
+      "observationFingerprint": "22fd761ece4ee3283f2b07464716fc908ab81bc0ef1feebec91f3c8bf6360456",
+      "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
+      "relation": "intentional_divergence"
+    }
   }
- }
 }


### PR DESCRIPTION
Closes #311.

## Дефект

`plugins/unica/references/specs/dcs-dsl-spec.md` публикует для `dataParameters` shorthand-строку:

> Формат: `"<Имя> [= <значение>] [@off] [@user] [@quickAccess] [@normal] [@inaccessible]"`

`dcs.edit` её разбирает (`dcs_edit_parse_data_parameter`). Компиляция читала `parameter` только из объектной формы:

```rust
let parameter = json_string_field(item, "parameter").unwrap_or_default();
```

Для строкового элемента это пустая строка. Отсюда ровно то, что описано в тикете: количество элементов совпадает с количеством параметров, но каждый выглядит так:

```xml
<dcscor:item xsi:type="dcsset:SettingsParameterValue">
    <dcscor:parameter></dcscor:parameter>
</dcscor:item>
```

Воспроизведение: `dcs_compile_variant_data_parameters_accept_the_published_shorthand` на коде до правки падает с

```
assertion `left == right` failed: the shorthand carries the parameter name
  left: ["", ""]
 right: ["Period", "Company"]
```

## Исправление

Компиляция использует тот же разбор и тот же эмиттер значения, что и `dcs.edit` (`dcs_edit_settings_value_lines`), поэтому грамматика у двух инструментов одна, а не две расходящиеся. Следствие: вариант периода доходит до вложенной формы вместо уплощения в текст —

```xml
<dcscor:value xsi:type="v8:StandardPeriod">
    <v8:variant xsi:type="v8:StandardPeriodVariant">ThisMonth</v8:variant>
</dcscor:value>
```

— то есть ровно то, что в тикете приходилось дописывать руками. Порядок детей 8.3.27 сохранён: `parameter, value, viewMode, userSettingID`.

Закрыты два следствия того же дефекта:

1. **`@inaccessible`** входит в опубликованный список флагов, но не распознавался и не вырезался из строки — то есть попадал внутрь имени параметра. Флаг добавлен в общий разбор, поэтому исправление действует и в `dcs.edit`.
2. **Валидатор** пропускал `SettingsParameterValue` с пустым именем. Тикет просил это проверять. Без новой проверки тест валидатора получает `=== Validation OK: Template.xml (7 checks) ===` — то же самое `Validation OK`, о котором говорит тикет.

## Запись паритета с донором

`skd-compile/full-example` и `skd-compile/with-filters` используют этот shorthand, поэтому вывод Unica изменился и `observationFingerprint` перестал совпадать. Записи перезаписаны после проверки направления изменения:

| Кейс | Было | Стало |
| --- | --- | --- |
| `skd-compile/full-example` | 4503 байт | 4749 байт |
| `skd-compile/with-filters` | 4258 байт | 4461 байт |

Рост — ровно на имя параметра, вложенное значение и `userSettingID`, то есть на то, чего не хватало. `mismatchKind` остался `stdout_mismatch_snapshot_diff`: расхождение с донором было и до правки и к ней отношения не имеет.

## Проверка

- `dcs_compile_variant_data_parameters_accept_the_published_shorthand` — падал до правки, проходит после.
- `native_dcs_validate_rejects_a_data_parameter_without_a_name` — падал до правки (`Validation OK`), проходит после.
- `cargo test --package unica-coder --lib dcs` — 82 passed, 0 failed.
- `cargo test --package unica-coder --lib` — 2714 passed, 1 failed: единственное падение — известный флейк #432, чей фикс идёт отдельным PR #439.
- `python -m unittest discover -s tests/ci` — 644 passed, 3 skipped, 0 failed.
- `cargo fmt --check` — чисто.

## Не входит

`structure` с таблицами — отдельный дефект #312.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for shorthand data-parameter strings during DCS compilation.
  * Added support for nested typed values, including standard periods.
  * Added handling for `@inaccessible` data parameters and their corresponding view mode.

* **Bug Fixes**
  * Empty data-parameter names are now rejected.
  * Invalid settings variants now produce clear compilation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->