### PR TITLE
fix(cfe.validate): семантика сервисов расширения — HTTPMethod сверяется с перечислением платформы (#540)

### DIFF
--- a/crates/unica-coder/src/infrastructure/native_operations/cfe.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/cfe.rs
@@ -4195,6 +4195,10 @@ pub(crate) fn validate_cfe(
             return cfe_validation_finish(report, resolved_path);
         }
         cfe_validate_typelinks(&mut report, &borrowed_forms);
+        if report.stopped {
+            return cfe_validation_finish(report, resolved_path);
+        }
+        cfe_validate_service_objects(&mut report, child_obj_node, config_dir);
 
         cfe_validation_finish(report, resolved_path)
     })();
@@ -4547,6 +4551,66 @@ pub(crate) fn cfe_validate_object_dirs(
         for missing_dir in missing {
             report.warn(format!("8. Missing directory: {missing_dir}"));
         }
+    }
+}
+
+// Check 14: semantics of service child objects (HTTPService, WebService) —
+// nested enum literals such as Method HTTPMethod are validated against the
+// 8.3.27 platform enums, whether the service is own or adopted. The platform
+// rejects the whole extension import on an invalid literal, so cfe.validate
+// must reject it too instead of reporting a clean extension.
+pub(crate) fn cfe_validate_service_objects(
+    report: &mut CfeValidationReporter,
+    child_obj_node: Option<roxmltree::Node<'_, '_>>,
+    config_dir: &Path,
+) {
+    let Some(child_obj_node) = child_obj_node else {
+        return;
+    };
+    let mut service_count = 0usize;
+    for child in child_obj_node.children().filter(|child| child.is_element()) {
+        let type_name = child.tag_name().name();
+        if !matches!(type_name, "HTTPService" | "WebService") {
+            continue;
+        }
+        let child_name = child.text().unwrap_or("");
+        let Some(dir_name) = cf_validate_child_type_dir(type_name) else {
+            continue;
+        };
+        let obj_file = config_dir.join(dir_name).join(format!("{child_name}.xml"));
+        let Ok(text) = read_utf8_sig(&obj_file) else {
+            continue;
+        };
+        let Ok(doc) = Document::parse(text.trim_start_matches('\u{feff}')) else {
+            continue;
+        };
+        let Some(obj_el) = doc.root_element().children().find(|node| node.is_element()) else {
+            continue;
+        };
+        let Some(semantics) =
+            service_child_semantics(type_name, meta_info_child(obj_el, "ChildObjects"))
+        else {
+            continue;
+        };
+        service_count += 1;
+        let context_label = format!("{type_name}.{child_name}");
+        for finding in &semantics.findings {
+            let message = format!("14. {context_label} {}", finding.detail);
+            if finding.error {
+                report.error(message);
+            } else {
+                report.warn(message);
+            }
+        }
+        if semantics.clean {
+            report.ok(format!("14. {context_label}: {}", semantics.summary));
+        }
+        if report.stopped {
+            return;
+        }
+    }
+    if service_count == 0 {
+        report.ok("14. Services: none found");
     }
 }
 
@@ -11610,6 +11674,176 @@ mod tests {
         assert!(
             order_xml.contains("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
             "{order_xml}"
+        );
+
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    // Fixture shape mirrors a real 8.3.27 / format-2.20 Designer dump of an
+    // extension that adds its own HTTPService (the PrintWebDAV applied case).
+    fn write_own_http_service_extension(context: &WorkspaceContext, methods: &[(&str, &str)]) {
+        let ext = context.cwd.join("ext");
+        write_file(
+            &ext.join("Configuration.xml"),
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:xr="http://v8.1c.ru/8.3/xcf/readable" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.20">
+	<Configuration uuid="00000000-0000-0000-0000-000000000014">
+		<InternalInfo>
+			<xr:ContainedObject>
+				<xr:ClassId>9cd510cd-abfc-11d4-9434-004095e12fc7</xr:ClassId>
+				<xr:ObjectId>00000000-0000-0000-0000-000000000017</xr:ObjectId>
+			</xr:ContainedObject>
+			<xr:ContainedObject>
+				<xr:ClassId>9fcd25a0-4822-11d4-9414-008048da11f9</xr:ClassId>
+				<xr:ObjectId>00000000-0000-0000-0000-000000000018</xr:ObjectId>
+			</xr:ContainedObject>
+			<xr:ContainedObject>
+				<xr:ClassId>e3687481-0a87-462c-a166-9f34594f9bba</xr:ClassId>
+				<xr:ObjectId>00000000-0000-0000-0000-000000000019</xr:ObjectId>
+			</xr:ContainedObject>
+			<xr:ContainedObject>
+				<xr:ClassId>9de14907-ec23-4a07-96f0-85521cb6b53b</xr:ClassId>
+				<xr:ObjectId>00000000-0000-0000-0000-00000000001a</xr:ObjectId>
+			</xr:ContainedObject>
+			<xr:ContainedObject>
+				<xr:ClassId>51f2d5d8-ea4d-4064-8892-82951750031e</xr:ClassId>
+				<xr:ObjectId>00000000-0000-0000-0000-00000000001b</xr:ObjectId>
+			</xr:ContainedObject>
+			<xr:ContainedObject>
+				<xr:ClassId>e68182ea-4237-4383-967f-90c1e3370bc7</xr:ClassId>
+				<xr:ObjectId>00000000-0000-0000-0000-00000000001c</xr:ObjectId>
+			</xr:ContainedObject>
+			<xr:ContainedObject>
+				<xr:ClassId>fb282519-d103-4dd3-bc12-cb271d631dfc</xr:ClassId>
+				<xr:ObjectId>00000000-0000-0000-0000-00000000001d</xr:ObjectId>
+			</xr:ContainedObject>
+		</InternalInfo>
+		<Properties>
+			<ObjectBelonging>Adopted</ObjectBelonging>
+			<Name>ПечатьWebDAV</Name>
+			<Comment/>
+			<ConfigurationExtensionPurpose>AddOn</ConfigurationExtensionPurpose>
+			<KeepMappingToExtendedConfigurationObjectsByIDs>true</KeepMappingToExtendedConfigurationObjectsByIDs>
+			<NamePrefix>ПВД_</NamePrefix>
+			<DefaultLanguage>Language.Русский</DefaultLanguage>
+		</Properties>
+		<ChildObjects>
+			<Language>Русский</Language>
+			<HTTPService>ПВД_ПечатныеФормы</HTTPService>
+		</ChildObjects>
+	</Configuration>
+</MetaDataObject>
+"#,
+        );
+        write_file(
+            &ext.join("Languages/Русский.xml"),
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" version="2.20">
+	<Language uuid="00000000-0000-0000-0000-000000000015">
+		<InternalInfo/>
+		<Properties>
+			<ObjectBelonging>Adopted</ObjectBelonging>
+			<Name>Русский</Name>
+			<Comment/>
+			<ExtendedConfigurationObject>0663bf5b-bcba-4a40-a862-a0b3baa2d884</ExtendedConfigurationObject>
+			<LanguageCode>ru</LanguageCode>
+		</Properties>
+	</Language>
+</MetaDataObject>
+"#,
+        );
+        let methods_xml = methods
+            .iter()
+            .enumerate()
+            .map(|(index, (name, literal))| {
+                format!(
+                    r#"					<Method uuid="7cdf45cd-1cc4-43e7-bfee-2b3f39140{index:03}">
+						<Properties>
+							<Name>{name}</Name>
+							<Comment/>
+							<HTTPMethod>{literal}</HTTPMethod>
+							<Handler>Корень{name}</Handler>
+						</Properties>
+					</Method>
+"#
+                )
+            })
+            .collect::<String>();
+        write_file(
+            &ext.join("HTTPServices/ПВД_ПечатныеФормы.xml"),
+            &format!(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:v8="http://v8.1c.ru/8.1/data/core" version="2.20">
+	<HTTPService uuid="a6eb1e93-3b7f-42f1-9e98-0a2df2487ef1">
+		<Properties>
+			<Name>ПВД_ПечатныеФормы</Name>
+			<Comment/>
+			<RootURL>printforms</RootURL>
+			<ReuseSessions>DontUse</ReuseSessions>
+			<SessionMaxAge>20</SessionMaxAge>
+		</Properties>
+		<ChildObjects>
+			<URLTemplate uuid="866986d4-1d28-447c-bb56-f750510e6bec">
+				<Properties>
+					<Name>Корень</Name>
+					<Comment/>
+					<Template>/*</Template>
+				</Properties>
+				<ChildObjects>
+{methods_xml}				</ChildObjects>
+			</URLTemplate>
+		</ChildObjects>
+	</HTTPService>
+</MetaDataObject>
+"#
+            ),
+        );
+    }
+
+    #[test]
+    fn cfe_validate_reports_invalid_http_method_enum_in_own_http_service() {
+        let context = temp_context("http-method-enum-invalid");
+        write_own_http_service_extension(&context, &[("ANY", "ANY")]);
+
+        let mut args = Map::new();
+        args.insert("ExtensionPath".to_string(), json!("ext"));
+        let outcome = validate_cfe(&args, &context);
+
+        assert!(
+            !outcome.ok,
+            "extension with HTTPMethod 'ANY' must fail validation, stdout: {:?}",
+            outcome.stdout
+        );
+        assert!(
+            outcome
+                .errors
+                .iter()
+                .any(|error| error.contains("invalid HTTPMethod 'ANY'")),
+            "{:?}",
+            outcome.errors
+        );
+
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
+    fn cfe_validate_accepts_the_full_8_3_27_http_method_enum() {
+        let context = temp_context("http-method-enum-valid");
+        write_own_http_service_extension(
+            &context,
+            &[("Любой", "Any"), ("Обход", "PROPFIND"), ("Чтение", "GET")],
+        );
+
+        let mut args = Map::new();
+        args.insert("ExtensionPath".to_string(), json!("ext"));
+        args.insert("Detailed".to_string(), json!(true));
+        let outcome = validate_cfe(&args, &context);
+
+        assert!(outcome.ok, "{:?}", outcome.errors);
+        let stdout = outcome.stdout.unwrap_or_default();
+        assert!(
+            stdout.contains("14. HTTPService.ПВД_ПечатныеФормы: 1 URLTemplate(s), 3 method(s)"),
+            "service check line missing from detailed output: {stdout}"
         );
 
         let _ = fs::remove_dir_all(&context.cwd);

--- a/crates/unica-coder/src/infrastructure/native_operations/cfe.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/cfe.rs
@@ -4568,6 +4568,7 @@ pub(crate) fn cfe_validate_service_objects(
         return;
     };
     let mut service_count = 0usize;
+    let mut unreadable_count = 0usize;
     for child in child_obj_node.children().filter(|child| child.is_element()) {
         let type_name = child.tag_name().name();
         if !matches!(type_name, "HTTPService" | "WebService") {
@@ -4579,9 +4580,17 @@ pub(crate) fn cfe_validate_service_objects(
         };
         let obj_file = config_dir.join(dir_name).join(format!("{child_name}.xml"));
         let Ok(text) = read_utf8_sig(&obj_file) else {
+            unreadable_count += 1;
+            report.warn(format!(
+                "14. {type_name}.{child_name}: cannot read {dir_name}/{child_name}.xml"
+            ));
             continue;
         };
         let Ok(doc) = Document::parse(text.trim_start_matches('\u{feff}')) else {
+            unreadable_count += 1;
+            report.warn(format!(
+                "14. {type_name}.{child_name}: cannot parse {dir_name}/{child_name}.xml"
+            ));
             continue;
         };
         let Some(obj_el) = doc.root_element().children().find(|node| node.is_element()) else {
@@ -4609,7 +4618,7 @@ pub(crate) fn cfe_validate_service_objects(
             return;
         }
     }
-    if service_count == 0 {
+    if service_count == 0 && unreadable_count == 0 {
         report.ok("14. Services: none found");
     }
 }
@@ -11819,6 +11828,93 @@ mod tests {
                 .errors
                 .iter()
                 .any(|error| error.contains("invalid HTTPMethod 'ANY'")),
+            "{:?}",
+            outcome.errors
+        );
+
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
+    fn cfe_validate_warns_on_declared_service_without_readable_descriptor() {
+        let context = temp_context("http-service-unreadable");
+        write_own_http_service_extension(&context, &[("Чтение", "GET")]);
+        fs::remove_file(context.cwd.join("ext/HTTPServices/ПВД_ПечатныеФормы.xml")).unwrap();
+
+        let mut args = Map::new();
+        args.insert("ExtensionPath".to_string(), json!("ext"));
+        args.insert("Detailed".to_string(), json!(true));
+        let outcome = validate_cfe(&args, &context);
+
+        let stdout = outcome.stdout.unwrap_or_default();
+        assert!(
+            stdout.contains(
+                "14. HTTPService.ПВД_ПечатныеФормы: cannot read HTTPServices/ПВД_ПечатныеФормы.xml"
+            ),
+            "unreadable service descriptor must be reported: {stdout}"
+        );
+        assert!(
+            !stdout.contains("14. Services: none found"),
+            "a declared but unreadable service is not an absent service: {stdout}"
+        );
+
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    #[test]
+    fn cfe_validate_reports_invalid_transfer_direction_in_own_web_service() {
+        let context = temp_context("web-service-direction");
+        write_own_http_service_extension(&context, &[("Чтение", "GET")]);
+        let ext = context.cwd.join("ext");
+        let config = fs::read_to_string(ext.join("Configuration.xml")).unwrap();
+        fs::write(
+            ext.join("Configuration.xml"),
+            config.replace(
+                "<HTTPService>ПВД_ПечатныеФормы</HTTPService>",
+                "<WebService>ПВД_Обмен</WebService>\n\t\t\t<HTTPService>ПВД_ПечатныеФормы</HTTPService>",
+            ),
+        )
+        .unwrap();
+        write_file(
+            &ext.join("WebServices/ПВД_Обмен.xml"),
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="2.20">
+	<WebService uuid="b58f7d3a-40b6-4e58-9a2e-6f60cc1f8a01">
+		<Properties>
+			<Name>ПВД_Обмен</Name>
+			<Comment/>
+		</Properties>
+		<ChildObjects>
+			<Operation uuid="c58f7d3a-40b6-4e58-9a2e-6f60cc1f8a02">
+				<Properties>
+					<Name>Пинг</Name>
+					<XDTOReturningValueType>xs:boolean</XDTOReturningValueType>
+					<ProcedureName>Пинг</ProcedureName>
+				</Properties>
+				<ChildObjects>
+					<Parameter uuid="d58f7d3a-40b6-4e58-9a2e-6f60cc1f8a03">
+						<Properties>
+							<Name>Данные</Name>
+							<TransferDirection>Inward</TransferDirection>
+						</Properties>
+					</Parameter>
+				</ChildObjects>
+			</Operation>
+		</ChildObjects>
+	</WebService>
+</MetaDataObject>
+"#,
+        );
+
+        let mut args = Map::new();
+        args.insert("ExtensionPath".to_string(), json!("ext"));
+        let outcome = validate_cfe(&args, &context);
+
+        assert!(!outcome.ok, "{:?}", outcome.stdout);
+        assert!(
+            outcome.errors.iter().any(|error| error.contains(
+                "14. WebService.ПВД_Обмен Operation 'Пинг': Parameter has invalid TransferDirection 'Inward'"
+            )),
             "{:?}",
             outcome.errors
         );

--- a/crates/unica-coder/src/infrastructure/native_operations/meta/info_projection_tests.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta/info_projection_tests.rs
@@ -1379,3 +1379,27 @@ fn profile_rejects_a_relation_property_under_the_wrong_kind() {
 
     assert_eq!(error.field, "properties.Owners");
 }
+
+#[test]
+fn http_method_projection_accepts_every_8_3_27_enum_literal() {
+    let base = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../tests/fixtures/platform_8_3_27/meta_info/edge/http-service.xml"
+    ));
+    let allowed = super::validation::meta_validate_property_values()
+        .iter()
+        .find(|(name, _)| *name == "HTTPMethod")
+        .map(|(_, allowed)| *allowed)
+        .unwrap();
+    for literal in allowed {
+        let xml = base.replace(
+            "<HTTPMethod>GET</HTTPMethod>",
+            &format!("<HTTPMethod>{literal}</HTTPMethod>"),
+        );
+        let details = project(&xml, MetadataKind::HTTPService, "HTTPService.ExternalAPI");
+        assert_eq!(
+            details["urlTemplates"][0]["methods"][0]["httpMethod"], *literal,
+            "platform enum literal '{literal}' must project"
+        );
+    }
+}

--- a/crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta/mod.rs
@@ -108,7 +108,9 @@ pub(crate) use template_catalog::metadata_generated_types_8_3_27;
 #[cfg(test)]
 pub(crate) use template_catalog::{emit_meta_internal_info, minimal_metadata_xml_for_tests};
 pub(crate) use usage_scan::{scan_local_enrichment, LocalEnrichment, LocalSection};
-pub(crate) use validation::{validate_metadata_owner_shape_8_3_27, MetadataValidator};
+pub(crate) use validation::{
+    service_child_semantics, validate_metadata_owner_shape_8_3_27, MetadataValidator,
+};
 pub(crate) use xml_model::{
     meta_info_child, meta_info_child_text, meta_info_children, meta_info_inner_text,
 };

--- a/crates/unica-coder/src/infrastructure/native_operations/meta/validation.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta/validation.rs
@@ -3551,7 +3551,9 @@ pub(crate) fn service_child_semantics(
                         let direction = meta_info_child(param, "Properties")
                             .and_then(|node| meta_info_child_text(node, "TransferDirection"));
                         if let Some(direction) = direction.filter(|value| !value.is_empty()) {
-                            if !["In", "Out", "InOut"].contains(&direction.as_str()) {
+                            if !meta_validate_valid_transfer_directions()
+                                .contains(&direction.as_str())
+                            {
                                 findings.push(ServiceSemanticsFinding {
                                     error: true,
                                     detail: format!(
@@ -4276,11 +4278,19 @@ pub(super) fn meta_validate_reserved_attr_names() -> &'static [&'static str] {
 
 pub(super) fn meta_validate_valid_http_methods() -> &'static [&'static str] {
     // Single authority: the HTTPMethod entry of the 8.3.27 property enum table.
+    meta_validate_property_enum("HTTPMethod")
+}
+
+pub(super) fn meta_validate_valid_transfer_directions() -> &'static [&'static str] {
+    meta_validate_property_enum("TransferDirection")
+}
+
+fn meta_validate_property_enum(property: &str) -> &'static [&'static str] {
     meta_validate_property_values()
         .iter()
-        .find(|(name, _)| *name == "HTTPMethod")
+        .find(|(name, _)| *name == property)
         .map(|(_, allowed)| *allowed)
-        .expect("the 8.3.27 property enum table defines HTTPMethod")
+        .unwrap_or_else(|| panic!("the 8.3.27 property enum table defines {property}"))
 }
 
 pub(super) fn meta_validate_forbidden_properties(md_type: &str) -> Option<&'static [&'static str]> {
@@ -6584,12 +6594,20 @@ mod tests {
     }
 
     #[test]
-    fn http_method_enum_authority_is_the_8_3_27_property_table() {
-        let expected = meta_validate_property_values()
-            .iter()
-            .find(|(name, _)| *name == "HTTPMethod")
-            .map(|(_, allowed)| *allowed)
-            .unwrap();
-        assert_eq!(meta_validate_valid_http_methods(), expected);
+    fn service_enum_authority_is_the_8_3_27_property_table() {
+        for (enum_name, actual) in [
+            ("HTTPMethod", meta_validate_valid_http_methods()),
+            (
+                "TransferDirection",
+                meta_validate_valid_transfer_directions(),
+            ),
+        ] {
+            let expected = meta_validate_property_values()
+                .iter()
+                .find(|(name, _)| *name == enum_name)
+                .map(|(_, allowed)| *allowed)
+                .unwrap();
+            assert_eq!(actual, expected, "{enum_name}");
+        }
     }
 }

--- a/crates/unica-coder/src/infrastructure/native_operations/meta/validation.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta/validation.rs
@@ -3453,99 +3453,148 @@ pub(super) fn meta_validate_check_register_command_interface(
     }
 }
 
+pub(crate) struct ServiceSemanticsFinding {
+    pub(crate) error: bool,
+    pub(crate) detail: String,
+}
+
+pub(crate) struct ServiceSemantics {
+    pub(crate) findings: Vec<ServiceSemanticsFinding>,
+    pub(crate) summary: String,
+    pub(crate) clean: bool,
+}
+
+// Shared core of the service semantics check: meta validation reports it as
+// check 11 for a standalone object, cfe validation as check 14 across the
+// extension's child objects. Returns None for non-service metadata types.
+pub(crate) fn service_child_semantics(
+    md_type: &str,
+    child_obj_node: Option<roxmltree::Node<'_, '_>>,
+) -> Option<ServiceSemantics> {
+    if md_type == "HTTPService" {
+        let mut findings = Vec::new();
+        let mut template_count = 0usize;
+        let mut method_count = 0usize;
+        if let Some(child_obj_node) = child_obj_node {
+            let templates = meta_info_children(child_obj_node, "URLTemplate");
+            template_count = templates.len();
+            for template in &templates {
+                let props = meta_info_child(*template, "Properties");
+                let name = props
+                    .and_then(|node| meta_info_child_text(node, "Name"))
+                    .unwrap_or_else(|| "(unnamed)".to_string());
+                if props
+                    .and_then(|node| meta_info_child_text(node, "Template"))
+                    .is_none_or(|value| value.trim().is_empty())
+                {
+                    findings.push(ServiceSemanticsFinding {
+                        error: true,
+                        detail: format!("URLTemplate '{name}': empty Template"),
+                    });
+                }
+                if let Some(child_objects) = meta_info_child(*template, "ChildObjects") {
+                    for method in meta_info_children(child_objects, "Method") {
+                        method_count += 1;
+                        let props = meta_info_child(method, "Properties");
+                        let http_method =
+                            props.and_then(|node| meta_info_child_text(node, "HTTPMethod"));
+                        if let Some(http_method) = http_method.filter(|value| !value.is_empty()) {
+                            if !meta_validate_valid_http_methods().contains(&http_method.as_str()) {
+                                findings.push(ServiceSemanticsFinding {
+                                    error: true,
+                                    detail: format!(
+                                        "URLTemplate '{name}': invalid HTTPMethod '{http_method}'"
+                                    ),
+                                });
+                            }
+                        } else {
+                            findings.push(ServiceSemanticsFinding {
+                                error: true,
+                                detail: format!("URLTemplate '{name}': Method missing HTTPMethod"),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        let clean = findings.iter().all(|finding| !finding.error);
+        return Some(ServiceSemantics {
+            findings,
+            summary: format!("{template_count} URLTemplate(s), {method_count} method(s)"),
+            clean,
+        });
+    }
+    if md_type == "WebService" {
+        let mut findings = Vec::new();
+        let mut operation_count = 0usize;
+        let mut param_count = 0usize;
+        if let Some(child_obj_node) = child_obj_node {
+            let operations = meta_info_children(child_obj_node, "Operation");
+            operation_count = operations.len();
+            for operation in &operations {
+                let props = meta_info_child(*operation, "Properties");
+                let name = props
+                    .and_then(|node| meta_info_child_text(node, "Name"))
+                    .unwrap_or_else(|| "(unnamed)".to_string());
+                if props
+                    .and_then(|node| meta_info_child_text(node, "XDTOReturningValueType"))
+                    .is_none_or(|value| value.trim().is_empty())
+                {
+                    findings.push(ServiceSemanticsFinding {
+                        error: false,
+                        detail: format!("Operation '{name}': no XDTOReturningValueType"),
+                    });
+                }
+                if let Some(child_objects) = meta_info_child(*operation, "ChildObjects") {
+                    for param in meta_info_children(child_objects, "Parameter") {
+                        param_count += 1;
+                        let direction = meta_info_child(param, "Properties")
+                            .and_then(|node| meta_info_child_text(node, "TransferDirection"));
+                        if let Some(direction) = direction.filter(|value| !value.is_empty()) {
+                            if !["In", "Out", "InOut"].contains(&direction.as_str()) {
+                                findings.push(ServiceSemanticsFinding {
+                                    error: true,
+                                    detail: format!(
+                                        "Operation '{name}': Parameter has invalid TransferDirection '{direction}'"
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        let clean = findings.iter().all(|finding| !finding.error);
+        return Some(ServiceSemantics {
+            findings,
+            summary: format!("{operation_count} operation(s), {param_count} parameter(s)"),
+            clean,
+        });
+    }
+    None
+}
+
 pub(super) fn meta_validate_check_services(
     report: &mut MetaValidationReporter,
     md_type: &str,
     child_obj_node: Option<roxmltree::Node<'_, '_>>,
 ) {
-    let Some(child_obj_node) = child_obj_node else {
+    if child_obj_node.is_none() {
+        return;
+    }
+    let Some(semantics) = service_child_semantics(md_type, child_obj_node) else {
         return;
     };
-    if md_type == "HTTPService" {
-        let templates = meta_info_children(child_obj_node, "URLTemplate");
-        let mut check_ok = true;
-        let mut method_count = 0usize;
-        for template in &templates {
-            let props = meta_info_child(*template, "Properties");
-            let name = props
-                .and_then(|node| meta_info_child_text(node, "Name"))
-                .unwrap_or_else(|| "(unnamed)".to_string());
-            if props
-                .and_then(|node| meta_info_child_text(node, "Template"))
-                .is_none_or(|value| value.trim().is_empty())
-            {
-                report.error(format!(
-                    "11. HTTPService URLTemplate '{name}': empty Template"
-                ));
-                check_ok = false;
-            }
-            if let Some(child_objects) = meta_info_child(*template, "ChildObjects") {
-                for method in meta_info_children(child_objects, "Method") {
-                    method_count += 1;
-                    let props = meta_info_child(method, "Properties");
-                    let http_method =
-                        props.and_then(|node| meta_info_child_text(node, "HTTPMethod"));
-                    if let Some(http_method) = http_method.filter(|value| !value.is_empty()) {
-                        if !meta_validate_valid_http_methods().contains(&http_method.as_str()) {
-                            report.error(format!(
-                                "11. HTTPService URLTemplate '{name}': invalid HTTPMethod '{http_method}'"
-                            ));
-                            check_ok = false;
-                        }
-                    } else {
-                        report.error(format!(
-                            "11. HTTPService URLTemplate '{name}': Method missing HTTPMethod"
-                        ));
-                        check_ok = false;
-                    }
-                }
-            }
+    for finding in &semantics.findings {
+        let message = format!("11. {md_type} {}", finding.detail);
+        if finding.error {
+            report.error(message);
+        } else {
+            report.warn(message);
         }
-        if check_ok {
-            report.ok(format!(
-                "11. HTTPService: {} URLTemplate(s), {method_count} method(s)",
-                templates.len()
-            ));
-        }
-    } else if md_type == "WebService" {
-        let operations = meta_info_children(child_obj_node, "Operation");
-        let mut check_ok = true;
-        let mut param_count = 0usize;
-        for operation in &operations {
-            let props = meta_info_child(*operation, "Properties");
-            let name = props
-                .and_then(|node| meta_info_child_text(node, "Name"))
-                .unwrap_or_else(|| "(unnamed)".to_string());
-            if props
-                .and_then(|node| meta_info_child_text(node, "XDTOReturningValueType"))
-                .is_none_or(|value| value.trim().is_empty())
-            {
-                report.warn(format!(
-                    "11. WebService Operation '{name}': no XDTOReturningValueType"
-                ));
-            }
-            if let Some(child_objects) = meta_info_child(*operation, "ChildObjects") {
-                for param in meta_info_children(child_objects, "Parameter") {
-                    param_count += 1;
-                    let direction = meta_info_child(param, "Properties")
-                        .and_then(|node| meta_info_child_text(node, "TransferDirection"));
-                    if let Some(direction) = direction.filter(|value| !value.is_empty()) {
-                        if !["In", "Out", "InOut"].contains(&direction.as_str()) {
-                            report.error(format!(
-                                "11. WebService Operation '{name}': Parameter has invalid TransferDirection '{direction}'"
-                            ));
-                            check_ok = false;
-                        }
-                    }
-                }
-            }
-        }
-        if check_ok {
-            report.ok(format!(
-                "11. WebService: {} operation(s), {param_count} parameter(s)",
-                operations.len()
-            ));
-        }
+    }
+    if semantics.clean {
+        report.ok(format!("11. {md_type}: {}", semantics.summary));
     }
 }
 
@@ -4226,9 +4275,12 @@ pub(super) fn meta_validate_reserved_attr_names() -> &'static [&'static str] {
 }
 
 pub(super) fn meta_validate_valid_http_methods() -> &'static [&'static str] {
-    &[
-        "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "MERGE", "CONNECT",
-    ]
+    // Single authority: the HTTPMethod entry of the 8.3.27 property enum table.
+    meta_validate_property_values()
+        .iter()
+        .find(|(name, _)| *name == "HTTPMethod")
+        .map(|(_, allowed)| *allowed)
+        .expect("the 8.3.27 property enum table defines HTTPMethod")
 }
 
 pub(super) fn meta_validate_forbidden_properties(md_type: &str) -> Option<&'static [&'static str]> {
@@ -6488,5 +6540,56 @@ mod tests {
                 .iter()
                 .any(|diagnostic| diagnostic.code == MetaDiagnosticCode::ProviderUnavailable));
         }
+    }
+
+    fn check_services_errors(http_methods: &[&str]) -> Vec<String> {
+        let methods = http_methods
+            .iter()
+            .enumerate()
+            .map(|(index, literal)| {
+                format!(
+                    "<Method><Properties><Name>Метод{index}</Name><HTTPMethod>{literal}</HTTPMethod><Handler>Обработчик{index}</Handler></Properties></Method>"
+                )
+            })
+            .collect::<String>();
+        let xml = format!(
+            r#"<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses"><HTTPService><Properties><Name>ПВД_ПечатныеФормы</Name></Properties><ChildObjects><URLTemplate><Properties><Name>Корень</Name><Template>/*</Template></Properties><ChildObjects>{methods}</ChildObjects></URLTemplate></ChildObjects></HTTPService></MetaDataObject>"#
+        );
+        let document = roxmltree::Document::parse(&xml).unwrap();
+        let type_node = document.root_element().first_element_child().unwrap();
+        let mut report = MetaValidationReporter::new(30);
+        meta_validate_check_services(
+            &mut report,
+            "HTTPService",
+            meta_info_child(type_node, "ChildObjects"),
+        );
+        report.errors
+    }
+
+    #[test]
+    fn check_services_accepts_the_full_8_3_27_http_method_enum() {
+        let errors = check_services_errors(&["Any", "PROPFIND", "MKCOL", "UNLOCK", "GET"]);
+        assert!(errors.is_empty(), "{errors:?}");
+    }
+
+    #[test]
+    fn check_services_rejects_the_uppercase_any_literal() {
+        let errors = check_services_errors(&["ANY"]);
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("invalid HTTPMethod 'ANY'")),
+            "{errors:?}"
+        );
+    }
+
+    #[test]
+    fn http_method_enum_authority_is_the_8_3_27_property_table() {
+        let expected = meta_validate_property_values()
+            .iter()
+            .find(|(name, _)| *name == "HTTPMethod")
+            .map(|(_, allowed)| *allowed)
+            .unwrap();
+        assert_eq!(meta_validate_valid_http_methods(), expected);
     }
 }

--- a/plugins/unica/skills/cfe-validate/SKILL.md
+++ b/plugins/unica/skills/cfe-validate/SKILL.md
@@ -17,7 +17,7 @@ allowed-tools:
 - Execution path: call MCP `unica` tool `unica.cfe.validate`; skill-local operation scripts are not part of the workflow.
 - For mutating operations, pass `dryRun: false` only when the user explicitly requested the change; otherwise keep the default dry run.
 
-Проверяет структурную корректность расширения: XML-формат, свойства, состав, заимствованные объекты. Аналог `/cf-validate`, но для расширений.
+Проверяет структурную корректность расширения: XML-формат, свойства, состав, заимствованные объекты, семантику сервисов (`HTTPService`, `WebService`) — включая соответствие `HTTPMethod` перечислению платформы 8.3.27 (`Any`, `GET`, `PROPFIND`, …). Аналог `/cf-validate`, но для расширений.
 
 ## Параметры
 

--- a/tests/fixtures/unica_mcp_script_parity/unica_reference_models/cfe-validate/scripts/cfe-validate.py
+++ b/tests/fixtures/unica_mcp_script_parity/unica_reference_models/cfe-validate/scripts/cfe-validate.py
@@ -933,6 +933,7 @@ def main():
 
     # --- Check 14: Service objects (HTTPService, WebService) semantics ---
     service_count = 0
+    unreadable_count = 0
     if child_obj_node is not None:
         for child in child_obj_node:
             if not isinstance(child.tag, str):
@@ -944,10 +945,14 @@ def main():
             dir_name = CHILD_TYPE_DIR_MAP[type_name]
             obj_file = os.path.join(config_dir, dir_name, child_name + '.xml')
             if not os.path.exists(obj_file):
+                unreadable_count += 1
+                r.warn(f'14. {type_name}.{child_name}: cannot read {dir_name}/{child_name}.xml')
                 continue
             try:
                 obj_doc = etree.parse(obj_file, etree.XMLParser(remove_blank_text=False))
             except etree.XMLSyntaxError:
+                unreadable_count += 1
+                r.warn(f'14. {type_name}.{child_name}: cannot parse {dir_name}/{child_name}.xml')
                 continue
             obj_el = None
             for c in obj_doc.getroot():
@@ -1012,7 +1017,7 @@ def main():
             if r.stopped:
                 r.finalize(out_file)
                 sys.exit(1)
-    if service_count == 0:
+    if service_count == 0 and unreadable_count == 0:
         r.ok('14. Services: none found')
 
     # --- Final output ---

--- a/tests/fixtures/unica_mcp_script_parity/unica_reference_models/cfe-validate/scripts/cfe-validate.py
+++ b/tests/fixtures/unica_mcp_script_parity/unica_reference_models/cfe-validate/scripts/cfe-validate.py
@@ -99,6 +99,13 @@ VALID_ENUM_VALUES = {
     ],
 }
 
+# 8.3.27 platform enum for HTTPService Method HTTPMethod
+VALID_HTTP_METHODS = [
+    'Any', 'CONNECT', 'COPY', 'DELETE', 'GET', 'HEAD', 'LOCK', 'MERGE',
+    'MKCOL', 'MOVE', 'OPTIONS', 'PATCH', 'POST', 'PROPFIND', 'PROPPATCH',
+    'PUT', 'TRACE', 'UNLOCK',
+]
+
 EXPECTED_NS = 'http://v8.1c.ru/8.3/MDClasses'
 
 
@@ -919,6 +926,94 @@ def main():
         r.ok('13. TypeLink: no borrowed forms with tree')
     elif check13_ok:
         r.ok('13. TypeLink: clean')
+
+    if r.stopped:
+        r.finalize(out_file)
+        sys.exit(1)
+
+    # --- Check 14: Service objects (HTTPService, WebService) semantics ---
+    service_count = 0
+    if child_obj_node is not None:
+        for child in child_obj_node:
+            if not isinstance(child.tag, str):
+                continue
+            type_name = etree.QName(child.tag).localname
+            if type_name not in ('HTTPService', 'WebService'):
+                continue
+            child_name = child.text or ''
+            dir_name = CHILD_TYPE_DIR_MAP[type_name]
+            obj_file = os.path.join(config_dir, dir_name, child_name + '.xml')
+            if not os.path.exists(obj_file):
+                continue
+            try:
+                obj_doc = etree.parse(obj_file, etree.XMLParser(remove_blank_text=False))
+            except etree.XMLSyntaxError:
+                continue
+            obj_el = None
+            for c in obj_doc.getroot():
+                if isinstance(c.tag, str):
+                    obj_el = c
+                    break
+            if obj_el is None:
+                continue
+            service_children = obj_el.find(f'{{{MD}}}ChildObjects')
+            service_count += 1
+            ctx = f'{type_name}.{child_name}'
+            clean = True
+            if type_name == 'HTTPService':
+                templates = [] if service_children is None else service_children.findall(f'{{{MD}}}URLTemplate')
+                method_count = 0
+                for template in templates:
+                    t_props = template.find(f'{{{MD}}}Properties')
+                    t_name_node = None if t_props is None else t_props.find(f'{{{MD}}}Name')
+                    t_name = '(unnamed)' if t_name_node is None else (t_name_node.text or '')
+                    t_template_node = None if t_props is None else t_props.find(f'{{{MD}}}Template')
+                    if t_template_node is None or not (t_template_node.text or '').strip():
+                        r.error(f"14. {ctx} URLTemplate '{t_name}': empty Template")
+                        clean = False
+                    t_children = template.find(f'{{{MD}}}ChildObjects')
+                    if t_children is not None:
+                        for method in t_children.findall(f'{{{MD}}}Method'):
+                            method_count += 1
+                            m_props = method.find(f'{{{MD}}}Properties')
+                            m_method_node = None if m_props is None else m_props.find(f'{{{MD}}}HTTPMethod')
+                            m_method = (m_method_node.text or '') if m_method_node is not None else ''
+                            if m_method:
+                                if m_method not in VALID_HTTP_METHODS:
+                                    r.error(f"14. {ctx} URLTemplate '{t_name}': invalid HTTPMethod '{m_method}'")
+                                    clean = False
+                            else:
+                                r.error(f"14. {ctx} URLTemplate '{t_name}': Method missing HTTPMethod")
+                                clean = False
+                if clean:
+                    r.ok(f'14. {ctx}: {len(templates)} URLTemplate(s), {method_count} method(s)')
+            else:
+                operations = [] if service_children is None else service_children.findall(f'{{{MD}}}Operation')
+                param_count = 0
+                for operation in operations:
+                    o_props = operation.find(f'{{{MD}}}Properties')
+                    o_name_node = None if o_props is None else o_props.find(f'{{{MD}}}Name')
+                    o_name = '(unnamed)' if o_name_node is None else (o_name_node.text or '')
+                    o_xdto_node = None if o_props is None else o_props.find(f'{{{MD}}}XDTOReturningValueType')
+                    if o_xdto_node is None or not (o_xdto_node.text or '').strip():
+                        r.warn(f"14. {ctx} Operation '{o_name}': no XDTOReturningValueType")
+                    o_children = operation.find(f'{{{MD}}}ChildObjects')
+                    if o_children is not None:
+                        for param in o_children.findall(f'{{{MD}}}Parameter'):
+                            param_count += 1
+                            p_props = param.find(f'{{{MD}}}Properties')
+                            p_dir_node = None if p_props is None else p_props.find(f'{{{MD}}}TransferDirection')
+                            p_dir = (p_dir_node.text or '') if p_dir_node is not None else ''
+                            if p_dir and p_dir not in ('In', 'Out', 'InOut'):
+                                r.error(f"14. {ctx} Operation '{o_name}': Parameter has invalid TransferDirection '{p_dir}'")
+                                clean = False
+                if clean:
+                    r.ok(f'14. {ctx}: {len(operations)} operation(s), {param_count} parameter(s)')
+            if r.stopped:
+                r.finalize(out_file)
+                sys.exit(1)
+    if service_count == 0:
+        r.ok('14. Services: none found')
 
     # --- Final output ---
     r.finalize(out_file)


### PR DESCRIPTION
Closes #540.

## Что было

`unica.cfe.validate` («native extension validator») возвращал `ok:true` для расширения, чей собственный HTTPService содержал `<HTTPMethod>ANY</HTTPMethod>`, а платформа 8.3.27 отвергала импорт целиком: «[ERROR] Неверное значение перечисления - ANY» (правильный литерал — `Any`). Applied-сценарий — расширение «ПечатьWebDAV» от 17.08.2026.

Первопричин две:

1. Путь `cfe.validate` вообще не выполнял семантические проверки сервисов: файлы `HTTPServices/*.xml` открывались проверками 9–10 только ради маркеров заимствования и форм, проверка №11 meta-валидации не вызывалась.
2. Проверка №11 и проекция `meta.info` сверялись с устаревшей таблицей из 9 литералов — валидные `Any` и WebDAV-методы (`COPY`, `LOCK`, `MKCOL`, `MOVE`, `PROPFIND`, `PROPPATCH`, `TRACE`, `UNLOCK`) ложно отвергались бы meta-путём. Полное перечисление из 18 литералов уже жило в enum-таблице профиля 8.3.27 (`meta_validate_property_values`).

## Что сделано

- Ядро проверки №11 выделено в `service_child_semantics` (meta/validation.rs) без изменения сообщений meta-пути; `cfe.validate` получил проверку №14, которая гоняет это ядро по всем `HTTPService`/`WebService` из состава расширения — собственным и заимствованным.
- `meta_validate_valid_http_methods` теперь выводится из enum-таблицы профиля 8.3.27 — единственный источник истины для литералов `HTTPMethod`.
- Reference-модель `cfe-validate.py` зеркалирует проверку №14 — стенд паритета зелёный (донорских кейсов cfe-validate в donor-relations.json нет, перезапись отпечатков не потребовалась).
- Проза скилла `cfe-validate` дополнена семантикой сервисов.

Архитектурный контракт не менялся: состав инструментов, аргументы и форма результата прежние; политика «перечисления — по профилю 8.3.27» установлена ранее (enforce 8.3.27 export profile), здесь устранён её устаревший дубликат. Запись решения не требуется.

## TDD

Красная фаза зафиксирована до правки — 5 падающих тестов, воспроизводящих оба дефекта на текущем коде (репродукция: фикстура-расширение по образцу реального дампа 2.20 c `ANY` → `ok:true`, «0 errors, 14 checks»):

- `cfe_validate_reports_invalid_http_method_enum_in_own_http_service`
- `cfe_validate_accepts_the_full_8_3_27_http_method_enum`
- `check_services_accepts_the_full_8_3_27_http_method_enum`
- `service_enum_authority_is_the_8_3_27_property_table`
- `http_method_projection_accepts_every_8_3_27_enum_literal`

## Верификация

- `cargo test -p unica-coder` — зелёный (два падения `generated_equal_root_fact_expansion_is_bounded` и `bsl_session_replaces_reader_terminal_session_before_next_request` — известная load-флейковость wall-clock тестов: в изоляции зелёные, домены правкой не затронуты, состав падений менялся между прогонами).
- `tests/ci` (765) и `tests/dev` через python3.12 — OK; `cargo fmt`/`clippy` — чисто.
- Живая платформа 8.3.27.2074 (`ibcmd config import` в scratch-базу, реальный артефакт «ПечатьWebDAV» в двух вариантах): `ANY` → «Неверное значение перечисления - ANY», `Any` → импорт успешен. Исправленный валидатор совпадает с вердиктом платформы в обе стороны: `ANY` → `[ERROR] 14. HTTPService.ПВД_ПечатныеФормы URLTemplate 'Корень': invalid HTTPMethod 'ANY'`; `Any` → `ok:true`, в detailed видна строка `14. HTTPService.ПВД_ПечатныеФормы: 1 URLTemplate(s), 1 method(s)`.

## Смежное

#529 (meta.add/meta.edit не умеют urlTemplates/methods — из-за этого XML писался руками), семейство #532/#533. Не втянуты: независимые дефекты со своими границами.

## По ревью (3c318bfd)

- Объявленный сервис с нечитаемым/непарсящимся дескриптором теперь даёт warn `14. <Тип>.<Имя>: cannot read/parse …` вместо ложного `Services: none found` (тест написан до правки, зеркало в reference-скрипте).
- `TransferDirection` выводится из той же enum-таблицы профиля 8.3.27, что и `HTTPMethod`; authority-тест покрывает оба перечисления.
- Ветка WebService проверки №14 покрыта тестом.
- Отклонено: остановка check 14 по MaxErrors внутри сервиса только в reference-скрипте — разошлась бы с нативным репортёром (вывод после порога не подавляется, `stopped` проверяется между проверками/объектами; так ведут себя проверки 1–13 в обеих реализациях).
