### PR TITLE
feat(warden): перезапускать упавшие чеки промоушена после появления тега

### DIFF
--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -38,10 +38,13 @@ gate: nothing reaches consumers until it exists.
 
 **Release Warden** (`.github/workflows/release-warden.yml`) advances the release
 whenever it can. It runs every 20 minutes, merges the staging pull request once
-its checks are green, asks for the promotion, and merges the promotion once its
+its checks are green, asks for the promotion, reruns the failed promotion
+checks once it sees the marketplace tag, and merges the promotion once its
 checks are green. It cannot skip the tag: the promotion checks install through
 the catalog ref, so they stay red until the tag is published, which keeps the tag
-as the approval rather than a formality.
+as the approval rather than a formality. The rerun happens once — a failure on
+a second attempt with the tag in place is a real defect and surfaces as an
+alert instead of another retry.
 
 That leaves two actions, both tags:
 
@@ -178,8 +181,9 @@ merge itself. Run it by hand only if the warden is disabled or failing.
 
 Order differs between the two paths, and both are fine. By hand, tagging first
 means the promotion pull request is green on its first run. The warden opens it
-as soon as staging lands, so it sits red until you publish the tag and then goes
-green on the next run. Either way nothing merges before the tag exists.
+as soon as staging lands, so it sits red until you publish the tag; on its next
+cycle the warden notices the tag and reruns the failed checks itself. Either
+way nothing merges before the tag exists.
 
 ```bash
 gh workflow run publish-unica-marketplace.yml --repo IngvarConsulting/unica \
@@ -301,7 +305,7 @@ Protecting tags in the marketplace repository removes the first cause outright.
 
 | Symptom | Cause | Action |
 | --- | --- | --- |
-| Promotion checks fail with `pathspec 'vX.Y.Z' did not match any file(s)` | The marketplace tag is missing | Do step 4, then `gh run rerun <run-id> --failed` |
+| Promotion checks fail with `pathspec 'vX.Y.Z' did not match any file(s)` | The marketplace tag is missing | Do step 4; the warden reruns the failed checks on its next cycle. `gh run rerun <run-id> --failed` only if you want it sooner |
 | `regression-policy` reports `consumer-fresh-install is required but concluded failure` | Aggregate gate reflecting the row above | Same as above |
 | Packaging fails with `release tag ... != ...` | Step 0 missed the workflow `RELEASE_TAG` fallback | Bump it and re-run |
 | Scheduled warden run fails with `release is stalled` | A published release nothing is serving, and nothing open to advance | Finish the release, or mark it a prerelease if it was abandoned |

--- a/scripts/ci/release-warden.py
+++ b/scripts/ci/release-warden.py
@@ -11,6 +11,7 @@ The state machine is deliberately small:
 
     catalog ref == latest release      -> nothing in flight
     staging pull request, all green    -> merge it, then ask for promotion
+    promotion red, tag now exists      -> rerun the failed checks, once
     promotion pull request, all green  -> merge it, the release goes live
     anything else                      -> report what is being waited on
 
@@ -19,6 +20,12 @@ marketplace tag exists, because its checks install through the catalog ref, so
 merging on green keeps the tag as the human approval rather than bypassing it.
 The marketplace default branch has no protection rules, so the greenness check
 here is the only gate and must never be relaxed.
+
+The rerun exists because a tag push re-triggers nothing on the pull request:
+the checks that failed before the tag stay failed on their own, and the release
+would stall right after the human's approval. One rerun is enough — a failure
+on a later attempt cannot be explained by the missing tag, so it is an alert,
+not another retry.
 """
 
 from __future__ import annotations
@@ -75,16 +82,24 @@ class PullRequest:
 
 
 @dataclass(frozen=True)
+class WorkflowRun:
+    id: int
+    attempt: int
+
+
+@dataclass(frozen=True)
 class ReleaseState:
     latest_release: str | None
     catalog_ref: str | None
     stage_pr: PullRequest | None = None
     promote_pr: PullRequest | None = None
+    marketplace_tag_exists: bool = False
+    promotion_checks_run: WorkflowRun | None = None
 
 
 @dataclass(frozen=True)
 class Action:
-    kind: str  # noop | merge-stage | merge-promote | wait | alert
+    kind: str  # noop | merge-stage | merge-promote | kick-promotion | wait | alert
     detail: str
     pull_request: int | None = None
     context: dict[str, str] = field(default_factory=dict)
@@ -126,6 +141,28 @@ def decide(state: ReleaseState) -> Action:
         if blocking:
             # The install checks resolve the catalog ref, so they cannot pass
             # before the marketplace tag is published. That is the human gate.
+            pending = any(item.endswith(": pending") for item in blocking)
+            if state.marketplace_tag_exists and not pending:
+                # A tag push re-triggers nothing on the pull request, so a
+                # failure observed before the tag existed stays red on its own.
+                # The first rerun is the warden's to make; a failure on a later
+                # attempt cannot be explained by the missing tag and retrying
+                # it would only hide a broken install path.
+                run = state.promotion_checks_run
+                if run is not None and run.attempt == 1:
+                    return Action(
+                        "kick-promotion",
+                        f"the {promote.release_tag} tag exists, rerunning the failed "
+                        f"promotion checks: {', '.join(blocking)}",
+                        promote.number,
+                        {"run_id": str(run.id)},
+                    )
+                return Action(
+                    "alert",
+                    f"promotion checks failed although the {promote.release_tag} tag "
+                    f"exists: {', '.join(blocking)}",
+                    promote.number,
+                )
             return Action(
                 "wait",
                 f"promotion is waiting for the {promote.release_tag} tag or a green run: "
@@ -234,7 +271,47 @@ def observe() -> ReleaseState:
         elif PROMOTE_BRANCH.match(pull.branch):
             promote_pr = pull
 
-    return ReleaseState(latest, catalog_ref, stage_pr, promote_pr)
+    marketplace_tag_exists = False
+    promotion_checks_run = None
+    if promote_pr is not None and promote_pr.release_tag:
+        probe = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{MARKETPLACE}/git/ref/tags/{promote_pr.release_tag}",
+                "--silent",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        marketplace_tag_exists = probe.returncode == 0
+        runs = gh_json(
+            [
+                "run",
+                "list",
+                "--repo",
+                MARKETPLACE,
+                "--branch",
+                promote_pr.branch,
+                "--limit",
+                "1",
+                "--json",
+                "databaseId,attempt",
+            ]
+        )
+        if runs:
+            promotion_checks_run = WorkflowRun(
+                id=runs[0]["databaseId"], attempt=runs[0].get("attempt") or 1
+            )
+
+    return ReleaseState(
+        latest,
+        catalog_ref,
+        stage_pr,
+        promote_pr,
+        marketplace_tag_exists=marketplace_tag_exists,
+        promotion_checks_run=promotion_checks_run,
+    )
 
 
 def apply(action: Action, *, dry_run: bool) -> None:
@@ -278,6 +355,19 @@ def apply(action: Action, *, dry_run: bool) -> None:
     elif action.kind == "merge-promote":
         subprocess.run(
             ["gh", "pr", "merge", str(action.pull_request), "--repo", MARKETPLACE, "--merge"],
+            check=True,
+        )
+    elif action.kind == "kick-promotion":
+        subprocess.run(
+            [
+                "gh",
+                "run",
+                "rerun",
+                action.context["run_id"],
+                "--failed",
+                "--repo",
+                MARKETPLACE,
+            ],
             check=True,
         )
 

--- a/scripts/ci/release-warden.py
+++ b/scripts/ci/release-warden.py
@@ -51,12 +51,16 @@ PENDING_STATES = {"PENDING", "QUEUED", "IN_PROGRESS", "WAITING", "REQUESTED", No
 PASSING_CONCLUSIONS = {"SUCCESS", "NEUTRAL", "SKIPPED"}
 
 
+PROMOTION_WORKFLOW = "verify.yml"
+
+
 @dataclass(frozen=True)
 class PullRequest:
     number: int
     branch: str
     files: tuple[str, ...]
     checks: tuple[tuple[str, str | None, str | None], ...]  # name, status, conclusion
+    head_sha: str | None = None
 
     @property
     def release_tag(self) -> str | None:
@@ -178,6 +182,26 @@ def decide(state: ReleaseState) -> Action:
     return Action("alert", f"release is stalled with no open pull request; {detail_suffix}")
 
 
+def select_promotion_run(runs: Sequence[dict], head_sha: str | None) -> WorkflowRun | None:
+    """Pick the run whose failed checks the promotion is actually blocked on.
+
+    A bare branch listing carries runs of every workflow and every pushed
+    commit, newest first. Kicking whatever sits at index zero could rerun an
+    unrelated workflow, and reading its attempt count could fake the
+    second-attempt failure that turns a kick into an alert. The blocking
+    checks belong to the pull_request run at the pull request's head, so only
+    that run is safe to select — and none at all is an answer, not an excuse
+    to guess.
+    """
+    for run in runs or []:
+        if run.get("event") != "pull_request":
+            continue
+        if head_sha and run.get("headSha") != head_sha:
+            continue
+        return WorkflowRun(id=run["databaseId"], attempt=run.get("attempt") or 1)
+    return None
+
+
 def latest_servable_release(releases: Sequence[dict]) -> str | None:
     """The newest release that is meant to reach consumers.
 
@@ -215,6 +239,7 @@ def load_pull_request(entry: dict) -> PullRequest:
         branch=entry["headRefName"],
         files=tuple(item["path"] for item in entry.get("files") or []),
         checks=checks,
+        head_sha=entry.get("headRefOid"),
     )
 
 
@@ -259,7 +284,7 @@ def observe() -> ReleaseState:
             "--state",
             "open",
             "--json",
-            "number,headRefName,files,statusCheckRollup",
+            "number,headRefName,headRefOid,files,statusCheckRollup",
         ]
     )
     stage_pr = None
@@ -291,18 +316,17 @@ def observe() -> ReleaseState:
                 "list",
                 "--repo",
                 MARKETPLACE,
+                "--workflow",
+                PROMOTION_WORKFLOW,
                 "--branch",
                 promote_pr.branch,
                 "--limit",
-                "1",
+                "10",
                 "--json",
-                "databaseId,attempt",
+                "databaseId,attempt,event,headSha",
             ]
         )
-        if runs:
-            promotion_checks_run = WorkflowRun(
-                id=runs[0]["databaseId"], attempt=runs[0].get("attempt") or 1
-            )
+        promotion_checks_run = select_promotion_run(runs or [], promote_pr.head_sha)
 
     return ReleaseState(
         latest,

--- a/tests/ci/test_release_warden.py
+++ b/tests/ci/test_release_warden.py
@@ -93,6 +93,79 @@ class ReleaseWardenTests(unittest.TestCase):
         self.assertEqual(action.kind, "wait")
         self.assertIn("v0.9.2", action.detail)
 
+    def test_a_failed_promotion_is_kicked_once_the_tag_exists(self) -> None:
+        """Pushing the tag re-triggers nothing by itself.
+
+        The install checks failed before the tag existed, and GitHub does not
+        re-run a pull request's checks on a tag push. Without this action the
+        release stalls right after the human does their part, until someone
+        reruns the failed run by hand — the one manual step the runbook still
+        carried.
+        """
+        promote = self.pull(
+            "codex/promote-v0.9.2-1",
+            checks=(("consumer-fresh-install", "COMPLETED", "FAILURE"),),
+        )
+
+        action = self.module.decide(
+            self.module.ReleaseState(
+                "v0.9.2",
+                "v0.9.1",
+                promote_pr=promote,
+                marketplace_tag_exists=True,
+                promotion_checks_run=self.module.WorkflowRun(id=42, attempt=1),
+            )
+        )
+
+        self.assertEqual(action.kind, "kick-promotion")
+        self.assertEqual(action.pull_request, 7)
+        self.assertEqual(action.context["run_id"], "42")
+
+    def test_a_promotion_that_failed_after_the_kick_is_an_alert_not_a_loop(self) -> None:
+        """A second failure with the tag published is a real defect.
+
+        The first failure is expected — the checks ran before the tag. A rerun
+        that fails again cannot be explained by the missing tag, so kicking it
+        every scheduled run would just hide a broken install path behind
+        retries.
+        """
+        promote = self.pull(
+            "codex/promote-v0.9.2-1",
+            checks=(("consumer-fresh-install", "COMPLETED", "FAILURE"),),
+        )
+
+        action = self.module.decide(
+            self.module.ReleaseState(
+                "v0.9.2",
+                "v0.9.1",
+                promote_pr=promote,
+                marketplace_tag_exists=True,
+                promotion_checks_run=self.module.WorkflowRun(id=42, attempt=2),
+            )
+        )
+
+        self.assertEqual(action.kind, "alert")
+        self.assertIn("tag", action.detail)
+
+    def test_a_pending_promotion_run_is_not_kicked(self) -> None:
+        """A rerun of an in-flight run would cancel the very evidence awaited."""
+        promote = self.pull(
+            "codex/promote-v0.9.2-1",
+            checks=(("consumer-fresh-install", "IN_PROGRESS", None),),
+        )
+
+        action = self.module.decide(
+            self.module.ReleaseState(
+                "v0.9.2",
+                "v0.9.1",
+                promote_pr=promote,
+                marketplace_tag_exists=True,
+                promotion_checks_run=self.module.WorkflowRun(id=42, attempt=1),
+            )
+        )
+
+        self.assertEqual(action.kind, "wait")
+
     def test_a_green_promotion_publishes_the_release(self) -> None:
         promote = self.pull("codex/promote-v0.9.2-1", checks=self.green())
 

--- a/tests/ci/test_release_warden.py
+++ b/tests/ci/test_release_warden.py
@@ -166,6 +166,48 @@ class ReleaseWardenTests(unittest.TestCase):
 
         self.assertEqual(action.kind, "wait")
 
+    def test_the_promotion_run_is_selected_by_event_and_head_sha(self) -> None:
+        """The branch also carries runs of other workflows and other commits.
+
+        `runs[0]` of a bare branch listing can be a newer unrelated run; kicking
+        it would rerun someone else's jobs, and its attempt count would fake a
+        second-attempt failure. The blocking checks belong to the pull_request
+        run at the PR head, so that is the only run worth selecting.
+        """
+        runs = [
+            {"databaseId": 99, "attempt": 3, "event": "push", "headSha": "aaa"},
+            {"databaseId": 42, "attempt": 1, "event": "pull_request", "headSha": "abc"},
+        ]
+
+        selected = self.module.select_promotion_run(runs, "abc")
+
+        self.assertEqual(selected, self.module.WorkflowRun(id=42, attempt=1))
+
+    def test_an_unidentifiable_promotion_run_is_not_kicked(self) -> None:
+        """No matching run means nothing safe to rerun — surface it instead."""
+        self.assertIsNone(
+            self.module.select_promotion_run(
+                [{"databaseId": 99, "attempt": 1, "event": "pull_request", "headSha": "zzz"}],
+                "abc",
+            )
+        )
+
+        promote = self.pull(
+            "codex/promote-v0.9.2-1",
+            checks=(("consumer-fresh-install", "COMPLETED", "FAILURE"),),
+        )
+        action = self.module.decide(
+            self.module.ReleaseState(
+                "v0.9.2",
+                "v0.9.1",
+                promote_pr=promote,
+                marketplace_tag_exists=True,
+                promotion_checks_run=None,
+            )
+        )
+
+        self.assertEqual(action.kind, "alert")
+
     def test_a_green_promotion_publishes_the_release(self) -> None:
         promote = self.pull("codex/promote-v0.9.2-1", checks=self.green())
 


### PR DESCRIPTION
## Что меняется

После пуша тега маркетплейса релиз застревал: пуш тега не перетриггеривает
чеки промоушен-PR, упавшие до тега чеки остаются красными сами по себе, а
warden умел только ждать «зелёного прогона», который без ручного
`gh run rerun --failed` не наступит. Runbook нёс этот ручной шаг в таблице
отказов; v0.12.0 упёрся ровно в него.

Warden теперь при красном промоушене проверяет существование тега:

- тег есть и первая попытка прогона упала → `kick-promotion`, перезапуск
  упавших джоб;
- тег есть, но упала уже повторная попытка → `alert`: это настоящий дефект
  пути установки, а не следствие отсутствующего тега, и ретраить его —
  значит прятать;
- прогон ещё идёт → по-прежнему `wait`: перезапуск отменил бы то самое
  свидетельство, которого ждём.

Человеческий гейт не ослаблен: без тега поведение не изменилось, мёрж
по-прежнему только по зелёному.

## Проверка

```sh
python -m unittest tests.ci.test_release_warden
python -m unittest discover -s tests/ci
python scripts/ci/check-architecture-sync.py --base origin/main --strict
git diff --check
```

- `test_release_warden`: 16 passed (3 новых — kick по тегу, alert на второй
  попытке, отсутствие kick при pending; все падали до реализации).
- Полный `tests/ci`: 778 passed, 3 skipped.
- Runbook обновлён: ручной rerun стал необязательным ускорением.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release promotion checks automatically retry once after the marketplace tag becomes available.
  * A second failed promotion check triggers an alert instead of repeated retries.
  * In-progress checks remain pending, and matching promotion runs are selected automatically.

* **Documentation**
  * Updated release guidance to explain automatic retries, temporary failures, and optional manual reruns.

* **Tests**
  * Added coverage for retries, repeated-failure alerts, pending checks, and promotion run selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->