### PR TITLE
Исправить Windows path identity в logical support reader

### DIFF
--- a/crates/unica-coder/src/infrastructure/native_operations/logical_selector.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/logical_selector.rs
@@ -312,7 +312,7 @@ pub(crate) fn physical_selection(
     }
     Ok(ResolvedReadTarget {
         target: resolution.resolved,
-        resource_path: proven,
+        resource_path: proven_identity,
     })
 }
 
@@ -849,7 +849,10 @@ mod tests {
         assert_eq!(selection.target.source_set, "main");
         assert_eq!(selection.target.metadata_path, None);
         assert_eq!(selection.target.target_kind, TargetKind::SourceRoot);
-        assert_eq!(selection.resource_path, fs::canonicalize(resource).unwrap());
+        assert_eq!(
+            selection.resource_path,
+            normalize_path_identity(&resource).unwrap()
+        );
         cleanup(&context);
     }
 
@@ -870,7 +873,10 @@ mod tests {
             Some("Subsystem.SalesOps")
         );
         assert_eq!(selection.target.target_kind, TargetKind::MetadataObject);
-        assert_eq!(selection.resource_path, fs::canonicalize(resource).unwrap());
+        assert_eq!(
+            selection.resource_path,
+            normalize_path_identity(&resource).unwrap()
+        );
         cleanup(&context);
     }
 

--- a/crates/unica-coder/src/infrastructure/native_operations/logical_selector.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/logical_selector.rs
@@ -310,15 +310,9 @@ pub(crate) fn physical_selection(
             "the physical selector did not reproduce the proven target resource",
         ));
     }
-    let resource_path = fs::canonicalize(&proven).map_err(|_| {
-        LogicalSelectorFailure::new(
-            "provider_unavailable",
-            "the proven physical resource identity is unavailable",
-        )
-    })?;
     Ok(ResolvedReadTarget {
         target: resolution.resolved,
-        resource_path,
+        resource_path: proven,
     })
 }
 

--- a/crates/unica-coder/src/infrastructure/native_operations/logical_selector.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/logical_selector.rs
@@ -880,6 +880,54 @@ mod tests {
         cleanup(&context);
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn physical_support_target_accepts_regular_and_verbatim_windows_paths() {
+        let context = fixture("physical-windows-verbatim");
+        let resource = context.workspace_root.join("src/Configuration.xml");
+        let verbatim = PathBuf::from(format!(r"\\?\{}", resource.display()));
+
+        let regular = physical_selection(&resource, &context, AttachedResource::ConfigurationRoot)
+            .expect("the regular Windows spelling resolves");
+        let extended = physical_selection(&verbatim, &context, AttachedResource::ConfigurationRoot)
+            .expect("the equivalent verbatim Windows spelling resolves");
+
+        assert_eq!(extended.target, regular.target);
+        assert_eq!(extended.resource_path, regular.resource_path);
+        assert!(
+            !extended
+                .resource_path
+                .as_os_str()
+                .to_string_lossy()
+                .starts_with(r"\\?\"),
+            "the public resource identity must not expose a Windows service prefix"
+        );
+        cleanup(&context);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn physical_support_target_rejects_a_parent_directory_reparse_point() {
+        let context = fixture("physical-windows-parent-reparse");
+        let src = context.workspace_root.join("src");
+        let linked_parent = src.join("Roles/Sales");
+        let referent = src.join("linked-sales");
+        fs::rename(&linked_parent, &referent).unwrap();
+        std::os::windows::fs::symlink_dir(&referent, &linked_parent).unwrap();
+
+        let failure = physical_selection(
+            &linked_parent.join("Ext/Rights.xml"),
+            &context,
+            AttachedResource::Rights,
+        )
+        .expect_err("a resource below a reparse-point parent must be refused");
+
+        assert_eq!(failure.code(), "containment_denied");
+        crate::infrastructure::platform::filesystem::remove_dir_symlink_for_test(&linked_parent)
+            .unwrap();
+        cleanup(&context);
+    }
+
     #[test]
     fn logical_selector_reports_a_proven_object_without_the_resource_as_absent() {
         let context = fixture("binary-template");

--- a/crates/unica-coder/src/infrastructure/native_operations/logical_selector.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/logical_selector.rs
@@ -23,6 +23,7 @@ use crate::infrastructure::native_operations::common::string_arg;
 use crate::infrastructure::path_policy::WorkspacePathPolicy;
 use crate::infrastructure::platform::filesystem::{
     metadata_is_link_or_reparse_point, path_starts_with_host_root,
+    strip_windows_extended_length_prefix,
 };
 use crate::infrastructure::platform_xml_source_targets::{
     locate_platform_xml_reader_path, platform_xml_resource_evidence, resolve_platform_xml_target,
@@ -309,9 +310,15 @@ pub(crate) fn physical_selection(
             "the physical selector did not reproduce the proven target resource",
         ));
     }
+    let resource_path = fs::canonicalize(&proven).map_err(|_| {
+        LogicalSelectorFailure::new(
+            "provider_unavailable",
+            "the proven physical resource identity is unavailable",
+        )
+    })?;
     Ok(ResolvedReadTarget {
         target: resolution.resolved,
-        resource_path: proven,
+        resource_path,
     })
 }
 
@@ -478,7 +485,7 @@ fn prove_regular_file(
     let normalized = normalize_path_identity(&candidate).map_err(|_| {
         LogicalSelectorFailure::new("resource_absent", "the requested resource is not present")
     })?;
-    if !normalized.starts_with(&normalized_root) {
+    if !path_starts_with_host_root(&normalized, &normalized_root) {
         return Err(LogicalSelectorFailure::new(
             "containment_denied",
             "the resource escaped the selected source set",
@@ -500,14 +507,21 @@ fn ensure_no_link_components(
     source_root: &Path,
     target: &Path,
 ) -> Result<(), LogicalSelectorFailure> {
-    let relative = target.strip_prefix(source_root).map_err(|_| {
-        LogicalSelectorFailure::new(
+    // Keep the lexical components and remove only Windows' equivalent verbatim
+    // spelling. Canonicalizing here would erase a linked parent before it can
+    // be rejected by the component walk.
+    let source_root = strip_windows_extended_length_prefix(source_root);
+    let target = strip_windows_extended_length_prefix(target);
+    if !path_starts_with_host_root(&target, &source_root) {
+        return Err(LogicalSelectorFailure::new(
             "containment_denied",
             "the resource escaped the selected source set",
-        )
-    })?;
-    let mut current = source_root.to_path_buf();
-    for component in relative.components() {
+        ));
+    }
+    let root_component_count = source_root.components().count();
+    let relative = target.components().skip(root_component_count);
+    let mut current = source_root;
+    for component in relative {
         let std::path::Component::Normal(component) = component else {
             return Err(LogicalSelectorFailure::new(
                 "containment_denied",

--- a/crates/unica-coder/src/infrastructure/native_operations/logical_selector.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/logical_selector.rs
@@ -552,6 +552,10 @@ fn ensure_no_link_components(
 mod tests {
     use super::*;
     use crate::domain::workspace::WorkspaceContext;
+    use crate::infrastructure::platform::testing::{
+        create_directory_link_fixture_for_test, remove_dir_symlink_for_test,
+        windows_extended_length_path_for_test, FileLinkFixtureOutcome,
+    };
     use serde_json::{Map, Value};
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -880,12 +884,14 @@ mod tests {
         cleanup(&context);
     }
 
-    #[cfg(windows)]
     #[test]
     fn physical_support_target_accepts_regular_and_verbatim_windows_paths() {
         let context = fixture("physical-windows-verbatim");
         let resource = context.workspace_root.join("src/Configuration.xml");
-        let verbatim = PathBuf::from(format!(r"\\?\{}", resource.display()));
+        let Some(verbatim) = windows_extended_length_path_for_test(&resource) else {
+            cleanup(&context);
+            return;
+        };
 
         let regular = physical_selection(&resource, &context, AttachedResource::ConfigurationRoot)
             .expect("the regular Windows spelling resolves");
@@ -905,15 +911,21 @@ mod tests {
         cleanup(&context);
     }
 
-    #[cfg(windows)]
     #[test]
-    fn physical_support_target_rejects_a_parent_directory_reparse_point() {
+    fn physical_support_target_rejects_a_parent_directory_link_or_reparse_point() {
         let context = fixture("physical-windows-parent-reparse");
         let src = context.workspace_root.join("src");
         let linked_parent = src.join("Roles/Sales");
         let referent = src.join("linked-sales");
         fs::rename(&linked_parent, &referent).unwrap();
-        std::os::windows::fs::symlink_dir(&referent, &linked_parent).unwrap();
+        match create_directory_link_fixture_for_test(&referent, &linked_parent).unwrap() {
+            FileLinkFixtureOutcome::Created => {}
+            FileLinkFixtureOutcome::Unsupported
+            | FileLinkFixtureOutcome::WindowsPrivilegeUnavailable => {
+                cleanup(&context);
+                return;
+            }
+        }
 
         let failure = physical_selection(
             &linked_parent.join("Ext/Rights.xml"),
@@ -923,8 +935,7 @@ mod tests {
         .expect_err("a resource below a reparse-point parent must be refused");
 
         assert_eq!(failure.code(), "containment_denied");
-        crate::infrastructure::platform::filesystem::remove_dir_symlink_for_test(&linked_parent)
-            .unwrap();
+        remove_dir_symlink_for_test(&linked_parent).unwrap();
         cleanup(&context);
     }
 

--- a/crates/unica-coder/src/infrastructure/native_operations/mxl.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/mxl.rs
@@ -3367,7 +3367,12 @@ mod tests {
         assert!(execution.outcome.ok, "{:?}", execution.outcome);
         assert_eq!(
             execution.outcome.artifacts,
-            vec![template_path.canonicalize().unwrap().display().to_string()]
+            vec![
+                crate::infrastructure::source_roots::normalize_path_identity(&template_path)
+                    .unwrap()
+                    .display()
+                    .to_string()
+            ]
         );
         let _ = fs::remove_dir_all(&context.cwd);
     }

--- a/crates/unica-coder/src/infrastructure/platform/testing.rs
+++ b/crates/unica-coder/src/infrastructure/platform/testing.rs
@@ -15,6 +15,16 @@ pub(crate) fn path_text_for_test(path: &Path) -> String {
     normalize_path_text_for_test(&path.display().to_string())
 }
 
+#[cfg(windows)]
+pub(crate) fn windows_extended_length_path_for_test(path: &Path) -> Option<PathBuf> {
+    Some(PathBuf::from(format!(r"\\?\{}", path.display())))
+}
+
+#[cfg(not(windows))]
+pub(crate) fn windows_extended_length_path_for_test(_path: &Path) -> Option<PathBuf> {
+    None
+}
+
 #[cfg(unix)]
 pub(crate) fn can_rename_parent_with_retained_cleanup_child_for_test() -> bool {
     true

--- a/scripts/ci/classify-workflow-changes.py
+++ b/scripts/ci/classify-workflow-changes.py
@@ -57,7 +57,12 @@ PLATFORM_CONTRACT_PATHS = {
     "tests/ci/test_rust_platform_boundary.py",
 }
 PLATFORM_SOURCE_PATHS = {
+    "crates/unica-coder/src/infrastructure/native_operations/logical_selector.rs",
+    "crates/unica-coder/src/infrastructure/path_policy.rs",
     "crates/unica-coder/src/infrastructure/platform_xml_owner.rs",
+    "crates/unica-coder/src/infrastructure/platform_xml_source_targets.rs",
+    "crates/unica-coder/src/infrastructure/source_roots.rs",
+    "crates/unica-coder/src/infrastructure/support_state.rs",
 }
 PLATFORM_PREFIXES = (
     "crates/unica-coder/src/infrastructure/platform/",

--- a/tests/ci/test_classify_workflow_changes.py
+++ b/tests/ci/test_classify_workflow_changes.py
@@ -67,6 +67,11 @@ class ClassifyWorkflowChangesTests(unittest.TestCase):
         for path in (
             "crates/unica-coder/src/infrastructure/platform/filesystem.rs",
             "crates/unica-coder/src/infrastructure/platform_xml_owner.rs",
+            "crates/unica-coder/src/infrastructure/platform_xml_source_targets.rs",
+            "crates/unica-coder/src/infrastructure/source_roots.rs",
+            "crates/unica-coder/src/infrastructure/path_policy.rs",
+            "crates/unica-coder/src/infrastructure/support_state.rs",
+            "crates/unica-coder/src/infrastructure/native_operations/logical_selector.rs",
             "crates/unica-bootstrap/src/platform/mod.rs",
             "crates/unica-coder/tests/platform/new_contract.rs",
             "crates/unica-coder/tests/platform_external_init.rs",


### PR DESCRIPTION
## Что меняется

Исправляется Windows-регрессия, обнаруженная полным platform matrix в PR #469
после слияния #468: provider-neutral physical selector смешивал обычное
`C:\...` и verbatim `\\?\C:\...` написание одного пути.

## Причина

Host-aware проверка правильно считала эти пути эквивалентными, но затем
компонентный security-walk использовал обычный `strip_prefix` и отказывал с
`containment_denied`. Одновременно physical selector возвращал lexical path
вместо прежнего canonical path, что меняло legacy-контракт артефактов на
Windows.

## Решение

- перед компонентным обходом удаляется только эквивалентный Windows verbatim
  prefix; сами lexical-компоненты не канонизируются, поэтому symlink/reparse
  parent по-прежнему обнаруживается;
- containment identity сравнивается по host-aware правилам;
- physical selector возвращает доказанный canonical path, сохраняя прежнее
  поведение legacy path-вызовов;
- path-identity, platform XML, logical-selector и support-state файлы добавлены
  в `platform_changed`, чтобы их изменения всегда запускали Windows/macOS/Linux
  matrix. Именно отсутствие этой маршрутизации позволило #468 пройти только
  через macOS primary.

## Проверка

Исходное воспроизведение: Windows job PR #469, run `31638015387`, завершился
12 падениями (`containment_denied` и различие `C:\...`/`\\?\C:\...`), при этом
2816 тестов прошли.

Локально после исправления:

```sh
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test -p unica-coder infrastructure::native_operations::logical_selector::tests -- --test-threads=1
cargo test -p unica-coder cf_info_and_validate_recognize_bot_in_canonical_order -- --test-threads=1
cargo test -p unica-coder read_only_path_aliases_still_reach_the_format_warning -- --test-threads=1
python3.12 -m unittest tests.ci.test_classify_workflow_changes tests.ci.test_evaluate_ci_gate tests.ci.test_unica_workflow
git diff --check
```

Windows matrix этого PR является обязательной проверкой исправления.

Unblocks #469.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource selection to return consistent normalized identities across platforms.
  * Improved containment checks for host-root paths and symbolic links, including Windows extended-length paths.
  * Updated artifact and descriptor comparisons to reliably recognize equivalent paths.

* **Tests**
  * Expanded coverage for normalized path handling, symbolic-link validation, and platform-specific path scenarios.
  * Improved platform change detection for relevant infrastructure updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->