### PR TITLE
test(mcp): событийная проверка общего grace в EOF-уборке вместо wall-clock-замера

### DIFF
--- a/crates/unica-coder/src/interfaces/mcp.rs
+++ b/crates/unica-coder/src/interfaces/mcp.rs
@@ -2034,12 +2034,16 @@ mod tests {
 
     #[test]
     fn eof_cleanup_shares_one_aggregate_grace_between_calls_and_provider_workers() {
-        // The call is released by a channel rather than by a sleep, and the
-        // budget is compared against the *measured* time the call stayed
-        // tracked. A loaded runner moves both sides of that comparison
-        // together, so the aggregate grace only has to outlast the test, not
-        // the scheduler.
-        const AGGREGATE_GRACE: Duration = Duration::from_secs(30);
+        // The tracked call outlives the whole grace: its release is only
+        // published after the drain has returned, so the call phase provably
+        // consumes the entire aggregate budget and provider cleanup must be
+        // handed exactly the remainder — zero. A drain that granted provider
+        // cleanup a fresh grace would hand over the full `AGGREGATE_GRACE`
+        // instead. Every assertion below rests on event ordering alone
+        // (channels and thread joins), never on wall-clock measurements, so
+        // scheduler delays on a loaded runner stretch the test but can never
+        // flip a comparison.
+        const AGGREGATE_GRACE: Duration = Duration::from_millis(200);
 
         let registry = Arc::new(InFlightRegistry::default());
         let guard = registry.admit().unwrap();
@@ -2065,32 +2069,34 @@ mod tests {
             (drained, provider_budget)
         });
 
-        // Cancellation only reaches the call from inside the drain, so the
-        // deadline was already running when this arrives: everything measured
-        // from here is budget the call spent before provider cleanup starts.
+        // Liveness handshake, deliberately not bounded by the grace: it only
+        // proves the drain cancelled the tracked call, so the zero remainder
+        // below is the shared deadline at work and not an idle registry.
         cancelled_rx
-            .recv_timeout(AGGREGATE_GRACE)
-            .expect("cancellation did not reach the tracked call within the aggregate grace");
-        let held_since = Instant::now();
-        std::thread::sleep(Duration::from_millis(20));
-        // Sampled *before* the release is published, so `held` is a strict
-        // sub-interval of what the drain observes. Sampling after the send
-        // charges this thread's own scheduling delay to `held` while the drain
-        // never sees it, and a loaded runner then inverts the comparison.
-        let held = held_since.elapsed();
-        release_tx.send(()).unwrap();
+            .recv_timeout(4 * TEST_STEP)
+            .expect("cancellation did not reach the tracked call");
 
+        // Joining before the release is the point of the test: the call is
+        // still tracked for the drain's whole lifetime, purely by ordering.
         let (drained, provider_budget) = drain_thread.join().unwrap();
         assert!(
-            drained,
-            "the drain gave up while the call was still tracked"
+            !drained,
+            "the drain reported success while the call was still tracked"
         );
-        assert!(
-            provider_budget.unwrap() <= AGGREGATE_GRACE.saturating_sub(held),
+        assert_eq!(
+            provider_budget,
+            Some(Duration::ZERO),
             "provider cleanup received a fresh grace instead of the aggregate remainder"
         );
 
+        // The call still cleans up after the grace expired; the registry must
+        // come back to idle once the release is published.
+        release_tx.send(()).unwrap();
         guard_thread.join().unwrap();
+        assert!(
+            registry.wait_idle(Duration::ZERO),
+            "the released call did not leave the in-flight registry"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #513
Фаза 0 плана #517

## Корневая причина

`eof_cleanup_shares_one_aggregate_grace_between_calls_and_provider_workers` сравнивал бюджет провайдерской уборки, снятый внутри drain, с независимым wall-clock-замером вокруг `sleep(20ms)` в другом потоке. Сравнение корректно, только пока замеренный интервал остаётся строгим под-интервалом интервала, наблюдаемого drain-ом. Вытеснение основного потока между `release_tx.send(())` и `held.elapsed()` записывает задержку планировщика в `held`, drain её не видит — и неравенство инвертируется. Именно это сделал загруженный `windows-latest` (run 31906010756 на #469).

## Выбранный вариант: №1 (событийная синхронизация), доведённый до конца

Из трёх направлений issue выбран первый — и в форме, где в утверждениях вообще нет измеренных длительностей:

- сценарий перевёрнут: отслеживаемый вызов переживает весь grace — освобождение публикуется только после `join` drain-потока, поэтому фаза вызова доказуемо съедает весь общий бюджет;
- следствие: провайдерская уборка обязана получить ровно `Duration::ZERO` — остаток общего дедлайна. Drain со «свежим grace» отдал бы полный `AGGREGATE_GRACE`, и `assert_eq` ловит это точным сравнением, без epsilon;
- `!drained` фиксирует, что drain не рапортует успех, пока вызов отслеживается; финальный `wait_idle(Duration::ZERO)` — что после освобождения реестр опустел.

Все утверждения держатся только на порядке событий (каналы и join) и точных значениях. Единственная граница по времени — liveness-таймаут 40 с на доставку cancellation; он ограничивает зависание, а не участвует в измерении. Нагрузка может растянуть тест, но не может перевернуть ни одно сравнение: зависимость от планировщика устранена, а не спрятана за допуском — поэтому не вариант №2; вариант №3 (ретрай джобы) — страховка уровня CI, не замена исправлению.

Замер «по букве» варианта №1 (сравнивать бюджет с моментом фактического освобождения) всё равно оставил бы арифметику на `Instant`-ах, снятых в разных потоках; нулевой остаток убирает и её.

Покрытие позитивного пути не потеряно: `eof_cancels_active_calls_within_a_bounded_grace` уже доказывает `drained == true` для кооперативного вызова, а `eof_cleanup_drains_noncooperative_diagnostic_worker_within_the_same_grace` — что провайдеры успевают убраться в остаток. Уникальное свойство этого теста — «остаток общий, а не свежий» — теперь проверяется в самой сильной форме.

## Красное состояние (TDD)

**1. Дефект старой формы показан детерминированно.** Честное воспроизведение под нагрузкой на macOS не выстрелило: ~10 800 итераций до-#511 порядка замера (нагрузка 28 и 84 спиннера на 14 ядрах, тестовый процесс под `nice -n 19`) — ноль падений: хвост задержек планировщика XNU короче виндового. Поэтому гоночная точка показана инъекцией вытеснения: `sleep(30ms)` между `send` и `elapsed()` — ровно та задержка, которую на загруженном раннере вставляет планировщик, — валит старую проверку каждый раз с тем же сообщением, что в CI (номера строк — из scratch-состояния):

```text
panicked at crates/unica-coder/src/interfaces/mcp.rs:2087:
provider cleanup received a fresh grace instead of the aggregate remainder
(iteration 0, budget 29.966390625s, allowance 29.941790333s, held 58.209667ms)
```

**2. Новый тест ловит охраняемые дефекты (мутации продукта, обе откатаны).**

`drain_providers(grace)` — свежий grace провайдерам:

```text
assertion `left == right` failed: provider cleanup received a fresh grace instead of the aggregate remainder
  left: Some(200ms)
 right: Some(0ns)
```

`calls_idle = true` — drain не ждёт отслеживаемые вызовы:

```text
panicked at crates/unica-coder/src/interfaces/mcp.rs:2082:
the drain reported success while the call was still tracked
```

## Устойчивость (зелёное состояние)

- `cargo fmt --check` — чисто; `cargo clippy -p unica-coder --all-targets -- -D warnings` — чисто.
- Модуль целиком: `interfaces::mcp` — 30/30 под `--test-threads=1`.
- Цикл из задачи: 50 подряд `cargo test -p unica-coder eof_cleanup_shares_one_aggregate_grace -- --test-threads=1` — 50/50, из них 25 под фоновой нагрузкой 56 спиннеров на 14 ядрах (~4×).
- Дополнительно 150 прямых запусков тестового бинаря под той же нагрузкой при `nice -n 19` — 150/150.

Контекст: #511 попутно сузил окно (перенёс снятие `held` до `send`), но проверка осталась wall-clock-замером, чья корректность держалась на комментарии про строгий под-интервал и кросс-поточную монотонность `Instant`; issue оставался открытым. Эта правка убирает сам класс проверки, а не одно его проявление.
