### PR TITLE
test(docs): register title-first legacy designs

### DIFF
--- a/tests/ci/test_design_documents.py
+++ b/tests/ci/test_design_documents.py
@@ -68,8 +68,10 @@ TITLE_FIRST_LEGACY = {
     "2026-07-30-structured-bsl-outline-result-design.md",
     "2026-07-30-windows-applied-full-dump-design.md",
     "2026-08-02-xdto-package-domain-review-fixes-design.md",
+    "2026-08-03-issue-186-research-slicing-design.md",
     "2026-08-03-issue-286-rlm-source-generation-design.md",
     "2026-08-03-meta-surface-design.md",
+    "2026-08-04-issue-186-russian-screening-design.md",
     "2026-08-08-meta-object-integrity-design.md",
     "2026-08-08-platform-help-documentation-provider-design.md",
 }


### PR DESCRIPTION
## Что меняется

Регистрирует два design-документа issue #186 в явном списке исторических документов с заголовком H1 перед полями Date / Status / Decision. Документы попали в `main` после введения guardrail и из-за этого `Verify source guardrails` падал также в несвязанных PR, включая #461.

## Корневая причина

Guardrail `test_required_header_is_the_first_content_in_each_document` намеренно не переписывает архивную design-историю и хранит известный долг в `TITLE_FIRST_LEGACY`. Два документа существовали до правила, но были слиты после него без регистрации в этом списке.

## Архитектурный слой

- Затронутые записи реестра: нет.
- Решение (ADR): нет — архитектурный и публичный контракт не меняется.
- Чек-лист изменений просмотрен в относящейся к тестовой правке части.

## RED / GREEN

- RED на чистом `origin/main`: 1 падение из 9; шесть диагностик указывали на первые три строки двух документов.
- GREEN после исправления: 9 из 9 тестов `test_design_documents.py` проходят.

## Проверка

- `python tests/ci/test_design_documents.py`
- `python -m py_compile tests/ci/test_design_documents.py`
- `python scripts/ci/check-architecture-sync.py --base origin/main --strict`
- `python scripts/ci/check-version-contract.py`
- `git diff --check origin/main...HEAD`