### PR TITLE
fix(skills): route applied build to durable job

### DIFF
--- a/plugins/unica/references/use-cases/workspace-runtime.md
+++ b/plugins/unica/references/use-cases/workspace-runtime.md
@@ -13,7 +13,8 @@ subsystems, interfaces, and templates.
 ## Primary path
 
 Use the `v8-runner` skill and MCP `unica.runtime.execute` only to preview typed
-runtime arguments.
+runtime arguments. For an explicitly requested applied build, select the
+separate durable workflow described below before calling `runtime.execute`.
 
 По INV-MCP-RUNTIME-RECEIPT текущий runtime-контракт: `unica.runtime.execute` — preview-only и вызывается
 только с `dryRun: true`; любой applied-режим возвращает fail-closed до
@@ -27,6 +28,21 @@ call `unica.project.status`. It returns `ready`, `repositoryReady`, `checks[]`,
 until its source-set problem is fixed. In particular, `sourceSet.path: .` is an
 error: explain how to move the export into a strict child such as `src/` and
 update `v8project.yaml` safely.
+
+### Explicitly selected applied build
+
+When the user explicitly asks to build, load, or update the infobase from
+sources, treat that applied intent as a separate, explicitly selected durable
+workflow. After `unica.project.status` reports `ready: true`, explain that the
+operation continues as a background job and call `unica.runtime.job.start`
+with `operation=build` and `dryRun: false`. This is a direct workflow choice,
+not a fallback, continuation, or retry after `unica.runtime.execute` refusal.
+
+Keep the returned `jobId`. Read progress with `unica.runtime.job.status`, wait
+for a bounded interval with `unica.runtime.job.wait`, and fetch diagnostic
+tails with `unica.runtime.job.logs`. A normal build can keep both logs empty
+until its terminal JSON envelope; use phase and heartbeat to distinguish that
+from a stalled job.
 
 Each `sourceSets[].sourceFormat` describes working-tree discovery. Repository
 checks may additionally become applicable from staged index markers; do not
@@ -58,6 +74,7 @@ source-set path itself has no stronger structural evidence.
 | Preview binding an external EPF config locally | `operation=config-init`, required `config`, `sourceSet`, `connection`, `dryRun=true`; no local overlay is created |
 | Preview runtime state creation | `operation=init`, `dryRun=true` |
 | Preview applying sources to the infobase | `operation=build`, optional `sourceSet`, `fullRebuild`, `dryRun=true` |
+| Apply sources through an explicitly selected durable job | `unica.runtime.job.start`, `operation=build`, optional `sourceSet`/`fullRebuild`, `dryRun=false` |
 | Preview exporting infobase state | `operation=dump`, `mode=full`, optional matching `sourceSet`/`extension`, `dryRun=true` |
 | Preview Designer/EDT conversion | `operation=convert`, optional `sourceSet`, `output`, `dryRun=true` |
 | Preview CF/CFE/EPF/ERF export | `operation=make`, required `output`, optional `sourceSet`, `extension`, `dryRun=true` |
@@ -68,7 +85,8 @@ source-set path itself has no stronger structural evidence.
 | Preview external EPF wait arguments | `operation=launch`, `clientMode=thin`, `execute`, distinct `output`/`stderrOutput`, `waitForExit=true`, bounded `waitTimeoutMs`, `dryRun=true` |
 | Preview extension property sync | `operation=extensions`, `dryRun=true` |
 
-Every current applied operation is fail-closed before discovery or spawn. The
+Every current applied `unica.runtime.execute` operation is fail-closed before
+discovery or spawn. The
 operation-specific risks include non-interruptible phases, persistent writes
 without bounded recovery, and unproved ownership of separately grouped 1C
 processes. Designer `rawKeys` may not contain `DumpConfigToFiles` or

--- a/plugins/unica/references/use-cases/workspace-runtime.md
+++ b/plugins/unica/references/use-cases/workspace-runtime.md
@@ -14,7 +14,7 @@ subsystems, interfaces, and templates.
 
 Use the `v8-runner` skill and MCP `unica.runtime.execute` only to preview typed
 runtime arguments. For an explicitly requested applied build, select the
-separate durable workflow described below before calling `runtime.execute`.
+separate durable workflow described below instead of calling `runtime.execute`.
 
 По INV-MCP-RUNTIME-RECEIPT текущий runtime-контракт: `unica.runtime.execute` — preview-only и вызывается
 только с `dryRun: true`; любой applied-режим возвращает fail-closed до

--- a/plugins/unica/skills/v8-runner/SKILL.md
+++ b/plugins/unica/skills/v8-runner/SKILL.md
@@ -13,16 +13,48 @@ allowed-tools:
 
 ## MCP routing
 
-- Preferred path: use MCP `unica` tool `unica.runtime.execute` to preview typed v8-runner arguments; no current applied operation is admitted.
+- Preferred preview path: use MCP `unica` tool `unica.runtime.execute` to inspect typed v8-runner arguments; no current applied operation is admitted on that tool.
 - По INV-MCP-RUNTIME-RECEIPT текущий runtime-контракт: `unica.runtime.execute` — preview-only и вызывается только с `dryRun: true`; любой applied-режим возвращает fail-closed до workspace discovery и process spawn. Preview не является runtime verification. Не обходи этот отказ прямым runner-ом, через `unica.build.*` или fallback через `unica.runtime.job.*`.
 - Do not start internal runner MCP servers, package launchers, or shell runners directly, including for maintainer/debug workflows. Report the public contract gap instead.
 
 ## Lifecycle одного вызова
 
 - Каждый текущий применённый `unica.runtime.execute` возвращает терминальный fail-closed результат в исходном `tools/call` до запуска процесса. Для будущей доказанно ограниченной операции этот же вызов сможет передавать смысловые фазы через `notifications/progress`; не интерпретируй прогресс как процент или отдельный результат.
-- Общая конфигурация пакета сейчас не увеличивает крайний срок хоста и не передаёт серверу неподтверждённую метку бюджета: допущенных applied-операций нет. Будущий допуск потребует отдельно доказать сохранение исходного вызова хостом, достаточный бюджет ответа и полное владение деревом процессов.
-- Все текущие операции, включая Designer/EDT `syntax` и `launch` с `waitForExit=true`, пока preview-only. У закреплённого runner-а запись/публикация, непрерываемые фазы либо владение отдельно сгруппированным процессом 1С не имеют доказанного ограниченного восстановления на каждом error/cancel/timeout пути, поэтому применённый вызов завершится fail-closed до запуска дочернего процесса.
+- Общая конфигурация пакета сейчас не увеличивает крайний срок хоста и не передаёт серверу неподтверждённую метку бюджета: допущенных applied-операций `unica.runtime.execute` нет. Будущий допуск потребует отдельно доказать сохранение исходного вызова хостом, достаточный бюджет ответа и полное владение деревом процессов.
+- Все текущие операции `unica.runtime.execute`, включая Designer/EDT `syntax` и `launch` с `waitForExit=true`, пока preview-only. У закреплённого runner-а запись/публикация, непрерываемые фазы либо владение отдельно сгруппированным процессом 1С не имеют доказанного ограниченного восстановления на каждом error/cancel/timeout пути, поэтому применённый вызов завершится fail-closed до запуска дочернего процесса.
 - Не используй `unica.runtime.job.*` как fallback, продолжение или повтор `unica.runtime.execute`: долговременное задание — отдельный явно выбранный workflow, а не способ получить потерянный receipt.
+
+## Явно выбранный applied build
+
+Если пользователь прямо просит собрать, загрузить или обновить информационную
+базу из исходников, а не только показать команду, выбери отдельный
+долговременный workflow до вызова `unica.runtime.execute`. После успешного
+`unica.project.status` с `ready: true` предупреди, что сборка продолжится как
+фоновое задание, и вызови `unica.runtime.job.start` с `operation=build` и
+`dryRun: false`. Это прямой выбор applied workflow, не fallback после отказа
+одиночного вызова.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "unica.runtime.job.start",
+    "arguments": {
+      "cwd": "<workspace>",
+      "operation": "build",
+      "sourceSet": "<source-set>",
+      "dryRun": false
+    }
+  }
+}
+```
+
+Сохрани возвращённый `jobId`. Наблюдай фазу и heartbeat через
+`unica.runtime.job.status` или ограниченно жди через
+`unica.runtime.job.wait`; диагностические хвосты запрашивай через
+`unica.runtime.job.logs`. У обычного build логи могут оставаться пустыми до
+завершения — это не признак зависания.
 
 ## Project health preflight
 
@@ -49,6 +81,7 @@ then call `unica.project.status` again after the approved fix.
 | Предпросмотреть создание `v8project.yaml` | `config-init` (preview-only) | — |
 | Предпросмотреть инициализацию базы/workspace | `init` (preview-only) | — |
 | Предпросмотреть загрузку XML/EDT исходников в базу | `build` (preview-only) | — |
+| Реально загрузить XML/EDT исходники в базу | явно выбранный `unica.runtime.job.start`, `operation=build`, `dryRun: false` | `jobId` |
 | Предпросмотреть выгрузку базы в исходники | `dump` (preview-only) | — |
 | Предпросмотреть конвертацию Designer/EDT sources | `convert` (preview-only) | — |
 | Предпросмотреть сборку CF/CFE/EPF/ERF артефакта | `make` (preview-only) | — |

--- a/plugins/unica/skills/v8-runner/SKILL.md
+++ b/plugins/unica/skills/v8-runner/SKILL.md
@@ -28,7 +28,7 @@ allowed-tools:
 
 Если пользователь прямо просит собрать, загрузить или обновить информационную
 базу из исходников, а не только показать команду, выбери отдельный
-долговременный workflow до вызова `unica.runtime.execute`. После успешного
+долговременный workflow без вызова `unica.runtime.execute`. После успешного
 `unica.project.status` с `ready: true` предупреди, что сборка продолжится как
 фоновое задание, и вызови `unica.runtime.job.start` с `operation=build` и
 `dryRun: false`. Это прямой выбор applied workflow, не fallback после отказа

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -2029,11 +2029,18 @@ class UnicaSkillRoutingTests(unittest.TestCase):
         operations = set()
         for block in examples:
             payload = json.loads(block)
-            self.assertEqual(payload["params"]["name"], "unica.runtime.execute")
+            tool_name = payload["params"]["name"]
+            self.assertIn(
+                tool_name,
+                {"unica.runtime.execute", "unica.runtime.job.start"},
+            )
             arguments = payload["params"]["arguments"]
             self.assertIn("operation", arguments)
             self.assertNotEqual(set(arguments.keys()), {"cwd"})
             self.assertNotIn("args", arguments)
+            if tool_name == "unica.runtime.job.start":
+                self.assertEqual(arguments["operation"], "build")
+                self.assertIs(arguments.get("dryRun"), False)
             operations.add(arguments["operation"])
 
         self.assertTrue(
@@ -2397,6 +2404,43 @@ class UnicaSkillRoutingTests(unittest.TestCase):
                     self.assertIn(token, text)
                 for claim in forbidden_applied_claims:
                     self.assertNotRegex(text, claim)
+
+    def test_v8_runner_routes_explicit_applied_build_to_durable_job(self) -> None:
+        skill = self.skill_root() / "v8-runner" / "SKILL.md"
+        workspace_runtime = (
+            self.reference_root() / "use-cases" / "workspace-runtime.md"
+        )
+        skill_text = skill.read_text(encoding="utf-8")
+        workspace_runtime_text = workspace_runtime.read_text(encoding="utf-8")
+
+        calls = [
+            payload
+            for payload in (
+                json.loads(block)
+                for block in re.findall(
+                    r"```json\n(.*?)\n```", skill_text, flags=re.DOTALL
+                )
+            )
+            if payload.get("method") == "tools/call"
+        ]
+        durable_builds = [
+            call["params"]["arguments"]
+            for call in calls
+            if call.get("params", {}).get("name")
+            == "unica.runtime.job.start"
+            and call["params"]["arguments"].get("operation") == "build"
+        ]
+
+        self.assertEqual(len(durable_builds), 1)
+        self.assertIs(durable_builds[0].get("dryRun"), False)
+        self.assertIn("явно выбран", skill_text)
+        self.assertIn("explicitly selected", workspace_runtime_text)
+        for text in (skill_text, workspace_runtime_text):
+            self.assertIn("`unica.runtime.job.start`", text)
+            self.assertIn("`dryRun: false`", text)
+            self.assertIn("`unica.runtime.job.status`", text)
+            self.assertIn("`unica.runtime.job.wait`", text)
+            self.assertIn("`unica.runtime.job.logs`", text)
 
     def test_shipped_guidance_never_routes_runtime_refusal_through_fallbacks(
         self,

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -2435,12 +2435,29 @@ class UnicaSkillRoutingTests(unittest.TestCase):
         self.assertIs(durable_builds[0].get("dryRun"), False)
         self.assertIn("явно выбран", skill_text)
         self.assertIn("explicitly selected", workspace_runtime_text)
+        self.assertNotIn("до вызова `runtime.execute`", skill_text)
+        self.assertNotIn(
+            "before calling `runtime.execute`", workspace_runtime_text
+        )
         for text in (skill_text, workspace_runtime_text):
             self.assertIn("`unica.runtime.job.start`", text)
             self.assertIn("`dryRun: false`", text)
+            self.assertIn("`jobId`", text)
             self.assertIn("`unica.runtime.job.status`", text)
             self.assertIn("`unica.runtime.job.wait`", text)
             self.assertIn("`unica.runtime.job.logs`", text)
+            self.assertLess(
+                text.index("`unica.runtime.job.start`"),
+                text.index("`unica.runtime.job.status`"),
+            )
+            self.assertLess(
+                text.index("`unica.runtime.job.status`"),
+                text.index("`unica.runtime.job.wait`"),
+            )
+            self.assertLess(
+                text.index("`unica.runtime.job.wait`"),
+                text.index("`unica.runtime.job.logs`"),
+            )
 
     def test_shipped_guidance_never_routes_runtime_refusal_through_fallbacks(
         self,


### PR DESCRIPTION
## Что меняется

Fixes #554.

`v8-runner` теперь различает preview через `unica.runtime.execute` и заранее явно выбранный applied build через `unica.runtime.job.start`. Для реальной загрузки исходников skill показывает `operation=build`, `dryRun=false`, сохраняет `jobId` и направляет наблюдение в `status`/`wait`/`logs`.

Синхронизирован `workspace-runtime.md`, а regression-тест закрепляет положительный durable-маршрут, не ослабляя запрет использовать его как fallback после отказа `runtime.execute`.

## Почему

В 0.12.0 MCP-сервер уже поддерживает applied build как долговременное задание, но prompt-visible guidance показывал только preview-only маршрут. Поэтому агент ошибочно сообщал пользователям, что для реальной сборки нужна другая версия Unica.

## Архитектурный слой

- Затронутые записи реестра: `INV-MCP-RUNTIME-RECEIPT`, `REQ-OBS-DETACHED-PROGRESS` — реализация не меняется, guidance приводится в соответствие с действующим контрактом.
- Решение (ADR), если публичный или архитектурный контракт меняется: нет — публичная поверхность и lifecycle не меняются.

- [x] Пройден [чек-лист изменений](../spec/architecture/change-checklist.md) в части, относящейся к этому изменению.

## Проверка

```text
python -m pytest tests/ci/test_unica_skills.py -q
96 passed, 4625 subtests passed

git diff --check upstream/main...HEAD
exit 0
```

- [x] Новое поведение покрыто тестом `test_v8_runner_routes_explicit_applied_build_to_durable_job`.
- [x] Документация, описывающая изменённое поведение, обновлена в этом же PR.

Полный Rust/MCP smoke не заявляется: production Rust-код не менялся; локальная попытка `cargo build --bin unica` была заблокирована Windows при записи `target/debug/unica.d` (`os error 5`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for explicitly requested applied builds through durable runtime jobs.
  * Applied builds now provide job progress, status, wait, and log monitoring.
  * Preview-only runtime executions remain available for non-applied workflows.
  * Applied builds validate project readiness before starting.
* **Documentation**
  * Updated runtime guidance and operation-selection documentation to clarify preview versus applied build workflows.
* **Tests**
  * Added validation for applied build routing and required durable job monitoring steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->