### PR TITLE
fix(windows): restore transactional rollback

### DIFF
--- a/crates/unica-coder/src/infrastructure/native_operations/role.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/role.rs
@@ -4185,8 +4185,8 @@ mod role_edit_contract_tests {
     }
 
     #[test]
-    fn role_edit_rejects_invalid_nested_object_name_without_changing_rights() {
-        let (context, args, rights) = fixture("invalid-nested-object");
+    fn role_edit_rejects_invalid_right_for_nested_object_without_changing_rights() {
+        let (context, args, rights) = fixture("invalid-nested-right");
         let before = fs::read(&rights).unwrap();
 
         let mut nested = args.clone();
@@ -4200,7 +4200,18 @@ mod role_edit_contract_tests {
             }]),
         );
         let invalid = apply_edit_with_data(&nested, &context);
-        assert!(!invalid.outcome.ok);
+        assert!(!invalid.outcome.ok, "{:?}", invalid.outcome);
+        let data = invalid.data.expect("typed failure data");
+        assert_eq!(data.diagnostics.len(), 1);
+        assert_eq!(data.diagnostics[0].code, "unsupported_right");
+        assert_eq!(data.diagnostics[0].operation_index, Some(0));
+        assert!(
+            data.diagnostics[0]
+                .message
+                .contains("DataProcessor.Worker.Command.Run"),
+            "{:?}",
+            data.diagnostics
+        );
         assert_eq!(fs::read(&rights).unwrap(), before);
         fs::remove_dir_all(context.workspace_root).unwrap();
     }
@@ -4238,7 +4249,6 @@ mod role_edit_contract_tests {
     #[test]
     fn role_edit_changes_editable_vendor_supported_role_addressed_logically() {
         let (context, args, rights) = fixture("editable-vendor-supported-role");
-        let before = fs::read(&rights).unwrap();
         fs::create_dir_all(context.workspace_root.join("src/Ext")).unwrap();
         fs::write(
             context
@@ -4258,10 +4268,41 @@ mod role_edit_contract_tests {
         )
         .unwrap();
 
+        let support = WorkspaceSupportStateReader::new(&context)
+            .object_support(&crate::domain::source_target::ResolvedTarget {
+                source_set: "main".to_string(),
+                metadata_path: Some(
+                    MetadataAddress::parse(PLATFORM_XML_8_3_27_FORMAT_2_20, "Role.Demo").unwrap(),
+                ),
+                target_kind: TargetKind::MetadataObject,
+            })
+            .unwrap();
+        assert_eq!(
+            support.state,
+            crate::domain::support_state::ObjectSupportState::EditableWithSupport
+        );
+        assert_eq!(support.direct_edit_safe, Some(true));
+
+        let expected_body = [
+            r#"<Rights xmlns="http://v8.1c.ru/8.2/roles" xmlns:r="http://v8.1c.ru/8.2/roles" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="Rights" version="2.20">"#,
+            "\t<setForNewObjects>false</setForNewObjects>",
+            "\t<setForAttributesByDefault>true</setForAttributesByDefault>",
+            "\t<independentRightsOfChildObjects>false</independentRightsOfChildObjects>",
+            "\t<object>",
+            "\t\t<name>Catalog.Demo</name>",
+            "\t\t<future><name>Delete</name><value>false</value></future>",
+            "\t\t<right><name>FuturePlatformRight</name><value>true</value><future/></right>",
+            "\t</object>",
+            "\t<restrictionTemplate><name>Keep</name><condition>TRUE</condition></restrictionTemplate>",
+            "</Rights>",
+        ]
+        .join("\r\n");
+        let expected = encode_role_xml(true, &expected_body);
+
         let changed = apply_edit_with_data(&args, &context);
 
         assert!(changed.outcome.ok, "{:?}", changed.outcome);
-        assert_ne!(fs::read(&rights).unwrap(), before);
+        assert_eq!(fs::read(&rights).unwrap(), expected);
         assert!(changed.data.expect("typed success data").changed);
         fs::remove_dir_all(context.workspace_root).unwrap();
     }
@@ -4911,7 +4952,7 @@ mod role_compile_contract_tests {
     }
 
     #[test]
-    fn role_compile_validates_supported_format_owner_that_appears_after_owner_probe() {
+    fn role_compile_validates_invalid_format_owner_that_appears_after_owner_probe() {
         let workspace = temp_root("invalid-owner-appears-after-probe");
         let source = temp_root("detached-invalid-owner-appears-after-probe");
         fs::create_dir_all(source.join("Languages")).unwrap();

--- a/crates/unica-coder/src/infrastructure/native_operations/role.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/role.rs
@@ -3937,8 +3937,15 @@ mod role_edit_contract_tests {
     }
 
     #[test]
-    fn preview_apply_repeat_are_typed_logical_and_idempotent() {
+    fn role_edit_without_vendor_support_is_logically_addressed_and_idempotent() {
         let (context, args, rights) = fixture("roundtrip");
+        assert!(
+            !context
+                .workspace_root
+                .join("src/Ext/ParentConfigurations.bin")
+                .exists(),
+            "the no-support case must not accidentally inherit vendor support evidence"
+        );
         let before = fs::read(&rights).unwrap();
         let preview = preview_edit_with_data(&args, &context);
         assert!(preview.outcome.ok, "{:?}", preview.outcome);
@@ -4178,8 +4185,8 @@ mod role_edit_contract_tests {
     }
 
     #[test]
-    fn support_deny_and_invalid_nested_matrix_leave_rights_unchanged() {
-        let (context, args, rights) = fixture("deny-and-matrix");
+    fn role_edit_rejects_invalid_nested_object_name_without_changing_rights() {
+        let (context, args, rights) = fixture("invalid-nested-object");
         let before = fs::read(&rights).unwrap();
 
         let mut nested = args.clone();
@@ -4195,6 +4202,13 @@ mod role_edit_contract_tests {
         let invalid = apply_edit_with_data(&nested, &context);
         assert!(!invalid.outcome.ok);
         assert_eq!(fs::read(&rights).unwrap(), before);
+        fs::remove_dir_all(context.workspace_root).unwrap();
+    }
+
+    #[test]
+    fn role_edit_rejects_locked_vendor_supported_role_without_changing_rights() {
+        let (context, args, rights) = fixture("locked-vendor-supported-role");
+        let before = fs::read(&rights).unwrap();
 
         fs::create_dir_all(context.workspace_root.join("src/Ext")).unwrap();
         fs::write(
@@ -4218,6 +4232,37 @@ mod role_edit_contract_tests {
         assert!(!denied.outcome.ok, "{:?}", denied.outcome);
         assert!(denied.outcome.errors[0].contains("support_locked"));
         assert_eq!(fs::read(&rights).unwrap(), before);
+        fs::remove_dir_all(context.workspace_root).unwrap();
+    }
+
+    #[test]
+    fn role_edit_changes_editable_vendor_supported_role_addressed_logically() {
+        let (context, args, rights) = fixture("editable-vendor-supported-role");
+        let before = fs::read(&rights).unwrap();
+        fs::create_dir_all(context.workspace_root.join("src/Ext")).unwrap();
+        fs::write(
+            context
+                .workspace_root
+                .join("src/Ext/ParentConfigurations.bin"),
+            concat!(
+                "\u{feff}{6,0,1,dddddddd-dddd-dddd-dddd-dddddddddddd,0,",
+                "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee,\"1.0\",\"Vendor\",",
+                "\"VendorConf\",3,1,0,aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa,",
+                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa,1,0,",
+                "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb,",
+                "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb,2,0,",
+                "cccccccc-cccc-cccc-cccc-cccccccccccc,",
+                "cccccccc-cccc-cccc-cccc-cccccccccccc}"
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+
+        let changed = apply_edit_with_data(&args, &context);
+
+        assert!(changed.outcome.ok, "{:?}", changed.outcome);
+        assert_ne!(fs::read(&rights).unwrap(), before);
+        assert!(changed.data.expect("typed success data").changed);
         fs::remove_dir_all(context.workspace_root).unwrap();
     }
 
@@ -4839,7 +4884,7 @@ mod role_compile_contract_tests {
     }
 
     #[test]
-    fn role_compile_rolls_back_if_supported_configuration_appears_during_publication() {
+    fn role_compile_rolls_back_if_supported_format_owner_appears_during_publication() {
         let workspace = temp_root("supported-owner-appears-during-publication");
         let source = temp_root("detached-supported-owner-appears-during-publication");
         fs::create_dir_all(&source).unwrap();
@@ -4866,7 +4911,7 @@ mod role_compile_contract_tests {
     }
 
     #[test]
-    fn role_compile_validates_supported_configuration_that_appears_after_owner_probe() {
+    fn role_compile_validates_supported_format_owner_that_appears_after_owner_probe() {
         let workspace = temp_root("invalid-owner-appears-after-probe");
         let source = temp_root("detached-invalid-owner-appears-after-probe");
         fs::create_dir_all(source.join("Languages")).unwrap();

--- a/crates/unica-coder/src/infrastructure/native_operations/subsystem.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/subsystem.rs
@@ -4242,7 +4242,7 @@ mod tests {
     }
 
     #[test]
-    fn root_subsystem_compile_validates_supported_format_owner_that_appears_after_probe() {
+    fn root_subsystem_compile_validates_invalid_format_owner_that_appears_after_probe() {
         let context = temp_context("root-invalid-owner-appears-after-probe");
         let detached = temp_context("detached-root-invalid-owner-appears-after-probe");
         let source = detached.cwd.clone();

--- a/crates/unica-coder/src/infrastructure/native_operations/subsystem.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/subsystem.rs
@@ -4209,7 +4209,7 @@ mod tests {
     }
 
     #[test]
-    fn root_subsystem_compile_rolls_back_if_supported_configuration_appears_during_publication() {
+    fn root_subsystem_compile_rolls_back_if_supported_format_owner_appears_during_publication() {
         let context = temp_context("root-owner-appears-during-publication");
         let detached = temp_context("detached-root-owner-appears-during-publication");
         let source = detached.cwd.clone();
@@ -4242,7 +4242,7 @@ mod tests {
     }
 
     #[test]
-    fn root_subsystem_compile_validates_supported_configuration_that_appears_after_probe() {
+    fn root_subsystem_compile_validates_supported_format_owner_that_appears_after_probe() {
         let context = temp_context("root-invalid-owner-appears-after-probe");
         let detached = temp_context("detached-root-invalid-owner-appears-after-probe");
         let source = detached.cwd.clone();

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -2288,7 +2288,92 @@ pub(crate) fn create_new_directory_child(
             )),
         };
     }
-    Ok(created)
+    // A directory handle with listing or deletion access blocks the internal
+    // cross-directory target open performed by FILE_RENAME_INFORMATION on
+    // Windows. Keep the creation handle until the identity-safe reopen has
+    // succeeded, then retain only the least-privilege destination handle.
+    let expected_identity = match file_identity(&created) {
+        Ok(identity) => identity,
+        Err(primary) => {
+            return match discard_created_child(&created) {
+                Ok(()) => Err(primary),
+                Err(cleanup) => Err(io::Error::new(
+                    primary.kind(),
+                    format!(
+                        "{primary}; failed to remove unverified directory created through the retained parent: {cleanup}"
+                    ),
+                )),
+            };
+        }
+    };
+    let reopened = match open_directory_child_for_rename_destination(parent, name) {
+        Ok(reopened) => reopened,
+        Err(primary) => {
+            return match discard_created_child(&created) {
+                Ok(()) => Err(primary),
+                Err(cleanup) => Err(io::Error::new(
+                    primary.kind(),
+                    format!(
+                        "{primary}; failed to remove unreopenable directory created through the retained parent: {cleanup}"
+                    ),
+                )),
+            };
+        }
+    };
+    let actual_identity = match file_identity(&reopened) {
+        Ok(identity) => identity,
+        Err(primary) => {
+            return match discard_created_child(&created) {
+                Ok(()) => Err(primary),
+                Err(cleanup) => Err(io::Error::new(
+                    primary.kind(),
+                    format!(
+                        "{primary}; failed to remove unverified reopened directory created through the retained parent: {cleanup}"
+                    ),
+                )),
+            };
+        }
+    };
+    if actual_identity != expected_identity {
+        let primary = io::Error::new(
+            io::ErrorKind::InvalidData,
+            "created directory identity changed before rename-compatible reopen",
+        );
+        return match discard_created_child(&created) {
+            Ok(()) => Err(primary),
+            Err(cleanup) => Err(io::Error::new(
+                primary.kind(),
+                format!("{primary}; failed to remove replaced created directory: {cleanup}"),
+            )),
+        };
+    }
+    drop(created);
+    Ok(reopened)
+}
+
+#[cfg(windows)]
+fn open_directory_child_for_rename_destination(
+    parent: &fs::File,
+    name: &std::ffi::OsStr,
+) -> io::Result<fs::File> {
+    const FILE_OPEN: u32 = 0x0000_0001;
+    const FILE_DIRECTORY_FILE: u32 = 0x0000_0001;
+    const FILE_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_READ_ATTRIBUTES, FILE_TRAVERSE, SYNCHRONIZE,
+    };
+
+    let directory = open_relative_child(
+        parent,
+        name,
+        FILE_TRAVERSE | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+        0,
+        FILE_OPEN,
+        FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT,
+        None,
+    )?;
+    validate_directory_handle(&directory)?;
+    Ok(directory)
 }
 
 #[cfg(not(any(unix, windows)))]
@@ -3179,7 +3264,7 @@ pub(crate) fn remove_identity_bound_empty_directory_child(
             "directory child identity changed; replacement left untouched",
         ));
     }
-    delete_open_child(retained)
+    delete_open_child(&named)
 }
 
 #[cfg(not(any(unix, windows)))]
@@ -3242,14 +3327,15 @@ mod tests {
     mod windows {
         use super::{fs, io, unique_temp_root};
         use crate::infrastructure::platform::filesystem::{
-            capture_windows_immutable_entry_evidence, create_owner_only_directory,
-            create_owner_only_directory_child, create_owner_only_file,
+            capture_windows_immutable_entry_evidence, create_new_directory_child,
+            create_owner_only_directory, create_owner_only_directory_child, create_owner_only_file,
             create_owner_only_file_child, delete_open_child, directory_query_is_end, file_identity,
             nt_create_options_for_std_file, open_any_child_for_delete, open_any_child_nofollow,
             open_directory_child_for_rename, open_directory_child_nofollow,
             open_directory_nofollow, open_regular_child_nofollow, opened_child_kind,
             parse_directory_information_buffer, read_directory_names,
-            rename_directory_handle_child_no_replace, verify_owner_only_acl,
+            rename_directory_handle_child_no_replace,
+            rename_identity_bound_regular_child_no_replace, verify_owner_only_acl,
             verify_owner_only_security_descriptor, verify_thread_token_fallback_error,
             verify_windows_elevation_value, verify_windows_immutable_security_descriptor,
             verify_windows_local_fixed_device_info, verify_windows_local_fixed_volume,
@@ -3755,6 +3841,40 @@ mod tests {
             drop(retained_file);
             drop(created);
             drop(parent);
+            drop(root_handle);
+            fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn regular_child_moves_into_live_created_directory_handle() {
+            let root = unique_temp_root("regular-child-live-destination");
+            fs::create_dir_all(&root).unwrap();
+            let root_handle = open_directory_nofollow(&root).unwrap();
+            let source_name = std::ffi::OsStr::new("published.bin");
+            let destination_name = std::ffi::OsStr::new("quarantined.bin");
+            fs::write(root.join(source_name), b"published bytes").unwrap();
+            let retained_source = open_regular_child_nofollow(&root_handle, source_name).unwrap();
+            let source_identity = file_identity(&retained_source).unwrap();
+            let recovery =
+                create_new_directory_child(&root_handle, std::ffi::OsStr::new("recovery")).unwrap();
+
+            rename_identity_bound_regular_child_no_replace(
+                &root_handle,
+                source_name,
+                source_identity,
+                &retained_source,
+                &recovery,
+                destination_name,
+            )
+            .expect("a retained recovery directory must accept an identity-bound child move");
+
+            assert!(!root.join(source_name).exists());
+            assert_eq!(
+                fs::read(root.join("recovery").join(destination_name)).unwrap(),
+                b"published bytes"
+            );
+            drop(retained_source);
+            drop(recovery);
             drop(root_handle);
             fs::remove_dir_all(root).unwrap();
         }


### PR DESCRIPTION
## Problem

Issue #474 reports 63 Windows failures across transactional publication, rollback, concurrent drift, and exact-byte recovery. A representative rollback left the changed document in place because moving the published file into the retained recovery directory failed with sharing violation `os error 32`.

The same 63 tests fail at `f9d6cbf9` (before #468/#470) and at `37b0d757` (after them), so logical support addressing is not the cause. The retained Windows recovery-directory handle requested listing and deletion access; that access conflicts with the internal cross-directory target open used by `FILE_RENAME_INFORMATION`.

## Changes

- Reopen a newly created recovery directory with rename-compatible least privilege (`FILE_TRAVERSE | FILE_READ_ATTRIBUTES | SYNCHRONIZE`).
- Verify the reopened handle has the exact identity of the directory that was created before dropping the creation handle.
- Open a fresh identity-checked delete handle for final empty-directory cleanup.
- Add a Windows regression test that moves a retained regular child into a live newly created recovery-directory handle.
- Clarify support tests so format-profile ownership is not confused with vendor support.
- Cover separately a role without vendor support, an editable vendor-supported role, and a locked vendor-supported role, all addressed logically.

## Verification

```text
cargo test -q -p unica-coder --lib -- --test-threads=1
2828 passed; 0 failed; 2 ignored

cargo fmt --all -- --check
python scripts/ci/check-rust-platform-boundary.py
```

The representative #474 test and neighboring identity-bound rename/cleanup tests also pass independently.

Fixes #474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows directory handling for moving items into newly created directories.
  * Strengthened directory identity checks and cleanup when filesystem operations fail.
  * Improved cleanup of empty directories through the correct directory reference.
* **Tests**
  * Expanded coverage for role editing and compilation scenarios, including invalid names, locked roles, vendor support, and rollback behavior.
  * Clarified test coverage for format-owner validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->