### PR TITLE
test(code.patch): доказать, что writer не добавляет trailing whitespace

### DIFF
--- a/crates/unica-coder/src/infrastructure/native_operations/code.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/code.rs
@@ -2605,6 +2605,46 @@ mod tests {
         fs::remove_dir_all(&context.workspace_root).unwrap();
     }
 
+    /// #420. The writer must not be the source of a dirty diff: content that
+    /// carries no trailing whitespace must not gain any on the way in, and the
+    /// separator the writer adds itself is a bare EOL, never an indented blank
+    /// line. What the caller wrote is preserved verbatim — the writer neither
+    /// adds whitespace nor silently edits the body it was given.
+    #[test]
+    fn code_patch_insert_adds_no_trailing_whitespace_of_its_own() {
+        let context = temp_context("insert-trailing-whitespace");
+        let module = context
+            .workspace_root
+            .join("src/CommonModules/Sample/Ext/Module.bsl");
+        fs::create_dir_all(module.parent().unwrap()).unwrap();
+        fs::write(
+            &module,
+            "Процедура Первая()\r\nКонецПроцедуры\r\n\
+             Процедура Цель()\r\n\tСтарое = 1;\r\nКонецПроцедуры\r\n",
+        )
+        .unwrap();
+        let mut args = tail_args(
+            "main",
+            "CommonModule.Sample.Module",
+            "Процедура Помощник()\n\tЗначение = 1;\n\n\tВозврат Значение;\nКонецПроцедуры",
+        );
+        args.insert("selector".to_string(), json!({"method": "Цель"}));
+        args.insert("position".to_string(), json!("before"));
+
+        let applied = patch_inner(&args, &context, PatchMode::Apply);
+
+        assert!(applied.outcome.ok, "{:?}", applied.outcome.errors);
+        let after = fs::read_to_string(&module).unwrap();
+        let dirty = after
+            .split("\r\n")
+            .enumerate()
+            .filter(|(_, line)| line.len() != line.trim_end().len())
+            .collect::<Vec<_>>();
+        assert!(dirty.is_empty(), "git diff --check would flag {dirty:?}");
+        assert!(after.contains("\tВозврат Значение;"), "{after}");
+        fs::remove_dir_all(&context.workspace_root).unwrap();
+    }
+
     fn tail_args(source_set: &str, metadata_path: &str, content: &str) -> Map<String, Value> {
         Map::from_iter([
             ("sourceSet".to_string(), json!(source_set)),


### PR DESCRIPTION
Closes #420. **PR только с тестом**: дефект на текущем коде не воспроизводится.

## Проверка воспроизведения

Задача сообщала о двух вещах.

### 1. «Нет пути remediation кроме `insert`» — не воспроизводится

Проба из задачи возвращала `unica.code.patch supports only operation 'insert'`. Сейчас `replace` есть:

- в схеме: `"operation": {"type": "string", "enum": ["insert", "replace"]}`, закреплено `code_patch_schema_accepts_each_documented_selector_variant`;
- в реализации: ветка `PatchOperation::Replace` в `build_patch`;
- в поведении: `code_patch_replaces_one_method_and_leaves_its_neighbours_untouched`, `code_patch_replace_that_consumes_its_selector_cannot_apply_twice`, `code_patch_replace_keeps_an_anchor_edit_inline`.

Путь remediation, которого требовала задача — заменить вставленный блок, — существует и покрыт.

### 2. «Writer вставил trailing whitespace» — не воспроизводится, покрытия не было

`normalized_content` нормализует только EOL и дописывает завершающий перевод строки; тело вызывающего переносится дословно. То есть writer источником trailing whitespace быть не может — он его и не убирает, но и не добавляет.

Эта половина тестом покрыта не была, поэтому добавлен `code_patch_insert_adds_no_trailing_whitespace_of_its_own`. Он вставляет тело без trailing whitespace — включая пустую строку внутри метода, самое вероятное место для отбитого пробела, — и проверяет **весь файл** тем же условием, что и `git diff --check`:

```rust
let dirty = after.split("\r\n").enumerate()
    .filter(|(_, line)| line.len() != line.trim_end().len())
    .collect::<Vec<_>>();
assert!(dirty.is_empty(), "git diff --check would flag {dirty:?}");
```

Заодно проверяется, что разделитель, который writer добавляет сам, — голый EOL, а не отбитая пустая строка, и что отступ тела не потерян.

## Проверка

- `code_patch_insert_adds_no_trailing_whitespace_of_its_own` — новый, проходит.
- `cargo test --package unica-coder --lib code_patch` — 34 passed, 0 failed.
- `cargo test --package unica-coder --lib` — 2713 passed, 1 failed: единственное падение — известный флейк #432, чей фикс идёт отдельным PR #439.
- `cargo fmt --check` — чисто.

## Замечание

Если trailing whitespace всё же приходит от вызывающего, вопрос «должен ли BSL-writer молча править переданное тело» — отдельное решение, а не дефект: молчаливая правка содержимого у writer-а с узкими границами (ADR-0015) требует записи решения. Здесь такой правки нет, и тест это фиксирует.