### PR TITLE
fix(windows): accept volumes without per-directory case sensitivity

### DIFF
--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -1620,8 +1620,12 @@ fn query_parent_case_sensitive_flags(parent: &fs::File) -> io::Result<u32> {
     Ok(information.flags)
 }
 
-/// Reports whether the file system answered that it does not implement per-directory case
-/// sensitivity at all, which is a proven state rather than an unproven one.
+/// Reports whether Windows declined to serve the per-directory case-sensitivity query rather
+/// than answering it. Two distinct layers decline the same way: a file system without the
+/// feature, and the Win32 entry point on a build that does not carry the information class.
+/// Windows Server 2019 (build 17763) is the measured case of the second — `fsutil`, which asks
+/// through `NtQueryInformationFile`, answers for the same directory that
+/// `GetFileInformationByHandleEx` rejects with `ERROR_INVALID_PARAMETER`.
 #[cfg(windows)]
 fn case_sensitivity_query_is_unsupported(error: &io::Error) -> bool {
     use windows_sys::Win32::Foundation::{
@@ -1646,10 +1650,12 @@ fn relative_child_object_attributes(parent: &fs::File) -> io::Result<u32> {
 
     let flags = match query_parent_case_sensitive_flags(parent) {
         Ok(flags) => flags,
-        // Only local NTFS volumes carry per-directory case sensitivity. A file system that does
-        // not implement the information class has answered that no directory it hosts can be
-        // case-sensitive, so the insensitive match every ordinary Win32 open already performs is
-        // exact here rather than a guess. Every other failure leaves the parent unproven.
+        // A declined query is an answer about the platform, not an unproven parent. Where the
+        // file system lacks the feature no directory can be case-sensitive and the insensitive
+        // match is exact; where only the Win32 entry point lacks the class, this open matches
+        // names the way every ordinary Win32 open on that host already does, including std::fs.
+        // Refusing instead would strand the whole surface on a host that is merely older.
+        // Every other failure still leaves the parent unproven and fails closed.
         Err(error) if case_sensitivity_query_is_unsupported(&error) => {
             return Ok(OBJ_CASE_INSENSITIVE)
         }
@@ -4326,7 +4332,7 @@ mod tests {
         }
 
         #[test]
-        fn windows_relative_open_accepts_a_volume_without_per_directory_case_sensitivity() {
+        fn windows_relative_open_accepts_a_declined_case_sensitivity_query() {
             use std::io::Read;
 
             for reported in [
@@ -4344,7 +4350,7 @@ mod tests {
                     open_regular_child_nofollow(&parent, std::ffi::OsStr::new("entry.txt"))
                 })
                 .unwrap_or_else(|error| {
-                    panic!("a volume without per-directory case sensitivity must open its child, but Windows error {reported} was reported as {error}")
+                    panic!("a declined case-sensitivity query must still open the child, but Windows error {reported} was reported as {error}")
                 });
 
                 let mut contents = Vec::new();

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -1620,6 +1620,25 @@ fn query_parent_case_sensitive_flags(parent: &fs::File) -> io::Result<u32> {
     Ok(information.flags)
 }
 
+/// Reports whether the file system answered that it does not implement per-directory case
+/// sensitivity at all, which is a proven state rather than an unproven one.
+#[cfg(windows)]
+fn case_sensitivity_query_is_unsupported(error: &io::Error) -> bool {
+    use windows_sys::Win32::Foundation::{
+        ERROR_CALL_NOT_IMPLEMENTED, ERROR_INVALID_FUNCTION, ERROR_INVALID_PARAMETER,
+        ERROR_NOT_SUPPORTED,
+    };
+
+    matches!(
+        error.raw_os_error(),
+        Some(code)
+            if code == ERROR_INVALID_FUNCTION as i32
+                || code == ERROR_INVALID_PARAMETER as i32
+                || code == ERROR_NOT_SUPPORTED as i32
+                || code == ERROR_CALL_NOT_IMPLEMENTED as i32
+    )
+}
+
 #[cfg(windows)]
 fn relative_child_object_attributes(parent: &fs::File) -> io::Result<u32> {
     const OBJ_CASE_INSENSITIVE: u32 = 0x40;
@@ -1627,6 +1646,13 @@ fn relative_child_object_attributes(parent: &fs::File) -> io::Result<u32> {
 
     let flags = match query_parent_case_sensitive_flags(parent) {
         Ok(flags) => flags,
+        // Only local NTFS volumes carry per-directory case sensitivity. A file system that does
+        // not implement the information class has answered that no directory it hosts can be
+        // case-sensitive, so the insensitive match every ordinary Win32 open already performs is
+        // exact here rather than a guess. Every other failure leaves the parent unproven.
+        Err(error) if case_sensitivity_query_is_unsupported(&error) => {
+            return Ok(OBJ_CASE_INSENSITIVE)
+        }
         Err(error) => {
             return Err(io::Error::new(
                 error.kind(),

--- a/crates/unica-coder/src/infrastructure/platform/filesystem.rs
+++ b/crates/unica-coder/src/infrastructure/platform/filesystem.rs
@@ -156,19 +156,19 @@ pub(crate) fn create_test_directory_link(target: &Path, link: &Path) -> io::Resu
 
 #[cfg(all(test, windows))]
 thread_local! {
-    static TEST_CASE_SENSITIVITY_QUERY_FAILURE: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static TEST_CASE_SENSITIVITY_QUERY_ERROR: std::cell::Cell<Option<u32>> = const { std::cell::Cell::new(None) };
 }
 
 #[cfg(all(test, windows))]
-fn with_case_sensitivity_query_failure<T>(action: impl FnOnce() -> T) -> T {
-    struct Reset(bool);
+fn with_case_sensitivity_query_error<T>(error: u32, action: impl FnOnce() -> T) -> T {
+    struct Reset(Option<u32>);
     impl Drop for Reset {
         fn drop(&mut self) {
-            TEST_CASE_SENSITIVITY_QUERY_FAILURE.with(|slot| slot.set(self.0));
+            TEST_CASE_SENSITIVITY_QUERY_ERROR.with(|slot| slot.set(self.0));
         }
     }
 
-    let previous = TEST_CASE_SENSITIVITY_QUERY_FAILURE.with(|slot| slot.replace(true));
+    let previous = TEST_CASE_SENSITIVITY_QUERY_ERROR.with(|slot| slot.replace(Some(error)));
     let _reset = Reset(previous);
     action()
 }
@@ -1586,7 +1586,7 @@ fn nt_create_options_for_std_file(desired_access: u32, create_options: u32) -> i
 }
 
 #[cfg(windows)]
-fn relative_child_object_attributes(parent: &fs::File) -> io::Result<u32> {
+fn query_parent_case_sensitive_flags(parent: &fs::File) -> io::Result<u32> {
     use std::mem::size_of;
     use std::os::windows::io::AsRawHandle;
     use windows_sys::Win32::Storage::FileSystem::{
@@ -1598,15 +1598,9 @@ fn relative_child_object_attributes(parent: &fs::File) -> io::Result<u32> {
         flags: u32,
     }
 
-    const OBJ_CASE_INSENSITIVE: u32 = 0x40;
-    const FILE_CS_FLAG_CASE_SENSITIVE_DIR: u32 = 1;
-
     #[cfg(test)]
-    if TEST_CASE_SENSITIVITY_QUERY_FAILURE.with(|slot| slot.get()) {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            "failed to query parent directory case-sensitive state",
-        ));
+    if let Some(error) = TEST_CASE_SENSITIVITY_QUERY_ERROR.with(|slot| slot.get()) {
+        return Err(io::Error::from_raw_os_error(error as i32));
     }
 
     let mut information = FileCaseSensitiveInformation { flags: 0 };
@@ -1621,28 +1615,36 @@ fn relative_child_object_attributes(parent: &fs::File) -> io::Result<u32> {
         )
     } == 0
     {
-        let error = io::Error::last_os_error();
-        return Err(io::Error::new(
-            error.kind(),
-            format!("failed to query parent directory case-sensitive state: {error}"),
-        ));
+        return Err(io::Error::last_os_error());
     }
-    if information.flags & !FILE_CS_FLAG_CASE_SENSITIVE_DIR != 0 {
+    Ok(information.flags)
+}
+
+#[cfg(windows)]
+fn relative_child_object_attributes(parent: &fs::File) -> io::Result<u32> {
+    const OBJ_CASE_INSENSITIVE: u32 = 0x40;
+    const FILE_CS_FLAG_CASE_SENSITIVE_DIR: u32 = 1;
+
+    let flags = match query_parent_case_sensitive_flags(parent) {
+        Ok(flags) => flags,
+        Err(error) => {
+            return Err(io::Error::new(
+                error.kind(),
+                format!("failed to query parent directory case-sensitive state: {error}"),
+            ))
+        }
+    };
+    if flags & !FILE_CS_FLAG_CASE_SENSITIVE_DIR != 0 {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
-            format!(
-                "parent directory reported unsupported case-sensitive flags 0x{:08x}",
-                information.flags
-            ),
+            format!("parent directory reported unsupported case-sensitive flags 0x{flags:08x}"),
         ));
     }
-    Ok(
-        if information.flags & FILE_CS_FLAG_CASE_SENSITIVE_DIR != 0 {
-            0
-        } else {
-            OBJ_CASE_INSENSITIVE
-        },
-    )
+    Ok(if flags & FILE_CS_FLAG_CASE_SENSITIVE_DIR != 0 {
+        0
+    } else {
+        OBJ_CASE_INSENSITIVE
+    })
 }
 
 #[cfg(windows)]
@@ -3822,7 +3824,7 @@ mod tests {
             verify_owner_only_security_descriptor, verify_thread_token_fallback_error,
             verify_windows_elevation_value, verify_windows_immutable_security_descriptor,
             verify_windows_local_fixed_device_info, verify_windows_local_fixed_volume,
-            with_case_sensitivity_query_failure, EffectiveTokenSource, OpenedChildKind,
+            with_case_sensitivity_query_error, EffectiveTokenSource, OpenedChildKind,
             OwnerOnlySecurityAttributes, ProcessToken, WindowsImmutableAclProfile,
         };
         use std::ffi::OsString;
@@ -3830,8 +3832,9 @@ mod tests {
         use std::ptr;
         use windows_sys::Win32::Foundation::{LocalFree, GENERIC_ALL, GENERIC_WRITE};
         use windows_sys::Win32::Foundation::{
-            ERROR_ACCESS_DENIED, ERROR_CANT_OPEN_ANONYMOUS, ERROR_FILE_NOT_FOUND,
-            ERROR_NO_MORE_FILES, ERROR_NO_TOKEN,
+            ERROR_ACCESS_DENIED, ERROR_CALL_NOT_IMPLEMENTED, ERROR_CANT_OPEN_ANONYMOUS,
+            ERROR_FILE_NOT_FOUND, ERROR_INVALID_FUNCTION, ERROR_INVALID_PARAMETER,
+            ERROR_NOT_SUPPORTED, ERROR_NO_MORE_FILES, ERROR_NO_TOKEN,
         };
         use windows_sys::Win32::Security::Authorization::{
             ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
@@ -4286,7 +4289,7 @@ mod tests {
             fs::write(root.join("entry.txt"), b"entry").unwrap();
             let parent = open_directory_nofollow(&root).unwrap();
 
-            let error = with_case_sensitivity_query_failure(|| {
+            let error = with_case_sensitivity_query_error(ERROR_ACCESS_DENIED, || {
                 open_regular_child_nofollow(&parent, std::ffi::OsStr::new("entry.txt"))
             })
             .expect_err("an ambiguous parent case-sensitivity query must fail closed");
@@ -4294,6 +4297,37 @@ mod tests {
             assert!(error.to_string().contains("case-sensitive"), "{error}");
             drop(parent);
             fs::remove_dir_all(root).unwrap();
+        }
+
+        #[test]
+        fn windows_relative_open_accepts_a_volume_without_per_directory_case_sensitivity() {
+            use std::io::Read;
+
+            for reported in [
+                ERROR_INVALID_FUNCTION,
+                ERROR_INVALID_PARAMETER,
+                ERROR_NOT_SUPPORTED,
+                ERROR_CALL_NOT_IMPLEMENTED,
+            ] {
+                let root = unique_temp_root("unsupported-parent-case-sensitivity");
+                fs::create_dir_all(&root).unwrap();
+                fs::write(root.join("entry.txt"), b"entry").unwrap();
+                let parent = open_directory_nofollow(&root).unwrap();
+
+                let mut child = with_case_sensitivity_query_error(reported, || {
+                    open_regular_child_nofollow(&parent, std::ffi::OsStr::new("entry.txt"))
+                })
+                .unwrap_or_else(|error| {
+                    panic!("a volume without per-directory case sensitivity must open its child, but Windows error {reported} was reported as {error}")
+                });
+
+                let mut contents = Vec::new();
+                child.read_to_end(&mut contents).unwrap();
+                assert_eq!(contents, b"entry");
+                drop(child);
+                drop(parent);
+                fs::remove_dir_all(root).unwrap();
+            }
         }
 
         #[test]


### PR DESCRIPTION
## Дефект

На Windows у пользователя отказывают `unica.meta.add` (публикация),
`unica.subsystem.compile` и `unica.project.status`:

```
failed to query parent directory case-sensitive state:
Параметр задан неверно. (os error 87)
```

## Причина

Каждое открытие дочернего элемента по имени на Windows идёт через
`open_relative_child` → `relative_child_object_attributes`
([filesystem.rs](crates/unica-coder/src/infrastructure/platform/filesystem.rs)).
Хелпер спрашивает у родительского каталога его per-directory case-sensitive
состояние и **любой** отказ этого запроса считает недоказанным состоянием
родителя — fail closed.

Но `ERROR_INVALID_PARAMETER` (87) здесь — не неопределённость, а отказ
обслужить information class. Per-directory case sensitivity реализуют только
локальные тома NTFS начиная с Windows 10 build 17107. Где класс не обслужен, ни
один каталог case-sensitive быть не может, значит регистронезависимое
сопоставление имени — точное совпадение с фактическим поведением, а не догадка.
Ровно его выполняет любой обычный вызов Win32, включая `std::fs`.

Через этот хелпер проходит каждое относительное открытие, поэтому отказ снимает
слой `secure_read` целиком — отсюда полный набор отказавших инструментов.

### Причина на машине автора отчёта — установлена замером

Первоначальная версия — неподдерживающая файловая система — опровергнута.
Измерено на его хосте (Windows Server 2019, сборка 17763.7314, том
`FileSystem=NTFS`, `DriveType=3`):

| Путь к одному и тому же вопросу | Корень тома | Каталог проекта |
| --- | --- | --- |
| `fsutil file queryCaseSensitiveInfo` (через `NtQueryInformationFile`) | отвечает: атрибут отключён | отвечает: атрибут отключён |
| `GetFileInformationByHandleEx` + `FileCaseSensitiveInfo` | отказ 87 | отказ 87 |

То есть NTFS класс обслуживает, а Win32-обёртка на этой сборке — нет. Она
сверяет номер класса с таблицей своей сборки: документация
`FILE_INFO_BY_HANDLE_CLASS` называет `MaximumFileInfoByHandleClass` значением
именно для такой проверки, и `FileCaseSensitiveInfo` не имеет там описанной
строки. Unica зовёт обёртку, поэтому получает отказ там, где `fsutil` получает
ответ.

Отсюда два следствия для оценки правки.

1. Для этого хоста `OBJ_CASE_INSENSITIVE` — не безопасное приближение, а
   фактически верное значение: `fsutil` показал, что оба каталога не
   case-sensitive.
2. Отказ обёртки **не** доказывает, что на томе нет case-sensitive каталогов —
   на Server 2019 NTFS их поддерживает, просто не через этот вход. Там, где
   отказывает только обёртка, правка переходит к сопоставлению, которое на том
   же хосте выполняет любое обычное Win32-открытие, включая `std::fs`.
   Каталог, явно помеченный case-sensitive, был бы сопоставлен без учёта
   регистра — ровно как его сопоставляет проводник и любая другая программа.
   Это осознанный выбор, а не недосмотр: см. «Альтернатива» ниже.

### Альтернатива, не выбранная в этом PR

Отказ обёртки можно обойти, спросив `NtQueryInformationFile` с
`FileCaseSensitiveInformation` напрямую — тем путём, которым ходит `fsutil`.
Тогда на Server 2019 сохранилось бы точное знание вместо умолчания платформы.
В файле уже есть ручные привязки `NtCreateFile` и
`NtQueryVolumeInformationFile`, так что путь для кодовой базы не чужой.

Здесь не сделано намеренно: это расширяет границу правки и добавляет unsafe FFI
ради случая, где текущий выбор совпадает с поведением платформы. Если ревью
считает, что уровень доказанности здесь ронять нельзя, скажите — вынесу
отдельной задачей или доложу в этот PR.

## Исправление

Сам запрос отделён от политики, читающей его исход. Семейство кодов, которыми
файловая система сообщает «класс не реализован» — `ERROR_INVALID_FUNCTION`,
`ERROR_INVALID_PARAMETER`, `ERROR_NOT_SUPPORTED`, `ERROR_CALL_NOT_IMPLEMENTED` —
классифицируется как доказанный ответ и даёт `OBJ_CASE_INSENSITIVE`. Любой
другой отказ (доступ, недействительный дескриптор) по-прежнему оставляет
состояние родителя недоказанным и падает закрыто.

Порог безопасности не понижается: fallback совпадает с умолчанием платформы, а
не слабее его.

## Проверка

Первый коммит — только падающий тест: он открывает дочерний файл, пока запрос
сообщает каждый из четырёх кодов, и падает на всех четырёх. Второй коммит —
исправление, тест зеленеет. Существующий тест fail-closed сохранён и теперь
явно называет внедряемый код (`ERROR_ACCESS_DENIED`).

Тесты Windows-only, поэтому красный и зелёный прогон доказывает CI
(`Rust tests (windows-latest)`). Локально на macOS: `cargo fmt --check`,
`cargo clippy -D warnings`, `cargo test -p unica-coder --lib` (3221 passed),
`scripts/ci/check-rust-platform-boundary.py`; Windows-код дополнительно
проверен типами против `windows-sys` 0.59 под `x86_64-pc-windows-msvc`.

## Что не входит

`read_directory_names_bounded` запрашивает `FileIdBothDirectoryInfo`. Класс
намного старше и шире поддержан, но на экзотическом редиректоре может отказать
следующим. В этот PR не втягивается: свидетельства нет, и это был бы уже другой
дефект.

База — `release-v0.12` по просьбе автора отчёта. `filesystem.rs` в
`release-v0.12` и `main` совпадает байт в байт, так что правка переносится
слиянием без конфликта.
