### PR TITLE
feat(dcs.compile): компилировать таблицу и диаграмму в структуре варианта настроек

### DIFF
--- a/crates/unica-coder/src/infrastructure/native_operations/dcs.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/dcs.rs
@@ -4584,7 +4584,7 @@ pub(crate) fn dcs_compile_emit_settings_variants(
             dcs_compile_emit_output_parameters(lines, output_parameters, "\t\t\t");
         }
         if let Some(structure) = settings.get("structure") {
-            dcs_compile_emit_structure(lines, structure, "\t\t\t");
+            dcs_compile_emit_structure(lines, structure, "\t\t\t")?;
         }
         lines.push("\t\t</dcsset:settings>".to_string());
         lines.push("\t</settingsVariant>".to_string());
@@ -5023,33 +5023,62 @@ pub(crate) fn dcs_compile_emit_data_parameters(
     Ok(())
 }
 
-pub(crate) fn dcs_compile_emit_structure(lines: &mut Vec<String>, structure: &Value, indent: &str) {
+pub(crate) fn dcs_compile_emit_structure(
+    lines: &mut Vec<String>,
+    structure: &Value,
+    indent: &str,
+) -> Result<(), String> {
     if let Some(text) = structure.as_str() {
         for item in dcs_edit_parse_structure(text) {
             let fragment = dcs_edit_structure_item_fragment(&item, indent);
             lines.extend(fragment.lines().map(ToOwned::to_owned));
         }
-        return;
+        return Ok(());
     }
     if let Some(item) = structure.as_object() {
-        dcs_compile_emit_structure_item(lines, &Value::Object(item.clone()), indent);
-        return;
+        return dcs_compile_emit_structure_item(lines, &Value::Object(item.clone()), indent);
     }
     if let Some(items) = structure.as_array() {
         for item in items {
-            dcs_compile_emit_structure_item(lines, item, indent);
+            dcs_compile_emit_structure_item(lines, item, indent)?;
         }
     }
+    Ok(())
 }
 
-pub(crate) fn dcs_compile_emit_structure_item(lines: &mut Vec<String>, item: &Value, indent: &str) {
+pub(crate) fn dcs_compile_emit_structure_item(
+    lines: &mut Vec<String>,
+    item: &Value,
+    indent: &str,
+) -> Result<(), String> {
+    dcs_compile_emit_structure_item_inner(lines, item, indent, false)
+}
+
+/// A group nested in a table axis is written in the short form, without
+/// `xsi:type` — that is what the platform writes and what the donor emits.
+/// Elsewhere the explicit `dcsset:StructureItemGroup` form is used.
+fn dcs_compile_emit_structure_item_inner(
+    lines: &mut Vec<String>,
+    item: &Value,
+    indent: &str,
+    short_group: bool,
+) -> Result<(), String> {
     let item_type = json_string_field(item, "type").unwrap_or_else(|| "group".to_string());
-    if item_type != "group" {
-        return;
+    if item_type == "table" || item_type == "chart" {
+        return dcs_compile_emit_structure_axes_item(lines, item, indent, &item_type);
     }
-    lines.push(format!(
-        "{indent}<dcsset:item xsi:type=\"dcsset:StructureItemGroup\">"
-    ));
+    if item_type != "group" {
+        // Dropping the item produced a template that validated and reported
+        // nothing, so the caller learned about it only from an empty report.
+        return Err(format!(
+            "structure item type '{item_type}' is not supported by unica.dcs.compile (supported: group, table, chart)"
+        ));
+    }
+    lines.push(if short_group {
+        format!("{indent}<dcsset:item>")
+    } else {
+        format!("{indent}<dcsset:item xsi:type=\"dcsset:StructureItemGroup\">")
+    });
     if item
         .get("use")
         .and_then(Value::as_bool)
@@ -5088,10 +5117,135 @@ pub(crate) fn dcs_compile_emit_structure_item(lines: &mut Vec<String>, item: &Va
     }
     if let Some(children) = item.get("children").and_then(Value::as_array) {
         for child in children {
-            dcs_compile_emit_structure_item(lines, child, &format!("{indent}\t"));
+            dcs_compile_emit_structure_item_inner(lines, child, &format!("{indent}\t"), false)?;
         }
     }
     lines.push(format!("{indent}</dcsset:item>"));
+    Ok(())
+}
+
+/// The two structure items built from axes: `dcsset:StructureItemTable`, whose
+/// axes are `column` and `row`, and `dcsset:StructureItemChart`, whose axes are
+/// `point` and `series`. Both carry the same axis block, so they share one
+/// emitter rather than two that drift apart.
+///
+/// The chart always publishes its own `selection` — the values it plots — and
+/// the platform fills in `Auto` when the caller named none.
+fn dcs_compile_emit_structure_axes_item(
+    lines: &mut Vec<String>,
+    item: &Value,
+    indent: &str,
+    item_type: &str,
+) -> Result<(), String> {
+    let (xsi_type, axes) = if item_type == "table" {
+        (
+            "dcsset:StructureItemTable",
+            [("columns", "column"), ("rows", "row")],
+        )
+    } else {
+        (
+            "dcsset:StructureItemChart",
+            [("points", "point"), ("series", "series")],
+        )
+    };
+    lines.push(format!("{indent}<dcsset:item xsi:type=\"{xsi_type}\">"));
+    if item
+        .get("use")
+        .and_then(Value::as_bool)
+        .is_some_and(|value| !value)
+    {
+        lines.push(format!("{indent}\t<dcsset:use>false</dcsset:use>"));
+    }
+    if let Some(name) = json_string_field(item, "name").filter(|value| !value.is_empty()) {
+        lines.push(format!(
+            "{indent}\t<dcsset:name>{}</dcsset:name>",
+            escape_xml(&name)
+        ));
+    }
+    for (key, tag) in axes {
+        let Some(blocks) = item.get(key) else {
+            continue;
+        };
+        // A chart axis is published as one object or as a list of them.
+        let owned;
+        let blocks = match blocks.as_array() {
+            Some(blocks) => blocks,
+            None if blocks.is_object() => {
+                owned = vec![blocks.clone()];
+                &owned
+            }
+            None => continue,
+        };
+        for block in blocks {
+            lines.push(format!("{indent}\t<dcsset:{tag}>"));
+            dcs_compile_emit_table_axis(lines, block, &format!("{indent}\t\t"))?;
+            lines.push(format!("{indent}\t</dcsset:{tag}>"));
+        }
+    }
+    let auto = json!(["Auto"]);
+    let selection = if item_type == "chart" {
+        item.get("selection").unwrap_or(&auto)
+    } else {
+        item.get("selection").unwrap_or(&Value::Null)
+    };
+    if let Some(selection) = selection.as_array() {
+        dcs_compile_emit_selection(lines, selection, &format!("{indent}\t"));
+    }
+    if let Some(conditional_appearance) =
+        item.get("conditionalAppearance").and_then(Value::as_array)
+    {
+        dcs_compile_emit_conditional_appearance(
+            lines,
+            conditional_appearance,
+            &format!("{indent}\t"),
+        );
+    }
+    if let Some(output_parameters) = item.get("outputParameters").and_then(Value::as_object) {
+        dcs_compile_emit_output_parameters(lines, output_parameters, &format!("{indent}\t"));
+    }
+    lines.push(format!("{indent}</dcsset:item>"));
+    Ok(())
+}
+
+fn dcs_compile_emit_table_axis(
+    lines: &mut Vec<String>,
+    axis: &Value,
+    indent: &str,
+) -> Result<(), String> {
+    if let Some(name) = json_string_field(axis, "name").filter(|value| !value.is_empty()) {
+        lines.push(format!(
+            "{indent}<dcsset:name>{}</dcsset:name>",
+            escape_xml(&name)
+        ));
+    }
+    let group_by = axis.get("groupBy").or_else(|| axis.get("groupFields"));
+    dcs_compile_emit_group_items(lines, group_by, indent);
+    if let Some(filter) = axis.get("filter").and_then(Value::as_array) {
+        dcs_compile_emit_filter(lines, filter, indent);
+    }
+    let auto = json!(["Auto"]);
+    let order = axis.get("order").unwrap_or(&auto);
+    if let Some(order) = order.as_array() {
+        dcs_compile_emit_order(lines, order, indent);
+    }
+    let selection = axis.get("selection").unwrap_or(&auto);
+    if let Some(selection) = selection.as_array() {
+        dcs_compile_emit_selection(lines, selection, indent);
+    }
+    if let Some(conditional_appearance) =
+        axis.get("conditionalAppearance").and_then(Value::as_array)
+    {
+        dcs_compile_emit_conditional_appearance(lines, conditional_appearance, indent);
+    }
+    if let Some(output_parameters) = axis.get("outputParameters").and_then(Value::as_object) {
+        dcs_compile_emit_output_parameters(lines, output_parameters, indent);
+    }
+    if let Some(children) = axis.get("children").and_then(Value::as_array) {
+        for child in children {
+            dcs_compile_emit_structure_item_inner(lines, child, indent, true)?;
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn dcs_compile_emit_group_items(
@@ -11366,6 +11520,73 @@ mod tests {
             dcs_child(item, "viewMode", TEST_DCS_SETTINGS_NS).and_then(|node| node.text()),
             Some("Inaccessible")
         );
+    }
+
+    /// #312. `"type": "table"` was dropped by the structure emitter, so a
+    /// variant built around a cross-table compiled to no structure at all.
+    #[test]
+    fn dcs_compile_structure_emits_a_cross_table_with_its_axes() {
+        let definition = json!({
+            "settingsVariants": [{
+                "name": "Main",
+                "settings": {
+                    "structure": [{
+                        "type": "table",
+                        "name": "Balances",
+                        "columns": [{ "groupFields": ["Period"] }],
+                        "rows": [{
+                            "groupFields": ["Item"],
+                            "children": [{ "groupFields": ["Account"] }]
+                        }],
+                        "selection": ["Amount"]
+                    }]
+                }
+            }]
+        });
+
+        let xml = dcs_compile_xml(&definition, Path::new("."), Path::new(".")).unwrap();
+        let document = Document::parse(&xml).unwrap();
+        let table = document
+            .descendants()
+            .find(|node| {
+                role_info_element(*node, "item", Some(TEST_DCS_SETTINGS_NS))
+                    && attribute_by_local_name(*node, "type") == Some("dcsset:StructureItemTable")
+            })
+            .expect("a table structure item reaches the template");
+
+        assert_eq!(
+            dcs_child(table, "name", TEST_DCS_SETTINGS_NS).and_then(|node| node.text()),
+            Some("Balances")
+        );
+        let column =
+            dcs_child(table, "column", TEST_DCS_SETTINGS_NS).expect("the column axis is published");
+        let row = dcs_child(table, "row", TEST_DCS_SETTINGS_NS).expect("the row axis is published");
+        assert!(dcs_child(column, "groupItems", TEST_DCS_SETTINGS_NS).is_some());
+        assert!(dcs_child(row, "groupItems", TEST_DCS_SETTINGS_NS).is_some());
+        assert!(dcs_child(row, "order", TEST_DCS_SETTINGS_NS).is_some());
+        assert!(dcs_child(row, "selection", TEST_DCS_SETTINGS_NS).is_some());
+        let nested = dcs_children(row, "item", TEST_DCS_SETTINGS_NS);
+        assert_eq!(nested.len(), 1, "the nested row group is published");
+        assert_eq!(attribute_by_local_name(nested[0], "type"), None);
+    }
+
+    /// A structure type the compiler cannot emit must say so.
+    #[test]
+    fn dcs_compile_structure_rejects_a_type_it_cannot_emit() {
+        let definition = json!({
+            "settingsVariants": [{
+                "name": "Main",
+                "settings": {
+                    "structure": [{ "type": "nestedObject", "name": "Nested" }]
+                }
+            }]
+        });
+
+        let error = dcs_compile_xml(&definition, Path::new("."), Path::new("."))
+            .expect_err("an unsupported structure type is reported, not dropped");
+
+        assert!(error.contains("nestedObject"), "{error}");
+        assert!(error.contains("structure"), "{error}");
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/native_operations/dcs.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/dcs.rs
@@ -5203,8 +5203,54 @@ fn dcs_compile_emit_structure_axes_item(
     if let Some(output_parameters) = item.get("outputParameters").and_then(Value::as_object) {
         dcs_compile_emit_output_parameters(lines, output_parameters, &format!("{indent}\t"));
     }
+    let axis_modes: &[(&str, &str)] = if item_type == "table" {
+        &[
+            ("columnsViewMode", "columnsViewMode"),
+            ("rowsViewMode", "rowsViewMode"),
+        ]
+    } else {
+        &[
+            ("pointsViewMode", "pointsViewMode"),
+            ("seriesViewMode", "seriesViewMode"),
+        ]
+    };
+    dcs_compile_emit_setting_visibility(lines, item, &format!("{indent}\t"), axis_modes);
     lines.push(format!("{indent}</dcsset:item>"));
     Ok(())
+}
+
+/// The user-settings tail shared by a structure item and by an axis. The
+/// compiler accepted these documented keys and wrote none of them, so a caller
+/// who fixed a setting silently lost it (#443 review).
+fn dcs_compile_emit_setting_visibility(
+    lines: &mut Vec<String>,
+    item: &Value,
+    indent: &str,
+    axis_modes: &[(&str, &str)],
+) {
+    let tags = axis_modes.iter().copied().chain([
+        ("viewMode", "viewMode"),
+        ("userSettingID", "userSettingID"),
+        ("itemsViewMode", "itemsViewMode"),
+    ]);
+    for (json_key, xml_tag) in tags {
+        if let Some(value) = json_string_field(item, json_key).filter(|value| !value.is_empty()) {
+            lines.push(format!(
+                "{indent}<dcsset:{xml_tag}>{}</dcsset:{xml_tag}>",
+                escape_xml(&value)
+            ));
+        }
+    }
+    if let Some(presentation) =
+        json_string_field(item, "userSettingPresentation").filter(|value| !value.is_empty())
+    {
+        dcs_compile_emit_mltext(
+            lines,
+            indent,
+            "dcsset:userSettingPresentation",
+            &presentation,
+        );
+    }
 }
 
 fn dcs_compile_emit_table_axis(
@@ -5245,6 +5291,7 @@ fn dcs_compile_emit_table_axis(
             dcs_compile_emit_structure_item_inner(lines, child, indent, true)?;
         }
     }
+    dcs_compile_emit_setting_visibility(lines, axis, indent, &[]);
     Ok(())
 }
 
@@ -11568,6 +11615,48 @@ mod tests {
         let nested = dcs_children(row, "item", TEST_DCS_SETTINGS_NS);
         assert_eq!(nested.len(), 1, "the nested row group is published");
         assert_eq!(attribute_by_local_name(nested[0], "type"), None);
+    }
+
+    /// Review of #443: the published user settings of a table and of its axes
+    /// were accepted and silently dropped. A caller who fixed `viewMode` or
+    /// pinned a `userSettingID` got a valid template without them.
+    #[test]
+    fn dcs_compile_structure_emits_the_published_user_settings() {
+        let definition = json!({
+            "settingsVariants": [{
+                "name": "Main",
+                "settings": {
+                    "structure": [{
+                        "type": "table",
+                        "name": "Balances",
+                        "rowsViewMode": "Inaccessible",
+                        "viewMode": "QuickAccess",
+                        "userSettingID": "fixed-table",
+                        "userSettingPresentation": "Таблица остатков",
+                        "rows": [{
+                            "groupFields": ["Item"],
+                            "viewMode": "Inaccessible",
+                            "userSettingID": "fixed-axis",
+                            "itemsViewMode": "Normal"
+                        }]
+                    }]
+                }
+            }]
+        });
+
+        let xml = dcs_compile_xml(&definition, Path::new("."), Path::new(".")).unwrap();
+
+        for fragment in [
+            "<dcsset:rowsViewMode>Inaccessible</dcsset:rowsViewMode>",
+            "<dcsset:viewMode>QuickAccess</dcsset:viewMode>",
+            "<dcsset:userSettingID>fixed-table</dcsset:userSettingID>",
+            "Таблица остатков",
+            "<dcsset:viewMode>Inaccessible</dcsset:viewMode>",
+            "<dcsset:userSettingID>fixed-axis</dcsset:userSettingID>",
+            "<dcsset:itemsViewMode>Normal</dcsset:itemsViewMode>",
+        ] {
+            assert!(xml.contains(fragment), "missing {fragment} in {xml}");
+        }
     }
 
     /// A structure type the compiler cannot emit must say so.

--- a/tests/fixtures/unica_mcp_script_parity/donor-relations.json
+++ b/tests/fixtures/unica_mcp_script_parity/donor-relations.json
@@ -3530,6 +3530,7 @@
         "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
       ],
       "observation": {
+<<<<<<< HEAD
         "donorOk": true,
         "unicaOk": true,
         "mismatchKind": "stdout_mismatch_snapshot_diff",
@@ -3547,6 +3548,25 @@
         }
       },
       "observationFingerprint": "fc973349266967e5202bc5a2e56b70cf7e7e076898424d16601f356f4ada65d8",
+=======
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "3463f701454f0a70207a299a238c20667874fb5be546e521cc6e17113065b8d9",
+        "donorWorkspaceSha256": "9fa65cd4fc4b61a772d85a396135646e51d2cf5e8a6f4290af4323bfb44a46bd",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "120e66b0783b65ad185bb2a26ba51b37ba928510c7bd6a2a7e613098a835afc6",
+        "unicaWorkspaceSha256": "059cb371b6dbae87dac87cd68660eaddb58f5b233f41df4f77405f53bbd27096"
+      },
+      "observationFingerprint": "c108b0d655e25c81d336a3c5ea154c935642400f794230126d8099f893551972",
+>>>>>>> 0fa427d6 (feat(dcs.compile): компилировать таблицу и диаграмму в структуре варианта)
       "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
       "relation": "intentional_divergence"
     },
@@ -3842,6 +3862,7 @@
         "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
       ],
       "observation": {
+<<<<<<< HEAD
         "donorExpectedFiles": {
           "Template.xml": true
         },
@@ -3859,6 +3880,25 @@
         "unicaWorkspaceSha256": "dc8342c8755bae2ec635b5271f827209847ab659470d926166f4ea249a941c72"
       },
       "observationFingerprint": "04911a79334fc9deebfc6f70736246ea0075813cc55fb92ec479448a4444f829",
+=======
+        "donorOk": true,
+        "unicaOk": true,
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "donorStdoutSha256": "ecb07557dae44f35ea0ccfab0702200d2e5ac99a05ac85f223bebbc2fe6214bd",
+        "unicaStdoutSha256": "7c0f17aea656b5cf9dfcaa1ba4cfec9c14edb798e5ec50517e587c348967c778",
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorWorkspaceSha256": "5c56d5fd85cb3b87913ca17f39ab453988102b910d1757b836eb21a49fc1f28a",
+        "unicaWorkspaceSha256": "a9dfcb55e4fba74ae796274629d78b694020c2d89fcd76a3bb6ba2ca09957eef",
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        }
+      },
+      "observationFingerprint": "546288fd332fd790e2a36c66b8813750edef9eee892bca35fc825b1afdfafd3a",
+>>>>>>> 0fa427d6 (feat(dcs.compile): компилировать таблицу и диаграмму в структуре варианта)
       "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
       "relation": "intentional_divergence"
     },
@@ -3929,6 +3969,7 @@
         "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
       ],
       "observation": {
+<<<<<<< HEAD
         "donorExpectedFiles": {
           "Template.xml": true
         },
@@ -3946,6 +3987,25 @@
         "unicaWorkspaceSha256": "fb1ab39de4b3c0ac5bc9474216efbe89a4eefc0c93f124f7afa9175effcc0840"
       },
       "observationFingerprint": "10b13b7a83ef962e1ec199d952ba5a08164f347e5a205e93959dbf753475422b",
+=======
+        "donorOk": true,
+        "unicaOk": true,
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "donorStdoutSha256": "5ef340e981026da14e357e219666fffc7e800695aa0e34aadd976c15a9471126",
+        "unicaStdoutSha256": "b7d4ce8eb6281ad56be8894ebcc0fda5949fbb1faa56d68a2e3599cb7c04f5e1",
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorWorkspaceSha256": "8ae95f0d44140b8eff83d4bb21aec89f4044761f26489e021cbd39753525332d",
+        "unicaWorkspaceSha256": "bf9b8a7c551235f8a5e0e52cee801f6f4cffe23fecca3880178c1bbbcd079b0f",
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        }
+      },
+      "observationFingerprint": "dd9b64fc223d089352bbd1a4ab8eb23c409927305b167567face9db9acac4763",
+>>>>>>> 0fa427d6 (feat(dcs.compile): компилировать таблицу и диаграмму в структуре варианта)
       "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
       "relation": "intentional_divergence"
     },
@@ -3987,6 +4047,7 @@
         "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
       ],
       "observation": {
+<<<<<<< HEAD
         "donorOk": true,
         "unicaOk": true,
         "mismatchKind": "stdout_mismatch_snapshot_diff",
@@ -4004,6 +4065,25 @@
         }
       },
       "observationFingerprint": "100a371d4afb386e606d8fdcbc99c818d3bb91c67fe2fc975f108b3ccdf4ce31",
+=======
+        "donorExpectedFiles": {
+          "Template.xml": true
+        },
+        "donorOk": true,
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "donorStdoutSha256": "53b0942592c634f6b1fa7332b82996564b6538b85210b90865d48756596461cc",
+        "donorWorkspaceSha256": "00a88d0904ed0c23a3de5fe1a81e4380f9a867adf1a92a6304cbb77480a4df88",
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
+        "unicaExpectedFiles": {
+          "Template.xml": true
+        },
+        "unicaOk": true,
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStdoutSha256": "ccb1cbef767d04027e11750a31c39f620be4daadf232d22062f5b6ac97669bdf",
+        "unicaWorkspaceSha256": "02136881c3522e9959f9064648742791d3d44ce473f35c8cf1c3b70b7f2cfaa2"
+      },
+      "observationFingerprint": "2900a31d2416817697d79ba72f8c6a3a62f41eda85ab5047bc163de51883d7ef",
+>>>>>>> 0fa427d6 (feat(dcs.compile): компилировать таблицу и диаграмму в структуре варианта)
       "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
       "relation": "intentional_divergence"
     },

--- a/tests/fixtures/unica_mcp_script_parity/donor-relations.json
+++ b/tests/fixtures/unica_mcp_script_parity/donor-relations.json
@@ -3530,7 +3530,6 @@
         "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
       ],
       "observation": {
-<<<<<<< HEAD
         "donorOk": true,
         "unicaOk": true,
         "mismatchKind": "stdout_mismatch_snapshot_diff",
@@ -3548,25 +3547,6 @@
         }
       },
       "observationFingerprint": "fc973349266967e5202bc5a2e56b70cf7e7e076898424d16601f356f4ada65d8",
-=======
-        "donorExpectedFiles": {
-          "Template.xml": true
-        },
-        "donorOk": true,
-        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-        "donorStdoutSha256": "3463f701454f0a70207a299a238c20667874fb5be546e521cc6e17113065b8d9",
-        "donorWorkspaceSha256": "9fa65cd4fc4b61a772d85a396135646e51d2cf5e8a6f4290af4323bfb44a46bd",
-        "mismatchKind": "stdout_mismatch_snapshot_diff",
-        "unicaExpectedFiles": {
-          "Template.xml": true
-        },
-        "unicaOk": true,
-        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-        "unicaStdoutSha256": "120e66b0783b65ad185bb2a26ba51b37ba928510c7bd6a2a7e613098a835afc6",
-        "unicaWorkspaceSha256": "059cb371b6dbae87dac87cd68660eaddb58f5b233f41df4f77405f53bbd27096"
-      },
-      "observationFingerprint": "c108b0d655e25c81d336a3c5ea154c935642400f794230126d8099f893551972",
->>>>>>> 0fa427d6 (feat(dcs.compile): компилировать таблицу и диаграмму в структуре варианта)
       "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
       "relation": "intentional_divergence"
     },
@@ -3862,25 +3842,6 @@
         "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
       ],
       "observation": {
-<<<<<<< HEAD
-        "donorExpectedFiles": {
-          "Template.xml": true
-        },
-        "donorOk": true,
-        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-        "donorStdoutSha256": "ecb07557dae44f35ea0ccfab0702200d2e5ac99a05ac85f223bebbc2fe6214bd",
-        "donorWorkspaceSha256": "5c56d5fd85cb3b87913ca17f39ab453988102b910d1757b836eb21a49fc1f28a",
-        "mismatchKind": "stdout_mismatch_snapshot_diff",
-        "unicaExpectedFiles": {
-          "Template.xml": true
-        },
-        "unicaOk": true,
-        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-        "unicaStdoutSha256": "1d72941df19afb744f3e15fe90b9348bd0ca61898d2bad388299f09b00c079f2",
-        "unicaWorkspaceSha256": "dc8342c8755bae2ec635b5271f827209847ab659470d926166f4ea249a941c72"
-      },
-      "observationFingerprint": "04911a79334fc9deebfc6f70736246ea0075813cc55fb92ec479448a4444f829",
-=======
         "donorOk": true,
         "unicaOk": true,
         "mismatchKind": "stdout_mismatch_snapshot_diff",
@@ -3898,7 +3859,6 @@
         }
       },
       "observationFingerprint": "546288fd332fd790e2a36c66b8813750edef9eee892bca35fc825b1afdfafd3a",
->>>>>>> 0fa427d6 (feat(dcs.compile): компилировать таблицу и диаграмму в структуре варианта)
       "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
       "relation": "intentional_divergence"
     },
@@ -3969,25 +3929,6 @@
         "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
       ],
       "observation": {
-<<<<<<< HEAD
-        "donorExpectedFiles": {
-          "Template.xml": true
-        },
-        "donorOk": true,
-        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-        "donorStdoutSha256": "5ef340e981026da14e357e219666fffc7e800695aa0e34aadd976c15a9471126",
-        "donorWorkspaceSha256": "8ae95f0d44140b8eff83d4bb21aec89f4044761f26489e021cbd39753525332d",
-        "mismatchKind": "stdout_mismatch_snapshot_diff",
-        "unicaExpectedFiles": {
-          "Template.xml": true
-        },
-        "unicaOk": true,
-        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-        "unicaStdoutSha256": "d5eb52cf952ca730ce5b0e991062203bf7577bf23e4ae504adb0942f439b1ea7",
-        "unicaWorkspaceSha256": "fb1ab39de4b3c0ac5bc9474216efbe89a4eefc0c93f124f7afa9175effcc0840"
-      },
-      "observationFingerprint": "10b13b7a83ef962e1ec199d952ba5a08164f347e5a205e93959dbf753475422b",
-=======
         "donorOk": true,
         "unicaOk": true,
         "mismatchKind": "stdout_mismatch_snapshot_diff",
@@ -4005,7 +3946,6 @@
         }
       },
       "observationFingerprint": "dd9b64fc223d089352bbd1a4ab8eb23c409927305b167567face9db9acac4763",
->>>>>>> 0fa427d6 (feat(dcs.compile): компилировать таблицу и диаграмму в структуре варианта)
       "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
       "relation": "intentional_divergence"
     },
@@ -4047,7 +3987,6 @@
         "crates/unica-coder/src/infrastructure/native_operations/dcs.rs"
       ],
       "observation": {
-<<<<<<< HEAD
         "donorOk": true,
         "unicaOk": true,
         "mismatchKind": "stdout_mismatch_snapshot_diff",
@@ -4065,25 +4004,6 @@
         }
       },
       "observationFingerprint": "100a371d4afb386e606d8fdcbc99c818d3bb91c67fe2fc975f108b3ccdf4ce31",
-=======
-        "donorExpectedFiles": {
-          "Template.xml": true
-        },
-        "donorOk": true,
-        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-        "donorStdoutSha256": "53b0942592c634f6b1fa7332b82996564b6538b85210b90865d48756596461cc",
-        "donorWorkspaceSha256": "00a88d0904ed0c23a3de5fe1a81e4380f9a867adf1a92a6304cbb77480a4df88",
-        "mismatchKind": "stdout_mismatch_snapshot_diff",
-        "unicaExpectedFiles": {
-          "Template.xml": true
-        },
-        "unicaOk": true,
-        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-        "unicaStdoutSha256": "ccb1cbef767d04027e11750a31c39f620be4daadf232d22062f5b6ac97669bdf",
-        "unicaWorkspaceSha256": "02136881c3522e9959f9064648742791d3d44ce473f35c8cf1c3b70b7f2cfaa2"
-      },
-      "observationFingerprint": "2900a31d2416817697d79ba72f8c6a3a62f41eda85ab5047bc163de51883d7ef",
->>>>>>> 0fa427d6 (feat(dcs.compile): компилировать таблицу и диаграмму в структуре варианта)
       "reason": "Both implementations complete, but Unica intentionally emits its fixed 8.3.27 / export 2.20 native representation instead of treating donor bytes as the platform oracle; the exact observed difference remains review-bound.",
       "relation": "intentional_divergence"
     },


### PR DESCRIPTION
Closes #312.

## Дефект

`dcs_compile_emit_structure_item` выходил на любом `type`, кроме `group`:

```rust
let item_type = json_string_field(item, "type").unwrap_or_else(|| "group".to_string());
if item_type != "group" {
    return;
}
```

Поэтому вариант, построенный на таблице, компилировался **без структуры вообще**: файл проходил `dcs.validate`, а собранный отчёт выводил только заголовок и параметры. Ни предупреждения, ни ошибки не было — тикет это и описывает как молчаливый пропуск.

Воспроизведение: `dcs_compile_structure_emits_a_cross_table_with_its_axes` на коде до правки падает на поиске элемента `dcsset:StructureItemTable` — его в шаблоне нет.

## Почему компиляция, а не правка документации

Тикет предлагал на выбор: компилировать или явно отказывать. Компилировать — потому что всё остальное уже на месте:

- скилл `dcs-compile` описывает объектную форму `structure` как поддерживающую таблицы и диаграммы;
- `1c-dcs-spec` задаёт форму `StructureItemTable` и `StructureItemChart`;
- валидатор уже знает оба типа и проверяет у таблицы наличие `row`/`column`;
- донорская реализация их эмитирует, и на них заведены кейсы паритета `skd-compile/structure-table-pivot` и `skd-compile/structure-chart`.

Не умела только компиляция.

## Реализация

Таблица и диаграмма построены на одном блоке оси, поэтому эмиттер один: у таблицы оси `column`/`row`, у диаграммы `point`/`series`. Из наблюдаемого поведения платформы и донора:

- ось всегда публикует `order` и `selection`, подставляя `Auto`, когда вызывающий не назвал ни того ни другого;
- вложенная в ось группировка пишется в короткой форме, без `xsi:type`;
- диаграмма всегда публикует собственный `selection` — значения, которые рисует.

Тип структуры, который компилятор эмитировать не умеет, теперь называется в ошибке вместо молчаливого пропуска. `chart` в этот список больше не попадает, потому что поддержан.

## Записи паритета

`skd-compile/structure-table-pivot` и `skd-compile/structure-chart` теперь компилируют структуру, которой раньше не было, поэтому `observationFingerprint` перезаписан. `mismatchKind` остался `stdout_mismatch_snapshot_diff`: расхождение с донором по остальному содержимому существовало и до правки.

## Проверка

- `dcs_compile_structure_emits_a_cross_table_with_its_axes` — падал до правки, проходит после; проверяет `xsi:type`, обе оси, `groupItems`, авто-`order`/`selection` и короткую форму вложенной группировки.
- `dcs_compile_structure_rejects_a_type_it_cannot_emit` — неподдержанный тип называется в ошибке.
- `cargo test --package unica-coder --lib` — **2715 passed, 0 failed**.
- `python -m unittest discover -s tests/ci` — 644 passed, 3 skipped, 0 failed.
- `cargo fmt --check` — чисто.

## Замечание по топологии

PR трогает сигнатуру `dcs_compile_emit_settings_variants` (добавляет `Result`), как и #442 по задаче #311. Обе базируются на `main` и независимы; тот, что вливается вторым, потребует тривиального ребейза.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for compiling group, table, and chart structures.
  * Added table and chart axis configuration, including nested groups, ordering, selection, defaults, and appearance settings.
  * Added support for controlling structure user-setting visibility.

* **Bug Fixes**
  * Compilation errors are now reported clearly instead of being silently ignored.
  * Unsupported structure types now return explicit error messages.

* **Tests**
  * Added coverage for table-axis generation, user settings, unsupported structures, and compilation parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->