### PR TITLE
fix(subsystem): emit canonical UTF-8 declaration

### DIFF
--- a/crates/unica-coder/src/infrastructure/native_operations/common.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/common.rs
@@ -549,7 +549,7 @@ pub(crate) fn load_subsystem_edit_model(path: &Path) -> Result<SubsystemEditMode
 
 pub(crate) fn emit_subsystem_edit_model(model: &SubsystemEditModel) -> String {
     let mut lines = Vec::new();
-    lines.push("<?xml version=\"1.0\" encoding=\"utf-8\"?>".to_string());
+    lines.push("<?xml version=\"1.0\" encoding=\"UTF-8\"?>".to_string());
     lines.push(format!(
         "<MetaDataObject {} version=\"{}\">",
         full_md_namespace_declarations(),
@@ -1430,8 +1430,8 @@ pub(crate) fn stable_uuid(index: usize) -> String {
 #[cfg(test)]
 mod mutation_tests {
     use super::{
-        format_compatibility_warning, guard_active_format_owner, read_utf8_sig_snapshot,
-        utf8_bom_bytes, write_utf8_bom,
+        emit_subsystem_edit_model, format_compatibility_warning, guard_active_format_owner,
+        read_utf8_sig_snapshot, utf8_bom_bytes, write_utf8_bom,
     };
     use crate::domain::format_profile::{ExportFormatVersion, FormatCompatibility};
     use crate::domain::workspace::WorkspaceContext;
@@ -1439,8 +1439,33 @@ mod mutation_tests {
     use crate::infrastructure::native_operations::single_file_publisher::{
         with_before_commit_hook, with_publish_failpoints, PublishCheckpoint,
     };
+    use crate::infrastructure::native_operations::subsystem::SubsystemEditModel;
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn subsystem_edit_emits_platform_canonical_utf8_declaration() {
+        let xml = emit_subsystem_edit_model(&SubsystemEditModel {
+            version: "2.20".to_string(),
+            uuid: "11111111-2222-4333-8444-555555555555".to_string(),
+            name: "CanonicalEncoding".to_string(),
+            synonym: String::new(),
+            comment: String::new(),
+            include_help: "true".to_string(),
+            include_ci: "true".to_string(),
+            use_one_command: "false".to_string(),
+            explanation: String::new(),
+            picture: String::new(),
+            content: Vec::new(),
+            children: Vec::new(),
+        });
+
+        assert!(
+            xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"),
+            "subsystem XML must use the platform-canonical declaration: {}",
+            xml.lines().next().unwrap_or_default()
+        );
+    }
 
     fn format_owner_context(name: &str, version: &str) -> (WorkspaceContext, std::path::PathBuf) {
         let root = std::env::temp_dir().join(format!(


### PR DESCRIPTION
## Problem

Subsystem edit output hardcodes the XML declaration as `encoding=utf-8`, while the authoritative subsystem format specification and platform examples use canonical `encoding=UTF-8`.

This is independent of logical addressing and Windows rollback: `git blame` traces the lowercase literal to `aff5640a` from 2026-05-04, before #468/#470. The bytes are UTF-8 with the expected BOM; this change corrects the noncanonical declaration literal emitted into the XML.

## Changes

- Emit `encoding=UTF-8` from `emit_subsystem_edit_model`.
- Add a focused regression test against the complete subsystem emitter output.

## Verification

```text
cargo test -q -p unica-coder --lib infrastructure::native_operations::common::mutation_tests -- --test-threads=1
9 passed; 0 failed

cargo check -q -p unica-coder
cargo fmt --all -- --check
```

Windows note: the full subsystem suite on current `main` still contains the existing rollback failures from #474. This PR is independent and is based directly on `main`; draft PR #476 fixes that shared Windows transaction defect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated XML declarations to use the canonical uppercase `UTF-8` encoding format.

* **Tests**
  * Added coverage to verify the XML declaration uses the expected encoding format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->