### PR TITLE
research(mcp): переносимость Resources — вердикт и fixture (#336)

### DIFF
--- a/docs/design/2026-08-17-mcp-resources-portability-research.md
+++ b/docs/design/2026-08-17-mcp-resources-portability-research.md
@@ -1,0 +1,161 @@
+- Date: `2026-08-17`
+- Status: `draft`
+- Decision: `none` — research-записка по #336; изменение публичного контракта Resources оформляется отдельным решением после подтверждения рекомендации
+
+# Переносимость MCP Resources между Claude Code, Codex и Qwen Code (#336)
+
+## Итог в одну строку
+
+Fixed Resources переносимы как статичная необязательная справка (автономное
+обнаружение и чтение работают на Claude Code по обоим транспортам), но
+resource templates как примитив и динамический каталог (`list_changed`)
+непереносимы, а большой ресурс читается целиком без экономии контекста —
+поэтому рекомендация из трёх исходов постановки: **использовать только
+фиксированные Resources**, малым статичным каталогом, не вынося из
+`inputSchema` ничего invocation-critical.
+
+## Методика
+
+Fixture — логирующий MCP-сервер
+[`scripts/dev/mcp-resources-probe-server.py`](../../scripts/dev/mcp-resources-probe-server.py):
+stdio и Streamable HTTP (`FIXTURE_MODE=http`, `POST/GET /mcp`, SSE для
+server→client уведомлений, `Mcp-Session-Id`), JSONL-журнал каждого кадра
+(`FIXTURE_LOG`). Публикует:
+
+- fixed: `unica://meta/contracts/Catalog` (application/json, маркер
+  `CATALOG-MARKER-7A41`, кодовое слово АКВАМАРИН), `.../guide`
+  (text/markdown, содержит текстовую подсказку «для каждого вида есть
+  `unica://meta/contracts/<Kind>`»), `.../big` (242 744 байта, 512 маркеров
+  `BIGMARK-93F1`);
+- resource template `unica://meta/contracts/{kind}` — чтение любого
+  template-URI отвечает генерированным контрактом с маркером
+  `TEMPLATE-<kind>-MARKER-E1F0`;
+- инструмент `unica_add_contract {kind}` — добавляет fixed-ресурс и шлёт
+  `notifications/resources/list_changed`.
+
+Самотест raw-клиентом пройден по обоим транспортам до хостовых прогонов
+(list/read/templates/чтение template-URI/tool+`list_changed`, по SSE в HTTP).
+
+Запуск сценариев (каждый — свежий процесс сервера и свой журнал):
+
+```bash
+claude -p "<промпт>" --mcp-config mcp.json --strict-mcp-config \
+  --dangerously-skip-permissions --max-turns 8
+# stdio mcp.json: {"mcpServers":{"res336":{"command":"python3",
+#   "args":[".../mcp-resources-probe-server.py"],"env":{"FIXTURE_LOG":"<путь>.jsonl"}}}}
+# http mcp.json:  {"mcpServers":{"res336":{"type":"http","url":"http://127.0.0.1:8907/mcp"}}}
+
+/Applications/ChatGPT.app/Contents/Resources/codex exec --skip-git-repo-check \
+  -c 'approval_policy="never"' \
+  -c 'mcp_servers={"res336"={"command"="python3","args"=["...probe-server.py"],"env"={"FIXTURE_LOG"="..."}}}' "<промпт>"
+
+npx -y @qwen-code/qwen-code@latest -p "<промпт>"   # + .qwen/settings.json c mcpServers
+```
+
+Сценарии: S1/H1 — автономное обнаружение («не зная URI, найди контракт вида
+Catalog»); S2 — вид Document, которого нет в fixed-списке; S3/H3 — большой
+ресурс, пересчёт маркеров; S4/S4b/H4 — `unica_add_contract` и требование
+«заново получи список свежим вызовом листинга».
+
+## Таблица совместимости (прогоны 2026-08-17, macOS 26.5.2)
+
+| Возможность | Claude Code 2.1.220 stdio | Claude Code 2.1.220 Streamable HTTP | Codex 0.148.0-alpha.9 stdio | Qwen Code 0.21.13 |
+| --- | --- | --- | --- | --- |
+| `resources/list` при подключении | жадно, до хода модели | жадно | **не вызывается** (на connect только `tools/list`) | не измерено |
+| Автономное обнаружение (list → read без URI) | работает: маркер и кодовое слово процитированы | работает | не измерено (usage limit) | не измерено |
+| `resources/read` fixed URI | работает | работает | работает как model-visible операция (зонд матрицы 17.08) | не измерено |
+| `resources/templates/list` | **не вызывается никогда** (включая сценарий, где template был нужен) | не вызывается | работает как model-visible операция (зонд 17.08) | не измерено |
+| Чтение template-URI | работает по угаданному URI: модель вывела его из **содержимого** guide-ресурса, не из объявления template | аналогично | работает (зонд 17.08) | не измерено |
+| Большой ресурс 242 КБ | прочитан целиком, 512/512 маркеров, без усечения | прочитан целиком, 512/512 | не измерено | не измерено |
+| `notifications/resources/list_changed` | **инертен**: уведомление отправлено — повторного `resources/list` нет | **инертен при доказанной доставке**: клиент сам открыл GET SSE, уведомление доставлено (`sse-delivered`) — повторного list нет | не измерено | не измерено |
+| Свежий листинг по явной просьбе модели | **не доходит до сервера**: модель отчиталась «сделала свежий листинг», но кадра нет — хост отдаёт кеш снимка подключения | то же | не измерено | не измерено |
+| Транспорт | — | `MCP-Protocol-Version: 2025-11-25` на пост-init запросах; `Mcp-Session-Id` соблюдён; GET SSE открыт сразу после initialized | — | — |
+
+Ограничения прогона: Codex — model-side сценарии заблокированы usage limit
+аккаунта (до 2026-08-20 07:19; connect-поведение записано до отказа); Qwen —
+headless требует настроенного auth до старта MCP-клиентов («No auth type is
+selected»), MCP-кадров ноль; Qwen — только research-цель, официально не
+поддерживается (решение владельца 17.08.2026).
+
+## Вердикты
+
+- **Claude Code — partially supported**: fixed URI — supported (автономное
+  обнаружение, чтение, оба транспорта); resource templates — unsupported как
+  примитив (объявление не читается; доступ только по URI-конвенции,
+  выведенной из содержимого другого ресурса); динамический каталог —
+  unsupported (`list_changed` игнорируется, листинг модели заморожен на
+  снимке подключения даже при доставленном по SSE уведомлении).
+- **Codex — partially supported**: fixed list/read и templates/list доступны
+  как явные model-visible операции; жадного листинга нет; автономное
+  обнаружение и динамика не доказаны.
+- **Qwen Code — not measured**: auth-стена до старта MCP; по манифесту —
+  TS SDK `^1.30.0` (класс поведения TS-стека), runtime-проверка отложена.
+
+## Рекомендация для Unica
+
+Исход постановки — **«использовать только фиксированные Resources»**, с
+границами:
+
+1. Малый статичный плоский каталог, состав неизменен в течение сессии:
+   динамика невидима хостом (list_changed инертен, листинг кеширован).
+2. Большие корпуса не публиковать: чтение всегда полное, 242 КБ входят в
+   контекст целиком — Resources не экономят контекст (совпадает с допущением
+   #479).
+3. Resource templates контрактом не заявлять. Если нужен параметрический
+   доступ — только как документированная в содержимом фиксированного
+   «гида» URI-конвенция (измерено: модель строит URI из содержимого guide);
+   это degraded-режим, а не контракт — предпочтительный канал остаётся
+   инструментом.
+4. Граница данных: всё invocation-critical (аргументы, required, enum,
+   единицы) остаётся в `inputSchema`; в Resources — только необязательная
+   справка, отсутствие которой не меняет корректность вызова (`#479` E).
+5. Корректность `unica.*` от Resources не зависит ни при каком исходе.
+
+## Остаток исследования
+
+- Codex model-side: автономное обнаружение и list_changed — после
+  2026-08-20 либо квотой самого Codex.
+- Qwen Code runtime: нужен доступ (qwen.ai OAuth или OpenAI-совместимый
+  ключ); те же четыре сценария.
+- Packaged-путь плагина: после появления Resources в реализации Unica
+  (#490 их не вводит).
+- Вопрос 7 постановки (недоверенный workspace, OAuth): неприменим к
+  текущему deployment (локальный stdio); становится актуален только с
+  remote HTTP.
+
+## Приложение: ключевые wire-трейсы
+
+S4b, stdio (динамика; модели явно велено сделать свежий листинг):
+
+```text
+in  initialize / initialized / tools/list / resources/list   (3 ресурса, до хода модели)
+in  tools/call unica_add_contract{kind=Report}
+out notifications/resources/list_changed
+<повторного resources/list нет; ответ модели: «в свежем списке Report отсутствует»>
+```
+
+H4, Streamable HTTP (то же с доказанной доставкой):
+
+```text
+in  initialize / initialized ; note sse-open (GET, Mcp-Session-Id, MCP-Protocol-Version)
+in  tools/list / resources/list
+in  tools/call unica_add_contract
+out notifications/resources/list_changed  [sse-queued → sse-delivered]
+<повторного resources/list нет>
+```
+
+S2, stdio (template-вид без fixed-ресурса):
+
+```text
+in  resources/list
+in  resources/read unica://meta/contracts/guide      (модель ищет подсказку)
+in  resources/read unica://meta/contracts/Document   (URI построен из содержимого guide)
+<resources/templates/list не вызван ни разу ни в одном сценарии>
+```
+
+Codex C1, connect до usage-отказа:
+
+```text
+in  initialize (protocolVersion 2025-06-18) / notifications/initialized / tools/list
+<resources/list на подключении отсутствует>
+```

--- a/scripts/dev/mcp-resources-probe-server.py
+++ b/scripts/dev/mcp-resources-probe-server.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""#336 Resources portability fixture server.
+
+Modes:
+  FIXTURE_MODE=stdio (default) | http   (Streamable HTTP on FIXTURE_PORT, path /mcp)
+Env:
+  FIXTURE_LOG=<path.jsonl>   journal of every JSON-RPC frame (in/out) + notes
+  FIXTURE_PORT=8907
+  FIXTURE_AUTONOTIFY=1       add Report resource + send list_changed 1.5s after initialized
+
+Publishes:
+  fixed resources:
+    unica://meta/contracts/Catalog  application/json   marker CATALOG-MARKER-7A41
+    unica://meta/contracts/guide    text/markdown      marker GUIDE-MARKER-55C2
+    unica://meta/contracts/big      text/markdown      512x BIGMARK-93F1 (~208 KB)
+  resource template:
+    unica://meta/contracts/{kind}   -> generated JSON, marker TEMPLATE-<kind>-MARKER-E1F0
+  tool:
+    unica_add_contract {kind}       adds fixed resource for kind + notifications/resources/list_changed
+"""
+import json, os, sys, time, threading, queue
+
+LOG_PATH = os.environ.get("FIXTURE_LOG")
+MODE = os.environ.get("FIXTURE_MODE", "stdio")
+PORT = int(os.environ.get("FIXTURE_PORT", "8907"))
+AUTONOTIFY = os.environ.get("FIXTURE_AUTONOTIFY") == "1"
+
+log_lock = threading.Lock()
+
+def log(direction, message, **extra):
+    if not LOG_PATH:
+        return
+    rec = {"ts": round(time.time(), 3), "transport": MODE, "direction": direction, "message": message}
+    rec.update(extra)
+    with log_lock:
+        with open(LOG_PATH, "a") as f:
+            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+BIG_LINES = []
+for i in range(512):
+    BIG_LINES.append(f"- item {i:04d} BIGMARK-93F1 " + ("контрактное поле, тип, обязательность, ограничение значения; " * 4))
+BIG_TEXT = "# Большой справочный контракт\n\n" + "\n".join(BIG_LINES) + "\n"
+
+state_lock = threading.Lock()
+RESOURCES = {
+    "unica://meta/contracts/Catalog": {
+        "name": "contract-Catalog",
+        "title": "Контракт вида Catalog",
+        "mimeType": "application/json",
+        "text": json.dumps({
+            "kind": "Catalog", "marker": "CATALOG-MARKER-7A41",
+            "requiredProperties": ["Name", "Synonym"],
+            "note": "Порядок создания: сначала Name, затем Synonym; кодовое слово ответа: АКВАМАРИН"
+        }, ensure_ascii=False, indent=2),
+    },
+    "unica://meta/contracts/guide": {
+        "name": "contracts-guide",
+        "title": "Гид по контрактам метаданных",
+        "mimeType": "text/markdown",
+        "text": "# Гид\n\nGUIDE-MARKER-55C2\n\nДля каждого вида метаданных есть ресурс unica://meta/contracts/<Kind>.\n",
+    },
+    "unica://meta/contracts/big": {
+        "name": "contract-big",
+        "title": "Большой контракт",
+        "mimeType": "text/markdown",
+        "text": BIG_TEXT,
+    },
+}
+
+notify_queue = queue.Queue()  # http mode: queued server->client notifications
+
+def resource_list_entry(uri, r):
+    return {"uri": uri, "name": r["name"], "title": r.get("title"), "mimeType": r["mimeType"]}
+
+def make_notification(method, params=None):
+    n = {"jsonrpc": "2.0", "method": method}
+    if params is not None:
+        n["params"] = params
+    return n
+
+def add_contract(kind):
+    uri = f"unica://meta/contracts/{kind}"
+    with state_lock:
+        RESOURCES[uri] = {
+            "name": f"contract-{kind}",
+            "title": f"Контракт вида {kind}",
+            "mimeType": "application/json",
+            "text": json.dumps({"kind": kind, "marker": f"ADDED-{kind}-MARKER-D2E8"}, ensure_ascii=False),
+        }
+    return uri
+
+def handle(msg, send_notification):
+    """Returns response dict or None (for notifications)."""
+    method = msg.get("method")
+    msg_id = msg.get("id")
+    params = msg.get("params") or {}
+
+    def ok(result):
+        return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+
+    def err(code, message):
+        return {"jsonrpc": "2.0", "id": msg_id, "error": {"code": code, "message": message}}
+
+    if method == "initialize":
+        offered = params.get("protocolVersion") or "2025-11-25"
+        return ok({
+            "protocolVersion": offered,
+            "capabilities": {"resources": {"subscribe": False, "listChanged": True}, "tools": {}},
+            "serverInfo": {"name": "res336-fixture", "version": "1.0.0"},
+            "instructions": "Справочные контракты метаданных опубликованы как MCP Resources (unica://meta/contracts/...).",
+        })
+    if method == "notifications/initialized":
+        if AUTONOTIFY:
+            def later():
+                time.sleep(1.5)
+                add_contract("Report")
+                send_notification(make_notification("notifications/resources/list_changed"))
+            threading.Thread(target=later, daemon=True).start()
+        return None
+    if method == "ping":
+        return ok({})
+    if method == "tools/list":
+        return ok({"tools": [{
+            "name": "unica_add_contract",
+            "description": "Добавить справочный контракт вида метаданных как новый MCP-ресурс (после добавления сервер шлёт notifications/resources/list_changed).",
+            "inputSchema": {"type": "object", "properties": {"kind": {"type": "string", "description": "Вид метаданных, например Report"}}, "required": ["kind"]},
+        }]})
+    if method == "tools/call":
+        name = params.get("name")
+        if name == "unica_add_contract":
+            kind = (params.get("arguments") or {}).get("kind", "Report")
+            uri = add_contract(kind)
+            send_notification(make_notification("notifications/resources/list_changed"))
+            return ok({"content": [{"type": "text", "text": f"added {uri}"}], "isError": False})
+        return err(-32602, f"unknown tool {name}")
+    if method == "resources/list":
+        with state_lock:
+            entries = [resource_list_entry(u, r) for u, r in sorted(RESOURCES.items())]
+        return ok({"resources": entries})
+    if method == "resources/read":
+        uri = params.get("uri") or ""
+        with state_lock:
+            r = RESOURCES.get(uri)
+        if r:
+            return ok({"contents": [{"uri": uri, "mimeType": r["mimeType"], "text": r["text"]}]})
+        if uri.startswith("unica://meta/contracts/"):
+            kind = uri.rsplit("/", 1)[-1]
+            text = json.dumps({"kind": kind, "marker": f"TEMPLATE-{kind}-MARKER-E1F0",
+                               "requiredProperties": ["Name", "Synonym"]}, ensure_ascii=False, indent=2)
+            return ok({"contents": [{"uri": uri, "mimeType": "application/json", "text": text}]})
+        return err(-32002, f"resource not found: {uri}")
+    if method == "resources/templates/list":
+        return ok({"resourceTemplates": [{
+            "uriTemplate": "unica://meta/contracts/{kind}",
+            "name": "metadata-contract",
+            "title": "Контракт вида метаданных",
+            "mimeType": "application/json",
+            "description": "Справочный контракт создания вида метаданных: обязательные свойства и порядок операций.",
+        }]})
+    if method == "prompts/list":
+        return ok({"prompts": []})
+    if method and msg_id is not None:
+        return err(-32601, f"Method not found: {method}")
+    return None
+
+# ---------------- stdio ----------------
+
+def run_stdio():
+    out_lock = threading.Lock()
+
+    def send(obj):
+        log("out", obj)
+        with out_lock:
+            sys.stdout.write(json.dumps(obj, ensure_ascii=False) + "\n")
+            sys.stdout.flush()
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            log("note", {"unparsed": line[:200]})
+            continue
+        log("in", msg)
+        resp = handle(msg, send)
+        if resp is not None:
+            send(resp)
+    log("note", {"event": "eof"})
+
+# ---------------- Streamable HTTP ----------------
+
+def run_http():
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    session_id = "res336-" + hex(int(time.time()))[2:]
+    sse_clients = []
+    sse_lock = threading.Lock()
+
+    def send_notification(n):
+        log("out", n, channel="sse-queued")
+        with sse_lock:
+            for q in sse_clients:
+                q.put(n)
+
+    class H(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, *a):
+            pass
+
+        def _headers_subset(self):
+            keep = ("mcp-session-id", "mcp-protocol-version", "accept", "content-type", "last-event-id")
+            return {k: v for k, v in self.headers.items() if k.lower() in keep}
+
+        def do_POST(self):
+            if self.path.rstrip("/") != "/mcp":
+                self.send_response(404); self.end_headers(); return
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length)
+            try:
+                msg = json.loads(body)
+            except json.JSONDecodeError:
+                self.send_response(400); self.end_headers(); return
+            msgs = msg if isinstance(msg, list) else [msg]
+            responses = []
+            for m in msgs:
+                log("in", m, http=self._headers_subset())
+                r = handle(m, send_notification)
+                if r is not None:
+                    responses.append(r)
+            if not responses:
+                self.send_response(202)
+                self.send_header("Mcp-Session-Id", session_id)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+            out = responses[0] if len(responses) == 1 else responses
+            for r in responses:
+                log("out", r, channel="http-post")
+            data = json.dumps(out, ensure_ascii=False).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Mcp-Session-Id", session_id)
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def do_GET(self):
+            if self.path.rstrip("/") != "/mcp":
+                self.send_response(404); self.end_headers(); return
+            log("note", {"event": "sse-open", "http": self._headers_subset()})
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Mcp-Session-Id", session_id)
+            self.end_headers()
+            q = queue.Queue()
+            with sse_lock:
+                sse_clients.append(q)
+            try:
+                while True:
+                    try:
+                        n = q.get(timeout=15)
+                        payload = f"event: message\ndata: {json.dumps(n, ensure_ascii=False)}\n\n"
+                        self.wfile.write(payload.encode()); self.wfile.flush()
+                        log("out", n, channel="sse-delivered")
+                    except queue.Empty:
+                        self.wfile.write(b": keepalive\n\n"); self.wfile.flush()
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                log("note", {"event": "sse-closed"})
+            finally:
+                with sse_lock:
+                    if q in sse_clients:
+                        sse_clients.remove(q)
+
+        def do_DELETE(self):
+            log("note", {"event": "session-delete", "http": self._headers_subset()})
+            self.send_response(200)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+    srv = ThreadingHTTPServer(("127.0.0.1", PORT), H)
+    log("note", {"event": "http-listening", "port": PORT})
+    srv.serve_forever()
+
+if __name__ == "__main__":
+    if MODE == "http":
+        run_http()
+    else:
+        run_stdio()


### PR DESCRIPTION
## Что это

Research-записка по #336 и воспроизводимая fixture. Прогоны 17.08.2026: Claude Code 2.1.220 (stdio и Streamable HTTP, свежие журналы), Codex 0.148.0-alpha.9 (connect-кадры; model-side упёрся в usage limit до 20.08), Qwen Code 0.21.13 (auth-стена до старта MCP).

## Ключевые факты

- Автономное обнаружение fixed URI работает на обоих транспортах; 242 КБ прочитаны без усечения (контекст не экономится).
- `resources/templates/list` не вызывается никогда: template-URI модель строит из содержимого guide-ресурса — конвенция, не примитив.
- **`list_changed` инертен на обоих транспортах при доказанной доставке** (в HTTP клиент сам открыл SSE и получил уведомление): повторного `resources/list` нет, явная просьба о свежем листинге до сервера не доходит — каталог заморожен на снимке подключения.
- Codex на подключении не зовёт `resources/list` вовсе — жадный листинг оказался особенностью Claude Code.

## Рекомендация (внесена в #336)

Использовать **только фиксированные Resources**: малый статичный каталог, без больших корпусов, templates контрактом не заявлять, invocation-critical остаётся в `inputSchema`, корректность `unica.*` от Resources не зависит.

## Состав

- `docs/design/2026-08-17-mcp-resources-portability-research.md` — методика, таблица совместимости, вердикты, wire-трейсы (`tests.ci.test_design_documents` зелёный).
- `scripts/dev/mcp-resources-probe-server.py` — fixture: stdio + Streamable HTTP, JSONL-журнал, большой ресурс, template, инструмент-триггер `list_changed`.

Остаток исследования зафиксирован в #336 (Codex model-side после 20.08, Qwen при появлении доступа, @-подключение пользователем, packaged-путь после реализации).

Closes #336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added research documenting MCP Resources portability across Claude Code, Codex, and Qwen Code.
  - Included compatibility findings for fixed resources, resource templates, dynamic updates, stdio, and Streamable HTTP.
  - Documented recommended usage: keep optional resources small and static, while placing critical data in tool input schemas.

- **Testing**
  - Added a standalone MCP fixture server for validating resource listing, reading, templates, notifications, and transport behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->