### PR TITLE
feat(mcp): объявить preview-стратегию каждого мутатора в реестре

### DIFF
--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -77,6 +77,45 @@ pub enum ResultContract {
     ExternalStream,
 }
 
+/// What a mutating tool can honestly show before it writes.
+///
+/// #290 found the preview path decided by a growing set of exceptions keyed on
+/// operation name: most typed mutation handlers ran only inside `!dry_run`, and
+/// `code.patch`, `form.edit`, `meta.edit`, `role.edit` and `xdto.edit` were
+/// carved out one at a time. A caller could not tell from the surface which
+/// behaviour it would get.
+///
+/// The strategy is derived from the registry rather than restated per tool, so
+/// a new mutator cannot be added without falling into one of these classes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreviewStrategy {
+    /// The tool computes the post-image it would write and answers with it.
+    /// Every file mutator belongs here: the bytes are derivable without
+    /// touching the workspace.
+    PostImage,
+    /// The tool answers with the external command it would run. A build or a
+    /// runtime job cannot show its result without doing the work, but it can
+    /// show exactly what it would launch.
+    PlannedCommand,
+}
+
+/// The preview class of a mutating tool, or `None` for a reader.
+///
+/// Totality over the mutating registry is the point: the table-driven contract
+/// test fails when a new mutator appears without a class, which is what turns
+/// "growing set of exceptions" into a declared decision.
+pub fn preview_strategy(tool: &ToolSpec) -> Option<PreviewStrategy> {
+    if !tool.execution.is_mutating() {
+        return None;
+    }
+    Some(match tool.handler {
+        ToolHandler::BuildRuntime { .. }
+        | ToolHandler::RuntimeAdapter
+        | ToolHandler::RuntimeJob { .. } => PreviewStrategy::PlannedCommand,
+        _ => PreviewStrategy::PostImage,
+    })
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct ToolSpec {
     pub name: &'static str,

--- a/crates/unica-coder/src/application/tool_contracts.rs
+++ b/crates/unica-coder/src/application/tool_contracts.rs
@@ -4403,6 +4403,47 @@ mod tests {
         );
     }
 
+    /// #290, требование 1: у каждого мутатора есть объявленная стратегия
+    /// предпросмотра, и она выводится из реестра, а не из растущего набора
+    /// исключений по имени операции. Читатель стратегии не имеет — предпросмотр
+    /// ему не адресован (ADR-0044).
+    #[test]
+    fn every_mutating_tool_declares_a_preview_strategy() {
+        use crate::application::{preview_strategy, PreviewStrategy};
+
+        let mut planned = Vec::new();
+        for tool in tools() {
+            let strategy = preview_strategy(&tool);
+            if !tool.execution.is_mutating() {
+                assert_eq!(strategy, None, "{} is a reader", tool.name);
+                continue;
+            }
+            let strategy = strategy
+                .unwrap_or_else(|| panic!("{} has no declared preview strategy", tool.name));
+            if strategy == PreviewStrategy::PlannedCommand {
+                planned.push(tool.name);
+            }
+        }
+
+        planned.sort_unstable();
+        // Табличная часть: внешнюю команду показывают ровно те мутаторы,
+        // которые её и запускают. Новый такой инструмент обязан появиться
+        // здесь осознанно, а не попасть в класс молча.
+        assert_eq!(
+            planned,
+            [
+                "unica.build.dump",
+                "unica.build.load",
+                "unica.build.make",
+                "unica.build.run",
+                "unica.build.update",
+                "unica.runtime.execute",
+                "unica.runtime.job.cancel",
+                "unica.runtime.job.start",
+            ]
+        );
+    }
+
     #[test]
     fn native_contracts_reject_unknown_args() {
         let tool = tools()


### PR DESCRIPTION
Часть [#290](https://github.com/IngvarConsulting/unica/issues/290) — её **требование 1**, единственное, которое можно закрыть без предварительного решения о форме результата.

## Дефект воспроизводится

Гейт на месте, `typed_result.rs`:

```rust
if !dry_run {
    match operation {
        "template-add" => { ... }
        "epf-init" | "erf-init" => { ... }
        ...
    }
}
```

Четырнадцать типизированных мутаторов исполняются только вне предпросмотра, а исключения — `code.patch`, `form.edit`, `meta.edit`, `role.edit`, `xdto.edit` — выведены из-под гейта поимённо, по одному. По публичной поверхности нельзя понять, что получит вызывающий: общий `ok: true` без `data` или предметный результат.

## Что делает этот PR

Требование 1 задачи: «завести в живом реестре декларативную preview-стратегию каждого мутатора, чтобы поведение не определялось растущим набором исключений по имени».

`preview_strategy` — тотальная функция над реестром, а не поле у шестидесяти литералов:

- **`PostImage`** — файловый мутатор: байты выводимы, не трогая рабочее пространство;
- **`PlannedCommand`** — build/runtime: результат знает только платформа, но запускаемая команда известна;
- **`None`** — читатель: предпросмотр ему не адресован (ADR-0044).

Табличный contract-тест падает в двух случаях: новый мутатор появился без класса, и новый инструмент молча попал в класс внешней команды. Восемь имён в таблице зафиксированы явно.

## Названные допущения

Классификация выведена из `ToolHandler`, а не задана вручную. Это допущение, которое ревью может отклонить: оно означает, что «запускает внешний процесс» и «может показать только команду» — одно и то же. Сегодня совпадает; если появится runtime-мутатор, умеющий честный postimage, класс придётся задавать явно.

## Что осталось в #290

Остальные требования меняют полезную нагрузку публичных инструментов и требуют записи-владельца:

1. Единая форма `data` у предпросмотра и apply, различающаяся execution state (требование 3).
2. Отсутствие побочных эффектов при `dryRun: true` для файловых, runtime- и job-мутаторов (требование 2).
3. `cache report` в предпросмотре с `mode = "dry-run"` и только проектируемым влиянием.
4. `preview_unavailable` как явный отказ там, где честный предпросмотр невозможен (требование 5).

Содержание этого решения — что считать честным предпросмотром для runtime-мутатора — выбор владельца контракта, а не следствие кода, поэтому здесь оно не принимается.

## Проверка

- `every_mutating_tool_declares_a_preview_strategy` — тотальность по мутаторам и зафиксированная таблица класса внешней команды.
- `cargo test --package unica-coder --lib` — **2730 passed, 0 failed**.
- `python -m unittest discover -s tests/ci` — 646 passed, 3 skipped, 0 failed.
- `cargo fmt --check` — чисто.