### PR TITLE
test(ci): два файла решений с одним номером ADR валят guardrail

### DIFF
--- a/tests/ci/test_architecture_registry.py
+++ b/tests/ci/test_architecture_registry.py
@@ -630,13 +630,78 @@ def ci_invocations() -> str:
     return "\n".join(blobs)
 
 
-def decision_numbers_on_disk() -> set[str]:
-    numbers = set()
-    for path in DECISIONS_DIR.glob("*.md"):
+def relative_to_repo(path: Path) -> str:
+    """Render a path the way a reader will look it up.
+
+    Fixture catalogues live outside the repository, so their claimants are
+    reported by absolute path rather than not at all.
+    """
+    if path.is_relative_to(REPO_ROOT):
+        return path.relative_to(REPO_ROOT).as_posix()
+    return path.as_posix()
+
+
+def decision_number_claims(directory: Path = DECISIONS_DIR) -> dict[str, list[Path]]:
+    """Which decision files claim each ADR number, in file-name order.
+
+    The claims stay a list on purpose. `ADR-NNNN` is the stable identity a
+    reader cites, so two files sharing a number are two records claiming one
+    identity — and a scan that collapses file names into a set of numbers
+    cannot represent that collision, let alone report it.
+    """
+    claims: dict[str, list[Path]] = {}
+    for path in sorted(directory.glob("*.md")):
         match = ADR_FILE.match(path.name)
         if match:
-            numbers.add(match.group("number"))
-    return numbers
+            claims.setdefault(match.group("number"), []).append(path)
+    return claims
+
+
+def decision_numbers_on_disk(directory: Path = DECISIONS_DIR) -> set[str]:
+    return set(decision_number_claims(directory))
+
+
+def indexed_decision_claims(index: Path = DECISIONS_INDEX) -> dict[str, set[str]]:
+    """Which decision file names the index links, keyed by claimed number."""
+    claims: dict[str, set[str]] = {}
+    for target in MARKDOWN_LINK.findall(index.read_text(encoding="utf-8")):
+        match = ADR_FILE.match(Path(target).name)
+        if match:
+            claims.setdefault(match.group("number"), set()).add(Path(target).name)
+    return claims
+
+
+def decision_catalogue_offenders(
+    directory: Path = DECISIONS_DIR, index: Path = DECISIONS_INDEX
+) -> list[str]:
+    """Everything wrong with the identity bookkeeping of the decision catalogue."""
+    disk_claims = decision_number_claims(directory)
+    index_claims = indexed_decision_claims(index)
+    offenders: list[str] = []
+    # Uniqueness is proven on the raw claims, before the set conversion below:
+    # a set of numbers is exactly the representation under which two 0056
+    # files looked like one record and the collision passed CI silently.
+    for number, paths in sorted(disk_claims.items()):
+        if len(paths) > 1:
+            offenders.append(
+                f"ADR-{number} is claimed by {len(paths)} records: "
+                + ", ".join(relative_to_repo(path) for path in paths)
+            )
+    for number, names in sorted(index_claims.items()):
+        if len(names) > 1:
+            offenders.append(
+                f"{relative_to_repo(index)} links ADR-{number} as "
+                f"{len(names)} different files: " + ", ".join(sorted(names))
+            )
+    linked = set(index_claims)
+    on_disk = set(disk_claims)
+    for number in sorted(on_disk - linked):
+        offenders.append(f"{relative_to_repo(index)} does not link ADR-{number}")
+    for number in sorted(linked - on_disk):
+        offenders.append(
+            f"{relative_to_repo(index)} links ADR-{number} which has no file on disk"
+        )
+    return offenders
 
 
 class RegistryFormatTests(unittest.TestCase):
@@ -1476,17 +1541,11 @@ class LogicalSourceContractTests(unittest.TestCase):
 
 class IndexSynchronizationTests(unittest.TestCase):
     def test_decision_index_lists_exactly_the_records_on_disk(self) -> None:
-        index_text = DECISIONS_INDEX.read_text(encoding="utf-8")
-        linked = {
-            match.group("number")
-            for target in MARKDOWN_LINK.findall(index_text)
-            for match in [ADR_FILE.match(Path(target).name)]
-            if match
-        }
         self.assertEqual(
-            linked,
-            decision_numbers_on_disk(),
-            "spec/decisions/README.md must link every decision record and nothing else",
+            decision_catalogue_offenders(),
+            [],
+            "spec/decisions/README.md must link every decision record and "
+            "nothing else, and one number must name exactly one record",
         )
 
     def test_no_architecture_document_enumerates_the_decision_records(self) -> None:
@@ -1511,6 +1570,75 @@ class IndexSynchronizationTests(unittest.TestCase):
                     "cite by ID and leave the list to spec/decisions/README.md"
                 )
         self.assertEqual(offenders, [])
+
+
+class DecisionNumberCollisionTests(unittest.TestCase):
+    """Two records claiming one ADR number must fail, naming both claimants.
+
+    While a branch was being updated from main, two `0056-*.md` files with
+    different decisions coexisted, both were linked from the index, and the
+    guardrail stayed silent: each scan collapsed file names into a set of
+    numbers before comparing, and a set cannot hold the same number twice.
+    Uniqueness therefore has to be proven on the raw claims, before any set
+    conversion.
+    """
+
+    def write_catalogue(
+        self, directory: Path, files: list[str], links: list[str]
+    ) -> Path:
+        for name in files:
+            (directory / name).write_text(f"# {name}\n", encoding="utf-8")
+        index = directory / "README.md"
+        index.write_text(
+            "# Реестр решений\n\n"
+            + "".join(f"- [{name}]({name})\n" for name in links),
+            encoding="utf-8",
+        )
+        return index
+
+    def test_two_files_claiming_one_number_are_reported_with_both_paths(self) -> None:
+        first = "0056-observable-code-search.md"
+        second = "0056-terminal-runtime-receipt.md"
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            index = self.write_catalogue(directory, [first, second], [first, second])
+            offenders = decision_catalogue_offenders(directory, index)
+            self.assertTrue(
+                offenders,
+                "a catalogue with two 0056 records passed the guardrail silently",
+            )
+            rendered = "\n".join(offenders)
+            self.assertIn("ADR-0056", rendered)
+            self.assertIn((directory / first).as_posix(), rendered)
+            self.assertIn((directory / second).as_posix(), rendered)
+
+    def test_index_linking_one_number_as_two_files_names_both_targets(self) -> None:
+        present = "0056-observable-code-search.md"
+        phantom = "0056-terminal-runtime-receipt.md"
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            index = self.write_catalogue(directory, [present], [present, phantom])
+            offenders = decision_catalogue_offenders(directory, index)
+            self.assertTrue(
+                offenders,
+                "an index claiming ADR-0056 with two file names passed silently",
+            )
+            rendered = "\n".join(offenders)
+            self.assertIn("ADR-0056", rendered)
+            self.assertIn(present, rendered)
+            self.assertIn(phantom, rendered)
+
+    def test_honest_catalogue_reports_nothing(self) -> None:
+        first = "0055-smoke-checks-packaged-runtime.md"
+        second = "0056-observable-code-search.md"
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            # The same file linked twice is a wording question for the index,
+            # not an identity collision: one number still names one record.
+            index = self.write_catalogue(
+                directory, [first, second], [first, second, second]
+            )
+            self.assertEqual(decision_catalogue_offenders(directory, index), [])
 
 
 class RuntimeArtifactFlowContractTests(unittest.TestCase):


### PR DESCRIPTION
## Что меняется

Guardrail каталога решений (`tests/ci/test_architecture_registry.py`) сводил имена файлов к `set` номеров до сравнения индекса с диском, поэтому два файла `0056-*.md`, претендующие на один устойчивый ADR-ID, проходили CI молча — ровно так коллизия ADR-0056 пережила обновление PR #483 от main. Теперь `decision_catalogue_offenders()` проверяет уникальность номеров на сырых списках претендентов — и на диске, и среди целей ссылок `spec/decisions/README.md` — до какого-либо преобразования к `set`, а диагностика называет все конфликтующие пути. Fixture-тесты `DecisionNumberCollisionTests` воспроизводят коллизию и закрепляют, что честный каталог остаётся зелёным.

Closes #493

Фаза 0 плана #517.

## Архитектурный слой

- Затронутые записи реестра: `INV-DOC-INDEX-SYNC` — усилена реализация его проверки; поле `Rule` не меняется, потому что правило «каждая перечисленная запись существует на диске» уже подразумевает, что номер называет ровно одну запись.
- Решение (ADR), если публичный или архитектурный контракт меняется: нет — контракт не меняется, изменение целиком в CI-тесте.

- [x] Пройден [чек-лист изменений](../spec/architecture/change-checklist.md)
      в части, относящейся к этому изменению (затронут только CI-guardrail;
      поверхность `unica.*`, кеш, упаковка и границы слоёв не затронуты).

## Проверка

Строгий TDD. Сначала логика текущего guardrail извлечена в `decision_catalogue_offenders()` без изменения поведения, и новые тесты запущены на дырявой версии — оба красные именно по причине дефекта (проверка вернула пустой список нарушений для каталога с двумя файлами `0056-*.md`, оба перечислены в индексе):

```text
FAIL: test_index_linking_one_number_as_two_files_names_both_targets
AssertionError: [] is not true : an index claiming ADR-0056 with two file names passed silently

FAIL: test_two_files_claiming_one_number_are_reported_with_both_paths
AssertionError: [] is not true : a catalogue with two 0056 records passed the guardrail silently

Ran 60 tests ... FAILED (failures=2)
```

После добавления проверки уникальности коллизия падает с диагностикой, называющей оба пути. Так выглядит падение на реальном каталоге со вторым файлом `0056-*` (временный файл создавался только для демонстрации и удалён):

```text
FAIL: test_decision_index_lists_exactly_the_records_on_disk
AssertionError: Lists differ:
- ['ADR-0056 is claimed by 2 records: '
-  'spec/decisions/0056-observable-provider-neutral-code-search.md, '
-  'spec/decisions/0056-vremennyy-dublikat-dlya-demonstracii.md']
+ [] : spec/decisions/README.md must link every decision record and nothing else, and one number must name exactly one record
```

Заметьте: этот дубликат даже не был перечислен в индексе — старая логика пропускала и такой случай, потому что множество номеров на диске не менялось.

Полный прогон `tests/ci` на требуемом интерпретаторе (Python 3.12.13, `/opt/homebrew/bin/python3.12`; pytest поднят через `uv run --with pytest --with lxml --with pyyaml`, так как в homebrew-окружении pytest не установлен):

```text
$ python -m pytest tests/ci/ -x -q
780 passed, 3 skipped, 6435 subtests passed in 197.39s (0:03:17)
```

- [x] Новое поведение покрыто тестом, который можно назвать по имени:
      `DecisionNumberCollisionTests.test_two_files_claiming_one_number_are_reported_with_both_paths`,
      `DecisionNumberCollisionTests.test_index_linking_one_number_as_two_files_names_both_targets`,
      `DecisionNumberCollisionTests.test_honest_catalogue_reports_nothing`.
- [x] Документация, описывающая изменённое поведение, обновлена в этом же PR —
      обновлять нечего: нормативный текст (`INV-DOC-INDEX-SYNC`, правила
      именования в `AGENTS.md`) уже требует уникальные номера, менялась только
      сила проверки.
