### PR TITLE
fix(runtime): привести поставляемую поверхность в согласие с допущенным применённым вызовом

### DIFF
--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -803,7 +803,7 @@ pub fn tools() -> Vec<ToolSpec> {
         ToolSpec {
             name: "unica.runtime.execute",
             description:
-                "Preview typed v8-runner workflows; current applied operations return a terminal fail-closed result before workspace discovery or process spawn.",
+                "Preview typed v8-runner workflows, or run a classified applied operation and answer with its terminal result plus a named risk warning; an unclassified operation still fails closed before workspace discovery or process spawn.",
             execution: ToolExecution::Mutation,
             result_contract: ResultContract::ExternalStream,
             cache_access: CacheAccess {

--- a/crates/unica-coder/src/application/runtime_admission.rs
+++ b/crates/unica-coder/src/application/runtime_admission.rs
@@ -111,7 +111,7 @@ pub(crate) fn runtime_risk_notice(
         RuntimeCompletionCapability::Detached => (
             "runtime_risk_detached_child",
             format!(
-                "operation `{operation}` would detach a child process, so the durable record cannot observe its exit"
+                "operation `{operation}` would detach a child process, so this call cannot observe its exit"
             ),
         ),
         RuntimeCompletionCapability::Unclassified => {

--- a/crates/unica-coder/src/application/tool_contracts.rs
+++ b/crates/unica-coder/src/application/tool_contracts.rs
@@ -3572,7 +3572,7 @@ fn property_schema_for_tool(tool: &ToolSpec, name: &str) -> Value {
         return json!({
             "type": "boolean",
             "default": true,
-            "description": "Preview typed v8-runner runtime arguments; omitted or true reports the planned command without mutation, while false runs the operation and returns its terminal result in this call, carrying the named applied risk as a warning."
+            "description": "Preview typed v8-runner runtime arguments; omitted or true reports the planned command without mutation, while false runs a classified operation and returns its terminal result in this call with a named risk warning; an unclassified operation stays refused."
         });
     }
     if tool.name == "unica.role.edit" {
@@ -6623,7 +6623,7 @@ mod tests {
         assert_eq!(schema["properties"]["projects"]["type"], "array");
         assert_eq!(
             schema["properties"]["dryRun"]["description"],
-            "Preview typed v8-runner runtime arguments; omitted or true reports the planned command without mutation, while false runs the operation and returns its terminal result in this call, carrying the named applied risk as a warning."
+            "Preview typed v8-runner runtime arguments; omitted or true reports the planned command without mutation, while false runs a classified operation and returns its terminal result in this call with a named risk warning; an unclassified operation stays refused."
         );
     }
 

--- a/crates/unica-coder/src/interfaces/mcp.rs
+++ b/crates/unica-coder/src/interfaces/mcp.rs
@@ -798,11 +798,11 @@ mod tests {
             .expect("runtime tool is listed");
         assert_eq!(
             runtime["description"],
-            "Preview typed v8-runner workflows; current applied operations return a terminal fail-closed result before workspace discovery or process spawn."
+            "Preview typed v8-runner workflows, or run a classified applied operation and answer with its terminal result plus a named risk warning; an unclassified operation still fails closed before workspace discovery or process spawn."
         );
         assert_eq!(
             runtime["inputSchema"]["properties"]["dryRun"]["description"],
-            "Preview typed v8-runner runtime arguments; omitted or true reports the planned command without mutation, while false runs the operation and returns its terminal result in this call, carrying the named applied risk as a warning."
+            "Preview typed v8-runner runtime arguments; omitted or true reports the planned command without mutation, while false runs a classified operation and returns its terminal result in this call with a named risk warning; an unclassified operation stays refused."
         );
         client.shutdown().await;
     }

--- a/plugins/unica/references/platform/development-standards.md
+++ b/plugins/unica/references/platform/development-standards.md
@@ -38,7 +38,8 @@ Use these standards during BSL implementation, review, and refactoring.
 `unica.build.*`.
 
 - Run object-specific validation after metadata changes.
-- Use `v8-runner` to preview or run `unica.runtime.execute` syntax/test arguments
-  with `dryRun: true`; retain an explicit residual risk because preview does not
-  validate BSL in the runtime.
+- Use `v8-runner` with `dryRun: true` to preview `unica.runtime.execute`
+  syntax/test arguments and with `dryRun: false` to run them; after a preview
+  alone, retain an explicit residual risk because preview does not validate BSL
+  in the runtime.
 - For risky changes, inspect metadata shape before and after the edit.

--- a/plugins/unica/references/tooling/runtime-build.md
+++ b/plugins/unica/references/tooling/runtime-build.md
@@ -139,7 +139,7 @@
 > Unica. Не направляй incremental/partial/CDFI-only команды прямо в
 > Git-visible source root: они допустимы только во временный private staging,
 > принадлежащий runtime-слою. Синхронный full dump (`mode=full`) для DESIGNER
-> `CONFIGURATION`/`EXTENSION` пока preview-only: его будущий applied path проходит через внешний private stage Unica,
+> `CONFIGURATION`/`EXTENSION` исполняется с названным риском записи без ограниченного восстановления: его applied path проходит через внешний private stage Unica,
 > платформа независимо фиксируется на exact 8.3.27.x, XML проверяется на raw
 > `version="2.20"` до целой публикации. На Windows, macOS и Linux verified
 > transactional publication определяет этот synchronous full dump, но
@@ -148,7 +148,7 @@
 > проверяемую транзакцию, а OS-зависимая реализация остаётся за
 > `INV-PLATFORM-OS-BEHIND-FACADE`.
 >
-> Async full и applied external source-set пока preview-only. Неполные режимы
+> Async full и applied external source-set несут тот же риск публикации. Неполные режимы
 > дополнительно не имеют безопасного merge receipt. На Windows Unica через
 > no-follow handles проверяет локальную системную установку: trusted owner и DACL
 > защищают install tree от изменения запускающим non-elevated пользователем, а
@@ -441,14 +441,16 @@ Legitimate metadata descriptor (включая external EPF/ERF) объекта 
 Платформа предоставляет параметры для использования вспомогательного CDFI при
 сравнении, но управление приватным CDFI для пары `source-set + ИБ` относится к
  runtime-слою. На Windows, macOS и Linux синхронный full dump (`mode=full`) для
-DESIGNER `CONFIGURATION`/`EXTENSION` пока preview-only; его verified transactional
+DESIGNER `CONFIGURATION`/`EXTENSION` исполняется с названным риском; его verified transactional
 publication Unica перенаправляет выбранный source-set во внешний private
 stage, платформа проверяется как exact 8.3.27.x, а version-bearing XML roots —
 как raw `2.20`; только затем целое дерево публикуется с проверкой preimage и
 rollback (ADR-0016, `INV-PLATFORM-OS-BEHIND-FACADE`). До реализации private
 state и shadow publication в `alkoleft/v8-runner-rust#30`
-`mode=incremental|partial` остаётся preview-only: закреплённый runner не
-возвращает точные processed paths/hashes и не выполняет divergence-safe merge.
+`mode=incremental|partial` исполняется, но доверять его результату вслепую
+нельзя: закреплённый runner не возвращает точные processed paths/hashes и не
+выполняет divergence-safe merge, поэтому расхождение обнаруживается только
+сравнением исходников после прогона.
 Будущий applied-маршрут сможет принять только системную установку платформы,
 неизменяемую для вызывающего пользователя; сейчас любой applied-вызов
 останавливается ещё до проверки или исполнения установки.

--- a/plugins/unica/references/tooling/v8project.md
+++ b/plugins/unica/references/tooling/v8project.md
@@ -149,9 +149,9 @@ publication contract; its transaction guarantees do not make the current
 applied route executable.
 
 On Windows, macOS, and Linux, synchronous full dump (`mode=full`) for DESIGNER
-`CONFIGURATION` and `EXTENSION` source-sets remains preview-only: verified
-transactional publication still has post-run work without a proved terminal
-receipt bound.
+`CONFIGURATION` and `EXTENSION` source-sets runs applied and answers with a named
+risk: verified transactional publication still has post-run work without a proved
+terminal receipt bound, so a cancelled or timed-out dump has no bounded recovery.
 
 On Windows, Unica attests a local system installation through no-follow handles:
 its trusted owner and DACL must prevent mutation of the install tree by the

--- a/plugins/unica/references/use-cases/code-quality-review.md
+++ b/plugins/unica/references/use-cases/code-quality-review.md
@@ -23,9 +23,10 @@ with object-specific info tools, source search, syntax checks, and focused tests
 - Inspect metadata shape with `unica.*.info` tools before changing code that
   depends on objects, forms, roles, or reports.
 - Use code search/analysis tools through MCP `unica` where available.
-- Use `v8-runner` to preview or run `unica.runtime.execute`
-  `operation=syntax`/`operation=test` arguments with `dryRun: true`; do not
-  claim YaXUnit, Vanessa Automation, or syntax validation from preview.
+- Use `v8-runner` with `dryRun: true` to preview `unica.runtime.execute`
+  `operation=syntax`/`operation=test` arguments and with `dryRun: false` to run
+  them; never claim YaXUnit, Vanessa Automation, or syntax validation from a
+  preview alone.
 - Report findings first for reviews, ordered by severity and grounded in file
   references.
 

--- a/plugins/unica/references/use-cases/integrations.md
+++ b/plugins/unica/references/use-cases/integrations.md
@@ -22,10 +22,10 @@ integration belongs in the 1C architecture.
 - Use metadata tools to inspect or create HTTP services, common modules,
   constants, catalogs, documents, and registers needed by the integration.
 - Use BSL source edits for modules and handlers.
-- Use `v8-runner` to preview or run `unica.runtime.execute`
-  `operation=syntax`/`operation=test` arguments with `dryRun: true`; report
-  syntax, tests, and integration runtime behavior as unverified without
-  separate execution evidence.
+- Use `v8-runner` with `dryRun: true` to preview `unica.runtime.execute`
+  `operation=syntax`/`operation=test` arguments and with `dryRun: false` to run
+  them; after a preview alone, report syntax, tests, and integration runtime
+  behavior as unverified without separate execution evidence.
 - For OpenSpec work, keep proposal/spec artifacts in the project’s chosen spec
   workspace and link implementation tasks to those artifacts.
 

--- a/plugins/unica/references/use-cases/workspace-runtime.md
+++ b/plugins/unica/references/use-cases/workspace-runtime.md
@@ -33,6 +33,17 @@ until its source-set problem is fixed. In particular, `sourceSet.path: .` is an
 error: explain how to move the export into a strict child such as `src/` and
 update `v8project.yaml` safely.
 
+### Work the call must not wait for
+
+A long applied operation belongs in a durable job: `unica.runtime.job.start` runs
+it in a detached process that outlives the call, so a host deadline cannot lose
+the result. Keep the returned `jobId`, read progress with
+`unica.runtime.job.status`, wait for a bounded interval with
+`unica.runtime.job.wait`, and fetch diagnostic tails with
+`unica.runtime.job.logs`. A normal build can keep both logs empty until its
+terminal envelope; phase and heartbeat are what distinguish that from a stalled
+job.
+
 Each `sourceSets[].sourceFormat` describes working-tree discovery. Repository
 checks may additionally become applicable from staged index markers; do not
 interpret that as a rewrite of the published working-tree format.

--- a/plugins/unica/skills/v8-runner/SKILL.md
+++ b/plugins/unica/skills/v8-runner/SKILL.md
@@ -26,6 +26,35 @@ allowed-tools:
 - Операция, которую платформа исполняет отдельно сгруппированным процессом (`syntax` в режимах Designer/EDT, `launch`), несёт риск недоказанного владения этим процессом: результат назовёт причину, а очистка на всех путях ошибки не гарантирована.
 - Не используй `unica.runtime.job.*` как fallback, продолжение или повтор `unica.runtime.execute`: долговременное задание — отдельный явно выбранный workflow, а не способ получить потерянный receipt.
 
+## Работа, которую вызов ждать не должен
+
+Если сборка длинная, а терять её результат нельзя, запусти её отдельным
+долговременным заданием: оно живёт в отсоединённом процессе и переживает обрыв
+вызова. После успешного `unica.project.status` предупреди пользователя, что
+работа пойдёт фоном, и вызови:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "unica.runtime.job.start",
+    "arguments": {
+      "cwd": "<workspace>",
+      "operation": "build",
+      "sourceSet": "<source-set>",
+      "dryRun": false
+    }
+  }
+}
+```
+
+Сохрани возвращённый `jobId`. Наблюдай фазу и heartbeat через
+`unica.runtime.job.status`, ограниченно жди через `unica.runtime.job.wait`,
+диагностические хвосты запрашивай через `unica.runtime.job.logs`. У обычной
+сборки логи могут оставаться пустыми до завершения — это не признак зависания,
+различать помогают фаза и heartbeat.
+
 ## Project health preflight
 
 After clone or workspace initialization, and before `build` or `dump`, call
@@ -362,9 +391,9 @@ Platform XML.
 с именем `ConfigDumpInfo.xml` remains source и должен храниться в Git.
 На Windows, macOS и Linux verified transactional publication описывает
 синхронный full dump (`mode=full`) только для DESIGNER source-set типа
-`CONFIGURATION` или `EXTENSION`, но в текущем single-call lifecycle его можно
-только предпросмотреть: проверка и публикация не имеют доказанного верхнего
-срока. Unica независимо проверяет установленную
+`CONFIGURATION` или `EXTENSION`. Он исполняется и несёт названный риск: проверка
+и публикация не имеют доказанного ограниченного восстановления, поэтому
+прерванный прогон верхнего срока не гарантирует. Unica независимо проверяет установленную
 платформу 8.3.27, подменяет выбранный target на private staging, проверяет
 владельца и все XML version-bearing roots на exact raw `2.20`, затем атомарно с
 rollback публикует целое дерево. Контракт публикации принадлежит ADR-0016:
@@ -374,9 +403,9 @@ rollback публикует целое дерево. Контракт публи
 
 Любой applied dump пока отказывает до spawn. Асинхронный full dump и dump для
 external source-set также доступны только как preview. `incremental` и
-`partial` preview-only: до private
-CDFI, точного receipt и divergence-safe merge (alkoleft/v8-runner-rust#30) им
-нельзя писать в Git-visible root.
+`partial` исполняются, но до private
+CDFI, точного receipt и divergence-safe merge (alkoleft/v8-runner-rust#30) их
+результату в Git-visible root доверять нельзя без сверки исходников.
 
 На Windows Unica проверяет локальную системную установку через no-follow
 handles: доверенный владелец и DACL должны защищать install tree от изменения
@@ -585,7 +614,7 @@ handles: доверенный владелец и DACL должны защища
 
 ## Syntax/tests/extensions
 
-Все режимы `syntax`, `test` и `extensions` остаются preview-only. Даже
+Все режимы `syntax`, `test` и `extensions` исполняются с названным риском. Даже
 Designer syntax может породить отдельную группу процесса 1С, владение которой
 закреплённый runner не доказывает на каждом аварийном пути; интерактивная
 EDT-сессия и build/extension-фазы также не имеют ограниченного восстановления.

--- a/plugins/unica/skills/v8-runner/references/command-selection.md
+++ b/plugins/unica/skills/v8-runner/references/command-selection.md
@@ -10,8 +10,8 @@ Use MCP `unica.runtime.execute` and choose `operation` by intent:
 `unica.runtime.job.start`. Не обходи контракт прямым runner-ом или через
 `unica.build.*`.
 
-All current operations are preview-only even when the user requested
-execution. Applied `config-init`, `init`, `build`, `dump`, `load`, `test`,
+Every classified operation runs when the user asks for it; the result names
+the risk it carries. Applied `config-init`, `init`, `build`, `dump`, `load`, `test`,
 `extensions`, `convert`, `make`, every `syntax`, `tools-download`, and every
 `launch` capability fails closed before spawn.
 
@@ -47,8 +47,8 @@ Operation-specific guardrails:
 - `build` does not accept `extension`; build an extension by selecting its configured `sourceSet`.
 - `convert` does not accept ad hoc `path`, `format`, or `extension`; use configured source-sets.
 - Applied `convert` remains blocked because it can publish Designer XML outside the verified dump boundary.
-- Applied `config-init`, `make`, and `tools-download` remain blocked because their persistent writes are not covered by a bounded rollback contract.
-- Every `syntax` mode remains preview-only: EDT may use an interactive session, while Designer may create a separately grouped 1C process whose cleanup is not proved for every runner failure path.
+- Applied `config-init`, `make`, and `tools-download` write persistent state without a bounded rollback contract; the result says so, and an interrupted run may leave partial output.
+- Every `syntax` mode carries unproved process ownership: EDT may use an interactive session, while Designer may create a separately grouped 1C process whose cleanup is not proved for every runner failure path.
 - Do not pass `DumpConfigToFiles` or `LoadConfigFromFiles` through Designer `rawKeys`; Unica rejects those bypasses.
 - `load` does not support `mode=update`; use `mode=load` or `mode=merge` with `settings`.
 - `test` uses `fullOutput=true` for v8-runner `--full`; it is not a build full rebuild.

--- a/plugins/unica/skills/v8-runner/references/file-and-artifact-workflows.md
+++ b/plugins/unica/skills/v8-runner/references/file-and-artifact-workflows.md
@@ -17,7 +17,7 @@ For a dump preview, use `dryRun=true`; select an extension with matching
 
 On Windows, macOS, and Linux, verified transactional publication describes the
 synchronous full dump (`mode=full`) for a DESIGNER `CONFIGURATION` or
-`EXTENSION` source-set. It is currently preview-only because post-run
+`EXTENSION` source-set. It runs applied and names its risk: post-run
 validation/publication has no proved receipt bound. Unica independently resolves an exact 8.3.27
 installation, redirects the selected source-set to a private stage, validates
 the required owner and every XML version-bearing root as the raw literal 2.20,
@@ -27,10 +27,11 @@ owns this publication contract;
 verified transaction behavior, while OS-specific mechanics stay behind
 `INV-PLATFORM-OS-BEHIND-FACADE`.
 
-All applied dump modes remain fail-closed. Async full dumps and dumps for
-external source-sets remain preview-only. `mode=incremental` and `mode=partial` are also available only as read-only
-previews with `dryRun=true`; they need shadow/staging publication with exact
-path/hash receipts.
+Every applied dump mode writes persistent state without a bounded recovery
+contract, and the result says so. Async full dumps, dumps for external
+source-sets and `mode=incremental`/`mode=partial` additionally lack shadow or
+staging publication with exact path/hash receipts, so preview them with
+`dryRun=true` first and verify the written sources afterwards.
 Partial preview also requires `object` or `objects`.
 
 The final stage-to-target move is tentative, not a source-identity CAS. Unica
@@ -69,4 +70,4 @@ Preview `load` with `dryRun=true` for `.cf` or `.cfe` artifacts; applied load is
 not currently admitted. Supported argument modes are `load` and `merge`;
 `merge` requires `settings`, and `update` is not supported. v8-runner rejects
 `.epf` and `.erf` for `load`; external processors/reports are handled through
-external source-sets with preview-only `build`, `dump`, and `make`.
+external source-sets through `build`, `dump`, and `make`.

--- a/plugins/unica/skills/v8-runner/references/project-workflows.md
+++ b/plugins/unica/skills/v8-runner/references/project-workflows.md
@@ -18,7 +18,7 @@ Typical empty workspace order:
 4. If the database is the source of truth, preview synchronous `operation=dump` with `mode=full`; applied dump remains fail-closed because its post-run validation/publication has no proved receipt bound.
 5. If Git sources are the source of truth, ask before previewing `operation=build` with `dryRun=true`; applied build is not currently admitted.
 
-All dump modes and applied `convert` remain preview-only. Designer `rawKeys` containing `DumpConfigToFiles` or
+All dump modes and applied `convert` write persistent state without a bounded recovery contract, and the result names that risk. Designer `rawKeys` containing `DumpConfigToFiles` or
 `LoadConfigFromFiles` are fail-closed until they share the verified publication
 boundary.
 

--- a/plugins/unica/skills/v8-runner/references/testing.md
+++ b/plugins/unica/skills/v8-runner/references/testing.md
@@ -1,8 +1,10 @@
 # Testing
 
-Test operations build first, so their applied capability is currently
-preview-only and fails closed before spawn. Use the argument selections below
-with `dryRun=true`; do not fall back to a runtime job.
+Test operations build first, so an applied run carries the build's
+non-interruptible phase: cancelling mid-run leaves the infobase in an unproved
+state. Preview the argument selections below with `dryRun=true`, run them with
+`dryRun=false`, and choose `unica.runtime.job.start` when the call must not wait
+for the result.
 
 Use `operation=test`, `testRunner=yaxunit`, `testScope=all` for full YaXUnit.
 Add `fullOutput=true` when you need the runner `--full` output verbosity.
@@ -18,7 +20,7 @@ Preview syntax validation with `operation=syntax`, `dryRun=true`, and
 `mode=designer-modules`, `mode=designer-config`, or `mode=edt`. Designer modes
 accept client/server flags such as `server`, `thinClient`, `webClient`,
 `mobileClient`, `extension`, and `allExtensions`; EDT accepts `projects`. Every
-mode remains preview-only because cleanup ownership is not proved for all
-runner failure paths.
+mode carries unproved cleanup ownership on every runner failure path, so a
+crashed run can leave a platform process behind.
 
 Preserve failed test artifacts and report their path when the runner prints one.

--- a/spec/architecture/tool-surface.md
+++ b/spec/architecture/tool-surface.md
@@ -1167,7 +1167,7 @@ Validate role Rights.xml.
 
 ### `unica.runtime.execute`
 
-Preview typed v8-runner workflows; current applied operations return a terminal fail-closed result before workspace discovery or process spawn.
+Preview typed v8-runner workflows, or run a classified applied operation and answer with its terminal result plus a named risk warning; an unclassified operation still fails closed before workspace discovery or process spawn.
 
 | Аргумент | Тип | Обяз. | Описание |
 | --- | --- | --- | --- |

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -2042,11 +2042,17 @@ class UnicaSkillRoutingTests(unittest.TestCase):
         operations = set()
         for block in examples:
             payload = json.loads(block)
-            self.assertEqual(payload["params"]["name"], "unica.runtime.execute")
+            tool_name = payload["params"]["name"]
+            self.assertIn(
+                tool_name,
+                {"unica.runtime.execute", "unica.runtime.job.start"},
+            )
             arguments = payload["params"]["arguments"]
             self.assertIn("operation", arguments)
             self.assertNotEqual(set(arguments.keys()), {"cwd"})
             self.assertNotIn("args", arguments)
+            if tool_name == "unica.runtime.job.start":
+                self.assertIs(arguments.get("dryRun"), False)
             operations.add(arguments["operation"])
 
         self.assertTrue(
@@ -2399,6 +2405,45 @@ class UnicaSkillRoutingTests(unittest.TestCase):
                     self.assertIn(token, text)
                 for claim in forbidden_applied_claims:
                     self.assertNotRegex(text, claim)
+
+    def test_v8_runner_routes_unwaitable_work_to_a_durable_job(self) -> None:
+        """The durable route is a first-class choice, not a way around a refusal.
+
+        ADR-0074 admits the applied call, so the shipped guidance has to say when
+        a durable job is still the right tool: work whose result the call must
+        not lose. Adapted from PR #555, which proposed the positive route while
+        the applied call was still refused.
+        """
+        skill_text = (self.skill_root() / "v8-runner" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        reference_text = (
+            self.reference_root() / "use-cases" / "workspace-runtime.md"
+        ).read_text(encoding="utf-8")
+
+        durable_calls = [
+            payload["params"]["arguments"]
+            for payload in (
+                json.loads(block)
+                for block in re.findall(
+                    r"```json\n(.*?)\n```", skill_text, flags=re.DOTALL
+                )
+            )
+            if payload.get("method") == "tools/call"
+            and payload.get("params", {}).get("name") == "unica.runtime.job.start"
+        ]
+        self.assertTrue(durable_calls, "the skill shows no durable job call")
+        for arguments in durable_calls:
+            self.assertIs(arguments.get("dryRun"), False)
+            self.assertIn("operation", arguments)
+
+        for text in (skill_text, reference_text):
+            for observation in (
+                "unica.runtime.job.status",
+                "unica.runtime.job.wait",
+                "unica.runtime.job.logs",
+            ):
+                self.assertIn(observation, text)
 
     def test_shipped_guidance_never_routes_runtime_refusal_through_fallbacks(
         self,
@@ -3236,7 +3281,7 @@ Use `.claude/commands/xdto.md` as the execution route.
         self.assertNotIn("V8_PATH", runtime_build)
         self.assertNotIn("V8_BASE", runtime_build)
 
-    def test_verified_full_dump_documents_preview_only_publication_contract(self) -> None:
+    def test_verified_full_dump_documents_its_publication_risk_contract(self) -> None:
         docs = [
             self.skill_root() / "v8-runner" / "SKILL.md",
             self.skill_root()
@@ -3265,7 +3310,14 @@ Use `.claude/commands/xdto.md` as the execution route.
                 re.IGNORECASE,
             ),
         }
-        preview_only = re.compile(r"(?:preview[- ]only|предпросмотр|fail[- ]closed)", re.I)
+        # Публикация полного дампа исполняется и несёт названный риск записи без
+        # ограниченного восстановления (ADR-0074), поэтому абзац контракта
+        # обязан говорить о риске, а не о былом отказе.
+        publication_risk = re.compile(
+            r"(?:bounded recovery|proved (?:terminal )?receipt|ограниченн\w*\s+восстановлени\w*|"
+            r"названн\w*\s+риск\w*|named risk)",
+            re.I,
+        )
 
         def markdown_paragraphs(text: str) -> list[str]:
             return re.split(r"\n(?:[ \t]*|>[ \t]*)\n", text)
@@ -3275,13 +3327,13 @@ Use `.claude/commands/xdto.md` as the execution route.
                 paragraph
                 for paragraph in markdown_paragraphs(text)
                 if all(pattern.search(paragraph) for pattern in required.values())
-                and preview_only.search(paragraph)
+                and publication_risk.search(paragraph)
             ]
 
         def contract_errors(text: str) -> list[str]:
             errors = []
             if not contract_paragraphs(text):
-                errors.append("missing complete preview-only full dump contract paragraph")
+                errors.append("missing complete full dump publication-risk paragraph")
             return errors
 
         document_texts = {
@@ -3294,8 +3346,8 @@ Use `.claude/commands/xdto.md` as the execution route.
 
         mixed_claims = (
             "On Windows, macOS, and Linux, synchronous full dump mode=full for "
-            "CONFIGURATION and EXTENSION remains preview-only while verified "
-            "transactional publication lacks a bounded terminal receipt."
+            "CONFIGURATION and EXTENSION runs with a named risk while verified "
+            "transactional publication lacks bounded recovery."
         )
         self.assertEqual(
             [],
@@ -3456,12 +3508,13 @@ Use `.claude/commands/xdto.md` as the execution route.
         )
         self.assertIn("legacy_target_removed", text)
 
-    def test_v8_runner_dump_references_keep_incomplete_and_external_routes_preview_only(
+    def test_v8_runner_dump_references_keep_incomplete_and_external_routes_guarded(
         self,
     ) -> None:
         v8_runner_root = self.skill_root() / "v8-runner"
         safety_context = re.compile(
-            r"dryRun.{0,8}(?:true|`true`)|preview|read-only|fail-closed|block",
+            r"dryRun.{0,8}(?:true|`true`)|preview|read-only|fail-closed|block|"
+            r"receipt|сверк\w*|довер\w*|verify",
             re.IGNORECASE | re.DOTALL,
         )
         paths = sorted(


### PR DESCRIPTION
Догоняет 0.12.1: применённый вызов допущен, но несколько мест продолжали описывать снятый отказ. Часть находок — из ревью CodeRabbit на #558.

## Что расходилось

- Описание `unica.runtime.execute` в `tools/list` обещало терминальный fail-closed для любой применённой операции, а транспортный тест фиксировал эту строку. Теперь описание говорит, что классифицированная операция исполняется и отвечает предупреждением с названным риском, а неклассифицированная по-прежнему отказывает.
- Текст `dryRun` не называл ветку отказа, из-за чего `false` читался как «всегда исполняет».
- Формулировка риска `Detached` ссылалась на долговременную запись, которую этот путь не заводит.
- Три блока инструкций читались как «preview or run … с `dryRun: true`», то есть предлагали исполнять в режиме предпросмотра.
- Пятнадцать упоминаний `preview-only` в справочниках описывали снятый отказ. Настоящие ограничения сохранены как риски: публикация без ограниченного восстановления, недоказанное владение отдельно сгруппированным процессом платформы, отсутствие точных receipts у `mode=incremental|partial`.

## Взято из #555

Положительный маршрут долговременного задания сохранён и переоформлен: это выбор для работы, результат которой вызов терять не должен, а не обход отказа. В скилл добавлен JSON-пример `unica.runtime.job.start` и операционная деталь — у обычной сборки логи могут оставаться пустыми до завершения, различать зависание помогают фаза и heartbeat. Два его гварда перенесены с той же переформулировкой.

## Гварды

Три гварда требовали именно старых слов — «preview-only» и «fail-closed» в контрактных абзацах про полный дамп и режимы `incremental|partial`. Теперь они требуют, чтобы абзац называл риск публикации, и самопроверка детектора обновлена на новом образце. Ведомость поверхности перегенерирована.

## Проверка

- `tests/ci` — 776 тестов, зелено после перегенерации ведомости;
- `cargo test -p unica-coder --lib` — 3220 passed, падает только `generated_equal_root_fact_expansion_is_bounded`: wall-clock-флейк с бюджетом в секунду, проходит в одиночку;
- `cargo fmt --all -- --check` — чисто.