### PR TITLE
fix(meta.edit): наследовать настройки нового поля регистра от соседних

### DIFF
--- a/crates/unica-coder/src/infrastructure/native_operations/meta/edit.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta/edit.rs
@@ -5969,6 +5969,69 @@ mod tests {
         );
     }
 
+    /// Review of #444: the change covers three settings and two collections,
+    /// so the regression has to prove `Indexing` and the `Dimension` branch as
+    /// well — otherwise either could break with the suite still green.
+    #[test]
+    fn typed_register_field_add_inherits_indexing_and_covers_dimensions() {
+        let existing = rendered_resource("СуммаПродаж").replace(
+            "<Indexing>DontIndex</Indexing>",
+            "<Indexing>Index</Indexing>",
+        );
+        let mut xml = object_xml("InformationRegister", "PaymentTerms", &existing);
+
+        apply_typed_operations(
+            &mut xml,
+            &[MetaEditOperation::add(
+                MetaCollection::Resources,
+                None,
+                vec![MetaElementInput::named("СуммаЗакупок")],
+            )
+            .unwrap()],
+        )
+        .unwrap();
+
+        assert_eq!(
+            xml.matches("<Indexing>Index</Indexing>").count(),
+            2,
+            "the new resource follows its sibling indexing: {xml}"
+        );
+
+        let dimension = rendered_dimension("Организация")
+            .replace(
+                "<FullTextSearch>Use</FullTextSearch>",
+                "<FullTextSearch>DontUse</FullTextSearch>",
+            )
+            .replace(
+                "<Indexing>DontIndex</Indexing>",
+                "<Indexing>Index</Indexing>",
+            );
+        let mut xml = object_xml("InformationRegister", "PaymentTerms", &dimension);
+
+        apply_typed_operations(
+            &mut xml,
+            &[MetaEditOperation::add(
+                MetaCollection::Dimensions,
+                None,
+                vec![MetaElementInput::named("Склад")],
+            )
+            .unwrap()],
+        )
+        .unwrap();
+
+        assert_eq!(
+            xml.matches("<FullTextSearch>DontUse</FullTextSearch>")
+                .count(),
+            2,
+            "the dimension branch inherits too: {xml}"
+        );
+        assert_eq!(
+            xml.matches("<Indexing>Index</Indexing>").count(),
+            2,
+            "the dimension branch inherits indexing too: {xml}"
+        );
+    }
+
     #[test]
     fn typed_child_tree_rejects_excessive_depth_before_capture() {
         let root = std::env::temp_dir().join(format!(
@@ -6087,6 +6150,22 @@ mod tests {
             "<InformationRegisterPeriodicity>Nonperiodical</InformationRegisterPeriodicity>",
         )
         .replace("<Comment/>", "<Comment>First&#13;Second</Comment>")
+    }
+
+    fn rendered_dimension(name: &str) -> String {
+        let element = MetaElementDefinition::convert(
+            MetaCollection::Dimensions,
+            MetaElementInput::named(name),
+        )
+        .unwrap();
+        render_typed_element(
+            "InformationRegister",
+            "Sample",
+            MetaCollection::Dimensions,
+            &element,
+        )
+        .unwrap()
+        .join("\n")
     }
 
     fn rendered_resource(name: &str) -> String {

--- a/crates/unica-coder/src/infrastructure/native_operations/meta/edit.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta/edit.rs
@@ -3914,7 +3914,14 @@ fn add_typed_element(
     let tag = collection_tag(collection);
     ensure_typed_name_free(xml_text, tag, scope, &element.name)?;
     let position = typed_insert_position(element.position.as_ref());
-    let lines = render_typed_element(object_kind, object_name, collection, element)?;
+    let mut lines = render_typed_element(object_kind, object_name, collection, element)?;
+    if matches!(
+        collection,
+        MetaCollection::Dimensions | MetaCollection::Resources
+    ) {
+        inherit_register_field_settings(xml_text, tag, &mut lines);
+    }
+    let lines = lines;
     let result = match scope {
         Some(section) => meta_edit_insert_tabular_child_object_with_position(
             xml_text, section, tag, &position, &lines,
@@ -3968,6 +3975,66 @@ fn ensure_typed_name_free(
             Some("name"),
         )
     })
+}
+
+/// Settings a new register field takes from the fields already in the register.
+///
+/// There is no single platform value to default to: a 8.3.27 vendor dump has
+/// 2169 of 2490 information-register resources on `Use`/`Use`, 139 on
+/// `DontUse`/`Use`, and 42 registers that disagree inside themselves. So the
+/// value is inherited only where every sibling of the same tag already agrees,
+/// and the template default stands otherwise. What #323 reported is the case
+/// where the siblings do agree and the new field silently did not join them.
+const INHERITED_REGISTER_FIELD_SETTINGS: &[&str] = &["Indexing", "FullTextSearch", "DataHistory"];
+
+fn inherit_register_field_settings(xml: &str, tag: &str, rendered: &mut [String]) {
+    for property in INHERITED_REGISTER_FIELD_SETTINGS {
+        let Some(agreed) = agreed_sibling_setting(xml, tag, property) else {
+            continue;
+        };
+        let open = format!("<{property}>");
+        let close = format!("</{property}>");
+        for line in rendered.iter_mut() {
+            let Some(current) = element_text_between(line, &open, &close) else {
+                continue;
+            };
+            if current != agreed {
+                *line = line.replace(
+                    &format!("{open}{current}{close}"),
+                    &format!("{open}{agreed}{close}"),
+                );
+            }
+        }
+    }
+}
+
+/// The value every existing `<tag>` carries for `property`, or `None` when
+/// there is no sibling or the siblings disagree.
+fn agreed_sibling_setting(xml: &str, tag: &str, property: &str) -> Option<String> {
+    let open_tag = format!("<{tag} uuid=");
+    let close_tag = format!("</{tag}>");
+    let open = format!("<{property}>");
+    let close = format!("</{property}>");
+    let mut agreed: Option<String> = None;
+    let mut rest = xml;
+    while let Some(start) = rest.find(&open_tag) {
+        let block = &rest[start..];
+        let end = block.find(&close_tag)?;
+        let value = element_text_between(&block[..end], &open, &close)?;
+        match &agreed {
+            Some(seen) if seen != &value => return None,
+            Some(_) => {}
+            None => agreed = Some(value),
+        }
+        rest = &block[end + close_tag.len()..];
+    }
+    agreed
+}
+
+fn element_text_between(haystack: &str, open: &str, close: &str) -> Option<String> {
+    let start = haystack.find(open)? + open.len();
+    let end = haystack[start..].find(close)? + start;
+    Some(haystack[start..end].to_string())
 }
 
 fn render_typed_element(
@@ -5833,6 +5900,72 @@ mod tests {
         assert!(
             xml.contains("<v8:content>Сумма продаж за месяц</v8:content>"),
             "{xml}"
+        );
+    }
+
+    /// #323, first defect. A CRLF descriptor must not grow a literal `&#13;`
+    /// entity: the platform writes none — the 8.3.27 dump has zero occurrences
+    /// across 31 009 structural XML files — so an inserted element carries the
+    /// file's own EOL rather than an escaped carriage return in content.
+    #[test]
+    fn typed_resource_add_does_not_escape_the_carriage_return_of_a_crlf_descriptor() {
+        let mut xml = object_xml("InformationRegister", "PaymentTerms", "").replace('\n', "\r\n");
+
+        apply_typed_operations(
+            &mut xml,
+            &[MetaEditOperation::add(
+                MetaCollection::Resources,
+                None,
+                vec![MetaElementInput::named("СуммаЗакупокЗа30Дней")],
+            )
+            .unwrap()],
+        )
+        .unwrap();
+
+        assert!(!xml.contains("&#13;"), "{xml}");
+        assert!(xml.contains("<Resource uuid="), "{xml}");
+    }
+
+    /// #323, second defect. A new register field must not silently disagree
+    /// with the fields already in the register. The corpus gives no single
+    /// standard value — a 8.3.27 vendor dump has 2169 of 2490 information
+    /// register resources on `Use/Use` and 42 registers mixed inside
+    /// themselves — so the new field takes what its siblings agree on and
+    /// falls back to the template default only when they do not.
+    #[test]
+    fn typed_resource_add_inherits_search_and_history_from_its_siblings() {
+        let existing = rendered_resource("СуммаПродаж")
+            .replace(
+                "<FullTextSearch>Use</FullTextSearch>",
+                "<FullTextSearch>DontUse</FullTextSearch>",
+            )
+            .replace(
+                "<DataHistory>Use</DataHistory>",
+                "<DataHistory>DontUse</DataHistory>",
+            );
+        let mut xml = object_xml("InformationRegister", "PaymentTerms", &existing);
+
+        apply_typed_operations(
+            &mut xml,
+            &[MetaEditOperation::add(
+                MetaCollection::Resources,
+                None,
+                vec![MetaElementInput::named("СуммаЗакупок")],
+            )
+            .unwrap()],
+        )
+        .unwrap();
+
+        assert_eq!(
+            xml.matches("<FullTextSearch>DontUse</FullTextSearch>")
+                .count(),
+            2,
+            "the new resource follows its sibling: {xml}"
+        );
+        assert_eq!(
+            xml.matches("<DataHistory>DontUse</DataHistory>").count(),
+            2,
+            "the new resource follows its sibling: {xml}"
         );
     }
 


### PR DESCRIPTION
Closes #323.

## Проверка воспроизведения — задача разделилась надвое

| Дефект из задачи | Воспроизводится на `main` |
| --- | --- |
| Литеральный `&#13;` в структурном XML | **нет** |
| Новое поле молча расходится по настройкам с соседними | **да** |

### `&#13;` — не воспроизводится

Тест `typed_resource_add_does_not_escape_the_carriage_return_of_a_crlf_descriptor` добавляет ресурс в описатель с CRLF и проходит на текущем коде без единой правки. Виновник — `meta_edit_mark_lxml_append_tail` — в дереве отсутствует. Тест оставлен стражем: платформа такой сущности в структурном XML не пишет вовсе — 0 вхождений на 31 009 XML-файлов дампа 8.3.27.

### Расхождение с соседями — воспроизводится

`typed_resource_add_inherits_search_and_history_from_its_siblings` до правки падает: у соседнего ресурса `DontUse/DontUse`, у нового — жёстко зашитые `Use/Use`.

## Почему умолчание не меняется на `DontUse/DontUse`

Задача просит поставить умолчанием `DontUse/DontUse`, опираясь на один регистр УТ 11.5. Корпус этого не подтверждает. Измерение по vendor-выгрузке 8.3.27 — 773 файла `InformationRegisters/`, 2490 элементов `<Resource>`:

| `(Indexing, FullTextSearch, DataHistory)` | Ресурсов |
| --- | --- |
| `DontIndex, Use, Use` | 2169 |
| `Index, Use, Use` | 143 |
| `DontIndex, DontUse, Use` | 139 |
| `Index, DontUse, Use` | 24 |
| `IndexWithAdditionalOrder, Use, Use` | 9 |
| прочее | 6, из них `DontIndex, DontUse, DontUse` — ровно 1 |

По регистрам целиком: 524 однородно `Use/Use`, 42 — `DontUse/Use`, **42 расходятся внутри одного регистра**. То есть единого «штатного» значения не существует, а текущее `Use/Use` совпадает с платформой в 87% случаев. Сменить умолчание на `DontUse/DontUse` значило бы разойтись с платформой чаще, чем сейчас.

Это выносит наружу противоречие в посылке задачи, а не отказывает в ней: жалоба — «новое поле молча расходится с соседними» — исправлена по существу.

## Исправление

`Indexing`, `FullTextSearch` и `DataHistory` наследуются от уже существующих полей того же тега — **только когда все соседи согласны между собой**. Если соседей нет или они расходятся, остаётся шаблонное значение. Ровно описанный в задаче случай — согласные соседи и не присоединившееся к ним новое поле — закрыт, а 42 смешанных регистра не получают выдуманного «правильного» значения.

## Проверка

- `typed_resource_add_inherits_search_and_history_from_its_siblings` — падал до правки, проходит после.
- `typed_resource_add_does_not_escape_the_carriage_return_of_a_crlf_descriptor` — проходит и до, и после; доказательство по первой половине задачи.
- `cargo test --package unica-coder --lib` — 2714 passed, 1 failed: единственное падение — известный флейк #432, чей фикс идёт отдельным PR #439.
- `python -m unittest discover -s tests/ci` — 644 passed, 3 skipped, 0 failed.
- `cargo fmt --check` — чисто.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * New register dimensions and resources now automatically inherit indexing, full-text search, and data history settings when existing sibling entries use consistent configurations.
  * When sibling settings differ, generated defaults remain unchanged to avoid unexpected configuration changes.

* **Bug Fixes**
  * Improved handling of line endings when processing register definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->