### PR TITLE
test(packaging): lock bsl-analyzer asset names

### DIFF
--- a/tests/ci/test_skill_provenance.py
+++ b/tests/ci/test_skill_provenance.py
@@ -599,11 +599,20 @@ class SkillProvenanceTests(unittest.TestCase):
         )
         self.assertEqual(analyzer["assetTag"], "bsl-analyzer-v0.2.67-build.1")
         self.assertEqual(
-            {target: asset["sha256"] for target, asset in analyzer["assets"].items()},
+            analyzer["assets"],
             {
-                "darwin-arm64": "d18c3b79d017d60f229faf4e427bcefc0a9da59a93b57acbb867b064c52926bd",
-                "linux-x64": "c476c10fcdfa6eb7d310e83d0e69b02a27f9afeec0d394681feadb889de97301",
-                "win-x64": "a54d883bcb7ed0e0039953fb4d5cd7c2efbf30155de9951952f1a4060776eb3e",
+                "darwin-arm64": {
+                    "assetName": "bsl-analyzer-darwin-arm64",
+                    "sha256": "d18c3b79d017d60f229faf4e427bcefc0a9da59a93b57acbb867b064c52926bd",
+                },
+                "linux-x64": {
+                    "assetName": "bsl-analyzer-linux-x64",
+                    "sha256": "c476c10fcdfa6eb7d310e83d0e69b02a27f9afeec0d394681feadb889de97301",
+                },
+                "win-x64": {
+                    "assetName": "bsl-analyzer-win-x64.exe",
+                    "sha256": "a54d883bcb7ed0e0039953fb4d5cd7c2efbf30155de9951952f1a4060776eb3e",
+                },
             },
         )
 


### PR DESCRIPTION
## Что меняется

Package-contract тест для bsl-analyzer теперь сравнивает полный assets mapping для всех поддерживаемых платформ: и assetName, и sha256.

## Почему

Текущий тест извлекал только SHA-256, поэтому переименование release asset не нарушало контрактный guard, хотя загрузка или упаковка поставляемого инструмента перестала бы работать. Это отдельный дефект актуального main, обнаруженный при подготовке #473 к вливанию.

## Проверка

- Mutation-check: подмена bsl-analyzer-linux-x64 на несуществующее имя до исправления проходила, после исправления тест падает на точном assetName.
- Полный Python CI: 708 passed, 3 skipped.
- git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated analyzer contract coverage to verify complete per-platform asset metadata, including asset names and SHA-256 hashes.
  * Improved validation to ensure asset details are reported consistently and accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->