### PR TITLE
feat(form.compile): компилировать документированный элемент label

### DIFF
--- a/crates/unica-coder/src/infrastructure/native_operations/form.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/form.rs
@@ -6637,6 +6637,7 @@ pub(crate) fn form_edit_element_summary(element: &Value) -> Option<String> {
     let kind = FormEditElementDefinitionKind::from_object(object).ok()?;
     let tag = match kind {
         FormEditElementDefinitionKind::Table => "Table",
+        FormEditElementDefinitionKind::Label => "Label",
         FormEditElementDefinitionKind::LabelField => "LabelField",
         FormEditElementDefinitionKind::Button => "Button",
         FormEditElementDefinitionKind::CommandBar => "CommandBar",
@@ -7302,6 +7303,7 @@ impl FormIdAllocator {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FormEditElementDefinitionKind {
     Table,
+    Label,
     LabelField,
     Button,
     CommandBar,
@@ -7320,6 +7322,7 @@ impl FormEditElementDefinitionKind {
         // considering those two standalone-element shorthands.
         let primary_candidates = [
             (Self::Table, "table", object.contains_key("table")),
+            (Self::Label, "label", object.contains_key("label")),
             (
                 Self::LabelField,
                 "labelField",
@@ -7374,6 +7377,7 @@ impl FormEditElementDefinitionKind {
     const fn event_kind(self) -> FormElementKind {
         match self {
             Self::Table => FormElementKind::Table,
+            Self::Label => FormElementKind::LabelDecoration,
             Self::LabelField => FormElementKind::LabelField,
             Self::Button => FormElementKind::Button,
             Self::CommandBar | Self::AutoCommandBar => FormElementKind::CommandBar,
@@ -7388,6 +7392,7 @@ impl FormEditElementDefinitionKind {
     fn name(self, object: &Map<String, Value>) -> Result<&str, String> {
         let (keys, description): (&[&str], &str) = match self {
             Self::Table => (&["table"], "table"),
+            Self::Label => (&["label"], "label decoration"),
             Self::LabelField => (&["labelField"], "label field"),
             Self::Button => (&["button"], "button"),
             Self::CommandBar => (&["cmdBar", "commandBar"], "command bar"),
@@ -8629,6 +8634,9 @@ fn emit_form_element_with_context(
         FormEditElementDefinitionKind::Table => {
             emit_form_table(lines, object, kind.name(object)?, indent, ids)
         }
+        FormEditElementDefinitionKind::Label => {
+            emit_form_label_decoration(lines, object, kind.name(object)?, indent, ids)
+        }
         FormEditElementDefinitionKind::LabelField => {
             emit_form_label_field(lines, object, kind.name(object)?, indent, ids);
             Ok(())
@@ -9304,6 +9312,117 @@ pub(crate) fn emit_form_command_bar_element(
     }
     lines.push(format!("{indent}</CommandBar>"));
     Ok(())
+}
+
+/// `LabelDecoration` — the documented `label` element.
+///
+/// The platform writes a decoration layout-first: own content — flags,
+/// hyperlink and geometry — comes before `Title`, unlike a field, whose title
+/// leads. `Title` on a decoration carries the `formatted` attribute, taken
+/// from the published `{text, formatted}` form or from the explicit
+/// back-compat `formatted` key.
+pub(crate) fn emit_form_label_decoration(
+    lines: &mut Vec<String>,
+    element: &Map<String, Value>,
+    name: &str,
+    indent: &str,
+    ids: &mut FormIdAllocator,
+) -> Result<(), String> {
+    let id = ids.next();
+    lines.push(format!(
+        "{indent}<LabelDecoration name=\"{}\" id=\"{id}\">",
+        escape_xml(name)
+    ));
+    let inner = format!("{indent}\t");
+    emit_form_common_flags(lines, element, &inner);
+    if element.get("hyperlink").and_then(Value::as_bool) == Some(true) {
+        lines.push(format!("{inner}<Hyperlink>true</Hyperlink>"));
+    }
+    for (json_key, xml_tag) in [("width", "Width"), ("height", "Height")] {
+        if let Some(value) = element.get(json_key) {
+            let number = value
+                .as_u64()
+                .filter(|number| *number <= u32::MAX as u64)
+                .ok_or_else(|| {
+                    format!(
+                        "form label property {json_key} must be an integer in 0..=4294967295 for 8.3.27"
+                    )
+                })?;
+            lines.push(format!("{inner}<{xml_tag}>{number}</{xml_tag}>"));
+        }
+    }
+    for (key, tag) in [
+        ("autoMaxWidth", "AutoMaxWidth"),
+        ("autoMaxHeight", "AutoMaxHeight"),
+    ] {
+        if element.get(key).and_then(Value::as_bool) == Some(false) {
+            lines.push(format!("{inner}<{tag}>false</{tag}>"));
+        }
+    }
+    if let Some(value) = element.get("tooltipRepresentation").and_then(Value::as_str) {
+        lines.push(format!(
+            "{inner}<ToolTipRepresentation>{}</ToolTipRepresentation>",
+            escape_xml(value)
+        ));
+    }
+    emit_form_decoration_title(lines, element, name, &inner);
+    emit_form_companion(
+        lines,
+        "ContextMenu",
+        &format!("{name}КонтекстноеМеню"),
+        &inner,
+        ids,
+    );
+    emit_form_companion(
+        lines,
+        "ExtendedTooltip",
+        &format!("{name}РасширеннаяПодсказка"),
+        &inner,
+        ids,
+    );
+    emit_form_element_events(lines, element, name, &inner);
+    lines.push(format!("{indent}</LabelDecoration>"));
+    Ok(())
+}
+
+/// A decoration `Title` carries `formatted`. The flag comes from the published
+/// `{text, formatted}` form, or from the back-compat `formatted` key beside a
+/// plain title.
+fn emit_form_decoration_title(
+    lines: &mut Vec<String>,
+    element: &Map<String, Value>,
+    name: &str,
+    indent: &str,
+) {
+    // A decoration without an explicit title takes its own name, the way the
+    // platform does; writing nothing left the element unlabelled (#450 review).
+    let fallback;
+    let title = match element.get("title") {
+        Some(title) => title,
+        None => {
+            fallback = Value::String(name.to_string());
+            &fallback
+        }
+    };
+    let formatted = title
+        .get("formatted")
+        .and_then(Value::as_bool)
+        .or_else(|| element.get("formatted").and_then(Value::as_bool))
+        .unwrap_or(false);
+    let text = title.get("text").unwrap_or(title);
+    let mut rendered = Vec::new();
+    emit_form_mltext_value(&mut rendered, indent, "Title", text);
+    // A decoration title always carries the attribute, true or false; the
+    // platform writes it either way, so omitting it when false would diverge.
+    if let Some(first) = rendered.first_mut() {
+        *first = first.replacen("<Title>", &format!("<Title formatted=\"{formatted}\">"), 1);
+        *first = first.replacen(
+            "<Title/>",
+            &format!("<Title formatted=\"{formatted}\"/>"),
+            1,
+        );
+    }
+    lines.extend(rendered);
 }
 
 pub(crate) fn emit_form_label_field(
@@ -11191,6 +11310,92 @@ mod tests {
                 .iter()
                 .chain(outcome.warnings.iter())
                 .any(|line| line.contains("External* type in configuration context")),
+            "{outcome:?}"
+        );
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    /// #389. `form-dsl-spec` documents `label` as `LabelDecoration`, the
+    /// pattern reference recommends it for forms built with
+    /// `unica.form.compile`, and `form-edit` says it uses the same DSL keys.
+    /// The native compiler had no such discriminator and answered
+    /// `Unsupported form element in native compiler`.
+    #[test]
+    fn form_compile_accepts_the_documented_label_decoration() {
+        let context = temp_context("compile-label-decoration");
+        let form_path = context.cwd.join("Form.xml");
+        fs::create_dir_all(&context.cwd).unwrap();
+        fs::write(&form_path, form_edit_remove_test_xml("")).unwrap();
+
+        let outcome = edit_form(
+            &Map::from_iter([
+                (
+                    "FormPath".to_string(),
+                    json!(form_path.display().to_string()),
+                ),
+                (
+                    "definition".to_string(),
+                    json!({
+                        "elements": [{
+                            "label": "ИнформационнаяНадпись",
+                            "title": "Выберите параметры",
+                            "hyperlink": true,
+                            "width": 40
+                        }]
+                    }),
+                ),
+            ]),
+            &context,
+        );
+
+        assert!(outcome.ok, "{outcome:?}");
+        let xml = fs::read_to_string(&form_path).unwrap();
+        assert!(
+            xml.contains("<LabelDecoration name=\"ИнформационнаяНадпись\""),
+            "{xml}"
+        );
+        assert!(xml.contains("<Hyperlink>true</Hyperlink>"), "{xml}");
+        assert!(xml.contains("<Width>40</Width>"), "{xml}");
+        assert!(xml.contains("Выберите параметры"), "{xml}");
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    /// Review of #450: `LabelDecoration` allows only `Click` and
+    /// `URLProcessing`. Classifying `label` as a `LabelField` let `OnChange`
+    /// through preflight and would have emitted an event the platform does
+    /// not accept on a decoration.
+    #[test]
+    fn form_compile_refuses_a_label_event_the_decoration_does_not_allow() {
+        let context = temp_context("label-event-registry");
+        let form_path = context.cwd.join("Form.xml");
+        fs::create_dir_all(&context.cwd).unwrap();
+        fs::write(&form_path, form_edit_remove_test_xml("")).unwrap();
+
+        let outcome = edit_form(
+            &Map::from_iter([
+                (
+                    "FormPath".to_string(),
+                    json!(form_path.display().to_string()),
+                ),
+                (
+                    "definition".to_string(),
+                    json!({
+                        "elements": [{
+                            "label": "Подсказка",
+                            "on": ["OnChange"]
+                        }]
+                    }),
+                ),
+            ]),
+            &context,
+        );
+
+        assert!(!outcome.ok, "{outcome:?}");
+        assert!(
+            outcome
+                .errors
+                .iter()
+                .any(|error| error.contains("OnChange")),
             "{outcome:?}"
         );
         let _ = fs::remove_dir_all(&context.cwd);

--- a/plugins/unica/skills/form-compile/SKILL.md
+++ b/plugins/unica/skills/form-compile/SKILL.md
@@ -130,6 +130,7 @@ allowed-tools:
 | `"group"`    | UsualGroup        | `"horizontal"` / `"vertical"` / `"alwaysHorizontal"` / `"alwaysVertical"` / `"collapsible"` |
 | `"input"`    | InputField        | имя элемента                                      |
 | `"check"`    | CheckBoxField     | имя                                               |
+| `"label"`    | LabelDecoration   | имя — надпись-декорация; текст задаётся `title`, гиперссылка `hyperlink` |
 | `"labelField"` | LabelField      | имя                                               |
 | `"table"`    | Table             | имя                                               |
 | `"pages"`    | Pages             | имя                                               |

--- a/tests/fixtures/unica_mcp_script_parity/donor-relations.json
+++ b/tests/fixtures/unica_mcp_script_parity/donor-relations.json
@@ -327,19 +327,19 @@
         "crates/unica-coder/src/infrastructure/native_operations/form.rs"
       ],
       "observation": {
-        "donorExpectedFiles": {},
         "donorOk": true,
-        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaOk": true,
+        "mismatchKind": "stdout_mismatch_snapshot_diff",
         "donorStdoutSha256": "9ce0d3f89a1f6bb5704e776305f5456801e9463bf48dd2ac3dff30179cbd5e9d",
+        "unicaStdoutSha256": "a178a9d664ae5a63c51090c9da02e390fa8559b63b86aaf9ebd87cfa8dd5aa74",
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
         "donorWorkspaceSha256": "7fb0bbc01cf8e153041cfffe8ead2046967c3114379b829ad5e53923ff2d0b16",
-        "mismatchKind": "unsupported_form_element",
-        "unicaExpectedFiles": {},
-        "unicaOk": false,
-        "unicaStderrSha256": "1982f74f27c4891fc5a84fa759013002d37d0545782b748f91f1d77863adac8a",
-        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-        "unicaWorkspaceSha256": "cb2ed64d993f9a118a6ffee0564d498e9827e0f0fdbabe929e84e2b610728bc8"
+        "unicaWorkspaceSha256": "944a13a41ef2a0a23174fdde81ac23a13c97646369a34f6bfa82b07bd2f1beca",
+        "donorExpectedFiles": {},
+        "unicaExpectedFiles": {}
       },
-      "observationFingerprint": "9ab2490ec6d5f8dbcd38d5e648030a570891e6f927af3e0ac5f1265c35f093e6",
+      "observationFingerprint": "6082a3915efcaff73b860c27977684f936973b5028e69813f3fd2d7071f56684",
       "owner": "unica-maintainers/form",
       "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
       "relation": "donor_ahead"
@@ -734,19 +734,19 @@
         "crates/unica-coder/src/infrastructure/native_operations/form.rs"
       ],
       "observation": {
-        "donorExpectedFiles": {},
         "donorOk": true,
-        "donorStderrSha256": "8524e598c6e0b2449e67266f6903301d8fa4cd33ba3dada468ee675f980a045f",
-        "donorStdoutSha256": "11d79454a1048222a2e7e2763a339adca0325ae15bec0f9082afa16e5fe1a86b",
-        "donorWorkspaceSha256": "69d59d3f06cc6d047c3abe025dc31de125b7f317d946faa921717ee96048be97",
-        "mismatchKind": "unsupported_form_element",
-        "unicaExpectedFiles": {},
         "unicaOk": false,
-        "unicaStderrSha256": "c00654f859c6e896059420e59102d049981117e41b90252da8aa39a0114ef3f9",
+        "mismatchKind": "unsupported_form_element",
+        "donorStdoutSha256": "11d79454a1048222a2e7e2763a339adca0325ae15bec0f9082afa16e5fe1a86b",
         "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-        "unicaWorkspaceSha256": "6905569628075f99ba247ba569508db45c8f500bc5c656c5aecac22566beabe6"
+        "donorStderrSha256": "8524e598c6e0b2449e67266f6903301d8fa4cd33ba3dada468ee675f980a045f",
+        "unicaStderrSha256": "e90242dcad4d565d0ef84b451803ef7167d48f88444825adccdd6637d65c6805",
+        "donorWorkspaceSha256": "69d59d3f06cc6d047c3abe025dc31de125b7f317d946faa921717ee96048be97",
+        "unicaWorkspaceSha256": "6905569628075f99ba247ba569508db45c8f500bc5c656c5aecac22566beabe6",
+        "donorExpectedFiles": {},
+        "unicaExpectedFiles": {}
       },
-      "observationFingerprint": "c3b8728c1ddac518e2137a68ace41e411d964797ea088952cbdde7e5515b8536",
+      "observationFingerprint": "bbb0dd92f9243b987e5305dc2f86b3d30efa15ae910049f5dfb1f68b836e9e62",
       "owner": "unica-maintainers/form",
       "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
       "relation": "donor_ahead"
@@ -760,19 +760,19 @@
         "crates/unica-coder/src/infrastructure/native_operations/form.rs"
       ],
       "observation": {
-        "donorExpectedFiles": {},
         "donorOk": true,
-        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaOk": true,
+        "mismatchKind": "snapshot_diff",
         "donorStdoutSha256": "8c07b9dae53ec1851f7836a8f8d8ec8d5f9cc3d3f9a24cf885d3f16d3562fd47",
+        "unicaStdoutSha256": "8c07b9dae53ec1851f7836a8f8d8ec8d5f9cc3d3f9a24cf885d3f16d3562fd47",
+        "donorStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
+        "unicaStderrSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
         "donorWorkspaceSha256": "c5d12993dba182d52dd0e7a364fd992ce2fd55ecf5f056bc93e26b7b11e53e2b",
-        "mismatchKind": "unsupported_form_element",
-        "unicaExpectedFiles": {},
-        "unicaOk": false,
-        "unicaStderrSha256": "98e0d10ef3b9b35c5ca91238642241ff67f163a8282f26b5e1ccaf653feebb32",
-        "unicaStdoutSha256": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
-        "unicaWorkspaceSha256": "17919d4b1725f875df61ce5d303d5db4a2650430733fdd03dc264c81549602d5"
+        "unicaWorkspaceSha256": "336a75ab9e402d66ad7d3ce121fc32364f08217203b83521d6b7750593c204ff",
+        "donorExpectedFiles": {},
+        "unicaExpectedFiles": {}
       },
-      "observationFingerprint": "989a41b2ae10d720c11c72096a89a3b5d9c3618421b18706cd5d5418cf6f7588",
+      "observationFingerprint": "22aa9287ba5bd618ce77b0e93d8a7141c5785802d99a8123638c09ea37fd9dff",
       "owner": "unica-maintainers/form",
       "reason": "The reviewed donor case exercises behavior or validation not implemented by the current native Unica operation; it is recorded for adoption review without blocking unrelated 8.3.27 work.",
       "relation": "donor_ahead"


### PR DESCRIPTION
Closes #389.

## Дефект

`plugins/unica/references/specs/form-dsl-spec.md` §«label — LabelDecoration» описывает элемент, справочник паттернов рекомендует его для форм, создаваемых через `unica.form.compile`, а `form-edit` заявляет те же DSL-ключи. Дискриминатора `label` в нативном компиляторе не было.

Воспроизведение — минимальный пример из задачи:

```
AdapterOutcome { ok: false, errors: ["Unsupported form element in native compiler:
  {\"label\":\"ИнформационнаяНадпись\",\"title\":\"Выберите параметры\",\"hyperlink\":true,\"width\":40}"] }
```

Ведомость паритета фиксировала тот же пробел напрямую: три кейса `form-compile` имели наблюдение `mismatchKind: unsupported_form_element` с `unicaOk: false`.

## Реализация

Декорация пишется **layout-first**: собственное содержимое — общие флаги, `Hyperlink`, `Width`/`Height`, `AutoMaxWidth`/`AutoMaxHeight` — идёт перед `Title`, в отличие от поля, у которого заголовок ведёт. Дальше `Title`, компаньоны `ContextMenu` и `ExtendedTooltip`, события — тот же порядок, что у донора.

`Title` декорации **всегда** несёт атрибут `formatted`, как и требует спека («у декораций `<Title>` всегда несёт атрибут `formatted`»). Значение берётся из опубликованной формы `{text, formatted}` или из back-compat ключа `formatted` рядом с обычным заголовком. Первая версия правки опускала атрибут при `false`; сверка с донором показала `<Title formatted="false">`, и это исправлено.

Сверка структуры с донорской реализацией на кейсе `form-compile/events` — `Hyperlink`, `Title`, `ContextMenu`, `ExtendedTooltip` совпадают по составу и порядку.

## Документация

Таблица элементов в `plugins/unica/skills/form-compile/SKILL.md` не содержала `label` — рассинхрон, отмеченный в задаче. Строка добавлена.

## Записи паритета

| Кейс | Было | Стало |
| --- | --- | --- |
| `form-compile/events` | `unsupported_form_element`, `unicaOk: false` | `snapshot_diff`, `unicaOk: true` |
| `form-compile/additional-columns` | `unsupported_form_element`, `unicaOk: false` | `stdout_mismatch_snapshot_diff`, `unicaOk: true` |
| `form-compile/element-appearance` | `unsupported_form_element`, `unicaOk: false` | без изменений |

Третий кейс упирается в **другой** неподдержанный элемент, не в `label`, — его наблюдение осталось прежним и здесь не решается.

## Проверка

- `form_compile_accepts_the_documented_label_decoration` — падал до правки, проходит после; проверяет `LabelDecoration`, `Hyperlink`, `Width` и текст заголовка.
- `cargo test --package unica-coder --lib form` — **783 passed, 0 failed**.
- `python -m unittest discover -s tests/ci` — 644 passed, 3 skipped, 0 failed.
- `cargo fmt --check` — чисто.

## Не входит

`ToolTipRepresentation` донор эмитит, а Unica нет — это общий для элементов пробел, а не свойство декорации; в границы задачи не входит.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for `label` elements in form definitions.
  - Labels can display formatted titles, hyperlinks, tooltips, custom dimensions, sizing options, and companion elements.
  - Generated forms now include label appearance, layout, and supported event details.

- **Documentation**
  - Updated the form element reference with `label` properties, including title text and hyperlinks.

- **Tests**
  - Added coverage for successful label editing and form output.
  - Added validation for unsupported label events and refreshed form compilation snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->