### PR TITLE
fix(meta): вернуть cwd на типизированную поверхность метаданных (0.12.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,7 +1832,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unica-bootstrap"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "flate2",
  "fs2",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "unica-coder"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "cap-fs-ext",
  "cap-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/unica-bootstrap", "crates/unica-coder"]
 resolver = "2"
 
 [workspace.package]
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 license = "LGPL-3.0-or-later"
 repository = "https://github.com/IngvarConsulting/unica"

--- a/crates/unica-coder/src/application/meta_add_surface_tests.rs
+++ b/crates/unica-coder/src/application/meta_add_surface_tests.rs
@@ -1159,3 +1159,75 @@ fn assert_partial_is_stable(workspace: &TempWorkspace, kind: &str, name: &str) {
     assert_eq!(result.diagnostics.unwrap()[0]["code"], "already_exists");
     assert_eq!(tree_snapshot(&workspace.path().join("src")), before);
 }
+
+/// Упакованный сервер стартует с рабочим каталогом в корне плагина
+/// (`cwd: "."` в `.mcp.json`), поэтому рабочее пространство адресуется только
+/// аргументом вызова: ADR-0006 §4 и ADR-0053 §2.
+#[test]
+fn metadata_operations_address_the_workspace_through_cwd_from_outside() {
+    let workspace = create_configuration_workspace("cwd-argument");
+    let outside = TempWorkspace::new("cwd-argument-host");
+    let _cwd = ProcessCwdGuard::enter(outside.path()).unwrap();
+    let cwd = json!(workspace.path().display().to_string());
+    let target = json!("Catalog.CwdAddressed");
+
+    let added = UnicaApplication::new()
+        .call_tool(
+            "unica.meta.add",
+            &Map::from_iter([
+                ("cwd".to_string(), cwd.clone()),
+                ("sourceSet".to_string(), json!("main")),
+                ("kind".to_string(), json!("Catalog")),
+                ("name".to_string(), json!("CwdAddressed")),
+                ("dryRun".to_string(), json!(false)),
+            ]),
+        )
+        .expect("typed meta.add call");
+    assert!(added.ok, "{:?}", added.errors);
+    assert!(workspace
+        .path()
+        .join("src/Catalogs/CwdAddressed.xml")
+        .is_file());
+
+    let inspected = UnicaApplication::new()
+        .call_tool(
+            "unica.meta.info",
+            &Map::from_iter([
+                ("cwd".to_string(), cwd.clone()),
+                ("sourceSet".to_string(), json!("main")),
+                ("metadataPath".to_string(), target.clone()),
+            ]),
+        )
+        .expect("typed meta.info call");
+    assert!(inspected.ok, "{:?}", inspected.errors);
+
+    let edited = UnicaApplication::new()
+        .call_tool(
+            "unica.meta.edit",
+            &Map::from_iter([
+                ("cwd".to_string(), cwd.clone()),
+                ("sourceSet".to_string(), json!("main")),
+                ("metadataPath".to_string(), target.clone()),
+                (
+                    "operations".to_string(),
+                    json!([{"op": "setProperties", "values": {"Comment": "addressed by cwd"}}]),
+                ),
+                ("dryRun".to_string(), json!(false)),
+            ]),
+        )
+        .expect("typed meta.edit call");
+    assert!(edited.ok, "{:?}", edited.errors);
+
+    let removed = UnicaApplication::new()
+        .call_tool(
+            "unica.meta.remove",
+            &Map::from_iter([
+                ("cwd".to_string(), cwd),
+                ("sourceSet".to_string(), json!("main")),
+                ("metadataPath".to_string(), target),
+                ("dryRun".to_string(), json!(true)),
+            ]),
+        )
+        .expect("typed meta.remove call");
+    assert!(removed.ok, "{:?}", removed.errors);
+}

--- a/crates/unica-coder/src/application/metadata.rs
+++ b/crates/unica-coder/src/application/metadata.rs
@@ -528,10 +528,17 @@ fn reject_unknown_top_level(
 
 fn metadata_top_level_fields(operation: MetadataOperation) -> &'static [&'static str] {
     match operation {
-        MetadataOperation::Info => &["sourceSet", "metadataPath", "sections", "limit"],
-        MetadataOperation::Add => &["sourceSet", "kind", "name", "operations", "dryRun"],
-        MetadataOperation::Edit => &["sourceSet", "metadataPath", "operations", "dryRun"],
-        MetadataOperation::Remove => &["sourceSet", "metadataPath", "dryRun", "force", "confirm"],
+        MetadataOperation::Info => &["cwd", "sourceSet", "metadataPath", "sections", "limit"],
+        MetadataOperation::Add => &["cwd", "sourceSet", "kind", "name", "operations", "dryRun"],
+        MetadataOperation::Edit => &["cwd", "sourceSet", "metadataPath", "operations", "dryRun"],
+        MetadataOperation::Remove => &[
+            "cwd",
+            "sourceSet",
+            "metadataPath",
+            "dryRun",
+            "force",
+            "confirm",
+        ],
     }
 }
 
@@ -1649,6 +1656,12 @@ pub(crate) fn metadata_input_schema(operation: MetadataOperation) -> Value {
     properties.insert(
         "sourceSet".into(),
         string("Exact Configuration source-set name from v8project.yaml."),
+    );
+    properties.insert(
+        "cwd".into(),
+        string(
+            "Absolute path to the workspace root holding v8project.yaml; it selects the workspace and never narrows the logical address.",
+        ),
     );
     let required = match operation {
         MetadataOperation::Info => {

--- a/crates/unica-coder/src/application/tool_contracts.rs
+++ b/crates/unica-coder/src/application/tool_contracts.rs
@@ -4137,22 +4137,22 @@ mod tests {
         let cases = [
             (
                 MetadataOperation::Info,
-                vec!["limit", "metadataPath", "sections", "sourceSet"],
+                vec!["cwd", "limit", "metadataPath", "sections", "sourceSet"],
                 json!(["sourceSet", "metadataPath"]),
             ),
             (
                 MetadataOperation::Add,
-                vec!["dryRun", "kind", "name", "operations", "sourceSet"],
+                vec!["cwd", "dryRun", "kind", "name", "operations", "sourceSet"],
                 json!(["sourceSet", "kind", "name"]),
             ),
             (
                 MetadataOperation::Edit,
-                vec!["dryRun", "metadataPath", "operations", "sourceSet"],
+                vec!["cwd", "dryRun", "metadataPath", "operations", "sourceSet"],
                 json!(["sourceSet", "metadataPath", "operations"]),
             ),
             (
                 MetadataOperation::Remove,
-                vec!["confirm", "dryRun", "force", "metadataPath", "sourceSet"],
+                vec!["confirm", "cwd", "dryRun", "force", "metadataPath", "sourceSet"],
                 json!(["sourceSet", "metadataPath"]),
             ),
         ];
@@ -7268,7 +7268,7 @@ mod tests {
             ),
             (
                 "unica.meta.info",
-                &["limit", "metadataPath", "sections", "sourceSet"],
+                &["cwd", "limit", "metadataPath", "sections", "sourceSet"],
                 // The metadata surface has no path aliases and validates its
                 // own closed shape, so `allowed_args` stays empty by design.
                 &[],

--- a/crates/unica-coder/src/application/tool_contracts.rs
+++ b/crates/unica-coder/src/application/tool_contracts.rs
@@ -4152,7 +4152,14 @@ mod tests {
             ),
             (
                 MetadataOperation::Remove,
-                vec!["confirm", "cwd", "dryRun", "force", "metadataPath", "sourceSet"],
+                vec![
+                    "confirm",
+                    "cwd",
+                    "dryRun",
+                    "force",
+                    "metadataPath",
+                    "sourceSet",
+                ],
                 json!(["sourceSet", "metadataPath"]),
             ),
         ];

--- a/plugins/unica/.claude-plugin/plugin.json
+++ b/plugins/unica/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unica",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Practical 1C:Enterprise development workflows for Claude Code.",
   "author": {
     "name": "Ingvar Consulting, LLC",

--- a/plugins/unica/.codex-plugin/plugin.json
+++ b/plugins/unica/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unica",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Practical 1C:Enterprise development workflows for Codex.",
   "author": {
     "name": "Ingvar Consulting, LLC",

--- a/plugins/unica/skills/meta-add/SKILL.md
+++ b/plugins/unica/skills/meta-add/SKILL.md
@@ -44,6 +44,7 @@ allowed-tools:
   "params": {
     "name": "unica.meta.add",
     "arguments": {
+      "cwd": "<workspace>",
       "sourceSet": "main",
       "kind": "Catalog",
       "name": "НовыйСправочник",
@@ -83,6 +84,7 @@ allowed-tools:
   "params": {
     "name": "unica.meta.add",
     "arguments": {
+      "cwd": "<workspace>",
       "sourceSet": "main",
       "kind": "EventSubscription",
       "name": "ПередЗаписьюНоменклатуры",

--- a/plugins/unica/skills/meta-edit/SKILL.md
+++ b/plugins/unica/skills/meta-edit/SKILL.md
@@ -109,6 +109,7 @@ writer; неизвестный QName также нельзя копироват�
   "params": {
     "name": "unica.meta.edit",
     "arguments": {
+      "cwd": "<workspace>",
       "sourceSet": "main",
       "metadataPath": "Catalog.Контрагенты",
       "operations": [
@@ -129,6 +130,7 @@ writer; неизвестный QName также нельзя копироват�
   "params": {
     "name": "unica.meta.edit",
     "arguments": {
+      "cwd": "<workspace>",
       "sourceSet": "main",
       "metadataPath": "Catalog.Контрагенты",
       "operations": [
@@ -165,6 +167,7 @@ writer; неизвестный QName также нельзя копироват�
   "params": {
     "name": "unica.meta.edit",
     "arguments": {
+      "cwd": "<workspace>",
       "sourceSet": "main",
       "metadataPath": "Document.ЗаказПокупателя",
       "operations": [
@@ -202,6 +205,7 @@ writer; неизвестный QName также нельзя копироват�
   "params": {
     "name": "unica.meta.edit",
     "arguments": {
+      "cwd": "<workspace>",
       "sourceSet": "main",
       "metadataPath": "Document.ЗаказПокупателя",
       "operations": [
@@ -229,6 +233,7 @@ writer; неизвестный QName также нельзя копироват�
   "params": {
     "name": "unica.meta.edit",
     "arguments": {
+      "cwd": "<workspace>",
       "sourceSet": "main",
       "metadataPath": "EventSubscription.ОбработкаИзменений",
       "operations": [
@@ -274,6 +279,7 @@ Unica проверяет итоговый post-image, поэтому поряд�
   "params": {
     "name": "unica.meta.edit",
     "arguments": {
+      "cwd": "<workspace>",
       "sourceSet": "main",
       "metadataPath": "Catalog.Валюты",
       "operations": [

--- a/plugins/unica/skills/meta-info/SKILL.md
+++ b/plugins/unica/skills/meta-info/SKILL.md
@@ -36,6 +36,7 @@ allowed-tools:
   "params": {
     "name": "unica.meta.info",
     "arguments": {
+      "cwd": "<workspace>",
       "sourceSet": "main",
       "metadataPath": "Catalog.Валюты"
     }
@@ -167,6 +168,7 @@ UUID в `id`, поддержанные typed-поля своего владел�
   "params": {
     "name": "unica.meta.info",
     "arguments": {
+      "cwd": "<workspace>",
       "sourceSet": "main",
       "metadataPath": "Document.АвансовыйОтчет"
     }
@@ -183,6 +185,7 @@ UUID в `id`, поддержанные typed-поля своего владел�
   "params": {
     "name": "unica.meta.info",
     "arguments": {
+      "cwd": "<workspace>",
       "sourceSet": "main",
       "metadataPath": "Document.АвансовыйОтчет",
       "sections": ["roles", "subscriptions", "functionalOptions"],
@@ -201,6 +204,7 @@ UUID в `id`, поддержанные typed-поля своего владел�
   "params": {
     "name": "unica.meta.info",
     "arguments": {
+      "cwd": "<workspace>",
       "sourceSet": "main",
       "metadataPath": "Catalog.Валюты",
       "sections": ["predefinedItems"],
@@ -223,6 +227,7 @@ UUID в `id`, поддержанные typed-поля своего владел�
   "params": {
     "name": "unica.meta.info",
     "arguments": {
+      "cwd": "<workspace>",
       "sourceSet": "main",
       "metadataPath": "HTTPService.ExternalAPI"
     }
@@ -239,6 +244,7 @@ UUID в `id`, поддержанные typed-поля своего владел�
   "params": {
     "name": "unica.meta.info",
     "arguments": {
+      "cwd": "<workspace>",
       "sourceSet": "main",
       "metadataPath": "WebService.EnterpriseDataUpload_1_0_1_1"
     }
@@ -255,6 +261,7 @@ UUID в `id`, поддержанные typed-поля своего владел�
   "params": {
     "name": "unica.meta.info",
     "arguments": {
+      "cwd": "<workspace>",
       "sourceSet": "main",
       "metadataPath": "DefinedType.GLN"
     }
@@ -271,6 +278,7 @@ UUID в `id`, поддержанные typed-поля своего владел�
   "params": {
     "name": "unica.meta.info",
     "arguments": {
+      "cwd": "<workspace>",
       "sourceSet": "main",
       "metadataPath": "EventSubscription.ОбработкаИзменений"
     }

--- a/plugins/unica/skills/meta-remove/SKILL.md
+++ b/plugins/unica/skills/meta-remove/SKILL.md
@@ -38,6 +38,7 @@ allowed-tools:
   "params": {
     "name": "unica.meta.remove",
     "arguments": {
+      "cwd": "<workspace>",
       "sourceSet": "main",
       "metadataPath": "Catalog.Устаревший",
       "dryRun": true

--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -150,7 +150,7 @@
     },
     {
       "name": "unica",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "repository": "https://github.com/IngvarConsulting/unica",
       "sourceTag": "workspace",
       "sourceCommit": "workspace",

--- a/spec/architecture/tool-surface.md
+++ b/spec/architecture/tool-surface.md
@@ -856,6 +856,7 @@ Create one metadata object from a typed internal template and optionally configu
 
 | Аргумент | Тип | Обяз. | Описание |
 | --- | --- | --- | --- |
+| `cwd` | string | нет | Absolute path to the workspace root holding v8project.yaml; it selects the workspace and never narrows the logical address. |
 | `dryRun` | boolean | нет | Preview the mutation without writing workspace files. |
 | `kind` | string | да | Supported metadata object kind for the minimal template. |
 | `name` | string | да | Metadata object name using a valid 1C identifier. |
@@ -880,6 +881,7 @@ Apply ordered typed metadata edit operations atomically.
 
 | Аргумент | Тип | Обяз. | Описание |
 | --- | --- | --- | --- |
+| `cwd` | string | нет | Absolute path to the workspace root holding v8project.yaml; it selects the workspace and never narrows the logical address. |
 | `dryRun` | boolean | нет | Preview the mutation without writing workspace files. |
 | `metadataPath` | string | да | Logical metadata path of the object to edit. |
 | `operations` | array | да | Ordered typed edit operations applied as one atomic change. |
@@ -902,6 +904,7 @@ Inspect one metadata object with validation, proven subsystem memberships, and s
 
 | Аргумент | Тип | Обяз. | Описание |
 | --- | --- | --- | --- |
+| `cwd` | string | нет | Absolute path to the workspace root holding v8project.yaml; it selects the workspace and never narrows the logical address. |
 | `limit` | integer | нет | Maximum `predefinedItems` returned (1 through 50). Usage lists are read from the source tree, so they are exact and complete and the limit does not apply to them. |
 | `metadataPath` | string | да | Logical metadata path of the object to inspect. |
 | `sections` | array | нет | Extra sections to compute, all read from the source tree: `roles`, `subscriptions` and `functionalOptions` land in `usage`, `predefinedItems` in its own field. Omit or pass [] to inspect the object alone. |
@@ -928,6 +931,7 @@ Remove one metadata object through a logical guarded target.
 | Аргумент | Тип | Обяз. | Описание |
 | --- | --- | --- | --- |
 | `confirm` | boolean | нет | Explicitly confirm a forced metadata object removal. |
+| `cwd` | string | нет | Absolute path to the workspace root holding v8project.yaml; it selects the workspace and never narrows the logical address. |
 | `dryRun` | boolean | нет | Preview the mutation without writing workspace files. |
 | `force` | boolean | нет | Allow removal despite discovered references when confirmed. |
 | `metadataPath` | string | да | Logical metadata path of the object to remove. |

--- a/tests/ci/test_meta_surface_contract.py
+++ b/tests/ci/test_meta_surface_contract.py
@@ -671,11 +671,14 @@ class MetaSurfaceContractTests(unittest.TestCase):
             "Edit": '["sourceSet", "metadataPath", "operations"]',
             "Remove": '["sourceSet", "metadataPath"]',
         }
+        # `cwd` адресует рабочее пространство и обязателен на всей поверхности:
+        # упакованный сервер стартует в каталоге плагина (ADR-0006 §4), а
+        # наследовать рабочий каталог вызова запрещено (ADR-0053 §2).
         expected_properties = {
-            "Info": {"sourceSet", "metadataPath", "sections", "limit"},
-            "Add": {"sourceSet", "kind", "name", "operations", "dryRun"},
-            "Edit": {"sourceSet", "metadataPath", "operations", "dryRun"},
-            "Remove": {"sourceSet", "metadataPath", "dryRun", "force", "confirm"},
+            "Info": {"cwd", "sourceSet", "metadataPath", "sections", "limit"},
+            "Add": {"cwd", "sourceSet", "kind", "name", "operations", "dryRun"},
+            "Edit": {"cwd", "sourceSet", "metadataPath", "operations", "dryRun"},
+            "Remove": {"cwd", "sourceSet", "metadataPath", "dryRun", "force", "confirm"},
         }
 
         for operation, required in expected_required.items():
@@ -687,7 +690,8 @@ class MetaSurfaceContractTests(unittest.TestCase):
             following = [position for position in following if position >= 0]
             end = min(following, default=len(schema))
             arm = schema[start:end]
-            properties = {"sourceSet"}
+            # Общие для всех операций поля вставляются до match-выражения.
+            properties = {"cwd", "sourceSet"}
             properties.update(
                 re.findall(r'properties\.insert\(\s*"([^"]+)"', arm)
             )

--- a/tests/ci/test_package_unica_plugin.py
+++ b/tests/ci/test_package_unica_plugin.py
@@ -422,7 +422,7 @@ class PackageUnicaPluginTests(unittest.TestCase):
 
         self.assertEqual(len(set(versions.values())), 1, versions)
 
-    def test_source_package_declares_the_0120_meta_delivery_version(self) -> None:
+    def test_source_package_declares_the_012_meta_delivery_version(self) -> None:
         repo_root = Path(__file__).resolve().parents[2]
         plugin_root = repo_root / "plugins/unica"
         host_versions = {
@@ -436,8 +436,11 @@ class PackageUnicaPluginTests(unittest.TestCase):
         )["tools"]
         unica_versions = [tool["version"] for tool in tools if tool["name"] == "unica"]
 
-        self.assertEqual(set(host_versions.values()), {"0.12.0"}, host_versions)
-        self.assertEqual(unica_versions, ["0.12.0"])
+        delivered = set(host_versions.values())
+        self.assertEqual(len(delivered), 1, host_versions)
+        version = next(iter(delivered))
+        self.assertRegex(version, r"^0\.12\.\d+$")
+        self.assertEqual(unica_versions, [version])
 
     def test_claude_contracts_avoid_keys_older_clients_reject(self) -> None:
         """Pin the key sets that decide whether an older client loads Unica at all.

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -1402,7 +1402,7 @@ class UnicaSkillRoutingTests(unittest.TestCase):
             self.assertTrue({"sourceSet", "kind", "name"}.issubset(arguments))
             self.assertLessEqual(
                 set(arguments),
-                {"sourceSet", "kind", "name", "operations", "dryRun"},
+                {"cwd", "sourceSet", "kind", "name", "operations", "dryRun"},
             )
             if "operations" in arguments:
                 self.assertIsInstance(arguments["operations"], list)
@@ -1420,7 +1420,8 @@ class UnicaSkillRoutingTests(unittest.TestCase):
             arguments = call["params"]["arguments"]
             self.assertEqual(call["params"]["name"], "unica.meta.edit")
             self.assertEqual(
-                set(arguments) - {"sourceSet", "metadataPath", "operations", "dryRun"},
+                set(arguments)
+                - {"cwd", "sourceSet", "metadataPath", "operations", "dryRun"},
                 set(),
             )
             self.assertIsInstance(arguments["operations"], list)

--- a/tests/ci/test_version_contract.py
+++ b/tests/ci/test_version_contract.py
@@ -35,7 +35,7 @@ class VersionContractTests(unittest.TestCase):
         self.assertEqual(len(set(values.values())), 1, values)
         self.assertRegex(next(iter(values.values())), r"^\d+\.\d+\.\d+$")
 
-    def test_meta_surface_delivery_is_versioned_as_0120_everywhere(self) -> None:
+    def test_meta_surface_delivery_is_versioned_across_the_012_line(self) -> None:
         module = load_module()
         values = module.read_version_contract(REPO_ROOT)
         lock = (REPO_ROOT / "Cargo.lock").read_text(encoding="utf-8")
@@ -46,10 +46,16 @@ class VersionContractTests(unittest.TestCase):
             if name and version and name.group(1) in {"unica-bootstrap", "unica-coder"}:
                 workspace_packages[name.group(1)] = version.group(1)
 
-        self.assertEqual(set(values.values()), {"0.12.0"}, values)
+        # Ветка сопровождения выпускает исправительные версии одну за другой,
+        # поэтому пин держит линию поставки и согласие всех мест, а не один
+        # конкретный патч.
+        delivered = set(values.values())
+        self.assertEqual(len(delivered), 1, values)
+        version = next(iter(delivered))
+        self.assertRegex(version, r"^0\.12\.\d+$")
         self.assertEqual(
             workspace_packages,
-            {"unica-bootstrap": "0.12.0", "unica-coder": "0.12.0"},
+            {"unica-bootstrap": version, "unica-coder": version},
         )
 
     def test_0120_meta_migration_is_complete_and_linked(self) -> None:


### PR DESCRIPTION
Первый исправительный выпуск с ветки сопровождения `release-v0.12`, которая ответвлена от тега `v0.12.0`. В `main` эта правка уедет отдельно.

## Почему

Упакованный сервер стартует с рабочим каталогом в корне плагина — так его задаёт `.mcp.json` (`cwd: "."`, ADR-0006 §4), и на Codex это буквально каталог плагина. Наследовать рабочий каталог вызова запрещено (ADR-0053 §2), поэтому рабочее пространство адресуется только аргументом `cwd`.

Типизированная поверхность метаданных (a12ea328, приехала в 0.12.0) при переезде с `NativeOperation` на собственный `ToolHandler::Metadata` сняла общий словарь `COMMON_ARGS` целиком и вернула из него поимённо `dryRun` и `confirm`, но не `cwd`. С этого релиза `unica.meta.{info,add,edit,remove}` не могут дотянуться ни до какого рабочего пространства с хоста, который уважает упакованную запись запуска: вызов отвергается на проверке формы аргументов.

До редизайна `cwd` принимался: предшественники были нативными операциями, и список допустимых аргументов начинался с `COMMON_ARGS`. То есть для потребителя это регрессия ровно в 0.12.0.

Обращение пользователя и #544.

## Что сделано

- `cwd` принят и опубликован во всех четырёх операциях метаданных;
- тест воспроизводит упакованную конфигурацию: процесс работает вне рабочего пространства, дерево адресуется только аргументом, и проходит весь путь add → info → edit → remove;
- обновлены сторожа, которые пинили старый набор аргументов (два раста в `tool_contracts.rs`, два питоновских), перегенерирована ведомость поверхности;
- примеры в четырёх meta-скиллах показывают `"cwd": "<workspace>"` — по конвенции `role-info` и `xdto`;
- версия поднята до 0.12.1 штатным `scripts/dev/bump-version.py`; деливерные стражи переведены с одного патча на линию `0.12.x`, иначе их пришлось бы править при каждом исправительном выпуске с этой ветки.

## Проверки

- `tests/ci` — 775 OK (3 skipped), `tests/dev` — 246 OK;
- `cargo test -p unica-coder` — зелёный, кроме `generated_equal_root_fact_expansion_is_bounded`: это wall-clock-флейк с бюджетом в 1 секунду, падает только под параллельной нагрузкой и проходит в одиночку;
- `cargo fmt --all -- --check` и `cargo clippy --workspace --all-targets --all-features -- -D warnings` — чисто;
- `scripts/ci/check-version-contract.py` — `0.12.1`.