### PR TITLE
test(windows): make baseline assertions portable

### DIFF
--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -2810,7 +2810,7 @@ mod tests {
     use std::time::Duration;
 
     fn normalized_path(path: &std::path::Path) -> std::path::PathBuf {
-        crate::infrastructure::platform::testing::canonical_path_for_test(path)
+        crate::test_support::canonical_path(path)
     }
 
     fn call_public_tool_from_workspace(

--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -12007,15 +12007,26 @@ mod tests {
 
         assert!(borrowed.exists(), "the borrow must have created the object");
         assert!(
-            created.contains(&borrowed.display().to_string()),
+            created
+                .iter()
+                .any(|path| normalized_path(std::path::Path::new(path))
+                    == normalized_path(&borrowed)),
             "{created:?}"
         );
         assert!(
-            updated.contains(&extension_owner.display().to_string()),
+            updated.iter().any(|path| {
+                normalized_path(std::path::Path::new(path)) == normalized_path(&extension_owner)
+            }),
             "{updated:?}"
         );
         for path in &created {
-            assert!(!updated.contains(path), "{path} is created and updated");
+            assert!(
+                !updated.iter().any(|updated_path| {
+                    normalized_path(std::path::Path::new(updated_path))
+                        == normalized_path(std::path::Path::new(path))
+                }),
+                "{path} is created and updated"
+            );
         }
         let expected_changes = created
             .iter()

--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -2810,17 +2810,7 @@ mod tests {
     use std::time::Duration;
 
     fn normalized_path(path: &std::path::Path) -> std::path::PathBuf {
-        let canonical = std::fs::canonicalize(path).expect("test path identity must canonicalize");
-        if std::path::MAIN_SEPARATOR == '\\' {
-            let display = canonical.to_string_lossy();
-            if let Some(path) = display.strip_prefix(r"\\?\UNC\") {
-                return std::path::PathBuf::from(format!(r"\\{path}"));
-            }
-            if let Some(path) = display.strip_prefix(r"\\?\") {
-                return std::path::PathBuf::from(path);
-            }
-        }
-        canonical
+        crate::infrastructure::platform::testing::canonical_path_for_test(path)
     }
 
     fn call_public_tool_from_workspace(

--- a/crates/unica-coder/src/infrastructure/native_operations/cfe.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/cfe.rs
@@ -6790,7 +6790,7 @@ mod tests {
     use crate::infrastructure::native_operations::single_file_publisher::with_before_commit_hook;
     use serde_json::{json, Map, Value};
     use std::fs;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn temp_context(name: &str) -> WorkspaceContext {
@@ -6813,6 +6813,28 @@ mod tests {
             fs::create_dir_all(parent).unwrap();
         }
         fs::write(path, content).unwrap();
+    }
+
+    fn normalized_test_path(path: &Path) -> PathBuf {
+        let canonical = fs::canonicalize(path).expect("test path identity must canonicalize");
+        if std::path::MAIN_SEPARATOR == '\\' {
+            let display = canonical.to_string_lossy();
+            if let Some(path) = display.strip_prefix(r"\\?\UNC\") {
+                return PathBuf::from(format!(r"\\{path}"));
+            }
+            if let Some(path) = display.strip_prefix(r"\\?\") {
+                return PathBuf::from(path);
+            }
+        }
+        canonical
+    }
+
+    fn matching_mutation_path<'a>(paths: &'a [String], expected: &Path) -> Option<&'a str> {
+        let expected = normalized_test_path(expected);
+        paths
+            .iter()
+            .find(|path| normalized_test_path(Path::new(path)) == expected)
+            .map(String::as_str)
     }
 
     fn write_minimal_borrow_fixture(
@@ -8274,22 +8296,19 @@ mod tests {
             .expect("cfe.borrow answers with data")
             .mutation;
         assert!(mutation.applied);
-        let target_path = target.display().to_string();
-        let owner_path = extension_owner.display().to_string();
+        let target_path = matching_mutation_path(&mutation.created, &target).unwrap_or_else(|| {
+            panic!("a file that did not exist must be reported as created: {mutation:?}")
+        });
         assert!(
-            mutation.created.contains(&target_path),
-            "a file that did not exist must be reported as created: {mutation:?}"
-        );
-        assert!(
-            !mutation.updated.contains(&target_path),
+            matching_mutation_path(&mutation.updated, &target).is_none(),
             "a created file must not also be reported as updated: {mutation:?}"
         );
+        let owner_path = matching_mutation_path(&mutation.updated, &extension_owner)
+            .unwrap_or_else(|| {
+                panic!("the registered owner is rewritten, not created: {mutation:?}")
+            });
         assert!(
-            mutation.updated.contains(&owner_path),
-            "the registered owner is rewritten, not created: {mutation:?}"
-        );
-        assert!(
-            !mutation.created.contains(&owner_path),
+            matching_mutation_path(&mutation.created, &extension_owner).is_none(),
             "an existing owner must not be reported as created: {mutation:?}"
         );
         assert!(
@@ -8325,18 +8344,15 @@ mod tests {
             .as_ref()
             .expect("cfe.borrow answers with data")
             .mutation;
-        let owner_path = extension_owner.display().to_string();
         assert!(
             mutation.created.is_empty(),
             "nothing is created on a repeated borrow: {mutation:?}"
         );
-        assert!(
-            mutation.updated.contains(&owner_path),
-            "the owner registration is rewritten: {mutation:?}"
-        );
+        matching_mutation_path(&mutation.updated, &extension_owner)
+            .unwrap_or_else(|| panic!("the owner registration is rewritten: {mutation:?}"));
         for path in &mutation.created {
             assert!(
-                !mutation.updated.contains(path),
+                matching_mutation_path(&mutation.updated, Path::new(path)).is_none(),
                 "{path} must not be both created and updated"
             );
         }

--- a/crates/unica-coder/src/infrastructure/native_operations/cfe.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/cfe.rs
@@ -6816,13 +6816,10 @@ mod tests {
     }
 
     fn matching_mutation_path<'a>(paths: &'a [String], expected: &Path) -> Option<&'a str> {
-        let expected = crate::infrastructure::platform::testing::canonical_path_for_test(expected);
+        let expected = crate::test_support::canonical_path(expected);
         paths
             .iter()
-            .find(|path| {
-                crate::infrastructure::platform::testing::canonical_path_for_test(Path::new(path))
-                    == expected
-            })
+            .find(|path| crate::test_support::canonical_path(Path::new(path)) == expected)
             .map(String::as_str)
     }
 

--- a/crates/unica-coder/src/infrastructure/native_operations/cfe.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/cfe.rs
@@ -6790,7 +6790,7 @@ mod tests {
     use crate::infrastructure::native_operations::single_file_publisher::with_before_commit_hook;
     use serde_json::{json, Map, Value};
     use std::fs;
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn temp_context(name: &str) -> WorkspaceContext {
@@ -6815,25 +6815,14 @@ mod tests {
         fs::write(path, content).unwrap();
     }
 
-    fn normalized_test_path(path: &Path) -> PathBuf {
-        let canonical = fs::canonicalize(path).expect("test path identity must canonicalize");
-        if std::path::MAIN_SEPARATOR == '\\' {
-            let display = canonical.to_string_lossy();
-            if let Some(path) = display.strip_prefix(r"\\?\UNC\") {
-                return PathBuf::from(format!(r"\\{path}"));
-            }
-            if let Some(path) = display.strip_prefix(r"\\?\") {
-                return PathBuf::from(path);
-            }
-        }
-        canonical
-    }
-
     fn matching_mutation_path<'a>(paths: &'a [String], expected: &Path) -> Option<&'a str> {
-        let expected = normalized_test_path(expected);
+        let expected = crate::infrastructure::platform::testing::canonical_path_for_test(expected);
         paths
             .iter()
-            .find(|path| normalized_test_path(Path::new(path)) == expected)
+            .find(|path| {
+                crate::infrastructure::platform::testing::canonical_path_for_test(Path::new(path))
+                    == expected
+            })
             .map(String::as_str)
     }
 

--- a/crates/unica-coder/src/infrastructure/native_operations/meta/info_projection_tests.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta/info_projection_tests.rs
@@ -212,8 +212,9 @@ fn manifest_edge_fixtures_keep_the_canonical_platform_wrapper() {
         {
             let path = fixture_root.join(relative.as_str().unwrap());
             let xml = std::fs::read_to_string(&path).unwrap();
-            assert!(
-                xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"),
+            assert_eq!(
+                xml.lines().next(),
+                Some("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"),
                 "{} must preserve the canonical XML declaration",
                 path.display()
             );

--- a/crates/unica-coder/src/infrastructure/platform/testing.rs
+++ b/crates/unica-coder/src/infrastructure/platform/testing.rs
@@ -15,20 +15,6 @@ pub(crate) fn path_text_for_test(path: &Path) -> String {
     normalize_path_text_for_test(&path.display().to_string())
 }
 
-pub(crate) fn canonical_path_for_test(path: &Path) -> PathBuf {
-    let canonical = std::fs::canonicalize(path).expect("test path identity must canonicalize");
-    if std::path::MAIN_SEPARATOR == '\\' {
-        let display = canonical.to_string_lossy();
-        if let Some(path) = display.strip_prefix(r"\\?\UNC\") {
-            return PathBuf::from(format!(r"\\{path}"));
-        }
-        if let Some(path) = display.strip_prefix(r"\\?\") {
-            return PathBuf::from(path);
-        }
-    }
-    canonical
-}
-
 #[cfg(unix)]
 pub(crate) fn can_rename_parent_with_retained_cleanup_child_for_test() -> bool {
     true

--- a/crates/unica-coder/src/infrastructure/platform/testing.rs
+++ b/crates/unica-coder/src/infrastructure/platform/testing.rs
@@ -15,6 +15,20 @@ pub(crate) fn path_text_for_test(path: &Path) -> String {
     normalize_path_text_for_test(&path.display().to_string())
 }
 
+pub(crate) fn canonical_path_for_test(path: &Path) -> PathBuf {
+    let canonical = std::fs::canonicalize(path).expect("test path identity must canonicalize");
+    if std::path::MAIN_SEPARATOR == '\\' {
+        let display = canonical.to_string_lossy();
+        if let Some(path) = display.strip_prefix(r"\\?\UNC\") {
+            return PathBuf::from(format!(r"\\{path}"));
+        }
+        if let Some(path) = display.strip_prefix(r"\\?\") {
+            return PathBuf::from(path);
+        }
+    }
+    canonical
+}
+
 #[cfg(unix)]
 pub(crate) fn can_rename_parent_with_retained_cleanup_child_for_test() -> bool {
     true

--- a/crates/unica-coder/src/test_support.rs
+++ b/crates/unica-coder/src/test_support.rs
@@ -9,6 +9,20 @@ fn process_cwd_lock() -> MutexGuard<'static, ()> {
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
+pub(crate) fn canonical_path(path: &Path) -> PathBuf {
+    let canonical = std::fs::canonicalize(path).expect("test path identity must canonicalize");
+    if std::path::MAIN_SEPARATOR == '\\' {
+        let display = canonical.to_string_lossy();
+        if let Some(path) = display.strip_prefix(r"\\?\UNC\") {
+            return PathBuf::from(format!(r"\\{path}"));
+        }
+        if let Some(path) = display.strip_prefix(r"\\?\") {
+            return PathBuf::from(path);
+        }
+    }
+    canonical
+}
+
 pub(crate) struct ProcessCwdGuard {
     previous: PathBuf,
     _lock: MutexGuard<'static, ()>,


### PR DESCRIPTION
## Контекст

Windows CI в PR #454 выявил четыре падения, которые воспроизводятся на чистом `main` и не связаны с изменениями workspace service. Этот PR исправляет их отдельно, не расширяя scope #454.

## Что изменено

- проверки путей в тестах `cfe.borrow` теперь сравнивают физическую идентичность файлов после `canonicalize`, а не строковое представление пути;
- общий helper идентичности тестовых путей размещён в нейтральном `crate::test_support`, без нарушения границ слоёв;
- сохранена проверка согласованности `mutation.created`, `mutation.updated` и `changes`;
- проверка XML-декларации fixture принимает штатные окончания строк LF и CRLF, но по-прежнему требует точную каноническую декларацию UTF-8;
- production-код и архитектурный контракт не изменены.

## Причина

На Windows один и тот же файл может быть представлен путями с разными разделителями или через short-name alias (`RUNNER~1`). Кроме того, Git checkout может материализовать текстовые fixtures с CRLF. Строковое или байтовое сравнение в этих местах проверяло особенности окружения вместо поведения продукта.

## Проверка

- четыре исходно падавших теста: `4 passed`, `0 failed`;
- platform-boundary guard: `OK`;
- `cargo fmt --all -- --check`;
- `git diff --check`;
- [полный workflow на финальном SHA `3fec30d1`](https://github.com/Agrajaga/unica/actions/runs/31545326594): guardrails, `cargo test --workspace -- --test-threads=1` на Ubuntu, Windows и macOS, сборка, упаковка и platform probes — успешно;
- required checks непосредственно на PR #460 — успешно.

После слияния этот PR снимает независимый baseline-блокер с #454.
