### PR TITLE
fix: keep compile recovery outside source roots

### DIFF
--- a/arch/decisions/2026-08-23-private-compile-recovery.md
+++ b/arch/decisions/2026-08-23-private-compile-recovery.md
@@ -1,0 +1,23 @@
+---
+id: DEC.2026-08-23.PRIVATE-COMPILE-RECOVERY
+status: active
+governs: product
+realized: crates/unica-coder/src/infrastructure/native_operations/compile_transaction.rs::compile_recovery_is_reserved_outside_workspace_source_root
+supersedes: []
+superseded-by: null
+establishes: [INV.SOURCE.PRIVATE-COMPILE-RECOVERY]
+---
+
+# Recovery compile-транзакции остаётся вне дерева исходников
+
+**Решение.** Compile-транзакция размещает registration backup, removal backup
+и rollback quarantine под `<workspace>/.build/unica/recovery`, когда цель
+принадлежит workspace. Для цели без маркера workspace сохраняется локальный
+sibling recovery, необходимый автономным транзакциям.
+
+**Почему.** Наблюдатель исходников может удержать служебный каталог открытым и
+сделать последующую индексацию source-set невозможной. Приватный корень не
+попадает в обход исходников и остаётся на том же томе, что и workspace.
+
+**Цена.** Транзакция обязана найти ближайший `v8project.yaml` и подготовить
+приватный каталог до резервирования recovery.

--- a/arch/index.md
+++ b/arch/index.md
@@ -39,6 +39,7 @@
 | `DEC.2026-08-22.EVIDENCE-BOUNDED-PRESERVATION` | решение · product | active | да | Перенесённое обещание не шире исполняемого доказательства | [decisions/2026-08-22-evidence-bounded-preservation.md](decisions/2026-08-22-evidence-bounded-preservation.md) |
 | `DEC.2026-08-22.EVIDENCE-BOUNDED-SAFETY` | решение · product | active | да | Safety-правило не шире исполняемого доказательства | [decisions/2026-08-22-evidence-bounded-safety.md](decisions/2026-08-22-evidence-bounded-safety.md) |
 | `DEC.2026-08-22.LINEAR-PUBLICATION` | решение · product | active | да | Публикация выражается зависимостями одного конвейера | [decisions/2026-08-22-linear-publication.md](decisions/2026-08-22-linear-publication.md) |
+| `DEC.2026-08-23.PRIVATE-COMPILE-RECOVERY` | решение · product | active | да | Recovery compile-транзакции остаётся вне дерева исходников | [decisions/2026-08-23-private-compile-recovery.md](decisions/2026-08-23-private-compile-recovery.md) |
 | `INV.APP.CODE-DEFINITION-READINESS` | инвариант · product | active |  | Definition не публикует ложный типизированный успех | [invariants/INV.APP.CODE-DEFINITION-READINESS.md](invariants/INV.APP.CODE-DEFINITION-READINESS.md) |
 | `INV.APP.CONFIG-SNAPSHOT` | инвариант · product | active |  | Оверлей конфигурации не меняет исходный снимок | [invariants/INV.APP.CONFIG-SNAPSHOT.md](invariants/INV.APP.CONFIG-SNAPSHOT.md) |
 | `INV.APP.DEFERRED-MANIFEST` | инвариант · product | active |  | Большое чтение отвечает ограниченным манифестом | [invariants/INV.APP.DEFERRED-MANIFEST.md](invariants/INV.APP.DEFERRED-MANIFEST.md) |
@@ -202,6 +203,7 @@
 | `INV.SOURCE.PLATFORM-XML-ONLY` | инвариант · product | active |  | Физически адресованный нативный гейт не принимает EDT | [invariants/INV.SOURCE.PLATFORM-XML-ONLY.md](invariants/INV.SOURCE.PLATFORM-XML-ONLY.md) |
 | `INV.SOURCE.PORTABLE-GIT` | инвариант · product | active |  | Переносимость Git доказывается содержимым репозитория | [invariants/INV.SOURCE.PORTABLE-GIT.md](invariants/INV.SOURCE.PORTABLE-GIT.md) |
 | `INV.SOURCE.PORTABLE-LFS-ADVISORY` | инвариант · product | active |  | LFS остаётся необязательной подсказкой | [invariants/INV.SOURCE.PORTABLE-LFS-ADVISORY.md](invariants/INV.SOURCE.PORTABLE-LFS-ADVISORY.md) |
+| `INV.SOURCE.PRIVATE-COMPILE-RECOVERY` | инвариант · product | active |  | Recovery compile-транзакции не публикуется в source-set | [invariants/INV.SOURCE.PRIVATE-COMPILE-RECOVERY.md](invariants/INV.SOURCE.PRIVATE-COMPILE-RECOVERY.md) |
 | `INV.SOURCE.READER-MIGRATION` | инвариант · product | active |  | Режим миграции читателя объявлен явно | [invariants/INV.SOURCE.READER-MIGRATION.md](invariants/INV.SOURCE.READER-MIGRATION.md) |
 | `INV.SOURCE.READER-OUTPUT-PARITY` | инвариант · product | active |  | Мост читателя не меняет типизированный ответ | [invariants/INV.SOURCE.READER-OUTPUT-PARITY.md](invariants/INV.SOURCE.READER-OUTPUT-PARITY.md) |
 | `INV.SOURCE.READER-SELECTOR` | инвариант · product | active |  | Предметный читатель принимает ровно один селектор цели | [invariants/INV.SOURCE.READER-SELECTOR.md](invariants/INV.SOURCE.READER-SELECTOR.md) |

--- a/arch/invariants/INV.SOURCE.PRIVATE-COMPILE-RECOVERY.md
+++ b/arch/invariants/INV.SOURCE.PRIVATE-COMPILE-RECOVERY.md
@@ -1,0 +1,14 @@
+---
+id: INV.SOURCE.PRIVATE-COMPILE-RECOVERY
+status: active
+governs: product
+decision: DEC.2026-08-23.PRIVATE-COMPILE-RECOVERY
+check: crates/unica-coder/src/infrastructure/native_operations/compile_transaction.rs::compile_recovery_is_reserved_outside_workspace_source_root
+scope: [source]
+---
+
+# Recovery compile-транзакции не публикуется в source-set
+
+Registration backup, removal backup и rollback quarantine для цели внутри
+workspace резервируются под `<workspace>/.build/unica/recovery`, а не внутри
+дерева исходников.

--- a/crates/unica-coder/src/infrastructure/native_operations/compile_transaction.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/compile_transaction.rs
@@ -2716,8 +2716,9 @@ fn recheck_removal(removal: &PlannedRemoval) -> Result<(), String> {
 }
 
 fn reserve_removal_recovery(target: &Path) -> Result<PendingRemovalRecovery, String> {
+    let recovery_parent = recovery_parent(target)?;
     for attempt in 1..=16 {
-        let directory = unique_recovery_directory(target);
+        let directory = unique_recovery_directory(&recovery_parent, target);
         match fs::create_dir(&directory) {
             Ok(()) => {
                 return Ok(PendingRemovalRecovery {
@@ -2743,7 +2744,10 @@ fn reserve_removal_recovery(target: &Path) -> Result<PendingRemovalRecovery, Str
 }
 
 fn reserve_recovery(target: &Path) -> Result<PendingRecovery, String> {
-    reserve_recovery_with(target, || unique_recovery_directory(target))
+    let recovery_parent = recovery_parent(target)?;
+    reserve_recovery_with(target, || {
+        unique_recovery_directory(&recovery_parent, target)
+    })
 }
 
 fn reserve_recovery_with(
@@ -2775,8 +2779,24 @@ fn reserve_recovery_with(
     ))
 }
 
-fn unique_recovery_directory(target: &Path) -> PathBuf {
-    let parent = usable_parent(target);
+fn recovery_parent(target: &Path) -> Result<PathBuf, String> {
+    let workspace = usable_parent(target)
+        .ancestors()
+        .find(|ancestor| ancestor.join("v8project.yaml").is_file());
+    let Some(workspace) = workspace else {
+        return Ok(usable_parent(target).to_path_buf());
+    };
+    let private = workspace.join(".build/unica/recovery");
+    fs::create_dir_all(&private).map_err(|error| {
+        format!(
+            "failed to prepare private compile recovery directory {}: {error}",
+            private.display()
+        )
+    })?;
+    Ok(private)
+}
+
+fn unique_recovery_directory(parent: &Path, target: &Path) -> PathBuf {
     let mut name = OsString::from(".");
     name.push(
         target
@@ -3265,8 +3285,9 @@ fn inspect_published_target(
 }
 
 fn reserve_rollback_quarantine(target: &Path) -> Result<(PathBuf, PathBuf), String> {
+    let recovery_parent = recovery_parent(target)?;
     for attempt in 1..=16 {
-        let directory = unique_recovery_directory(target);
+        let directory = unique_recovery_directory(&recovery_parent, target);
         match fs::create_dir(&directory) {
             Ok(()) => {
                 let path = directory.join("published");
@@ -6916,6 +6937,46 @@ pub(crate) mod tests {
         assert!(reservation.cleanup.directory.path.is_dir());
         assert!(!reservation.path().exists());
         assert!(reservation.cleanup().is_empty());
+        fs::remove_dir_all(root).expect("temporary root must be removed");
+    }
+
+    #[test]
+    fn compile_recovery_is_reserved_outside_workspace_source_root() {
+        let root = temp_root("private-registration-recovery");
+        fs::write(root.join("v8project.yaml"), b"source-set: []")
+            .expect("workspace marker must be written");
+        let source_root = root.join("external-processors/sample");
+        fs::create_dir_all(source_root.join("Ext")).expect("source directories must be created");
+        let target = source_root.join("Ext/ObjectModule.bsl");
+        fs::write(&target, b"before").expect("registration target must be written");
+
+        let private_recovery = root.join(".build/unica/recovery");
+        let mut registration = reserve_recovery(&target).expect("recovery must be reserved");
+        let mut removal =
+            reserve_removal_recovery(&target).expect("removal recovery must be reserved");
+        let (rollback_directory, _rollback_path) =
+            reserve_rollback_quarantine(&target).expect("rollback quarantine must be reserved");
+
+        for recovery_directory in [
+            registration.cleanup.directory_path(),
+            removal.directory.as_path(),
+            rollback_directory.as_path(),
+        ] {
+            assert!(
+                !recovery_directory.starts_with(&source_root),
+                "recovery must stay outside the watched source root: {}",
+                recovery_directory.display()
+            );
+            assert!(
+                recovery_directory.starts_with(&private_recovery),
+                "recovery must use the private workspace recovery root: {}",
+                recovery_directory.display()
+            );
+        }
+
+        assert!(registration.cleanup().is_empty());
+        assert!(removal.cleanup().is_empty());
+        fs::remove_dir(&rollback_directory).expect("rollback quarantine must be removed");
         fs::remove_dir_all(root).expect("temporary root must be removed");
     }
 


### PR DESCRIPTION
## Что меняется

Compile-транзакция резервирует registration backup, removal backup и rollback quarantine под `<workspace>/.build/unica/recovery`, а не рядом с целевым файлом внутри source-set. Для автономных целей вне workspace сохраняется прежнее sibling-поведение.

Это предотвращает попадание служебных `*.unica-recovery-*` каталогов в наблюдаемое VS Code дерево исходников и последующий отказ сканирования source-set с `Access denied` на Windows.

## Архитектурный слой

- Затронутые записи реестра: `INV.SOURCE.PRIVATE-COMPILE-RECOVERY`
- Решение: `DEC.2026-08-23.PRIVATE-COMPILE-RECOVERY`
- Публичная поверхность `unica.*` не меняется.

- [x] Прочитаны относящиеся к изменению записи из `arch/index.md`.

## Проверка

- `compile_recovery_is_reserved_outside_workspace_source_root` — passed
- `python -m unittest discover -s tests/arch` — 117 passed
- `python scripts/arch/registry.py --check` — passed
- `python scripts/ci/check-rust-platform-boundary.py` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- compile transaction tests — 69 passed; 3 environment failures on Windows (symlink privilege and temporary-file access denied)
- `cargo clippy -p unica-coder --all-targets --all-features -- -D warnings` reaches an existing unrelated `unused import: std::fs` in `unica-bootstrap`

- [x] Новое поведение покрыто тестом `compile_recovery_is_reserved_outside_workspace_source_root`.
- [x] Архитектурное решение и проверяемый инвариант добавлены в этом PR.

Ручная проверка выполнена на Windows с открытым VS Code workspace: исходная проблема с recovery-каталогом больше не воспроизводится.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recovery and rollback files for workspace builds are now stored in a private `.build/unica/recovery` directory.
  * Prevented temporary recovery artifacts from appearing in watched source folders.
  * Maintained local recovery storage for targets outside a workspace.

* **Documentation**
  * Added architectural guidance and safeguards describing private recovery storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->