### PR TITLE
chore(release): set the version contract to 0.12.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,7 +1832,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unica-bootstrap"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "flate2",
  "fs2",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "unica-coder"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "cap-fs-ext",
  "cap-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/unica-bootstrap", "crates/unica-coder"]
 resolver = "2"
 
 [workspace.package]
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 license = "LGPL-3.0-or-later"
 repository = "https://github.com/IngvarConsulting/unica"

--- a/plugins/unica/.claude-plugin/plugin.json
+++ b/plugins/unica/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unica",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Practical 1C:Enterprise development workflows for Claude Code.",
   "author": {
     "name": "Ingvar Consulting, LLC",

--- a/plugins/unica/.codex-plugin/plugin.json
+++ b/plugins/unica/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unica",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "Practical 1C:Enterprise development workflows for Codex.",
   "author": {
     "name": "Ingvar Consulting, LLC",

--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -150,7 +150,7 @@
     },
     {
       "name": "unica",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "repository": "https://github.com/IngvarConsulting/unica",
       "sourceTag": "workspace",
       "sourceCommit": "workspace",


### PR DESCRIPTION
Шаг 0 [регламента релиза](docs/release-runbook.md): версия проставлена во всех
файлах, где её объявляет контракт пакета.

```
python3.12 scripts/dev/bump-version.py 0.12.2
cargo update --workspace --offline
```

## Что везёт 0.12.2

- #580 — Windows: отказ `GetFileInformationByHandleEx` для
  `FileCaseSensitiveInfo` больше не роняет весь слой `secure_read`. Замерено на
  хосте автора отчёта (Windows Server 2019, 17763.7314, локальный NTFS): `fsutil`
  через `NtQueryInformationFile` отвечает, Win32-обёртка отказывает с ошибкой 87.
  До правки отказывали публикация `meta.add`, `subsystem.compile` и
  `project.status`.
- #577 — вычищены остатки описаний отозванного отказа ADR-0074.
- #562 — согласована формулировка руководства по applied runtime.

## Проверка

- `scripts/ci/check-version-contract.py` — `Unica version contract: 0.12.2`, exit 0.
- `python3.12 -m unittest discover -s tests/ci` — `Ran 776 tests ... OK (skipped=3)`.
- `scripts/ci/check-architecture-sync.py` — `public MCP surface unchanged`, exit 0.

## Дальше по регламенту

После слияния этого PR тег `v0.12.2` на merge-коммите ставит владелец ключа —
подпись не автоматизируется. Далее Release Warden собирает, стейджит и вливает
staging сам; выпуск потребителям открывает тег в `unica-marketplace`, тоже
подписанный владельцем.

`main` этим релизом не закрывается: там 0.12.0, и правку нужно принести туда
отдельно приёмом `merge/release-v0.12-into-main`.
