### PR TITLE
fix(release): довести гейт обновления до конца — каталог-директория не умеет git-upgrade

### DIFF
--- a/.github/workflows/publish-unica-marketplace.yml
+++ b/.github/workflows/publish-unica-marketplace.yml
@@ -306,7 +306,13 @@ jobs:
           }
           if (Get-Command node -ErrorAction SilentlyContinue) { throw 'Node.js leaked into the consumer PATH' }
           $expected = $env:RELEASE_TAG.TrimStart('v')
-          & $env:CODEX_BIN plugin marketplace upgrade unica --json
+          # The seed above registered the candidate as a directory marketplace,
+          # which `plugin marketplace upgrade` refuses: it fetches a Git remote.
+          # A directory marketplace re-reads the catalog from disk, so the
+          # reinstall below is what carries the consumer from the previous
+          # stable to the candidate.
+          & $env:CODEX_BIN plugin remove unica@unica --json
+          & $env:CODEX_BIN plugin add unica@unica --json
           $state = (& $env:CODEX_BIN plugin list --available --json) | ConvertFrom-Json
           $found = @($state.installed | Where-Object {
             $_.pluginId -eq 'unica@unica' -and $_.version -eq $expected

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -574,7 +574,13 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         # Consumer verification installs the candidate the way a consumer does,
         # on every supported host, before the catalog moves.
         self.assertEqual(text.count("plugin marketplace add $candidate --json"), 2)
-        self.assertIn("plugin marketplace upgrade unica", text)
+        # The upgrade gate seeds the previous stable and then moves that same
+        # install to the candidate. The candidate is a directory marketplace, so
+        # the move is a reinstall against the rewritten catalog: `plugin
+        # marketplace upgrade` fetches a Git remote and refuses one.
+        self.assertNotIn("plugin marketplace upgrade unica", text)
+        self.assertIn("plugin remove unica@unica --json", text)
+        self.assertEqual(text.count("plugin add unica@unica --json"), 3)
         self.assertIn("verify --plugin-root $pluginRoot", text)
 
 


### PR DESCRIPTION
## Что чинит

Публикация v0.12.1 встала на гейте `verify-upgrade`: он падает на всех трёх целях, поэтому `promote` пропускается и каталог остаётся на `v0.12.0`, хотя байты уже застейджены и тег в маркетплейсе проставлен.

```
Error: marketplace `unica` is not configured as a Git marketplace
Expected exactly one installed unica@unica 0.12.1 after upgrade
```

## Почему

Гейт сеет предыдущий стабильный из локального клона застейдженного маркетплейса — `plugin marketplace add <path>`. Codex регистрирует его как каталог-директорию. Затем шаг зовёт `plugin marketplace upgrade unica`, а эта команда тянет git-remote и для каталога-директории отказывает.

Раньше это не всплывало: v0.12.1 — первый релиз через линейный конвейер ADR-0068.

## Как

Каталог-директория перечитывается с диска, поэтому после записи кандидатского каталога достаточно переустановить плагин: `plugin remove unica@unica` и `plugin add unica@unica`. Ровно эту пару выполняет и регрессионный workflow самого маркетплейса после своего git-обновления, так что проверка остаётся той же по смыслу: сид предыдущего стабильного, переход на кандидата, сверка версии и `bootstrap verify`.

Первую поломку того же прогона — контракт закреплённого Codex, который искался в рабочей области вызывающего репозитория, — чинит уже влитый [unica-marketplace#35](https://github.com/IngvarConsulting/unica-marketplace/pull/35). После этой правки прогон 32178449095 дошёл до сида: `verify-fresh-install` зелёный на всех трёх целях.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved marketplace upgrade verification by reinstalling the Unica plugin from the directory marketplace.
  * Continued validating the installed version and successful bootstrap after reinstallation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->