### PR TITLE
chore(release): set the version contract to 0.12.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,7 +1832,7 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unica-bootstrap"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "flate2",
  "fs2",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "unica-coder"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "cap-fs-ext",
  "cap-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/unica-bootstrap", "crates/unica-coder"]
 resolver = "2"
 
 [workspace.package]
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 license = "LGPL-3.0-or-later"
 repository = "https://github.com/IngvarConsulting/unica"

--- a/plugins/unica/.claude-plugin/plugin.json
+++ b/plugins/unica/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unica",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Practical 1C:Enterprise development workflows for Claude Code.",
   "author": {
     "name": "Ingvar Consulting, LLC",

--- a/plugins/unica/.codex-plugin/plugin.json
+++ b/plugins/unica/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unica",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Practical 1C:Enterprise development workflows for Codex.",
   "author": {
     "name": "Ingvar Consulting, LLC",

--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -150,7 +150,7 @@
     },
     {
       "name": "unica",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "repository": "https://github.com/IngvarConsulting/unica",
       "sourceTag": "workspace",
       "sourceCommit": "workspace",


### PR DESCRIPTION
Шаг 0 [регламента релиза](docs/release-runbook.md): версия проставлена во всех файлах, где её объявляет контракт пакета.

```
python3.12 scripts/dev/bump-version.py 0.12.3
cargo update --workspace --offline
```

## Что везёт 0.12.3

- #586 — упакованная запись `.mcp.json` объявляет собственный бюджет старта `startup_timeout_sec: 900`. До правки холодная установка runtime шла внутри стартового бюджета хоста, Codex давал на неё 30 секунд и по истечении убивал всё дерево процессов запускателя посреди загрузки, оставляя усечённый архив, который следующая попытка не переиспользует. Ключ кеша содержит версию плагина, поэтому в это упиралась первая сессия после каждой установки и каждого обновления. Симптом снят на стороне Codex; [#585](https://github.com/IngvarConsulting/unica/issues/585) остаётся открытым — докачки по Range и уборки незавершённых транзакций по-прежнему нет.

## Проверка

- `scripts/ci/check-version-contract.py` — `Unica version contract: 0.12.3`, exit 0.
- `python3.12 -m unittest discover -s tests/ci` — `Ran 777 tests ... OK (skipped=3)`.
- `python3.12 -m unittest discover -s tests/dev` — `Ran 246 tests ... OK`.
- `scripts/ci/check-architecture-sync.py --base origin/release-v0.12` — `public MCP surface unchanged`, exit 0.

## Порядок слияния

Сливать **после** #586, чтобы merge-коммит этого PR нёс и правку, и версию — тег `v0.12.3` ставится именно на него. Ruleset ветки не требует актуальности относительно базы (`strict_required_status_checks_policy: false`), поэтому перезапуск проверок после слияния #586 не нужен.

## Дальше по регламенту

Тег `v0.12.3` на merge-коммите ставит владелец ключа. Дальше сборка публикует ассеты и открывает staging-PR в `unica-marketplace`; выпуск потребителям открывает тег в маркетплейсе и слияние промоушена.

Внимание: **Release Warden в этом релизе не поможет.** `release-warden.yml` есть только на `release-v0.12` и отсутствует на `main`, а GitHub регистрирует `schedule` и `workflow_dispatch` только с ветки по умолчанию — GitHub про этот workflow не знает вовсе. Шаги 3, 5 и 6 придётся вести руками, как runbook и разрешает для отключённого warden. Принести warden в `main` стоит отдельным приёмом.

`main` этим релизом не закрывается: там 0.12.0, и правку нужно принести туда отдельно приёмом `merge/release-v0.12-into-main`.