### PR TITLE
docs(release): record release lines, the merge-back, and two real failure modes

### DIFF
--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -41,6 +41,7 @@ automatically when the tag-triggered build succeeds:
 | | create the anchor tag on the staging commit |
 | | consumer install checks: fresh + upgrade, three hosts |
 | | green → move the catalog → **live** |
+| Step 3 — merge the line back into `main` | |
 
 Your signed source tag is the human approval and the cryptographic anchor of
 the release. Be honest about what enforces it: the pipeline proves the tag
@@ -64,7 +65,19 @@ failed workflow resumes the publication — every stage is idempotent.
   cancelled` in a non-interactive shell, run
   `gpg-connect-agent updatestartuptty /bye` first, then
   `echo test | gpg --clearsign > /dev/null` to unlock the agent.
-- `main` is green, and the version bump is ready to verify and merge.
+- The branch the release is cut from is green, and the version bump is ready
+  to verify and merge.
+
+## Where a release is cut from
+
+A minor is cut from `main`. Patches for a minor that already shipped are cut
+from its line branch, `release-vX.Y`, and that branch is where the version bump
+lives: `main` keeps the minor's version and never takes the patch bumps. When
+0.12.3 shipped, `release-v0.12` declared 0.12.3 while `main` still declared
+0.12.0.
+
+Steps 0 and 1 therefore happen on the branch the release is cut from, and the
+tag names a commit on it. Step 3 brings the line back to `main`.
 
 ## Step 0 — prepare the version
 
@@ -92,13 +105,16 @@ python3.12 -m pip install -r tests/ci/requirements.txt
 python3.12 -m unittest discover -s tests/ci
 ```
 
-Then merge through a pull request as usual.
+Then merge through a pull request into the branch the release is cut from.
+Keep the bump its own pull request: step 1 tags its merge commit, so that commit
+has to carry both the bump and everything else the version ships.
 
 ## Step 1 — tag the source release
 
-Tag the merged release commit on `main` in `unica` and push. The tag triggers
-the release build, and the successful build starts the publication pipeline on
-its own.
+Tag the merge commit of the version pull request in `unica` and push. On a
+patch that commit is on `release-vX.Y`, not on `main`. The tag triggers the
+release build, and the successful build starts the publication pipeline on its
+own.
 
 ```bash
 git tag -s vX.Y.Z <release-commit-sha> -m "Unica vX.Y.Z"
@@ -130,6 +146,23 @@ move in the same commit:
 gh api repos/IngvarConsulting/unica-marketplace/contents/.agents/plugins/marketplace.json \
   --jq '.content' | base64 -d | grep '"ref"'
 ```
+
+The marketplace repository runs its own **Verify marketplace** on every push it
+receives, so `stage`, `tag` and `promote` each leave a run there, after the
+fact. Those runs do not gate anything: the pipeline's `verify-upgrade` and
+`verify-fresh-install` jobs already ran on three hosts before `promote` moved
+the catalog.
+
+## Step 3 — merge the line back into `main`
+
+A patch leaves `main` behind, because the fix and the bump landed on the line
+branch only. Merge the line back through a `merge/release-vX.Y.Z-into-main`
+pull request once the release is live.
+
+The version contract conflicts every time. Keep `main`'s side in all five files:
+the line changed nothing there but the number. `Cargo.lock` conflicts for the
+same reason and also keeps `main`'s side, which carries the real dependency
+state while the line moved only the two workspace crate versions.
 
 ## If a stage fails
 
@@ -220,7 +253,8 @@ marketplace repository: deleting or moving a published tag by hand.
 | Publish run failed at `stage` or `tag` | Transient push failure or a moved branch | `gh run rerun <run-id> --failed`; stages are idempotent |
 | Publish run failed at the install checks | The candidate does not install as a consumer | Fix forward; the version is burnt, the catalog never moved |
 | `tag` fails on an existing tag | The version was already published with different bytes | Never move the tag; release the next patch |
-| Packaging fails with `release tag ... != ...` | Step 0 missed the workflow `RELEASE_TAG` fallback | Bump it and re-run |
+| Packaging fails with `release tag vX.Y.Z != vA.B.C` | The tagged commit does not declare X.Y.Z: step 0 was not merged, or the wrong commit was tagged | Tag the merge commit of the version pull request. If the bad tag was pushed, that version is burnt — take the next patch |
+| `Verify marketplace` red after the catalog moved, at `previous-stable-upgrade` with `git clone marketplace source timed out after 30s` | Codex re-clones the whole marketplace on `plugin marketplace upgrade`; a clone that misses its own 30s budget leaves the stale local catalog, which then installs the previous version | Transient. `gh run rerun <run-id> --failed`. Consumers are unaffected: the catalog is already correct and the pipeline's own upgrade checks passed before promote |
 | Consumers still report the old version | The publish run did not finish | Check its failed stage and rerun |
 
 ## Never


### PR DESCRIPTION
Правки в `docs/release-runbook.md` по следам выпуска 0.12.3. Каждая опирается на то, что проверено на этом релизе, а не на общее соображение.

## 1. Runbook считает, что релиз всегда режется с `main`

Патчи режутся не с `main`. Бамп версии и тег живут на `release-vX.Y`, а `main` держит версию минора и патч-бампы не принимает.

Проверено: на момент выпуска линия объявляла `0.12.3`, `main` — `0.12.0`, а тег `v0.12.3` указывает на коммит, которого на `main` нет вовсе (`git merge-base --is-ancestor` отвечает отрицательно). При этом шаг 1 требовал «Tag the merged release commit on `main`» — по букве это неисполнимо.

Добавлен раздел «Where a release is cut from», уточнены предусловие, конец шага 0 и шаг 1.

## 2. Приёма линии обратно в `main` не было вовсе

Хотя для одной только линии 0.12 он случился четыре раза: #558, #564, #584, #588. Разрешение конфликтов каждый раз одно и то же — сторона `main` в пяти файлах контракта версии и в `Cargo.lock`.

Добавлен шаг 3 с этим правилом и строка в сводную таблицу «You / The pipeline».

## 3. Строка про `RELEASE_TAG` описывает механизм, которого больше нет

Было: «Step 0 missed the workflow `RELEASE_TAG` fallback | Bump it and re-run». Литерала в workflow нет — сборка выводит тег из контракта версии в дереве, и комментарий рядом прямо объясняет, что литерал убрали намеренно.

Настоящая причина `release tag ... != ...` — тег поставлен на коммит, который не объявляет эту версию: шаг 0 не влит или выбран не тот коммит. Строка переписана под это, с напоминанием, что уже отправленный неверный тег сжигает версию.

## 4. Собственная проверка репозитория маркетплейса не описана

`Verify marketplace` в `unica-marketplace` запускается на каждый пуш, поэтому `stage`, `tag` и `promote` оставляют там по прогону — уже постфактум. Ничего они не гейтят: `verify-upgrade` и `verify-fresh-install` конвейера отработали на трёх хостах **до** перевода каталога.

Это не мелочь, потому что джоба `previous-stable-upgrade` там регулярно падает на транзиентном таймауте клона и выглядит как сломанный релиз. Сегодня это случилось на linux-x64 (`git clone marketplace source timed out after 30s`, `fatal: early EOF`), 18.08 — на Windows при 0.12.1. Оба раза лечилось перезапуском упавших джоб. Добавлена строка в таблицу отказов.

## Проверка

- `python3.12 -m unittest discover -s tests/ci` — `Ran 765 tests ... OK (skipped=3)`.
- Правки только в `docs/release-runbook.md`, +40/−6.

## Область

Только документ. Поведение конвейера не меняется. Устаревшую копию runbook на `release-v0.12` этот PR не трогает — она отдельный предмет: там ещё двухфазный релиз со сторожем, отменённый ADR-0068.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the release runbook with branch-specific steps for preparing, publishing, and merging releases.
  - Clarified marketplace verification timing and documented handling for verification timeouts.
  - Added guidance for resolving packaging failures by tagging the correct version-bump commit.
  - Removed outdated fallback instructions for release tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->