### PR TITLE
perf(source): разрешать source-set один раз на вызов префиксного поиска

### DIFF
--- a/crates/unica-coder/src/infrastructure/platform_xml_source_targets.rs
+++ b/crates/unica-coder/src/infrastructure/platform_xml_source_targets.rs
@@ -1073,7 +1073,12 @@ fn exact_module_outcome(
         source_set: source_set.to_string(),
         metadata_path: Some(address.clone()),
     };
-    match resolve_platform_xml_target(context, &target, TargetKindPolicy::ModuleOnly) {
+    match resolve_platform_xml_target_in(
+        context,
+        &target,
+        TargetKindPolicy::ModuleOnly,
+        selected.clone(),
+    ) {
         Ok(_) => Ok(ExactCandidate::Proven),
         Err(error) if error.code == SourceTargetErrorCode::ContainmentDenied => {
             Err(error.to_string())
@@ -2177,6 +2182,21 @@ pub(crate) fn resolve_platform_xml_target(
     }
     let selected = resolve_named_source_set(context, &target.source_set)
         .map_err(|error| public_source_set_error(&target.source_set, error))?;
+    resolve_platform_xml_target_in(context, target, policy, selected)
+}
+
+/// The same resolution against an already-resolved source set.
+///
+/// A prefix scan proves thousands of candidates against one source set, and
+/// re-reading the project config for each of them was the whole cost of a
+/// bare-kind query (#277). The containment chain is unchanged — this takes the
+/// value the caller already proved instead of proving it again.
+pub(crate) fn resolve_platform_xml_target_in(
+    context: &WorkspaceContext,
+    target: &SourceTarget,
+    policy: TargetKindPolicy,
+    selected: ResolvedNamedSourceSet,
+) -> Result<PlatformXmlResolution, SourceTargetError> {
     validate_source_set(&selected)?;
     // The policy decides every target kind, including the source root a missing
     // `metadataPath` names. Answering the root before the policy is consulted
@@ -4444,6 +4464,56 @@ mod tests {
             assert_eq!(result.completeness, NavigationCompleteness::Partial);
         }
         cleanup(&context);
+    }
+
+    /// #277. A bare-kind prefix query proves every candidate of the kind, and
+    /// each proof used to re-read the project config. On a vendor-class
+    /// configuration that is thousands of re-parses and 2.5-4.4 s per query.
+    /// The source set is resolved once per call, whatever the candidate count.
+    #[test]
+    fn prefix_scan_resolves_the_source_set_once_per_call() {
+        let context = fixture(
+            "navigation-prefix-source-map",
+            project_yaml("main", "CONFIGURATION", "src"),
+        );
+        let root = context.workspace_root.join("src");
+        write_configuration_descriptor(&root, false);
+        for name in ["Items", "Goods", "Partners", "Orders"] {
+            write_metadata_descriptor(&root, "Catalogs", "Catalog", name, name);
+            fs::create_dir_all(root.join(format!("Catalogs/{name}/Ext"))).unwrap();
+            fs::write(
+                root.join(format!("Catalogs/{name}/Ext/ManagerModule.bsl")),
+                "Procedure Run()\nEndProcedure\n",
+            )
+            .unwrap();
+        }
+
+        crate::infrastructure::source_roots::NAMED_SOURCE_SET_RESOLUTIONS
+            .with(|count| count.set(0));
+        let answer = resolve_platform_xml_source_navigation(
+            &context,
+            &SourceResolveRequest {
+                source_set: "main".to_string(),
+                query: "Catalog".to_string(),
+                mode: SourceNavigationMode::Prefix,
+                target_kind: None,
+                limit: 50,
+                cursor: None,
+            },
+        )
+        .unwrap();
+        let resolutions = crate::infrastructure::source_roots::NAMED_SOURCE_SET_RESOLUTIONS
+            .with(|count| count.get());
+
+        assert!(
+            answer.candidates.len() >= 4,
+            "the scan still answers: {:?}",
+            answer.candidates
+        );
+        assert_eq!(
+            resolutions, 1,
+            "the project config is read once per call, not once per candidate"
+        );
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/source_roots.rs
+++ b/crates/unica-coder/src/infrastructure/source_roots.rs
@@ -64,11 +64,21 @@ pub(crate) fn resolve_source_root(
     result.map_err(invalid_source_root)
 }
 
-#[allow(dead_code)]
+#[cfg(test)]
+thread_local! {
+    /// Counts how many times a call re-reads the project config. A scan that
+    /// resolves the source set once per candidate instead of once per call is
+    /// what made a bare-kind prefix query cost seconds (#277).
+    pub(crate) static NAMED_SOURCE_SET_RESOLUTIONS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
 pub(crate) fn resolve_named_source_set(
     context: &WorkspaceContext,
     name: &str,
 ) -> Result<ResolvedNamedSourceSet, NamedSourceSetError> {
+    #[cfg(test)]
+    NAMED_SOURCE_SET_RESOLUTIONS.with(|count| count.set(count.get() + 1));
     if name.is_empty() {
         return Err(NamedSourceSetError::new(
             NamedSourceSetErrorKind::NotFound,


### PR DESCRIPTION
Closes #277.

## Причина — ровно та, что названа в задаче

`resolve_prefix_by_scoped_scan` доказывает каждого кандидата через `exact_module_outcome`, а тот вызывал `resolve_platform_xml_target`, который **начинался** с `resolve_named_source_set` — то есть заново разбирал `v8project.yaml` через `discover_project_source_map`. На ~3000 общих модулей это ~3000 повторных разборов конфига на один запрос, отсюда 2.5-4.4 с там, где узкий запрос стоит 0.06 с.

Разрешённый набор при этом уже был на руках: `resolve_prefix_by_scoped_scan` получает его в самом начале и передаёт вниз как `selected`.

## Воспроизведение

Тест-счётчик `prefix_scan_resolves_the_source_set_once_per_call` на четырёх справочниках до правки:

```
  left: 5
 right: 1
```

Пять разрешений конфига — по одному на кандидата плюс сам вызов. После правки — одно, независимо от числа кандидатов.

Счётчик измеряет причину напрямую, а не время, поэтому тест не зависит от машины и не требует конфигурации на 48 158 файлов.

## Исправление

Разрешение source-set отделено от разрешения цели: `resolve_platform_xml_target_in` принимает уже разрешённый `ResolvedNamedSourceSet`. Публичный `resolve_platform_xml_target` остался прежним и теперь просто делегирует ему.

**Цепочка containment-проверок не ослаблена.** Задача опасалась именно этого: «первое ослабляет цепочку containment-проверок». Здесь ничего не пропускается — `validate_source_set` и все последующие проверки выполняются как раньше. Берётся то же значение, которое вызывающий уже доказал, вместо повторного чтения его с диска. Второй вариант из задачи — кеш имён по `workspace_epoch` — не понадобился, новой сущности нет.

## Проверка

- `prefix_scan_resolves_the_source_set_once_per_call` — падал до правки (5 против 1), проходит после; заодно проверяет, что скан по-прежнему отвечает всеми кандидатами.
- `cargo test --package unica-coder --lib` — 2713 passed, 2 failed: оба падения — семейство известного флейка #432, чей фикс идёт отдельным PR #439.
- `python -m unittest discover -s tests/ci` — 644 passed, 3 skipped, 0 failed.
- `cargo fmt --check` — чисто.

## Граница

Счётчик `NAMED_SOURCE_SET_RESOLUTIONS` объявлен под `cfg(test)` и в поставку не попадает. Абсолютные величины из задачи заново не замерялись: для этого нужна та же конфигурация на 48 158 файлов, которой здесь нет. Устранена названная причина, и её устранение измерено напрямую.