### PR TITLE
fix(diagnostics): missing bundled tool no longer reported as retryable

### DIFF
--- a/crates/unica-coder/src/infrastructure/diagnostics.rs
+++ b/crates/unica-coder/src/infrastructure/diagnostics.rs
@@ -319,11 +319,14 @@ impl DiagnosticProvider for BslAnalyzerDiagnosticProvider<'_> {
                 "bsl-analyzer diagnostics request was cancelled",
                 false,
             ),
-            Err(_) => provider_failed(
+            Err(error) => provider_failed(
                 None,
                 "provider_unavailable",
                 "bsl-analyzer diagnostics provider is unavailable",
-                true,
+                // A structurally missing bundled tool (no materialized third-party
+                // binary/manifest entry — see #531) cannot be fixed by retrying the
+                // same call; only some other, genuinely transient backend failure can.
+                !crate::infrastructure::code_intelligence::is_provider_unavailable_error(&error),
             ),
         }
     }
@@ -801,6 +804,13 @@ mod bsl_diagnostics_provider_tests {
             }
         }
 
+        fn failing(error: impl Into<String>) -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                replies: Mutex::new(VecDeque::from([Err(error.into())])),
+            }
+        }
+
         fn resident(text: Value) -> BslDiagnosticBackendReply {
             BslDiagnosticBackendReply::Resident(BslDiagnosticResidentReply {
                 result_text: text.to_string(),
@@ -951,6 +961,44 @@ mod bsl_diagnostics_provider_tests {
         assert_eq!(outcome.status, DiagnosticProviderStatus::Completed);
         assert!(!outcome.complete);
         assert!(outcome.observations.is_empty());
+    }
+
+    #[test]
+    fn missing_bundled_tool_error_is_reported_as_not_retryable() {
+        let fixture = ProviderFixture::new();
+        let backend = FakeBackend::failing("tool not found in manifest: bsl-analyzer");
+        let provider = BslAnalyzerDiagnosticProvider::with_backend(&backend);
+
+        let outcome = execute(&provider, &fixture, DiagnosticAction::Analyze);
+
+        assert_eq!(outcome.status, DiagnosticProviderStatus::Failed);
+        let error = outcome
+            .error
+            .expect("unavailable outcome must carry an error");
+        assert_eq!(error.code, "provider_unavailable");
+        assert!(
+            !error.retryable,
+            "a structurally missing bundled tool cannot be fixed by retrying: {error:?}"
+        );
+    }
+
+    #[test]
+    fn generic_backend_failure_stays_retryable() {
+        let fixture = ProviderFixture::new();
+        let backend = FakeBackend::failing("resident session crashed unexpectedly");
+        let provider = BslAnalyzerDiagnosticProvider::with_backend(&backend);
+
+        let outcome = execute(&provider, &fixture, DiagnosticAction::Analyze);
+
+        assert_eq!(outcome.status, DiagnosticProviderStatus::Failed);
+        let error = outcome
+            .error
+            .expect("unavailable outcome must carry an error");
+        assert_eq!(error.code, "provider_unavailable");
+        assert!(
+            error.retryable,
+            "a transient backend failure should still be retryable: {error:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Что меняется

Fixes #531 (часть про `retryable`).

`BslAnalyzerDiagnosticProvider::execute` отбрасывала исходную строку ошибки через `Err(_) => ...` и всегда хардкодила `retryable: true` в результирующем `provider_unavailable`, даже когда реальная причина — структурно отсутствующий bundled-инструмент (нет материализованного third-party бинаря или записи в манифесте — например, сырой source-checkout по разделу «Разработка» из `README.md`, или любое другое окружение, где `bundled_tools::resolve_bundled_tool` падает с `"tool not found in manifest"`/`"tool not found in tools lock"`). Повтор того же вызова эту причину никогда не исправит — помогает только пересборка тулбандла.

`is_provider_unavailable_error` (`infrastructure/code_intelligence.rs`) уже классифицирует ровно эти причины «этого провайдера здесь нет» для `code.search`/`code.graph`. `execute` теперь использует тот же классификатор для `retryable` вместо хардкода: структурно отсутствующий инструмент даёт `retryable: false`, а по-настоящему временный сбой бэкенда остаётся `retryable: true`.

## Почему

Из #531: `retryable: true` вводит в заблуждение при source-checkout без материализованных инструментов — агент/пользователь видит `retryable: true` и пробует снова, хотя без пересборки тулбандла результат гарантированно тот же.

## Границы этого PR

Это только retryable-половина #531. Второе предложение issue — либо dev-шаг материализации third-party для source-checkout, либо более специфичный remediation прямо в тексте ошибки — оставлено на отдельный follow-up:

- richer remediation в тексте ошибки потребует согласования с `INV-MCP-DIAGNOSTIC-TARGET` (диагностика публикует только `location + focus`, никогда не абсолютные физические пути);
- dev-шаг материализации уже существует как двухкомандный ручной workflow (`scripts/ci/build-unica-tools.py` + `scripts/ci/package-unica-plugin.py --local-debug-host <host>`), и удобная обёртка вокруг него должна была бы повторить, а не задублировать этот путь.

## Проверка

Test-first (`AGENTS.md`): тест `missing_bundled_tool_error_is_reported_as_not_retryable` сначала прогнан против неисправленного кода — красный (`retryable: true`, ожидался `false`); после фикса — зелёный. Контрольный тест `generic_backend_failure_stays_retryable` подтверждает, что для НЕ структурно-отсутствующего сбоя `retryable` по-прежнему `true`.

```text
cargo test --package unica-coder --lib infrastructure::diagnostics::bsl_diagnostics_provider_tests
6 passed (все, включая 2 новых)

cargo test --package unica-coder --lib
3217+ passed; провалы совпадают с baseline на чистом main (flaky
process/timing-тесты в infrastructure::workspace_services, воспроизводятся
и без этого изменения) — ни одной новой регрессии

cargo clippy --package unica-coder --lib -- -D warnings
0 замечаний в diagnostics.rs

python -m pytest tests/ci/test_unica_skills.py -q
95 passed, 4625 subtests passed

git diff --check
exit 0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of bundled tool availability issues versus temporary backend failures.
  * Prevented retries for tools that are structurally unavailable while continuing to retry transient failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->