### PR TITLE
Implement ReceiptLedger cancellation and Direct ACK foundation

### DIFF
--- a/crates/unica-coder/src/application/invocation_v5.rs
+++ b/crates/unica-coder/src/application/invocation_v5.rs
@@ -1,0 +1,403 @@
+use crate::application::receipt_ledger::{
+    canonical_v5_terminal, CancelExpiryOutcome, CancelReservedReceipt, CancelResolution,
+    CanonicalTerminalError, DirectTerminalUnackedReceipt, ReceiptKey, ReceiptState,
+    ReceiptStateKind, ReceiptTerminalOutcome, ReceiptVersion, ReserveOutcome, ReservedReceipt,
+    V5CanonicalTerminal,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CancelReservationDisposition {
+    NewlyReserved,
+    ExistingExact,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ReceiptDecisionRejection {
+    state: Box<ReceiptState>,
+}
+
+impl ReceiptDecisionRejection {
+    fn new(state: ReceiptState) -> Self {
+        Self {
+            state: Box::new(state),
+        }
+    }
+
+    pub(crate) fn state_kind(&self) -> ReceiptStateKind {
+        self.state.kind()
+    }
+
+    pub(crate) fn into_state(self) -> ReceiptState {
+        *self.state
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum CancelInvocationDecision {
+    Accepted {
+        disposition: CancelReservationDisposition,
+        receipt: CancelReservedReceipt,
+    },
+    ExistingDirectTerminal(DirectTerminalUnackedReceipt),
+    Rejected(ReceiptDecisionRejection),
+}
+
+pub(crate) fn decide_cancel_resolution(resolution: CancelResolution) -> CancelInvocationDecision {
+    match resolution {
+        CancelResolution::NewlyReserved(receipt) => CancelInvocationDecision::Accepted {
+            disposition: CancelReservationDisposition::NewlyReserved,
+            receipt,
+        },
+        CancelResolution::ExistingExact(receipt) => CancelInvocationDecision::Accepted {
+            disposition: CancelReservationDisposition::ExistingExact,
+            receipt,
+        },
+        CancelResolution::ExistingWinner(winner) => match *winner {
+            ReceiptState::DirectTerminalUnacked(receipt) => {
+                CancelInvocationDecision::ExistingDirectTerminal(receipt)
+            }
+            state => CancelInvocationDecision::Rejected(ReceiptDecisionRejection::new(state)),
+        },
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct CancelledDirectTerminalIntent {
+    reservation: ReservedReceipt,
+    terminal: V5CanonicalTerminal,
+}
+
+impl CancelledDirectTerminalIntent {
+    pub(crate) fn reservation(&self) -> &ReservedReceipt {
+        &self.reservation
+    }
+
+    pub(crate) fn terminal(&self) -> &V5CanonicalTerminal {
+        &self.terminal
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum CancelReservedSubmitDecision {
+    PublishCancelledDirect(CancelledDirectTerminalIntent),
+    ExistingDirectTerminal(DirectTerminalUnackedReceipt),
+    Rejected(ReceiptDecisionRejection),
+}
+
+pub(crate) fn decide_cancel_reserved_submit(
+    outcome: ReserveOutcome,
+) -> Result<CancelReservedSubmitDecision, CanonicalTerminalError> {
+    match outcome.into_state() {
+        ReceiptState::Reserved(reservation) if reservation.cancel_requested() => {
+            let terminal = canonical_v5_terminal(&ReceiptTerminalOutcome::Cancelled)?;
+            Ok(CancelReservedSubmitDecision::PublishCancelledDirect(
+                CancelledDirectTerminalIntent {
+                    reservation,
+                    terminal,
+                },
+            ))
+        }
+        ReceiptState::DirectTerminalUnacked(receipt) => Ok(
+            CancelReservedSubmitDecision::ExistingDirectTerminal(receipt),
+        ),
+        state => Ok(CancelReservedSubmitDecision::Rejected(
+            ReceiptDecisionRejection::new(state),
+        )),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CancelReservedExpiryIntent {
+    receipt: CancelReservedReceipt,
+    observed_at_epoch_ms: u64,
+}
+
+impl CancelReservedExpiryIntent {
+    pub(crate) fn key(&self) -> &ReceiptKey {
+        self.receipt.key()
+    }
+
+    pub(crate) fn expected_version(&self) -> ReceiptVersion {
+        self.receipt.record_version()
+    }
+
+    pub(crate) fn expected_mutation_sequence(&self) -> u64 {
+        self.receipt.mutation_sequence()
+    }
+
+    pub(crate) fn observed_at_epoch_ms(&self) -> u64 {
+        self.observed_at_epoch_ms
+    }
+
+    pub(crate) fn into_receipt(self) -> CancelReservedReceipt {
+        self.receipt
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum CancelReservedRecoveryDecision {
+    Current(Box<ReceiptState>),
+    Expire(CancelReservedExpiryIntent),
+}
+
+pub(crate) fn classify_recovered_receipt(
+    state: ReceiptState,
+    observed_at_epoch_ms: u64,
+) -> CancelReservedRecoveryDecision {
+    match state {
+        ReceiptState::CancelReserved(receipt)
+            if observed_at_epoch_ms >= receipt.expires_at_epoch_ms() =>
+        {
+            CancelReservedRecoveryDecision::Expire(CancelReservedExpiryIntent {
+                receipt,
+                observed_at_epoch_ms,
+            })
+        }
+        state => CancelReservedRecoveryDecision::Current(Box::new(state)),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum CancelReservedExpiryDecision {
+    Expired,
+    Current(Box<ReceiptState>),
+}
+
+pub(crate) fn classify_cancel_reserved_expiry_outcome(
+    outcome: CancelExpiryOutcome,
+) -> CancelReservedExpiryDecision {
+    match outcome {
+        CancelExpiryOutcome::Expired | CancelExpiryOutcome::Missing => {
+            CancelReservedExpiryDecision::Expired
+        }
+        CancelExpiryOutcome::NotDue(receipt) => {
+            CancelReservedExpiryDecision::Current(Box::new(ReceiptState::CancelReserved(receipt)))
+        }
+        CancelExpiryOutcome::ExistingWinner(winner) => {
+            CancelReservedExpiryDecision::Current(winner)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        classify_cancel_reserved_expiry_outcome, classify_recovered_receipt,
+        decide_cancel_reserved_submit, decide_cancel_resolution, CancelInvocationDecision,
+        CancelReservationDisposition, CancelReservedExpiryDecision, CancelReservedRecoveryDecision,
+        CancelReservedSubmitDecision,
+    };
+    use crate::application::receipt_ledger::{
+        canonical_v5_terminal, receipt_key_digest, request_scope_hash, CancelExpiryOutcome,
+        CancelReservedReceipt, CancelResolution, CoreIdentityDigest, DirectTerminalUnackedReceipt,
+        OriginalCutoffDescriptor, ReceiptKey, ReceiptRecordHeader, ReceiptState, ReceiptStateKind,
+        ReceiptTerminalOutcome, ReceiptVersion, RequestIdentity, ReserveOutcome, ReservedPhase,
+        ReservedReceipt, V5ToolIdentity, MAX_RECEIPT_ENTITLEMENT_BYTES,
+    };
+    use crate::domain::invocation::{InvocationId, NormalizedArgumentsHash, TaskId};
+
+    fn receipt_key() -> ReceiptKey {
+        ReceiptKey::new(
+            InvocationId::new(),
+            TaskId::new(),
+            RequestIdentity::new(
+                CoreIdentityDigest::from_sha256([0x55; 32]),
+                V5ToolIdentity::View,
+                NormalizedArgumentsHash::from_sha256([0x11; 32]),
+                request_scope_hash("workspace-a").expect("valid request scope"),
+            ),
+        )
+    }
+
+    fn cancel_reserved() -> CancelReservedReceipt {
+        CancelReservedReceipt::new(receipt_key(), ReceiptVersion::initial(), 1, 512, 1_000)
+            .expect("valid cancellation reservation")
+    }
+
+    fn reserved(cancel_requested: bool) -> ReservedReceipt {
+        let key = receipt_key();
+        ReservedReceipt::new(
+            ReceiptRecordHeader::new(
+                key.clone(),
+                receipt_key_digest(&key),
+                ReceiptVersion::initial(),
+                1,
+                512,
+            ),
+            1_000,
+            OriginalCutoffDescriptor::new(1_000, 7_000).expect("valid cutoff"),
+            ReservedPhase::Unbound,
+            cancel_requested,
+            MAX_RECEIPT_ENTITLEMENT_BYTES - 512,
+        )
+    }
+
+    fn direct_terminal() -> DirectTerminalUnackedReceipt {
+        let key = receipt_key();
+        DirectTerminalUnackedReceipt::new(
+            ReceiptRecordHeader::new(
+                key.clone(),
+                receipt_key_digest(&key),
+                ReceiptVersion::new(2).expect("nonzero version"),
+                2,
+                700,
+            ),
+            OriginalCutoffDescriptor::new(1_000, 7_000).expect("valid cutoff"),
+            2_000,
+            canonical_v5_terminal(&ReceiptTerminalOutcome::Cancelled)
+                .expect("cancelled terminal is canonical"),
+            MAX_RECEIPT_ENTITLEMENT_BYTES - 700,
+        )
+    }
+
+    #[test]
+    fn cancel_resolution_preserves_new_vs_duplicate_acceptance_without_runtime_policy() {
+        let receipt = cancel_reserved();
+        let newly_reserved =
+            decide_cancel_resolution(CancelResolution::NewlyReserved(receipt.clone()));
+        let existing_exact =
+            decide_cancel_resolution(CancelResolution::ExistingExact(receipt.clone()));
+
+        assert_eq!(
+            newly_reserved,
+            CancelInvocationDecision::Accepted {
+                disposition: CancelReservationDisposition::NewlyReserved,
+                receipt: receipt.clone(),
+            }
+        );
+        assert_eq!(
+            existing_exact,
+            CancelInvocationDecision::Accepted {
+                disposition: CancelReservationDisposition::ExistingExact,
+                receipt,
+            }
+        );
+    }
+
+    #[test]
+    fn cancel_resolution_returns_an_exact_terminal_or_typed_state_rejection() {
+        let terminal = direct_terminal();
+        assert_eq!(
+            decide_cancel_resolution(CancelResolution::ExistingWinner(Box::new(
+                ReceiptState::DirectTerminalUnacked(terminal.clone()),
+            ))),
+            CancelInvocationDecision::ExistingDirectTerminal(terminal)
+        );
+
+        let reserved = ReceiptState::Reserved(reserved(false));
+        let decision =
+            decide_cancel_resolution(CancelResolution::ExistingWinner(Box::new(reserved.clone())));
+        let CancelInvocationDecision::Rejected(rejection) = decision else {
+            panic!("a nonterminal winner must be rejected by the CR0 decision model");
+        };
+        assert_eq!(rejection.state_kind(), ReceiptStateKind::ReservedUnbound);
+        assert_eq!(rejection.into_state(), reserved);
+    }
+
+    #[test]
+    fn converted_cancel_reservation_produces_only_a_canonical_cancelled_direct_intent() {
+        for outcome in [
+            ReserveOutcome::Created(reserved(true)),
+            ReserveOutcome::ExistingExact(ReceiptState::Reserved(reserved(true))),
+        ] {
+            let decision =
+                decide_cancel_reserved_submit(outcome).expect("fixed Cancelled is canonical");
+            let CancelReservedSubmitDecision::PublishCancelledDirect(intent) = decision else {
+                panic!("a converted cancellation reservation must bypass the callback");
+            };
+
+            assert!(intent.reservation().cancel_requested());
+            assert_eq!(
+                intent.terminal().outcome(),
+                &ReceiptTerminalOutcome::Cancelled
+            );
+            assert_eq!(intent.terminal().payload(), br#"{"status":"cancelled"}"#);
+            assert_eq!(
+                intent.terminal().digest().as_str(),
+                "f2d0423d2613a0d09397b750542e4542f7653d78ebd5e0448f1326d09145d9ae"
+            );
+        }
+    }
+
+    #[test]
+    fn converted_submit_returns_an_existing_direct_terminal_and_rejects_non_cancelled_work() {
+        let terminal = direct_terminal();
+        assert_eq!(
+            decide_cancel_reserved_submit(ReserveOutcome::ExistingExact(
+                ReceiptState::DirectTerminalUnacked(terminal.clone()),
+            ))
+            .expect("existing terminal needs no canonicalization"),
+            CancelReservedSubmitDecision::ExistingDirectTerminal(terminal)
+        );
+
+        let non_cancelled = ReceiptState::Reserved(reserved(false));
+        let decision =
+            decide_cancel_reserved_submit(ReserveOutcome::ExistingExact(non_cancelled.clone()))
+                .expect("rejection needs no canonicalization");
+        let CancelReservedSubmitDecision::Rejected(rejection) = decision else {
+            panic!("CR0 must not expose a callback path for an ordinary reservation");
+        };
+        assert_eq!(rejection.state_kind(), ReceiptStateKind::ReservedUnbound);
+        assert_eq!(rejection.into_state(), non_cancelled);
+    }
+
+    #[test]
+    fn recovered_cancel_reservation_is_current_before_expiry_and_requests_exact_expiry_at_boundary()
+    {
+        let receipt = cancel_reserved();
+        let state = ReceiptState::CancelReserved(receipt.clone());
+        assert_eq!(
+            classify_recovered_receipt(state.clone(), receipt.expires_at_epoch_ms() - 1),
+            CancelReservedRecoveryDecision::Current(Box::new(state))
+        );
+
+        let decision =
+            classify_recovered_receipt(ReceiptState::CancelReserved(receipt.clone()), 8_125);
+        let CancelReservedRecoveryDecision::Expire(intent) = decision else {
+            panic!("the exact absolute expiry must request a witnessed deletion");
+        };
+        assert_eq!(intent.key(), receipt.key());
+        assert_eq!(intent.expected_version(), receipt.record_version());
+        assert_eq!(
+            intent.expected_mutation_sequence(),
+            receipt.mutation_sequence()
+        );
+        assert_eq!(intent.observed_at_epoch_ms(), 8_125);
+        assert_eq!(intent.into_receipt(), receipt);
+    }
+
+    #[test]
+    fn cancel_expiry_result_closes_missing_and_preserves_not_due_or_racing_winner() {
+        assert_eq!(
+            classify_cancel_reserved_expiry_outcome(CancelExpiryOutcome::Expired),
+            CancelReservedExpiryDecision::Expired
+        );
+        assert_eq!(
+            classify_cancel_reserved_expiry_outcome(CancelExpiryOutcome::Missing),
+            CancelReservedExpiryDecision::Expired
+        );
+
+        let not_due = cancel_reserved();
+        assert_eq!(
+            classify_cancel_reserved_expiry_outcome(CancelExpiryOutcome::NotDue(not_due.clone())),
+            CancelReservedExpiryDecision::Current(Box::new(ReceiptState::CancelReserved(not_due)))
+        );
+
+        let terminal = ReceiptState::DirectTerminalUnacked(direct_terminal());
+        assert_eq!(
+            classify_cancel_reserved_expiry_outcome(CancelExpiryOutcome::ExistingWinner(Box::new(
+                terminal.clone()
+            ),)),
+            CancelReservedExpiryDecision::Current(Box::new(terminal))
+        );
+    }
+
+    #[test]
+    fn recovery_classification_leaves_non_cancel_receipt_states_exactly_unchanged() {
+        let state = ReceiptState::DirectTerminalUnacked(direct_terminal());
+        assert_eq!(
+            classify_recovered_receipt(state.clone(), u64::MAX),
+            CancelReservedRecoveryDecision::Current(Box::new(state))
+        );
+    }
+}

--- a/crates/unica-coder/src/application/mod.rs
+++ b/crates/unica-coder/src/application/mod.rs
@@ -31,6 +31,9 @@ pub(crate) mod invocation_store;
 pub(crate) mod invocation_store_actor;
 #[allow(dead_code)]
 pub(crate) mod invocation_store_v5;
+// Pure protocol-v5 lifecycle decisions are composed only by the hidden daemon.
+#[allow(dead_code)]
+pub(crate) mod invocation_v5;
 pub(crate) mod metadata;
 pub(crate) mod operation_descriptors;
 pub(crate) mod operational_config;

--- a/crates/unica-coder/src/application/receipt_ledger.rs
+++ b/crates/unica-coder/src/application/receipt_ledger.rs
@@ -219,11 +219,201 @@ impl fmt::Display for ReceiptLedgerError {
 
 impl std::error::Error for ReceiptLedgerError {}
 
+#[cfg(feature = "receipt-ledger-test-support")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReceiptLedgerCatalogSnapshot {
+    generation: u64,
+    keys: Vec<ReceiptKey>,
+    invocation_index: Vec<ReceiptKey>,
+    reserved_task_index: Vec<ReceiptKey>,
+    live_count: u64,
+    actual_bytes: u64,
+    reserved_result_bytes: u64,
+}
+
+#[cfg(feature = "receipt-ledger-test-support")]
+impl ReceiptLedgerCatalogSnapshot {
+    pub(crate) const fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub(crate) fn keys(&self) -> &[ReceiptKey] {
+        &self.keys
+    }
+
+    pub(crate) fn invocation_index(&self) -> &[ReceiptKey] {
+        &self.invocation_index
+    }
+
+    pub(crate) fn reserved_task_index(&self) -> &[ReceiptKey] {
+        &self.reserved_task_index
+    }
+
+    pub(crate) const fn live_count(&self) -> u64 {
+        self.live_count
+    }
+
+    pub(crate) const fn actual_bytes(&self) -> u64 {
+        self.actual_bytes
+    }
+
+    pub(crate) const fn reserved_result_bytes(&self) -> u64 {
+        self.reserved_result_bytes
+    }
+}
+
+/// One-shot construction authority for feature-only catalog telemetry.
+///
+/// Only the application actor can mint the authority. The concrete store may
+/// consume it after observing its complete catalog under the retained writer
+/// fence, while callers receive only the validated, read-only snapshot.
+#[cfg(feature = "receipt-ledger-test-support")]
+pub(crate) struct ReceiptLedgerCatalogSnapshotAuthority {
+    _private: (),
+}
+
+#[cfg(feature = "receipt-ledger-test-support")]
+pub(crate) struct ReceiptLedgerCatalogSnapshotParts {
+    generation: u64,
+    keys: Vec<ReceiptKey>,
+    invocation_index: Vec<ReceiptKey>,
+    reserved_task_index: Vec<ReceiptKey>,
+    live_count: u64,
+    actual_bytes: u64,
+    reserved_result_bytes: u64,
+}
+
+#[cfg(feature = "receipt-ledger-test-support")]
+impl ReceiptLedgerCatalogSnapshotParts {
+    pub(crate) fn new(
+        generation: u64,
+        keys: Vec<ReceiptKey>,
+        invocation_index: Vec<ReceiptKey>,
+        reserved_task_index: Vec<ReceiptKey>,
+        live_count: u64,
+        actual_bytes: u64,
+        reserved_result_bytes: u64,
+    ) -> Self {
+        Self {
+            generation,
+            keys,
+            invocation_index,
+            reserved_task_index,
+            live_count,
+            actual_bytes,
+            reserved_result_bytes,
+        }
+    }
+}
+
+#[cfg(feature = "receipt-ledger-test-support")]
+impl ReceiptLedgerCatalogSnapshotAuthority {
+    pub(super) const fn new() -> Self {
+        Self { _private: () }
+    }
+
+    pub(crate) fn seal(
+        self,
+        parts: ReceiptLedgerCatalogSnapshotParts,
+    ) -> Result<ReceiptLedgerCatalogSnapshot, ReceiptLedgerError> {
+        let ReceiptLedgerCatalogSnapshotParts {
+            generation,
+            keys,
+            invocation_index,
+            reserved_task_index,
+            live_count,
+            actual_bytes,
+            reserved_result_bytes,
+        } = parts;
+        let observed_count = u64::try_from(keys.len()).map_err(|_| {
+            ReceiptLedgerError::Corrupt("receipt catalog count does not fit telemetry")
+        })?;
+        if live_count != observed_count || keys.len() > MAX_LIVE_RECEIPTS {
+            return Err(ReceiptLedgerError::Corrupt(
+                "receipt catalog telemetry count contradicts its keys",
+            ));
+        }
+        if invocation_index.len() != keys.len()
+            || reserved_task_index.len() != keys.len()
+            || !same_exact_receipt_key_set(&keys, &invocation_index)
+            || !same_exact_receipt_key_set(&keys, &reserved_task_index)
+        {
+            return Err(ReceiptLedgerError::Corrupt(
+                "receipt catalog telemetry indexes contradict its keys",
+            ));
+        }
+        for (offset, key) in keys.iter().enumerate() {
+            let prior = &keys[..offset];
+            if prior
+                .iter()
+                .any(|candidate| receipt_key_digest(candidate) == receipt_key_digest(key))
+            {
+                return Err(ReceiptLedgerError::Corrupt(
+                    "receipt catalog telemetry contains a duplicate key digest",
+                ));
+            }
+            if prior
+                .iter()
+                .any(|candidate| candidate.invocation_id() == key.invocation_id())
+            {
+                return Err(ReceiptLedgerError::Corrupt(
+                    "receipt catalog telemetry contains a duplicate invocation id",
+                ));
+            }
+            if prior
+                .iter()
+                .any(|candidate| candidate.reserved_task_id() == key.reserved_task_id())
+            {
+                return Err(ReceiptLedgerError::Corrupt(
+                    "receipt catalog telemetry contains a duplicate reserved task id",
+                ));
+            }
+        }
+        if actual_bytes
+            .checked_add(reserved_result_bytes)
+            .is_none_or(|bytes| bytes > MAX_LIVE_RECEIPT_BYTES)
+        {
+            return Err(ReceiptLedgerError::Corrupt(
+                "receipt catalog telemetry exceeds its byte entitlement",
+            ));
+        }
+        Ok(ReceiptLedgerCatalogSnapshot {
+            generation,
+            keys,
+            invocation_index,
+            reserved_task_index,
+            live_count,
+            actual_bytes,
+            reserved_result_bytes,
+        })
+    }
+}
+
+#[cfg(feature = "receipt-ledger-test-support")]
+fn same_exact_receipt_key_set(expected: &[ReceiptKey], observed: &[ReceiptKey]) -> bool {
+    expected
+        .iter()
+        .all(|key| observed.iter().any(|candidate| candidate == key))
+}
+
 /// Sole-writer boundary owned by the application actor.
 ///
 /// The port deliberately requires only `Send`: the actor moves one concrete
 /// writer to its worker thread and never shares it behind a mutex.
 pub(crate) trait ReceiptLedgerPort: Send + 'static {
+    #[cfg(feature = "receipt-ledger-test-support")]
+    fn snapshot_catalog(
+        &mut self,
+        _authority: ReceiptLedgerCatalogSnapshotAuthority,
+        _deadline: Instant,
+    ) -> Result<ReceiptLedgerCatalogSnapshot, ReceiptLedgerError> {
+        Err(ReceiptLedgerError::StoreUnavailable)
+    }
+
+    fn generation(&mut self, _deadline: Instant) -> Result<u64, ReceiptLedgerError> {
+        Err(ReceiptLedgerError::StoreUnavailable)
+    }
+
     fn reserve(
         &mut self,
         key: ReceiptKey,

--- a/crates/unica-coder/src/application/receipt_ledger.rs
+++ b/crates/unica-coder/src/application/receipt_ledger.rs
@@ -518,6 +518,15 @@ pub(crate) trait ReceiptLedgerPort: Send + 'static {
         key: &ReceiptKey,
         deadline: Instant,
     ) -> Result<ReceiptState, ReceiptLedgerError>;
+
+    fn recover_at(
+        &mut self,
+        key: &ReceiptKey,
+        _observed_at_epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<ReceiptState, ReceiptLedgerError> {
+        self.recover(key, deadline)
+    }
 }
 
 impl CoreIdentityDigest {

--- a/crates/unica-coder/src/application/receipt_ledger.rs
+++ b/crates/unica-coder/src/application/receipt_ledger.rs
@@ -127,6 +127,7 @@ pub(crate) enum ReceiptLedgerError {
     ReceiptDigestCollision,
     ReceiptNotFound,
     CapacityExceeded,
+    TombstoneCapacityExceeded,
     RecordTooLarge,
     TimestampOverflow,
     StoreUnavailable,
@@ -188,6 +189,9 @@ impl fmt::Display for ReceiptLedgerError {
             }
             Self::ReceiptNotFound => formatter.write_str("receipt was not found"),
             Self::CapacityExceeded => formatter.write_str("receipt ledger capacity is exhausted"),
+            Self::TombstoneCapacityExceeded => {
+                formatter.write_str("receipt tombstone capacity is exhausted")
+            }
             Self::RecordTooLarge => formatter.write_str("receipt record exceeds its byte limit"),
             Self::TimestampOverflow => {
                 formatter.write_str("receipt retention timestamp exceeds u64")
@@ -224,11 +228,13 @@ impl std::error::Error for ReceiptLedgerError {}
 pub(crate) struct ReceiptLedgerCatalogSnapshot {
     generation: u64,
     keys: Vec<ReceiptKey>,
+    tombstones: Vec<AcknowledgedTombstoneReceipt>,
     invocation_index: Vec<ReceiptKey>,
     reserved_task_index: Vec<ReceiptKey>,
     live_count: u64,
     actual_bytes: u64,
     reserved_result_bytes: u64,
+    tombstone_bytes: u64,
 }
 
 #[cfg(feature = "receipt-ledger-test-support")]
@@ -239,6 +245,10 @@ impl ReceiptLedgerCatalogSnapshot {
 
     pub(crate) fn keys(&self) -> &[ReceiptKey] {
         &self.keys
+    }
+
+    pub(crate) fn tombstones(&self) -> &[AcknowledgedTombstoneReceipt] {
+        &self.tombstones
     }
 
     pub(crate) fn invocation_index(&self) -> &[ReceiptKey] {
@@ -260,6 +270,10 @@ impl ReceiptLedgerCatalogSnapshot {
     pub(crate) const fn reserved_result_bytes(&self) -> u64 {
         self.reserved_result_bytes
     }
+
+    pub(crate) const fn tombstone_bytes(&self) -> u64 {
+        self.tombstone_bytes
+    }
 }
 
 /// One-shot construction authority for feature-only catalog telemetry.
@@ -276,32 +290,39 @@ pub(crate) struct ReceiptLedgerCatalogSnapshotAuthority {
 pub(crate) struct ReceiptLedgerCatalogSnapshotParts {
     generation: u64,
     keys: Vec<ReceiptKey>,
+    tombstones: Vec<AcknowledgedTombstoneReceipt>,
     invocation_index: Vec<ReceiptKey>,
     reserved_task_index: Vec<ReceiptKey>,
     live_count: u64,
     actual_bytes: u64,
     reserved_result_bytes: u64,
+    tombstone_bytes: u64,
 }
 
 #[cfg(feature = "receipt-ledger-test-support")]
 impl ReceiptLedgerCatalogSnapshotParts {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         generation: u64,
         keys: Vec<ReceiptKey>,
+        tombstones: Vec<AcknowledgedTombstoneReceipt>,
         invocation_index: Vec<ReceiptKey>,
         reserved_task_index: Vec<ReceiptKey>,
         live_count: u64,
         actual_bytes: u64,
         reserved_result_bytes: u64,
+        tombstone_bytes: u64,
     ) -> Self {
         Self {
             generation,
             keys,
+            tombstones,
             invocation_index,
             reserved_task_index,
             live_count,
             actual_bytes,
             reserved_result_bytes,
+            tombstone_bytes,
         }
     }
 }
@@ -319,11 +340,13 @@ impl ReceiptLedgerCatalogSnapshotAuthority {
         let ReceiptLedgerCatalogSnapshotParts {
             generation,
             keys,
+            tombstones,
             invocation_index,
             reserved_task_index,
             live_count,
             actual_bytes,
             reserved_result_bytes,
+            tombstone_bytes,
         } = parts;
         let observed_count = u64::try_from(keys.len()).map_err(|_| {
             ReceiptLedgerError::Corrupt("receipt catalog count does not fit telemetry")
@@ -333,17 +356,41 @@ impl ReceiptLedgerCatalogSnapshotAuthority {
                 "receipt catalog telemetry count contradicts its keys",
             ));
         }
-        if invocation_index.len() != keys.len()
-            || reserved_task_index.len() != keys.len()
-            || !same_exact_receipt_key_set(&keys, &invocation_index)
-            || !same_exact_receipt_key_set(&keys, &reserved_task_index)
+        let tombstone_count = u64::try_from(tombstones.len()).map_err(|_| {
+            ReceiptLedgerError::Corrupt("receipt tombstone count does not fit telemetry")
+        })?;
+        if tombstones.len() > MAX_ACKNOWLEDGED_TOMBSTONES
+            || tombstones
+                .iter()
+                .any(|receipt| receipt.encoded_bytes() > MAX_ACKNOWLEDGED_TOMBSTONE_BYTES)
+            || tombstones.iter().try_fold(0_u64, |bytes, receipt| {
+                bytes.checked_add(receipt.encoded_bytes())
+            }) != Some(tombstone_bytes)
+            || tombstone_bytes > MAX_ACKNOWLEDGED_TOMBSTONE_POOL_BYTES
+        {
+            return Err(ReceiptLedgerError::Corrupt(
+                "receipt catalog telemetry contradicts its tombstone pool",
+            ));
+        }
+        let mut indexed_keys = keys.clone();
+        indexed_keys.extend(tombstones.iter().map(|receipt| receipt.key().clone()));
+        let indexed_count =
+            live_count
+                .checked_add(tombstone_count)
+                .ok_or(ReceiptLedgerError::Corrupt(
+                    "receipt catalog telemetry count overflow",
+                ))?;
+        if u64::try_from(invocation_index.len()).ok() != Some(indexed_count)
+            || u64::try_from(reserved_task_index.len()).ok() != Some(indexed_count)
+            || !same_exact_receipt_key_set(&indexed_keys, &invocation_index)
+            || !same_exact_receipt_key_set(&indexed_keys, &reserved_task_index)
         {
             return Err(ReceiptLedgerError::Corrupt(
                 "receipt catalog telemetry indexes contradict its keys",
             ));
         }
-        for (offset, key) in keys.iter().enumerate() {
-            let prior = &keys[..offset];
+        for (offset, key) in indexed_keys.iter().enumerate() {
+            let prior = &indexed_keys[..offset];
             if prior
                 .iter()
                 .any(|candidate| receipt_key_digest(candidate) == receipt_key_digest(key))
@@ -380,11 +427,13 @@ impl ReceiptLedgerCatalogSnapshotAuthority {
         Ok(ReceiptLedgerCatalogSnapshot {
             generation,
             keys,
+            tombstones,
             invocation_index,
             reserved_task_index,
             live_count,
             actual_bytes,
             reserved_result_bytes,
+            tombstone_bytes,
         })
     }
 }
@@ -445,6 +494,24 @@ pub(crate) trait ReceiptLedgerPort: Send + 'static {
         terminal: V5CanonicalTerminal,
         deadline: Instant,
     ) -> Result<CommittedDirectPublication, ReceiptLedgerError>;
+
+    fn acknowledge_direct(
+        &mut self,
+        _key: &ReceiptKey,
+        _terminal_digest: &TerminalDigest,
+        _acknowledged_at_epoch_ms: u64,
+        _deadline: Instant,
+    ) -> Result<AcknowledgedTombstoneReceipt, ReceiptLedgerError> {
+        Err(ReceiptLedgerError::StoreUnavailable)
+    }
+
+    fn reclaim_expired_tombstones(
+        &mut self,
+        _observed_at_epoch_ms: u64,
+        _deadline: Instant,
+    ) -> Result<usize, ReceiptLedgerError> {
+        Err(ReceiptLedgerError::StoreUnavailable)
+    }
 
     fn recover(
         &mut self,
@@ -610,6 +677,11 @@ pub(crate) const MAX_LIVE_RECEIPT_BYTES: u64 =
     MAX_RECEIPT_ENTITLEMENT_BYTES * MAX_LIVE_RECEIPTS as u64;
 pub(crate) const DIRECT_TERMINAL_RETENTION_MS: u64 = 3_600_000;
 pub(crate) const CANCEL_RESERVATION_TTL_MS: u64 = 7_125;
+pub(crate) const ACKNOWLEDGED_TOMBSTONE_TTL_MS: u64 = 900_000;
+pub(crate) const MAX_ACKNOWLEDGED_TOMBSTONES: usize = 28_864;
+pub(crate) const MAX_ACKNOWLEDGED_TOMBSTONE_BYTES: u64 = 512;
+pub(crate) const MAX_ACKNOWLEDGED_TOMBSTONE_POOL_BYTES: u64 =
+    MAX_ACKNOWLEDGED_TOMBSTONE_BYTES * MAX_ACKNOWLEDGED_TOMBSTONES as u64;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -1254,9 +1326,56 @@ impl DirectTerminalUnackedReceipt {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AcknowledgedTombstoneReceipt {
-    record: ReceiptRecordHeader,
+    key: ReceiptKey,
+    key_digest: ReceiptKeyDigest,
     terminal_digest: TerminalDigest,
     acknowledged_at_epoch_ms: u64,
+    encoded_bytes: u64,
+}
+
+impl AcknowledgedTombstoneReceipt {
+    pub(crate) fn new(
+        key: ReceiptKey,
+        key_digest: ReceiptKeyDigest,
+        terminal_digest: TerminalDigest,
+        acknowledged_at_epoch_ms: u64,
+        encoded_bytes: u64,
+    ) -> Result<Self, ReceiptLedgerError> {
+        acknowledged_at_epoch_ms
+            .checked_add(ACKNOWLEDGED_TOMBSTONE_TTL_MS)
+            .ok_or(ReceiptLedgerError::TimestampOverflow)?;
+        Ok(Self {
+            key,
+            key_digest,
+            terminal_digest,
+            acknowledged_at_epoch_ms,
+            encoded_bytes,
+        })
+    }
+
+    pub(crate) fn key(&self) -> &ReceiptKey {
+        &self.key
+    }
+
+    pub(crate) fn key_digest(&self) -> &ReceiptKeyDigest {
+        &self.key_digest
+    }
+
+    pub(crate) const fn terminal_digest(&self) -> &TerminalDigest {
+        &self.terminal_digest
+    }
+
+    pub(crate) const fn acknowledged_at_epoch_ms(&self) -> u64 {
+        self.acknowledged_at_epoch_ms
+    }
+
+    pub(crate) fn expires_at_epoch_ms(&self) -> u64 {
+        self.acknowledged_at_epoch_ms + ACKNOWLEDGED_TOMBSTONE_TTL_MS
+    }
+
+    pub(crate) const fn encoded_bytes(&self) -> u64 {
+        self.encoded_bytes
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2434,9 +2553,11 @@ mod tests {
                 reserved_result_bytes: 1_024,
             }),
             ReceiptState::AcknowledgedTombstone(AcknowledgedTombstoneReceipt {
-                record: record(),
+                key: key.clone(),
+                key_digest: key_digest.clone(),
                 terminal_digest: terminal_digest.clone(),
                 acknowledged_at_epoch_ms: 2_100,
+                encoded_bytes: 512,
             }),
             ReceiptState::TaskPromisedUnbound(TaskPromisedUnboundReceipt {
                 record: record(),

--- a/crates/unica-coder/src/application/receipt_ledger_actor.rs
+++ b/crates/unica-coder/src/application/receipt_ledger_actor.rs
@@ -252,6 +252,7 @@ enum Command {
     },
     Recover {
         key: ReceiptKey,
+        observed_at_epoch_ms: Option<u64>,
         deadline: Instant,
         ticket: Arc<Ticket<ReceiptState>>,
     },
@@ -615,6 +616,24 @@ impl ReceiptLedgerActor {
         key: ReceiptKey,
         deadline: Instant,
     ) -> Result<ReceiptState, ReceiptLedgerError> {
+        self.recover_inner(key, None, deadline)
+    }
+
+    pub(crate) fn recover_at(
+        &self,
+        key: ReceiptKey,
+        observed_at_epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<ReceiptState, ReceiptLedgerError> {
+        self.recover_inner(key, Some(observed_at_epoch_ms), deadline)
+    }
+
+    fn recover_inner(
+        &self,
+        key: ReceiptKey,
+        observed_at_epoch_ms: Option<u64>,
+        deadline: Instant,
+    ) -> Result<ReceiptState, ReceiptLedgerError> {
         if Instant::now() >= deadline {
             return Err(ReceiptLedgerError::DeadlineExceeded);
         }
@@ -631,6 +650,7 @@ impl ReceiptLedgerActor {
         self.enqueue(
             Command::Recover {
                 key,
+                observed_at_epoch_ms,
                 deadline,
                 ticket: Arc::clone(&ticket),
             },
@@ -917,14 +937,20 @@ fn run_worker(
             }
             Command::Recover {
                 key,
+                observed_at_epoch_ms,
                 deadline,
                 ticket,
             } => {
                 if !ticket.try_begin(&health) {
                     continue;
                 }
-                let result = catch_unwind(AssertUnwindSafe(|| port.recover(&key, deadline)))
-                    .unwrap_or(Err(ReceiptLedgerError::StoreUnavailable));
+                let result = catch_unwind(AssertUnwindSafe(|| match observed_at_epoch_ms {
+                    Some(observed_at_epoch_ms) => {
+                        port.recover_at(&key, observed_at_epoch_ms, deadline)
+                    }
+                    None => port.recover(&key, deadline),
+                }))
+                .unwrap_or(Err(ReceiptLedgerError::StoreUnavailable));
                 ticket.finish(result, &health);
             }
         }

--- a/crates/unica-coder/src/application/receipt_ledger_actor.rs
+++ b/crates/unica-coder/src/application/receipt_ledger_actor.rs
@@ -1,7 +1,8 @@
 use crate::application::receipt_ledger::{
-    receipt_key_digest, CancelExpiryOutcome, CancelResolution, CommittedDirectPublication,
-    OriginalCutoffDescriptor, ReceiptKey, ReceiptKeyDigest, ReceiptLedgerError, ReceiptLedgerPort,
-    ReceiptState, ReceiptVersion, ReserveOutcome, V5CanonicalTerminal,
+    receipt_key_digest, AcknowledgedTombstoneReceipt, CancelExpiryOutcome, CancelResolution,
+    CommittedDirectPublication, OriginalCutoffDescriptor, ReceiptKey, ReceiptKeyDigest,
+    ReceiptLedgerError, ReceiptLedgerPort, ReceiptState, ReceiptVersion, ReserveOutcome,
+    TerminalDigest, V5CanonicalTerminal,
 };
 #[cfg(feature = "receipt-ledger-test-support")]
 use crate::application::receipt_ledger::{
@@ -237,6 +238,18 @@ enum Command {
         deadline: Instant,
         ticket: Arc<Ticket<CommittedDirectPublication>>,
     },
+    AcknowledgeDirect {
+        key: ReceiptKey,
+        terminal_digest: TerminalDigest,
+        acknowledged_at_epoch_ms: u64,
+        deadline: Instant,
+        ticket: Arc<Ticket<AcknowledgedTombstoneReceipt>>,
+    },
+    ReclaimExpiredTombstones {
+        observed_at_epoch_ms: u64,
+        deadline: Instant,
+        ticket: Arc<Ticket<usize>>,
+    },
     Recover {
         key: ReceiptKey,
         deadline: Instant,
@@ -403,6 +416,8 @@ enum TimeoutClass {
     RequestCancelOrReserve(ReceiptKeyDigest),
     ExpireCancelReserved(ReceiptKeyDigest),
     PublishDirectTerminal(ReceiptKeyDigest),
+    AcknowledgeDirect(ReceiptKeyDigest),
+    ReclaimExpiredTombstones,
     Recover,
 }
 
@@ -415,9 +430,11 @@ impl TimeoutClass {
             Self::Reserve(receipt_key_digest)
             | Self::RequestCancelOrReserve(receipt_key_digest)
             | Self::ExpireCancelReserved(receipt_key_digest)
-            | Self::PublishDirectTerminal(receipt_key_digest) => {
+            | Self::PublishDirectTerminal(receipt_key_digest)
+            | Self::AcknowledgeDirect(receipt_key_digest) => {
                 ReceiptLedgerError::CommitUncertain { receipt_key_digest }
             }
+            Self::ReclaimExpiredTombstones => ReceiptLedgerError::StoreUnavailable,
             Self::Recover => ReceiptLedgerError::StoreUnavailable,
         }
     }
@@ -658,6 +675,67 @@ impl ReceiptLedgerActor {
         ticket.wait(&self.health)
     }
 
+    pub(crate) fn acknowledge_direct(
+        &self,
+        key: ReceiptKey,
+        terminal_digest: TerminalDigest,
+        acknowledged_at_epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<AcknowledgedTombstoneReceipt, ReceiptLedgerError> {
+        if Instant::now() >= deadline {
+            return Err(ReceiptLedgerError::DeadlineExceeded);
+        }
+        if !self.health.is_ready() {
+            return Err(ReceiptLedgerError::StoreUnavailable);
+        }
+
+        let heavy_result_permit = self.health.acquire_heavy_result_permit(deadline)?;
+        let digest = receipt_key_digest(&key);
+        let ticket = Arc::new(Ticket::queued_with_heavy_result_permit(
+            deadline,
+            TimeoutClass::AcknowledgeDirect(digest),
+            heavy_result_permit,
+        ));
+        self.enqueue(
+            Command::AcknowledgeDirect {
+                key,
+                terminal_digest,
+                acknowledged_at_epoch_ms,
+                deadline,
+                ticket: Arc::clone(&ticket),
+            },
+            deadline,
+        )?;
+        ticket.wait(&self.health)
+    }
+
+    pub(crate) fn reclaim_expired_tombstones(
+        &self,
+        observed_at_epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<usize, ReceiptLedgerError> {
+        if Instant::now() >= deadline {
+            return Err(ReceiptLedgerError::DeadlineExceeded);
+        }
+        if !self.health.is_ready() {
+            return Err(ReceiptLedgerError::StoreUnavailable);
+        }
+
+        let ticket = Arc::new(Ticket::queued(
+            deadline,
+            TimeoutClass::ReclaimExpiredTombstones,
+        ));
+        self.enqueue(
+            Command::ReclaimExpiredTombstones {
+                observed_at_epoch_ms,
+                deadline,
+                ticket: Arc::clone(&ticket),
+            },
+            deadline,
+        )?;
+        ticket.wait(&self.health)
+    }
+
     fn enqueue(&self, mut command: Command, deadline: Instant) -> Result<(), ReceiptLedgerError> {
         loop {
             if !self.health.is_ready() {
@@ -799,6 +877,44 @@ fn run_worker(
                 }));
                 ticket.finish(result, &health);
             }
+            Command::AcknowledgeDirect {
+                key,
+                terminal_digest,
+                acknowledged_at_epoch_ms,
+                deadline,
+                ticket,
+            } => {
+                if !ticket.try_begin(&health) {
+                    continue;
+                }
+                let digest = receipt_key_digest(&key);
+                let result = catch_unwind(AssertUnwindSafe(|| {
+                    port.acknowledge_direct(
+                        &key,
+                        &terminal_digest,
+                        acknowledged_at_epoch_ms,
+                        deadline,
+                    )
+                }))
+                .unwrap_or(Err(ReceiptLedgerError::CommitUncertain {
+                    receipt_key_digest: digest,
+                }));
+                ticket.finish(result, &health);
+            }
+            Command::ReclaimExpiredTombstones {
+                observed_at_epoch_ms,
+                deadline,
+                ticket,
+            } => {
+                if !ticket.try_begin(&health) {
+                    continue;
+                }
+                let result = catch_unwind(AssertUnwindSafe(|| {
+                    port.reclaim_expired_tombstones(observed_at_epoch_ms, deadline)
+                }))
+                .unwrap_or(Err(ReceiptLedgerError::StoreUnavailable));
+                ticket.finish(result, &health);
+            }
             Command::Recover {
                 key,
                 deadline,
@@ -822,11 +938,11 @@ mod tests {
     };
     use crate::application::invocation::normalized_arguments_hash;
     use crate::application::receipt_ledger::{
-        canonical_v5_terminal, receipt_key_digest, request_scope_hash, CancelExpiryOutcome,
-        CancelReservedReceipt, CancelResolution, CommittedDirectPublication, CoreIdentityDigest,
-        OriginalCutoffDescriptor, ReceiptKey, ReceiptLedgerError, ReceiptState,
-        ReceiptTerminalOutcome, ReceiptVersion, RequestIdentity, ReserveOutcome,
-        V5CanonicalTerminal, V5ToolIdentity,
+        canonical_v5_terminal, receipt_key_digest, request_scope_hash,
+        AcknowledgedTombstoneReceipt, CancelExpiryOutcome, CancelReservedReceipt, CancelResolution,
+        CommittedDirectPublication, CoreIdentityDigest, OriginalCutoffDescriptor, ReceiptKey,
+        ReceiptLedgerError, ReceiptState, ReceiptTerminalOutcome, ReceiptVersion, RequestIdentity,
+        ReserveOutcome, TerminalDigest, V5CanonicalTerminal, V5ToolIdentity,
     };
     use crate::domain::invocation::{InvocationId, TaskId};
     use std::cell::Cell;
@@ -1251,6 +1367,101 @@ mod tests {
     fn cancelled_terminal() -> V5CanonicalTerminal {
         canonical_v5_terminal(&ReceiptTerminalOutcome::Cancelled)
             .expect("cancelled terminal is canonical")
+    }
+
+    struct AcknowledgePort {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl ReceiptLedgerPort for AcknowledgePort {
+        fn reserve(
+            &mut self,
+            _key: ReceiptKey,
+            _original_cutoff: OriginalCutoffDescriptor,
+            _deadline: Instant,
+        ) -> Result<ReserveOutcome, ReceiptLedgerError> {
+            Err(ReceiptLedgerError::StoreUnavailable)
+        }
+
+        fn request_cancel_or_reserve(
+            &mut self,
+            _key: ReceiptKey,
+            _cancel_reserved_at_epoch_ms: u64,
+            _deadline: Instant,
+        ) -> Result<CancelResolution, ReceiptLedgerError> {
+            Err(ReceiptLedgerError::StoreUnavailable)
+        }
+
+        fn expire_cancel_reserved(
+            &mut self,
+            _key: ReceiptKey,
+            _expected_version: ReceiptVersion,
+            _expected_mutation_sequence: u64,
+            _observed_at_epoch_ms: u64,
+            _deadline: Instant,
+        ) -> Result<CancelExpiryOutcome, ReceiptLedgerError> {
+            Err(ReceiptLedgerError::StoreUnavailable)
+        }
+
+        fn publish_direct_terminal(
+            &mut self,
+            _key: &ReceiptKey,
+            _expected_version: ReceiptVersion,
+            _terminal_epoch_ms: u64,
+            _terminal: V5CanonicalTerminal,
+            _deadline: Instant,
+        ) -> Result<CommittedDirectPublication, ReceiptLedgerError> {
+            Err(ReceiptLedgerError::StoreUnavailable)
+        }
+
+        fn acknowledge_direct(
+            &mut self,
+            key: &ReceiptKey,
+            terminal_digest: &TerminalDigest,
+            acknowledged_at_epoch_ms: u64,
+            _deadline: Instant,
+        ) -> Result<AcknowledgedTombstoneReceipt, ReceiptLedgerError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            AcknowledgedTombstoneReceipt::new(
+                key.clone(),
+                receipt_key_digest(key),
+                terminal_digest.clone(),
+                acknowledged_at_epoch_ms,
+                256,
+            )
+        }
+
+        fn recover(
+            &mut self,
+            _key: &ReceiptKey,
+            _deadline: Instant,
+        ) -> Result<ReceiptState, ReceiptLedgerError> {
+            Err(ReceiptLedgerError::StoreUnavailable)
+        }
+    }
+
+    #[test]
+    fn acknowledge_direct_round_trips_through_the_serial_actor() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let actor = ReceiptLedgerActor::spawn(AcknowledgePort {
+            calls: Arc::clone(&calls),
+        });
+        let key = receipt_key();
+        let digest = cancelled_terminal().digest().clone();
+
+        let acknowledged = actor
+            .acknowledge_direct(
+                key.clone(),
+                digest.clone(),
+                1_234,
+                Instant::now() + Duration::from_secs(1),
+            )
+            .expect("acknowledgement reaches the ledger port");
+
+        assert_eq!(acknowledged.key(), &key);
+        assert_eq!(acknowledged.terminal_digest(), &digest);
+        assert_eq!(acknowledged.acknowledged_at_epoch_ms(), 1_234);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/crates/unica-coder/src/application/receipt_ledger_actor.rs
+++ b/crates/unica-coder/src/application/receipt_ledger_actor.rs
@@ -3,6 +3,10 @@ use crate::application::receipt_ledger::{
     OriginalCutoffDescriptor, ReceiptKey, ReceiptKeyDigest, ReceiptLedgerError, ReceiptLedgerPort,
     ReceiptState, ReceiptVersion, ReserveOutcome, V5CanonicalTerminal,
 };
+#[cfg(feature = "receipt-ledger-test-support")]
+use crate::application::receipt_ledger::{
+    ReceiptLedgerCatalogSnapshot, ReceiptLedgerCatalogSnapshotAuthority,
+};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::mpsc::{self, SyncSender, TrySendError};
@@ -92,8 +96,42 @@ impl Drop for HeavyResultPermit {
 
 #[derive(Clone)]
 pub(crate) struct ReceiptLedgerActor {
-    sender: SyncSender<Command>,
+    worker: Arc<ReceiptLedgerWorkerOwner>,
     health: Arc<ActorHealth>,
+}
+
+struct ReceiptLedgerWorkerOwner {
+    sender: Option<SyncSender<Command>>,
+    worker: Option<std::thread::JoinHandle<()>>,
+    health: Arc<ActorHealth>,
+}
+
+impl ReceiptLedgerWorkerOwner {
+    fn sender(&self) -> &SyncSender<Command> {
+        self.sender
+            .as_ref()
+            .expect("receipt ledger sender exists while an actor handle is alive")
+    }
+}
+
+impl Drop for ReceiptLedgerWorkerOwner {
+    fn drop(&mut self) {
+        drop(self.sender.take());
+        let Some(worker) = self.worker.take() else {
+            return;
+        };
+        if !self.health.is_ready() {
+            // A timed-out running port call is process-owned fail-stop work.
+            // Joining it here would keep the process alive indefinitely and
+            // violate the bounded caller contract.
+            drop(worker);
+            return;
+        }
+        if worker.thread().id() == std::thread::current().id() {
+            return;
+        }
+        let _ = worker.join();
+    }
 }
 
 struct ActorHealth {
@@ -162,6 +200,15 @@ impl ActorHealth {
 }
 
 enum Command {
+    #[cfg(feature = "receipt-ledger-test-support")]
+    SnapshotCatalog {
+        deadline: Instant,
+        ticket: Arc<Ticket<ReceiptLedgerCatalogSnapshot>>,
+    },
+    Generation {
+        deadline: Instant,
+        ticket: Arc<Ticket<u64>>,
+    },
     Reserve {
         key: ReceiptKey,
         original_cutoff: OriginalCutoffDescriptor,
@@ -349,6 +396,9 @@ impl<R> Ticket<R> {
 }
 
 enum TimeoutClass {
+    #[cfg(feature = "receipt-ledger-test-support")]
+    SnapshotCatalog,
+    Generation,
     Reserve(ReceiptKeyDigest),
     RequestCancelOrReserve(ReceiptKeyDigest),
     ExpireCancelReserved(ReceiptKeyDigest),
@@ -359,6 +409,9 @@ enum TimeoutClass {
 impl TimeoutClass {
     fn running_error(self) -> ReceiptLedgerError {
         match self {
+            #[cfg(feature = "receipt-ledger-test-support")]
+            Self::SnapshotCatalog => ReceiptLedgerError::StoreUnavailable,
+            Self::Generation => ReceiptLedgerError::StoreUnavailable,
             Self::Reserve(receipt_key_digest)
             | Self::RequestCancelOrReserve(receipt_key_digest)
             | Self::ExpireCancelReserved(receipt_key_digest)
@@ -375,11 +428,69 @@ impl ReceiptLedgerActor {
         let (sender, receiver) = mpsc::sync_channel(RECEIPT_LEDGER_CHANNEL_CAPACITY);
         let health = Arc::new(ActorHealth::ready());
         let worker_health = Arc::clone(&health);
-        std::thread::Builder::new()
+        let worker = std::thread::Builder::new()
             .name("unica-receipt-ledger".to_owned())
             .spawn(move || run_worker(port, receiver, worker_health))
             .expect("spawn receipt ledger actor");
-        Self { sender, health }
+        Self {
+            worker: Arc::new(ReceiptLedgerWorkerOwner {
+                sender: Some(sender),
+                worker: Some(worker),
+                health: Arc::clone(&health),
+            }),
+            health,
+        }
+    }
+
+    #[cfg(feature = "receipt-ledger-test-support")]
+    pub(crate) fn snapshot_catalog(
+        &self,
+        deadline: Instant,
+    ) -> Result<ReceiptLedgerCatalogSnapshot, ReceiptLedgerError> {
+        if Instant::now() >= deadline {
+            return Err(ReceiptLedgerError::DeadlineExceeded);
+        }
+        if !self.health.is_ready() {
+            return Err(ReceiptLedgerError::StoreUnavailable);
+        }
+
+        let heavy_result_permit = self.health.acquire_heavy_result_permit(deadline)?;
+        let ticket = Arc::new(Ticket::queued_with_heavy_result_permit(
+            deadline,
+            TimeoutClass::SnapshotCatalog,
+            heavy_result_permit,
+        ));
+        self.enqueue(
+            Command::SnapshotCatalog {
+                deadline,
+                ticket: Arc::clone(&ticket),
+            },
+            deadline,
+        )?;
+        ticket.wait(&self.health)
+    }
+
+    pub(crate) fn generation(&self, deadline: Instant) -> Result<u64, ReceiptLedgerError> {
+        if Instant::now() >= deadline {
+            return Err(ReceiptLedgerError::DeadlineExceeded);
+        }
+        if !self.health.is_ready() {
+            return Err(ReceiptLedgerError::StoreUnavailable);
+        }
+
+        let ticket = Arc::new(Ticket::queued(deadline, TimeoutClass::Generation));
+        self.enqueue(
+            Command::Generation {
+                deadline,
+                ticket: Arc::clone(&ticket),
+            },
+            deadline,
+        )?;
+        ticket.wait(&self.health)
+    }
+
+    pub(crate) fn restart_required(&self) -> bool {
+        !self.health.is_ready()
     }
 
     pub(crate) fn reserve(
@@ -557,7 +668,7 @@ impl ReceiptLedgerActor {
                 return Err(ReceiptLedgerError::DeadlineExceeded);
             }
 
-            match self.sender.try_send(command) {
+            match self.worker.sender().try_send(command) {
                 Ok(()) => return Ok(()),
                 Err(TrySendError::Full(returned)) => {
                     command = returned;
@@ -581,6 +692,25 @@ fn run_worker(
 ) {
     while let Ok(command) = receiver.recv() {
         match command {
+            #[cfg(feature = "receipt-ledger-test-support")]
+            Command::SnapshotCatalog { deadline, ticket } => {
+                if !ticket.try_begin(&health) {
+                    continue;
+                }
+                let result = catch_unwind(AssertUnwindSafe(|| {
+                    port.snapshot_catalog(ReceiptLedgerCatalogSnapshotAuthority::new(), deadline)
+                }))
+                .unwrap_or(Err(ReceiptLedgerError::StoreUnavailable));
+                ticket.finish(result, &health);
+            }
+            Command::Generation { deadline, ticket } => {
+                if !ticket.try_begin(&health) {
+                    continue;
+                }
+                let result = catch_unwind(AssertUnwindSafe(|| port.generation(deadline)))
+                    .unwrap_or(Err(ReceiptLedgerError::StoreUnavailable));
+                ticket.finish(result, &health);
+            }
             Command::Reserve {
                 key,
                 original_cutoff,
@@ -687,7 +817,9 @@ fn run_worker(
 
 #[cfg(test)]
 mod tests {
-    use super::{ActorHealth, ReceiptLedgerActor, ReceiptLedgerPort, Ticket, TimeoutClass};
+    use super::{
+        ActorHealth, Command, ReceiptLedgerActor, ReceiptLedgerPort, Ticket, TimeoutClass,
+    };
     use crate::application::invocation::normalized_arguments_hash;
     use crate::application::receipt_ledger::{
         canonical_v5_terminal, receipt_key_digest, request_scope_hash, CancelExpiryOutcome,
@@ -700,7 +832,7 @@ mod tests {
     use std::cell::Cell;
     use std::str::FromStr;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{mpsc, Arc};
+    use std::sync::{mpsc, Arc, Mutex};
     use std::time::{Duration, Instant};
 
     struct BlockingPort {
@@ -1015,6 +1147,85 @@ mod tests {
         }
     }
 
+    struct WorkerGenerationGate {
+        actor_to_drop: Option<Arc<Mutex<Option<ReceiptLedgerActor>>>>,
+        entered: mpsc::Sender<()>,
+        release: mpsc::Receiver<()>,
+    }
+
+    struct DropNotifyingPort {
+        generation: u64,
+        dropped: mpsc::Sender<()>,
+        worker_generation: Option<WorkerGenerationGate>,
+    }
+
+    impl Drop for DropNotifyingPort {
+        fn drop(&mut self) {
+            let _ = self.dropped.send(());
+        }
+    }
+
+    impl ReceiptLedgerPort for DropNotifyingPort {
+        fn generation(&mut self, _deadline: Instant) -> Result<u64, ReceiptLedgerError> {
+            if let Some(gate) = self.worker_generation.take() {
+                gate.entered.send(()).expect("report generation entry");
+                gate.release.recv().expect("release worker generation");
+                if let Some(actor) = gate.actor_to_drop {
+                    drop(actor.lock().expect("self-drop actor mutex poisoned").take());
+                }
+            }
+            Ok(self.generation)
+        }
+
+        fn reserve(
+            &mut self,
+            _key: ReceiptKey,
+            _original_cutoff: OriginalCutoffDescriptor,
+            _deadline: Instant,
+        ) -> Result<ReserveOutcome, ReceiptLedgerError> {
+            Err(ReceiptLedgerError::StoreUnavailable)
+        }
+
+        fn publish_direct_terminal(
+            &mut self,
+            _key: &ReceiptKey,
+            _expected_version: ReceiptVersion,
+            _terminal_epoch_ms: u64,
+            _terminal: V5CanonicalTerminal,
+            _deadline: Instant,
+        ) -> Result<CommittedDirectPublication, ReceiptLedgerError> {
+            Err(ReceiptLedgerError::StoreUnavailable)
+        }
+
+        fn request_cancel_or_reserve(
+            &mut self,
+            _key: ReceiptKey,
+            _cancel_reserved_at_epoch_ms: u64,
+            _deadline: Instant,
+        ) -> Result<CancelResolution, ReceiptLedgerError> {
+            Err(ReceiptLedgerError::StoreUnavailable)
+        }
+
+        fn expire_cancel_reserved(
+            &mut self,
+            _key: ReceiptKey,
+            _expected_version: ReceiptVersion,
+            _expected_mutation_sequence: u64,
+            _observed_at_epoch_ms: u64,
+            _deadline: Instant,
+        ) -> Result<CancelExpiryOutcome, ReceiptLedgerError> {
+            Err(ReceiptLedgerError::StoreUnavailable)
+        }
+
+        fn recover(
+            &mut self,
+            _key: &ReceiptKey,
+            _deadline: Instant,
+        ) -> Result<ReceiptState, ReceiptLedgerError> {
+            Err(ReceiptLedgerError::StoreUnavailable)
+        }
+    }
+
     fn receipt_key() -> ReceiptKey {
         ReceiptKey::new(
             InvocationId::new(),
@@ -1040,6 +1251,186 @@ mod tests {
     fn cancelled_terminal() -> V5CanonicalTerminal {
         canonical_v5_terminal(&ReceiptTerminalOutcome::Cancelled)
             .expect("cancelled terminal is canonical")
+    }
+
+    #[test]
+    fn dropping_last_actor_waits_until_the_port_is_released() {
+        let (entered, observed_entry) = mpsc::channel();
+        let (release, released) = mpsc::channel();
+        let (dropped, observed_drop) = mpsc::channel();
+        let actor = ReceiptLedgerActor::spawn(DropNotifyingPort {
+            generation: 41,
+            dropped,
+            worker_generation: Some(WorkerGenerationGate {
+                actor_to_drop: None,
+                entered,
+                release: released,
+            }),
+        });
+        let health = Arc::clone(&actor.health);
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let ticket = Arc::new(Ticket::queued(deadline, TimeoutClass::Generation));
+        actor
+            .enqueue(
+                Command::Generation {
+                    deadline,
+                    ticket: Arc::clone(&ticket),
+                },
+                deadline,
+            )
+            .expect("enqueue blocked generation probe");
+        observed_entry.recv().expect("worker enters generation");
+        let (drop_returned, observed_drop_return) = mpsc::channel();
+        let dropper = std::thread::spawn(move || {
+            drop(actor);
+            drop_returned.send(()).expect("report actor drop return");
+        });
+
+        let returned_before_release =
+            match observed_drop_return.recv_timeout(Duration::from_millis(100)) {
+                Ok(()) => true,
+                Err(mpsc::RecvTimeoutError::Timeout) => false,
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    panic!("actor dropper disconnected before reporting return")
+                }
+            };
+        release.send(()).expect("release blocked generation");
+
+        assert_eq!(ticket.wait(&health), Ok(41));
+        observed_drop
+            .recv_timeout(Duration::from_secs(1))
+            .expect("worker releases its port after generation returns");
+        if !returned_before_release {
+            observed_drop_return
+                .recv_timeout(Duration::from_secs(1))
+                .expect("actor drop returns after port release");
+        }
+        dropper.join().expect("actor dropper does not panic");
+        assert!(
+            !returned_before_release,
+            "last actor drop returned while its worker still owned the port"
+        );
+    }
+
+    #[test]
+    fn fail_stopped_actor_drop_does_not_wait_for_a_stuck_port() {
+        let (entered, observed_entry) = mpsc::channel();
+        let (release, released) = mpsc::channel();
+        let actor = ReceiptLedgerActor::spawn(BlockingPort {
+            entered: Some(entered),
+            release: released,
+            calls: Arc::new(AtomicUsize::new(0)),
+            direct_calls: Arc::new(AtomicUsize::new(0)),
+        });
+        let caller = actor.clone();
+        let key = receipt_key();
+        let call = std::thread::spawn(move || {
+            caller.reserve(key, cutoff(), Instant::now() + Duration::from_millis(30))
+        });
+        observed_entry
+            .recv_timeout(Duration::from_secs(1))
+            .expect("stuck port enters the mutation");
+        assert!(matches!(
+            call.join().expect("join timed-out actor caller"),
+            Err(ReceiptLedgerError::CommitUncertain { .. })
+        ));
+        assert!(actor.restart_required());
+
+        let (drop_returned, observed_drop_return) = mpsc::channel();
+        let dropper = std::thread::spawn(move || {
+            drop(actor);
+            drop_returned
+                .send(())
+                .expect("report fail-stopped actor drop return");
+        });
+        let returned_without_port = observed_drop_return
+            .recv_timeout(Duration::from_millis(100))
+            .is_ok();
+        release
+            .send(())
+            .expect("release stuck port after observation");
+        if !returned_without_port {
+            observed_drop_return
+                .recv_timeout(Duration::from_secs(1))
+                .expect("actor drop returns after cleanup release");
+        }
+        dropper.join().expect("join actor dropper");
+
+        assert!(
+            returned_without_port,
+            "fail-stop waited for a worker that process death must own"
+        );
+    }
+
+    #[test]
+    fn dropping_a_non_last_clone_keeps_the_worker_available() {
+        let (dropped, observed_drop) = mpsc::channel();
+        let actor = ReceiptLedgerActor::spawn(DropNotifyingPort {
+            generation: 41,
+            dropped,
+            worker_generation: None,
+        });
+        let survivor = actor.clone();
+
+        drop(actor);
+
+        assert_eq!(
+            observed_drop.try_recv(),
+            Err(mpsc::TryRecvError::Empty),
+            "a non-last clone cannot release the shared port"
+        );
+        assert_eq!(
+            survivor.generation(Instant::now() + Duration::from_secs(1)),
+            Ok(41)
+        );
+        drop(survivor);
+        observed_drop
+            .try_recv()
+            .expect("last surviving clone releases the port synchronously");
+    }
+
+    #[test]
+    fn dropping_last_actor_on_its_worker_never_self_joins() {
+        let actor_slot = Arc::new(Mutex::new(None));
+        let (entered, observed_entry) = mpsc::channel();
+        let (release, released) = mpsc::channel();
+        let (dropped, observed_drop) = mpsc::channel();
+        let actor = ReceiptLedgerActor::spawn(DropNotifyingPort {
+            generation: 43,
+            dropped,
+            worker_generation: Some(WorkerGenerationGate {
+                actor_to_drop: Some(Arc::clone(&actor_slot)),
+                entered,
+                release: released,
+            }),
+        });
+        actor_slot
+            .lock()
+            .expect("self-drop actor mutex poisoned")
+            .replace(actor.clone());
+        let health = Arc::clone(&actor.health);
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let ticket = Arc::new(Ticket::queued(deadline, TimeoutClass::Generation));
+        actor
+            .enqueue(
+                Command::Generation {
+                    deadline,
+                    ticket: Arc::clone(&ticket),
+                },
+                deadline,
+            )
+            .expect("enqueue self-drop probe");
+        observed_entry
+            .recv()
+            .expect("worker enters self-drop probe");
+
+        drop(actor);
+        release.send(()).expect("release worker self-drop");
+
+        assert_eq!(ticket.wait(&health), Ok(43));
+        observed_drop
+            .recv_timeout(Duration::from_secs(1))
+            .expect("worker exits and releases the port without self-join");
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/daemon/client_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/client_v5.rs
@@ -1,8 +1,11 @@
 use super::identity::{CoreIdentity, DaemonStateDirectory};
 use super::protocol_v5::{
-    read_bounded_v5_probe_response_frame_before, V5ClientRequest, V5EndpointRecord,
-    V5HandshakeServerResponse, V5ProbeResponseKind, V5ProbeServerResponse,
+    decode_v5_server_response, read_bounded_v5_probe_response_frame_before, V5ClientRequest,
+    V5EndpointRecord, V5HandshakeServerResponse, V5InvocationRequest, V5ProbeResponseKind,
+    V5ProbeServerResponse, V5ServerResponse,
 };
+use crate::application::invocation::RESPONSE_SERIALIZATION_MARGIN;
+use crate::application::receipt_ledger::ReceiptKey;
 use crate::infrastructure::platform::ManagedStartupChild;
 use std::io::{self, BufReader, Write};
 use std::net::TcpStream;
@@ -12,6 +15,7 @@ use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const OWNER_RESPONSE_SAFETY_TIMEOUT: Duration = Duration::from_secs(10);
 const SPAWN_LOCK_TIMEOUT: Duration = Duration::from_secs(5);
 const EXISTING_ENDPOINT_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
 const STARTUP_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
@@ -280,6 +284,79 @@ impl V5DaemonProcessOwner {
             return Err("protocol-v5 ping returned an unexpected response".to_string());
         }
         Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn submit_invocation(
+        &mut self,
+        invocation: V5InvocationRequest,
+    ) -> Result<V5ServerResponse, String> {
+        self.exchange(
+            V5ClientRequest::SubmitInvocation { invocation },
+            "submit invocation",
+        )
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn cancel_invocation(
+        &mut self,
+        receipt_key: ReceiptKey,
+    ) -> Result<V5ServerResponse, String> {
+        self.exchange(
+            V5ClientRequest::CancelInvocation { receipt_key },
+            "cancel invocation",
+        )
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn recover_invocation_receipt(
+        &mut self,
+        receipt_key: ReceiptKey,
+    ) -> Result<V5ServerResponse, String> {
+        self.exchange(
+            V5ClientRequest::RecoverInvocationReceipt { receipt_key },
+            "recover invocation receipt",
+        )
+    }
+
+    #[allow(dead_code)]
+    fn exchange(
+        &mut self,
+        request: V5ClientRequest,
+        stage: &'static str,
+    ) -> Result<V5ServerResponse, String> {
+        if self.poisoned {
+            return Err("protocol-v5 owner session is poisoned".to_string());
+        }
+        let response_timeout = match &request {
+            V5ClientRequest::SubmitInvocation { invocation } => {
+                Duration::from_millis(invocation.response_budget_ms())
+                    .saturating_add(RESPONSE_SERIALIZATION_MARGIN)
+            }
+            _ => CONNECT_TIMEOUT,
+        }
+        .min(OWNER_RESPONSE_SAFETY_TIMEOUT);
+        let deadline = Instant::now()
+            .checked_add(response_timeout)
+            .ok_or_else(|| format!("protocol-v5 {stage} deadline overflow"))?;
+        if let Err(error) = self.write_before(&request, deadline, stage) {
+            self.poison();
+            return Err(error);
+        }
+        let frame = match self.read_before(deadline, stage) {
+            Ok(frame) => frame,
+            Err(error) => {
+                self.poison();
+                return Err(error);
+            }
+        };
+        match decode_v5_server_response(&frame) {
+            Ok(response) => Ok(response),
+            Err(error) => {
+                self.poison();
+                Err(error)
+            }
+        }
     }
 
     fn write_before<T: serde::Serialize>(

--- a/crates/unica-coder/src/infrastructure/daemon/client_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/client_v5.rs
@@ -5,7 +5,7 @@ use super::protocol_v5::{
     V5ProbeServerResponse, V5ServerResponse,
 };
 use crate::application::invocation::RESPONSE_SERIALIZATION_MARGIN;
-use crate::application::receipt_ledger::ReceiptKey;
+use crate::application::receipt_ledger::{ReceiptKey, TerminalDigest};
 use crate::infrastructure::platform::ManagedStartupChild;
 use std::io::{self, BufReader, Write};
 use std::net::TcpStream;
@@ -316,6 +316,21 @@ impl V5DaemonProcessOwner {
         self.exchange(
             V5ClientRequest::RecoverInvocationReceipt { receipt_key },
             "recover invocation receipt",
+        )
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn acknowledge_invocation_receipt(
+        &mut self,
+        receipt_key: ReceiptKey,
+        terminal_digest: TerminalDigest,
+    ) -> Result<V5ServerResponse, String> {
+        self.exchange(
+            V5ClientRequest::AcknowledgeInvocationReceipt {
+                receipt_key,
+                terminal_digest,
+            },
+            "acknowledge invocation receipt",
         )
     }
 

--- a/crates/unica-coder/src/infrastructure/daemon/protocol_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/protocol_v5.rs
@@ -5,8 +5,9 @@ use crate::application::invocation_store::{
 };
 use crate::application::invocation_store_v5::V5SafeFailureReason;
 use crate::application::receipt_ledger::{
-    canonical_v5_terminal, receipt_key_digest, request_scope_hash, ReceiptKey, ReceiptKeyDigest,
-    ReceiptTerminalOutcome, RequestIdentity, TerminalDigest, V5ToolIdentity,
+    canonical_v5_terminal, receipt_key_digest, request_scope_hash, AcknowledgedTombstoneReceipt,
+    ReceiptKey, ReceiptKeyDigest, ReceiptTerminalOutcome, RequestIdentity, TerminalDigest,
+    V5ToolIdentity,
 };
 use crate::domain::invocation::{DomainResult, InvocationId, TaskId};
 #[cfg(feature = "receipt-ledger-test-support")]
@@ -587,6 +588,33 @@ pub(crate) struct V5AcknowledgedReceipt {
     terminal_digest: TerminalDigest,
     ack_epoch_ms: u64,
     expires_epoch_ms: u64,
+}
+
+impl V5AcknowledgedReceipt {
+    pub(crate) fn from_receipt(receipt: &AcknowledgedTombstoneReceipt) -> Self {
+        Self {
+            receipt_key: receipt.key().clone(),
+            terminal_digest: receipt.terminal_digest().clone(),
+            ack_epoch_ms: receipt.acknowledged_at_epoch_ms(),
+            expires_epoch_ms: receipt.expires_at_epoch_ms(),
+        }
+    }
+
+    pub(crate) fn receipt_key(&self) -> &ReceiptKey {
+        &self.receipt_key
+    }
+
+    pub(crate) fn terminal_digest(&self) -> &TerminalDigest {
+        &self.terminal_digest
+    }
+
+    pub(crate) const fn ack_epoch_ms(&self) -> u64 {
+        self.ack_epoch_ms
+    }
+
+    pub(crate) const fn expires_epoch_ms(&self) -> u64 {
+        self.expires_epoch_ms
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/unica-coder/src/infrastructure/daemon/protocol_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/protocol_v5.rs
@@ -3,11 +3,12 @@ use crate::application::invocation::normalized_arguments_hash;
 use crate::application::invocation_store::{
     MAX_CANONICAL_RESULT_BYTES, MAX_TASK_RECORD_ENVELOPE_BYTES,
 };
+use crate::application::invocation_store_v5::V5SafeFailureReason;
 use crate::application::receipt_ledger::{
-    receipt_key_digest, request_scope_hash, ReceiptKey, ReceiptKeyDigest, RequestIdentity,
-    TerminalDigest, V5ToolIdentity,
+    canonical_v5_terminal, receipt_key_digest, request_scope_hash, ReceiptKey, ReceiptKeyDigest,
+    ReceiptTerminalOutcome, RequestIdentity, TerminalDigest, V5ToolIdentity,
 };
-use crate::domain::invocation::{InvocationId, TaskId};
+use crate::domain::invocation::{DomainResult, InvocationId, TaskId};
 #[cfg(feature = "receipt-ledger-test-support")]
 use crate::infrastructure::receipt_ledger_test_evidence::ProductionMissingTransitionEvidence;
 use serde::{Deserialize, Serialize};
@@ -208,7 +209,6 @@ pub(crate) struct V5InvocationRequest {
 }
 
 impl V5InvocationRequest {
-    #[cfg(feature = "receipt-ledger-test-support")]
     pub(crate) fn new(
         invocation_id: InvocationId,
         reserved_task_id: TaskId,
@@ -530,6 +530,194 @@ impl V5ProbeServerResponse {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum V5InvocationPhase {
+    CancelReserved,
+    ReservedUnbound,
+    ReservedActorBound,
+    ReservedBegun,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct V5PendingDirectReceipt {
+    receipt_key: ReceiptKey,
+    terminal: ReceiptTerminalOutcome,
+    terminal_digest: TerminalDigest,
+    terminal_epoch_ms: u64,
+}
+
+impl V5PendingDirectReceipt {
+    pub(crate) fn new(
+        receipt_key: ReceiptKey,
+        terminal: ReceiptTerminalOutcome,
+        terminal_digest: TerminalDigest,
+        terminal_epoch_ms: u64,
+    ) -> Self {
+        Self {
+            receipt_key,
+            terminal,
+            terminal_digest,
+            terminal_epoch_ms,
+        }
+    }
+
+    pub(crate) fn receipt_key(&self) -> &ReceiptKey {
+        &self.receipt_key
+    }
+
+    pub(crate) fn terminal(&self) -> &ReceiptTerminalOutcome {
+        &self.terminal
+    }
+
+    pub(crate) fn terminal_digest(&self) -> &TerminalDigest {
+        &self.terminal_digest
+    }
+
+    pub(crate) const fn terminal_epoch_ms(&self) -> u64 {
+        self.terminal_epoch_ms
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct V5AcknowledgedReceipt {
+    receipt_key: ReceiptKey,
+    terminal_digest: TerminalDigest,
+    ack_epoch_ms: u64,
+    expires_epoch_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(
+    tag = "status",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub(crate) enum V5DaemonTaskSnapshot {
+    Queued {
+        task_id: TaskId,
+        invocation_id: InvocationId,
+        receipt_key_digest: ReceiptKeyDigest,
+        created_at_epoch_ms: u64,
+        updated_at_epoch_ms: u64,
+        ttl_ms: u64,
+        poll_interval_ms: u64,
+        version: u64,
+        cancel_requested: bool,
+    },
+    Working {
+        task_id: TaskId,
+        invocation_id: InvocationId,
+        receipt_key_digest: ReceiptKeyDigest,
+        created_at_epoch_ms: u64,
+        updated_at_epoch_ms: u64,
+        ttl_ms: u64,
+        poll_interval_ms: u64,
+        version: u64,
+        cancel_requested: bool,
+    },
+    Completed {
+        task_id: TaskId,
+        invocation_id: InvocationId,
+        receipt_key_digest: ReceiptKeyDigest,
+        created_at_epoch_ms: u64,
+        updated_at_epoch_ms: u64,
+        ttl_ms: u64,
+        poll_interval_ms: u64,
+        version: u64,
+        cancel_requested: bool,
+        terminal_epoch_ms: u64,
+        terminal_digest: TerminalDigest,
+        result: Box<DomainResult>,
+    },
+    Failed {
+        task_id: TaskId,
+        invocation_id: InvocationId,
+        receipt_key_digest: ReceiptKeyDigest,
+        created_at_epoch_ms: u64,
+        updated_at_epoch_ms: u64,
+        ttl_ms: u64,
+        poll_interval_ms: u64,
+        version: u64,
+        cancel_requested: bool,
+        terminal_epoch_ms: u64,
+        terminal_digest: TerminalDigest,
+        reason: V5SafeFailureReason,
+    },
+    Cancelled {
+        task_id: TaskId,
+        invocation_id: InvocationId,
+        receipt_key_digest: ReceiptKeyDigest,
+        created_at_epoch_ms: u64,
+        updated_at_epoch_ms: u64,
+        ttl_ms: u64,
+        poll_interval_ms: u64,
+        version: u64,
+        cancel_requested: bool,
+        terminal_epoch_ms: u64,
+        terminal_digest: TerminalDigest,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(
+    tag = "resultType",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub(crate) enum V5InvocationResponse {
+    ReceiptPending {
+        receipt_key: ReceiptKey,
+        phase: V5InvocationPhase,
+        accepted_epoch_ms: u64,
+        original_budget_ms: u64,
+        cancel_requested: bool,
+    },
+    Direct {
+        receipt: V5PendingDirectReceipt,
+    },
+    Task {
+        snapshot: V5DaemonTaskSnapshot,
+    },
+    Acknowledged {
+        acknowledgement: V5AcknowledgedReceipt,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+pub(crate) enum V5ServerResponse {
+    Ready {
+        protocol_version: u32,
+        core_identity: CoreIdentity,
+        daemon_pid: u32,
+        instance_id: String,
+    },
+    Pong,
+    Released,
+    Invocation {
+        outcome: V5InvocationResponse,
+    },
+    Task {
+        snapshot: V5DaemonTaskSnapshot,
+    },
+    InvocationAcknowledged {
+        acknowledgement: V5AcknowledgedReceipt,
+    },
+    Error {
+        code: V5DaemonErrorCode,
+    },
+}
+
 pub(crate) struct DecodedV5Request {
     raw_frame: Vec<u8>,
     request: V5ClientRequest,
@@ -559,6 +747,10 @@ impl StrictV5Submit {
     #[allow(dead_code)]
     pub(crate) fn response_budget_ms(&self) -> u64 {
         self.invocation.response_budget_ms()
+    }
+
+    pub(crate) fn into_parts(self) -> (ReceiptKey, u64) {
+        (self.receipt_key, self.invocation.response_budget_ms())
     }
 }
 
@@ -666,9 +858,14 @@ where
     R: BufRead,
     F: FnMut(&mut R) -> io::Result<()>,
 {
-    let raw_frame =
-        read_bounded_json_line_with_limit_before(reader, MAX_V5_REQUEST_LINE_BYTES, before_fill)
-            .map_err(V5RequestFrameError::Read)?;
+    let raw_frame = read_bounded_v5_request_frame_before(reader, before_fill)
+        .map_err(V5RequestFrameError::Read)?;
+    decode_v5_request_frame(raw_frame)
+}
+
+pub(crate) fn decode_v5_request_frame(
+    raw_frame: Vec<u8>,
+) -> Result<DecodedV5Request, V5RequestFrameError> {
     let request =
         decode_v5_client_request(&raw_frame).map_err(V5RequestFrameError::InvalidRequest)?;
     Ok(DecodedV5Request { raw_frame, request })
@@ -676,6 +873,17 @@ where
 
 pub(crate) fn read_bounded_v5_request_frame<R: BufRead>(reader: &mut R) -> io::Result<Vec<u8>> {
     read_bounded_json_line_with_limit(reader, MAX_V5_REQUEST_LINE_BYTES)
+}
+
+pub(crate) fn read_bounded_v5_request_frame_before<R, F>(
+    reader: &mut R,
+    before_fill: F,
+) -> io::Result<Vec<u8>>
+where
+    R: BufRead,
+    F: FnMut(&mut R) -> io::Result<()>,
+{
+    read_bounded_json_line_with_limit_before(reader, MAX_V5_REQUEST_LINE_BYTES, before_fill)
 }
 
 pub(crate) fn read_bounded_v5_probe_response_frame<R: BufRead>(
@@ -770,6 +978,23 @@ pub(crate) fn decode_v5_probe_response(bytes: &[u8]) -> Result<V5ProbeServerResp
     ensure_frame_fits(bytes, MAX_V5_RESPONSE_LINE_BYTES, "response")?;
     serde_json::from_slice(bytes)
         .map_err(|_| "v5 daemon probe response is not strict versioned JSON".to_string())
+}
+
+pub(crate) fn decode_v5_server_response(bytes: &[u8]) -> Result<V5ServerResponse, String> {
+    ensure_frame_fits(bytes, MAX_V5_RESPONSE_LINE_BYTES, "response")?;
+    let response: V5ServerResponse = serde_json::from_slice(bytes)
+        .map_err(|_| "v5 daemon response is not strict versioned JSON".to_string())?;
+    if let V5ServerResponse::Invocation {
+        outcome: V5InvocationResponse::Direct { receipt },
+    } = &response
+    {
+        let terminal = canonical_v5_terminal(receipt.terminal())
+            .map_err(|_| "v5 daemon direct receipt terminal is not canonical".to_string())?;
+        if terminal.digest() != receipt.terminal_digest() {
+            return Err("v5 daemon direct receipt terminal digest does not match".to_string());
+        }
+    }
+    Ok(response)
 }
 
 #[cfg(feature = "receipt-ledger-test-support")]
@@ -971,11 +1196,97 @@ mod tests {
     const TASK_ID: &str = "22222222-2222-4222-8222-222222222222";
     const CORE_IDENTITY: &str = "884b76181583ce34907a2a9758e2b493e5b40883e7cbb0d7f88dcec0e468cfa0";
     const ZERO_DIGEST: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+    const CANCELLED_DIGEST: &str =
+        "f2d0423d2613a0d09397b750542e4542f7653d78ebd5e0448f1326d09145d9ae";
 
     fn receipt_key_json() -> String {
         format!(
             "{{\"invocationId\":\"{INVOCATION_ID}\",\"reservedTaskId\":\"{TASK_ID}\",\"coreIdentityDigest\":\"{CORE_IDENTITY}\",\"tool\":\"unica.view\",\"normalizedArgumentsHash\":\"{ZERO_DIGEST}\",\"requestScopeHash\":\"{ZERO_DIGEST}\"}}"
         )
+    }
+
+    #[test]
+    fn strict_v5_server_response_round_trips_the_cr0_invocation_algebra() {
+        let frames = [
+            format!(
+                "{{\"kind\":\"invocation\",\"outcome\":{{\"resultType\":\"receipt_pending\",\"receiptKey\":{},\"phase\":\"cancel_reserved\",\"acceptedEpochMs\":1700000000000,\"originalBudgetMs\":0,\"cancelRequested\":true}}}}",
+                receipt_key_json()
+            ),
+            format!(
+                "{{\"kind\":\"invocation\",\"outcome\":{{\"resultType\":\"direct\",\"receipt\":{{\"receiptKey\":{},\"terminal\":{{\"status\":\"cancelled\"}},\"terminalDigest\":\"{CANCELLED_DIGEST}\",\"terminalEpochMs\":1700000000000}}}}}}",
+                receipt_key_json()
+            ),
+            "{\"kind\":\"error\",\"code\":\"receipt_not_found\"}".to_string(),
+        ];
+
+        for frame in frames {
+            let decoded = decode_v5_server_response(frame.as_bytes())
+                .unwrap_or_else(|error| panic!("decode frozen response {frame}: {error}"));
+            let encoded = serde_json::to_vec(&decoded).expect("encode typed response");
+            let round_tripped =
+                decode_v5_server_response(&encoded).expect("decode encoded typed response");
+            assert_eq!(round_tripped, decoded);
+        }
+    }
+
+    #[test]
+    fn strict_v5_server_response_rejects_unknown_kinds_extra_fields_and_invalid_enums() {
+        let cases = [
+            ("unknown kind", "{\"kind\":\"future_response\"}".to_string()),
+            (
+                "top-level extra field",
+                "{\"kind\":\"error\",\"code\":\"receipt_not_found\",\"unexpected\":true}"
+                    .to_string(),
+            ),
+            (
+                "nested outcome extra field",
+                format!(
+                    "{{\"kind\":\"invocation\",\"outcome\":{{\"resultType\":\"receipt_pending\",\"receiptKey\":{},\"phase\":\"cancel_reserved\",\"acceptedEpochMs\":1700000000000,\"originalBudgetMs\":0,\"cancelRequested\":true,\"unexpected\":true}}}}",
+                    receipt_key_json()
+                ),
+            ),
+            (
+                "nested direct receipt extra field",
+                format!(
+                    "{{\"kind\":\"invocation\",\"outcome\":{{\"resultType\":\"direct\",\"receipt\":{{\"receiptKey\":{},\"terminal\":{{\"status\":\"cancelled\"}},\"terminalDigest\":\"{CANCELLED_DIGEST}\",\"terminalEpochMs\":1700000000000,\"unexpected\":true}}}}}}",
+                    receipt_key_json()
+                ),
+            ),
+            (
+                "invalid invocation phase",
+                format!(
+                    "{{\"kind\":\"invocation\",\"outcome\":{{\"resultType\":\"receipt_pending\",\"receiptKey\":{},\"phase\":\"future_phase\",\"acceptedEpochMs\":1700000000000,\"originalBudgetMs\":0,\"cancelRequested\":true}}}}",
+                    receipt_key_json()
+                ),
+            ),
+            (
+                "invalid terminal outcome",
+                format!(
+                    "{{\"kind\":\"invocation\",\"outcome\":{{\"resultType\":\"direct\",\"receipt\":{{\"receiptKey\":{},\"terminal\":{{\"status\":\"future_terminal\"}},\"terminalDigest\":\"{CANCELLED_DIGEST}\",\"terminalEpochMs\":1700000000000}}}}}}",
+                    receipt_key_json()
+                ),
+            ),
+        ];
+
+        for (case, frame) in cases {
+            assert!(
+                decode_v5_server_response(frame.as_bytes()).is_err(),
+                "strict decoder accepted {case}: {frame}"
+            );
+        }
+    }
+
+    #[test]
+    fn strict_v5_direct_receipt_rejects_a_terminal_digest_mismatch() {
+        let frame = format!(
+            "{{\"kind\":\"invocation\",\"outcome\":{{\"resultType\":\"direct\",\"receipt\":{{\"receiptKey\":{},\"terminal\":{{\"status\":\"cancelled\"}},\"terminalDigest\":\"{ZERO_DIGEST}\",\"terminalEpochMs\":1700000000000}}}}}}",
+            receipt_key_json()
+        );
+
+        assert!(
+            decode_v5_server_response(frame.as_bytes()).is_err(),
+            "strict decoder accepted a digest that does not bind the terminal"
+        );
     }
 
     fn valid_request_frames() -> Vec<(V5ClientRequestKind, String)> {

--- a/crates/unica-coder/src/infrastructure/daemon/runtime_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/runtime_v5.rs
@@ -539,7 +539,7 @@ impl V5ReceiptRuntime {
         deadline: Instant,
     ) -> Result<V5RuntimeReply, ReceiptLedgerError> {
         self.validate_receipt_key(&key)?;
-        let state = self.receipt_ledger.recover(key, deadline)?;
+        let state = self.receipt_ledger.recover_at(key, epoch_ms, deadline)?;
         match classify_recovered_receipt(state, epoch_ms) {
             CancelReservedRecoveryDecision::Current(state) => {
                 let decision = decide_cancel_reserved_submit(ReserveOutcome::ExistingExact(*state))
@@ -1055,6 +1055,14 @@ fn handle_probe_connection(
                 deadlines.operation,
             ) {
                 Ok(reply) => {
+                    #[cfg(feature = "receipt-ledger-test-support")]
+                    if runtime
+                        .scenario_control
+                        .as_ref()
+                        .is_some_and(|control| control.take_ack_response_disconnect())
+                    {
+                        return Ok(());
+                    }
                     write_runtime_reply_before(&mut stream, runtime, reply, deadlines.response)
                 }
                 Err(

--- a/crates/unica-coder/src/infrastructure/daemon/runtime_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/runtime_v5.rs
@@ -820,8 +820,9 @@ fn run_daemon_configured_until(
                     return Err(error);
                 }
                 idle_since = Instant::now();
-                // This W0a shell deliberately handles one bounded probe synchronously. Full
-                // owner/session concurrency and invocation traffic remain separate W0b work.
+                // This CR0 slice handles one bounded authenticated session synchronously,
+                // including the partial submit/cancel/recover ReceiptLedger path. Full
+                // owner/session concurrency and execution traffic remain later work.
                 let _ = handle_probe_connection(stream, &record, &runtime);
                 if runtime.restart_required() {
                     restart_requested = true;

--- a/crates/unica-coder/src/infrastructure/daemon/runtime_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/runtime_v5.rs
@@ -468,8 +468,7 @@ impl V5ReceiptRuntime {
             CancelInvocationDecision::ExistingDirectTerminal(receipt) => self
                 .reply_for_existing_state(ReceiptState::DirectTerminalUnacked(receipt), deadline),
             CancelInvocationDecision::Rejected(rejection) => {
-                let _retained = rejection.into_state();
-                Err(ReceiptLedgerError::ReceiptRowPresentUnsupported)
+                self.reply_for_existing_state(rejection.into_state(), deadline)
             }
         }
     }
@@ -2047,6 +2046,52 @@ mod tests {
 
         assert!(error.requires_reopen());
         assert_eq!(daemon_error_code(&error), V5DaemonErrorCode::StoreFailed);
+    }
+
+    #[test]
+    fn cancel_existing_reserved_receipt_returns_the_typed_pending_winner() {
+        let root = tempfile::tempdir().expect("temporary existing-winner state root");
+        let state_root = std::fs::canonicalize(root.path()).expect("physical state root");
+        let identity = CoreIdentity::production_v5();
+        let state = DaemonStateDirectory::open(&state_root, &identity)
+            .expect("open existing-winner daemon state");
+        let runtime = V5ReceiptRuntime::open(
+            &state,
+            &DaemonServerConfig::new(state_root, identity.clone(), Duration::from_millis(50)),
+        )
+        .expect("open protocol-v5 runtime");
+        let key = ReceiptKey::new(
+            InvocationId::new(),
+            TaskId::new(),
+            RequestIdentity::new(
+                identity.digest().clone(),
+                V5ToolIdentity::View,
+                normalized_arguments_hash(&serde_json::Map::new()),
+                request_scope_hash("workspace-a").expect("request scope"),
+            ),
+        );
+        let cutoff = OriginalCutoffDescriptor::new(1_000, 7_000).expect("valid cutoff");
+        runtime
+            .receipt_ledger
+            .reserve(key.clone(), cutoff, Instant::now() + Duration::from_secs(2))
+            .expect("reserve exact receipt");
+
+        let reply = runtime
+            .cancel_invocation(key.clone(), 2_000, Instant::now() + Duration::from_secs(2))
+            .expect("return the existing reserved winner");
+
+        assert!(matches!(
+            reply,
+            V5RuntimeReply::Json(V5ServerResponse::Invocation {
+                outcome: V5InvocationResponse::ReceiptPending {
+                    receipt_key,
+                    phase: V5InvocationPhase::ReservedUnbound,
+                    accepted_epoch_ms: 1_000,
+                    original_budget_ms: 7_000,
+                    cancel_requested: false,
+                },
+            }) if receipt_key == key
+        ));
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/daemon/runtime_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/runtime_v5.rs
@@ -1,46 +1,283 @@
 use super::identity::{CoreIdentity, DaemonStateDirectory, ReceiptAuthorityLock};
-#[cfg(all(feature = "receipt-ledger-test-support", test))]
-use super::protocol_v5::read_and_decode_v5_request;
 use super::protocol_v5::{
-    read_and_decode_v5_request_before, DecodedV5Request, V5ClientRequestKind, V5DaemonErrorCode,
-    V5EndpointRecord, V5HandshakeServerResponse, V5ProbeServerResponse, V5RequestFrameError,
-    DAEMON_PROTOCOL_VERSION, MAX_V5_RESPONSE_LINE_BYTES,
+    decode_v5_request_frame, read_bounded_v5_request_frame_before, DecodedV5Request,
+    V5ClientRequest, V5ClientRequestKind, V5DaemonErrorCode, V5EndpointRecord,
+    V5HandshakeServerResponse, V5InvocationPhase, V5InvocationResponse, V5ProbeServerResponse,
+    V5RequestFrameError, V5ServerResponse, DAEMON_PROTOCOL_VERSION, MAX_V5_RESPONSE_LINE_BYTES,
 };
 #[cfg(feature = "receipt-ledger-test-support")]
 use super::protocol_v5::{
-    read_bounded_v5_probe_response_frame, V5ClientRequest, V5InvocationRequest,
+    decode_v5_server_response, read_bounded_v5_probe_response_frame, V5InvocationRequest,
 };
 use super::server::{CanonicalInvocationService, DaemonServerConfig};
+use crate::application::invocation::RESPONSE_SERIALIZATION_MARGIN;
+use crate::application::invocation_store::EpochMillisClock;
+use crate::application::invocation_v5::{
+    classify_cancel_reserved_expiry_outcome, classify_recovered_receipt,
+    decide_cancel_reserved_submit, decide_cancel_resolution, CancelInvocationDecision,
+    CancelReservedExpiryDecision, CancelReservedRecoveryDecision, CancelReservedSubmitDecision,
+};
+use crate::application::receipt_ledger::{
+    OriginalCutoffDescriptor, PreparedWireFrame, ReceiptKey, ReceiptLedgerError, ReceiptState,
+    ReserveOutcome, ReservedPhase,
+};
+use crate::application::receipt_ledger_actor::ReceiptLedgerActor;
 use crate::infrastructure::platform::filesystem::RetainedDirectoryCapability;
+use crate::infrastructure::receipt_ledger::ReceiptLedgerStore;
 #[cfg(feature = "receipt-ledger-test-support")]
 use crate::infrastructure::receipt_ledger::StableReceiptLedgerObservation;
-use crate::infrastructure::receipt_ledger::{MissingReceiptObservation, ReceiptLedgerStore};
 #[cfg(feature = "receipt-ledger-test-support")]
 use crate::infrastructure::receipt_ledger_test_evidence::ProductionMissingTransitionEvidence;
+use crate::infrastructure::task_store::SystemEpochMillisClock;
 use serde::Serialize;
 use std::io::{self, BufReader, Write};
 use std::net::{Ipv4Addr, TcpListener, TcpStream};
 #[cfg(feature = "receipt-ledger-test-support")]
 use std::sync::mpsc::{sync_channel, SyncSender};
 use std::sync::Arc;
+#[cfg(feature = "receipt-ledger-test-support")]
+use std::sync::{Condvar, Mutex, MutexGuard};
 use std::thread;
 use std::time::{Duration, Instant};
+
+#[cfg(feature = "receipt-ledger-test-support")]
+mod receipt_scenario_v5;
+#[cfg(feature = "receipt-ledger-test-support")]
+pub(crate) use receipt_scenario_v5::run_supported_receipt_scenario_for_test;
 
 const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const AUTHORITY_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(2);
 const HANDSHAKE_READ_TIMEOUT: Duration = Duration::from_secs(2);
 const SESSION_READ_TIMEOUT: Duration = Duration::from_secs(2);
+const OWNER_RESPONSE_WRITE_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[cfg(feature = "receipt-ledger-test-support")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum V5ReceiptRuntimeEventKind {
+    V5ReceiptRuntimeEntered,
+    CancelReservationConverted,
+    ReceiptTerminalCommitted,
+}
+
+#[cfg(feature = "receipt-ledger-test-support")]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct V5ReceiptRuntimeEvent {
+    sequence: u64,
+    monotonic_ms: u64,
+    epoch_ms: u64,
+    event: V5ReceiptRuntimeEventKind,
+}
+
+#[cfg(feature = "receipt-ledger-test-support")]
+#[derive(Debug, Clone, Copy, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct V5ReceiptRuntimeCallbackCounts {
+    validation: u64,
+    admission: u64,
+    prepare: u64,
+    execute: u64,
+}
+
+#[cfg(feature = "receipt-ledger-test-support")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum V5ReceiptRuntimeListenerState {
+    NotPublished,
+    Listening,
+    Closed,
+}
+
+#[cfg(feature = "receipt-ledger-test-support")]
+struct V5ReceiptRuntimeTelemetryState {
+    next_sequence: u64,
+    events: Vec<V5ReceiptRuntimeEvent>,
+    callbacks: V5ReceiptRuntimeCallbackCounts,
+    listener: V5ReceiptRuntimeListenerState,
+    active_listeners: u64,
+    daemon_running: bool,
+    actor_leases: u64,
+}
+
+#[cfg(feature = "receipt-ledger-test-support")]
+#[derive(Clone)]
+struct V5ReceiptRuntimeTelemetrySnapshot {
+    events: Vec<V5ReceiptRuntimeEvent>,
+    callbacks: V5ReceiptRuntimeCallbackCounts,
+    listener: V5ReceiptRuntimeListenerState,
+    daemon_running: bool,
+    actor_leases: u64,
+}
+
+#[cfg(feature = "receipt-ledger-test-support")]
+struct V5ReceiptRuntimeTelemetry {
+    started_at: Instant,
+    state: Mutex<V5ReceiptRuntimeTelemetryState>,
+    changed: Condvar,
+}
+
+#[cfg(feature = "receipt-ledger-test-support")]
+impl V5ReceiptRuntimeTelemetry {
+    fn new() -> Self {
+        Self {
+            started_at: Instant::now(),
+            state: Mutex::new(V5ReceiptRuntimeTelemetryState {
+                next_sequence: 1,
+                events: Vec::new(),
+                callbacks: V5ReceiptRuntimeCallbackCounts::default(),
+                listener: V5ReceiptRuntimeListenerState::NotPublished,
+                active_listeners: 0,
+                daemon_running: false,
+                actor_leases: 0,
+            }),
+            changed: Condvar::new(),
+        }
+    }
+
+    fn lock_state(&self) -> MutexGuard<'_, V5ReceiptRuntimeTelemetryState> {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn record_event(&self, event: V5ReceiptRuntimeEventKind, epoch_ms: u64) {
+        let monotonic_ms = u64::try_from(self.started_at.elapsed().as_millis()).unwrap_or(u64::MAX);
+        let mut state = self.lock_state();
+        let sequence = state.next_sequence;
+        state.next_sequence = state
+            .next_sequence
+            .checked_add(1)
+            .expect("protocol-v5 runtime telemetry sequence exhausted u64");
+        state.events.push(V5ReceiptRuntimeEvent {
+            sequence,
+            monotonic_ms,
+            epoch_ms,
+            event,
+        });
+        self.changed.notify_all();
+    }
+
+    fn snapshot(&self) -> V5ReceiptRuntimeTelemetrySnapshot {
+        let state = self.lock_state();
+        V5ReceiptRuntimeTelemetrySnapshot {
+            events: state.events.clone(),
+            callbacks: state.callbacks,
+            listener: state.listener,
+            daemon_running: state.daemon_running,
+            actor_leases: state.actor_leases,
+        }
+    }
+
+    fn wait_for_event(
+        &self,
+        event: V5ReceiptRuntimeEventKind,
+        deadline: Instant,
+    ) -> Result<(), String> {
+        let mut state = self.lock_state();
+        while !state.events.iter().any(|record| record.event == event) {
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .ok_or_else(|| format!("protocol-v5 runtime event {event:?} was not observed"))?;
+            let (next, timeout) = self
+                .changed
+                .wait_timeout(state, remaining)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state = next;
+            if timeout.timed_out() && !state.events.iter().any(|record| record.event == event) {
+                return Err(format!(
+                    "protocol-v5 runtime event {event:?} was not observed"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn listener_lease(self: &Arc<Self>) -> V5ReceiptRuntimeListenerLease {
+        let mut state = self.lock_state();
+        state.active_listeners = state
+            .active_listeners
+            .checked_add(1)
+            .expect("protocol-v5 runtime listener telemetry exhausted u64");
+        state.listener = V5ReceiptRuntimeListenerState::Listening;
+        state.daemon_running = true;
+        self.changed.notify_all();
+        V5ReceiptRuntimeListenerLease {
+            telemetry: Arc::clone(self),
+        }
+    }
+
+    fn actor_lease(self: &Arc<Self>) -> V5ReceiptRuntimeActorLease {
+        let mut state = self.lock_state();
+        state.actor_leases = state
+            .actor_leases
+            .checked_add(1)
+            .expect("protocol-v5 runtime actor-lease telemetry exhausted u64");
+        self.changed.notify_all();
+        V5ReceiptRuntimeActorLease {
+            telemetry: Arc::clone(self),
+        }
+    }
+}
+
+#[cfg(feature = "receipt-ledger-test-support")]
+struct V5ReceiptRuntimeListenerLease {
+    telemetry: Arc<V5ReceiptRuntimeTelemetry>,
+}
+
+#[cfg(feature = "receipt-ledger-test-support")]
+impl Drop for V5ReceiptRuntimeListenerLease {
+    fn drop(&mut self) {
+        let mut state = self.telemetry.lock_state();
+        state.active_listeners = state
+            .active_listeners
+            .checked_sub(1)
+            .expect("protocol-v5 runtime listener telemetry lease released only once");
+        if state.active_listeners == 0 {
+            state.listener = V5ReceiptRuntimeListenerState::Closed;
+            state.daemon_running = false;
+        }
+        self.telemetry.changed.notify_all();
+    }
+}
+
+#[cfg(feature = "receipt-ledger-test-support")]
+struct V5ReceiptRuntimeActorLease {
+    telemetry: Arc<V5ReceiptRuntimeTelemetry>,
+}
+
+#[cfg(feature = "receipt-ledger-test-support")]
+impl Drop for V5ReceiptRuntimeActorLease {
+    fn drop(&mut self) {
+        let mut state = self.telemetry.lock_state();
+        state.actor_leases = state
+            .actor_leases
+            .checked_sub(1)
+            .expect("protocol-v5 runtime actor telemetry lease released only once");
+        self.telemetry.changed.notify_all();
+    }
+}
 
 struct V5ReceiptRuntime {
     core_identity: CoreIdentity,
+    // On healthy shutdown Rust drops fields in declaration order: the actor
+    // joins and releases its store before named authority is released. A
+    // fail-stopped runtime is retained until process death instead.
+    receipt_ledger: ReceiptLedgerActor,
     _stable_authority: ReceiptAuthorityLock,
-    receipt_ledger: ReceiptLedgerStore,
+    epoch_clock: Arc<dyn EpochMillisClock>,
+    #[cfg(feature = "receipt-ledger-test-support")]
+    initial_receipt_observation: StableReceiptLedgerObservation,
     #[cfg_attr(not(feature = "receipt-ledger-test-support"), allow(dead_code))]
     invocation_executor: V5InvocationExecutor,
     #[cfg_attr(not(feature = "receipt-ledger-test-support"), allow(dead_code))]
     task_projection: V5TaskProjection,
     #[cfg(feature = "receipt-ledger-test-support")]
     evidence_capture: Option<SyncSender<ProductionMissingTransitionEvidence>>,
+    #[cfg(feature = "receipt-ledger-test-support")]
+    scenario_control: Option<Arc<receipt_scenario_v5::ReceiptScenarioControl>>,
+    #[cfg(feature = "receipt-ledger-test-support")]
+    telemetry: Arc<V5ReceiptRuntimeTelemetry>,
 }
 
 struct V5TaskProjection {
@@ -114,6 +351,7 @@ impl V5InvocationExecutor {
 #[cfg(feature = "receipt-ledger-test-support")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::infrastructure) enum V5ExecutorReachabilityAction {
+    SubmitInvocation,
     RunDirectLoad,
     RunLazyCancelStorm,
 }
@@ -122,6 +360,7 @@ pub(in crate::infrastructure) enum V5ExecutorReachabilityAction {
 impl V5ExecutorReachabilityAction {
     pub(in crate::infrastructure) const fn wire_name(self) -> &'static str {
         match self {
+            Self::SubmitInvocation => "submit",
             Self::RunDirectLoad => "run_direct_load",
             Self::RunLazyCancelStorm => "run_lazy_cancel_storm",
         }
@@ -147,6 +386,14 @@ impl V5ExecutorReachability {
 
 impl V5ReceiptRuntime {
     fn open(state: &DaemonStateDirectory, config: &DaemonServerConfig) -> Result<Self, String> {
+        Self::open_with_epoch_clock(state, config, Arc::new(SystemEpochMillisClock))
+    }
+
+    fn open_with_epoch_clock(
+        state: &DaemonStateDirectory,
+        config: &DaemonServerConfig,
+        epoch_clock: Arc<dyn EpochMillisClock>,
+    ) -> Result<Self, String> {
         let stable_authority = state.acquire_receipt_authority(AUTHORITY_ACQUIRE_TIMEOUT)?;
         let receipts = state.create_private_retained_subdirectory("receipts")?;
         let receipt_ledger = ReceiptLedgerStore::open_retained_directory(receipts)
@@ -154,34 +401,216 @@ impl V5ReceiptRuntime {
         receipt_ledger
             .generation()
             .map_err(|error| format!("read protocol-v5 receipt generation: {error}"))?;
+        #[cfg(feature = "receipt-ledger-test-support")]
+        let initial_receipt_observation = receipt_ledger
+            .observe_stable_generation()
+            .map_err(|error| format!("observe initial protocol-v5 receipt generation: {error}"))?;
+        let receipt_ledger = ReceiptLedgerActor::spawn(receipt_ledger);
         Ok(Self {
             core_identity: config.core_identity.clone(),
             _stable_authority: stable_authority,
             receipt_ledger,
+            epoch_clock,
+            #[cfg(feature = "receipt-ledger-test-support")]
+            initial_receipt_observation,
             invocation_executor: V5InvocationExecutor::new(config.invocation_service_for_v5()),
             task_projection: V5TaskProjection::open(state)?,
             #[cfg(feature = "receipt-ledger-test-support")]
             evidence_capture: None,
+            #[cfg(feature = "receipt-ledger-test-support")]
+            scenario_control: None,
+            #[cfg(feature = "receipt-ledger-test-support")]
+            telemetry: Arc::new(V5ReceiptRuntimeTelemetry::new()),
         })
     }
 
+    #[cfg(feature = "receipt-ledger-test-support")]
+    fn with_shared_telemetry(mut self, telemetry: Arc<V5ReceiptRuntimeTelemetry>) -> Self {
+        self.telemetry = telemetry;
+        self
+    }
+
     fn ensure_named_authority(&self) -> Result<(), String> {
+        self.ensure_named_authority_before(Instant::now() + AUTHORITY_ACQUIRE_TIMEOUT)
+    }
+
+    fn ensure_named_authority_before(&self, deadline: Instant) -> Result<(), String> {
         self.receipt_ledger
-            .generation()
+            .generation(deadline)
             .map(|_| ())
             .map_err(|error| format!("validate protocol-v5 receipt authority: {error}"))
     }
 
-    fn inspect_strict_submit(
+    fn restart_required(&self) -> bool {
+        self.receipt_ledger.restart_required()
+    }
+
+    fn epoch_ms(&self) -> u64 {
+        self.epoch_clock.now_epoch_millis()
+    }
+
+    fn cancel_invocation(
+        &self,
+        key: ReceiptKey,
+        epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<V5RuntimeReply, ReceiptLedgerError> {
+        self.validate_receipt_key(&key)?;
+        let resolution = self
+            .receipt_ledger
+            .request_cancel_or_reserve(key, epoch_ms, deadline)?;
+        match decide_cancel_resolution(resolution) {
+            CancelInvocationDecision::Accepted { receipt, .. } => {
+                Ok(V5RuntimeReply::Json(pending_cancel_response(&receipt)))
+            }
+            CancelInvocationDecision::ExistingDirectTerminal(receipt) => self
+                .reply_for_existing_state(ReceiptState::DirectTerminalUnacked(receipt), deadline),
+            CancelInvocationDecision::Rejected(rejection) => {
+                let _retained = rejection.into_state();
+                Err(ReceiptLedgerError::ReceiptRowPresentUnsupported)
+            }
+        }
+    }
+
+    fn submit_invocation(
         &self,
         decoded: DecodedV5Request,
-    ) -> Result<MissingReceiptObservation, String> {
+        epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<V5RuntimeReply, ReceiptLedgerError> {
         let strict = decoded
             .into_strict_submit(&self.core_identity)
-            .map_err(|error| format!("derive protocol-v5 receipt identity: {error}"))?;
-        self.receipt_ledger
-            .inspect_exact(strict.receipt_key_digest())
-            .map_err(|error| format!("inspect protocol-v5 receipt: {error}"))
+            .map_err(|_| ReceiptLedgerError::InvocationIdentityMismatch)?;
+        let (key, response_budget_ms) = strict.into_parts();
+        let cutoff = OriginalCutoffDescriptor::new(epoch_ms, response_budget_ms)
+            .map_err(|_| ReceiptLedgerError::TimestampOverflow)?;
+        let outcome = self.receipt_ledger.reserve(key, cutoff, deadline)?;
+        let decision = decide_cancel_reserved_submit(outcome).map_err(|_| {
+            ReceiptLedgerError::Corrupt("canonical cancelled terminal could not be constructed")
+        })?;
+        self.reply_for_cancel_submit_decision(decision, epoch_ms, deadline)
+    }
+
+    fn reply_for_cancel_submit_decision(
+        &self,
+        decision: CancelReservedSubmitDecision,
+        epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<V5RuntimeReply, ReceiptLedgerError> {
+        match decision {
+            CancelReservedSubmitDecision::PublishCancelledDirect(intent) => {
+                #[cfg(feature = "receipt-ledger-test-support")]
+                self.telemetry.record_event(
+                    V5ReceiptRuntimeEventKind::CancelReservationConverted,
+                    epoch_ms,
+                );
+                #[cfg(feature = "receipt-ledger-test-support")]
+                if let Some(control) = &self.scenario_control {
+                    control.pause_after_cancel_conversion(deadline)?;
+                }
+                let publication = self.receipt_ledger.publish_direct_terminal(
+                    intent.reservation().key().clone(),
+                    intent.reservation().record_version(),
+                    epoch_ms,
+                    intent.terminal().clone(),
+                    deadline,
+                )?;
+                #[cfg(feature = "receipt-ledger-test-support")]
+                self.telemetry.record_event(
+                    V5ReceiptRuntimeEventKind::ReceiptTerminalCommitted,
+                    epoch_ms,
+                );
+                Ok(V5RuntimeReply::Prepared(publication.into_parts().1))
+            }
+            CancelReservedSubmitDecision::ExistingDirectTerminal(receipt) => self
+                .reply_for_existing_state(ReceiptState::DirectTerminalUnacked(receipt), deadline),
+            CancelReservedSubmitDecision::Rejected(rejection) => {
+                self.reply_for_existing_state(rejection.into_state(), deadline)
+            }
+        }
+    }
+
+    fn recover_invocation(
+        &self,
+        key: ReceiptKey,
+        epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<V5RuntimeReply, ReceiptLedgerError> {
+        self.validate_receipt_key(&key)?;
+        let state = self.receipt_ledger.recover(key, deadline)?;
+        match classify_recovered_receipt(state, epoch_ms) {
+            CancelReservedRecoveryDecision::Current(state) => {
+                let decision = decide_cancel_reserved_submit(ReserveOutcome::ExistingExact(*state))
+                    .map_err(|_| {
+                        ReceiptLedgerError::Corrupt(
+                            "canonical recovery terminal could not be constructed",
+                        )
+                    })?;
+                self.reply_for_cancel_submit_decision(decision, epoch_ms, deadline)
+            }
+            CancelReservedRecoveryDecision::Expire(intent) => {
+                let outcome = self.receipt_ledger.expire_cancel_reserved(
+                    intent.key().clone(),
+                    intent.expected_version(),
+                    intent.expected_mutation_sequence(),
+                    intent.observed_at_epoch_ms(),
+                    deadline,
+                )?;
+                match classify_cancel_reserved_expiry_outcome(outcome) {
+                    CancelReservedExpiryDecision::Expired => {
+                        Err(ReceiptLedgerError::ReceiptNotFound)
+                    }
+                    CancelReservedExpiryDecision::Current(state) => {
+                        let decision =
+                            decide_cancel_reserved_submit(ReserveOutcome::ExistingExact(*state))
+                                .map_err(|_| {
+                                    ReceiptLedgerError::Corrupt(
+                                        "canonical expiry-winner terminal could not be constructed",
+                                    )
+                                })?;
+                        self.reply_for_cancel_submit_decision(decision, epoch_ms, deadline)
+                    }
+                }
+            }
+        }
+    }
+
+    fn reply_for_existing_state(
+        &self,
+        state: ReceiptState,
+        deadline: Instant,
+    ) -> Result<V5RuntimeReply, ReceiptLedgerError> {
+        match state {
+            ReceiptState::CancelReserved(receipt) => {
+                Ok(V5RuntimeReply::Json(pending_cancel_response(&receipt)))
+            }
+            ReceiptState::Reserved(reserved) => {
+                Ok(V5RuntimeReply::Json(pending_reserved_response(&reserved)))
+            }
+            ReceiptState::DirectTerminalUnacked(receipt) => {
+                let expected_version = receipt.record_version().checked_previous().ok_or(
+                    ReceiptLedgerError::Corrupt(
+                        "direct terminal receipt has no predecessor version",
+                    ),
+                )?;
+                let publication = self.receipt_ledger.publish_direct_terminal(
+                    receipt.key().clone(),
+                    expected_version,
+                    receipt.terminal_epoch_ms(),
+                    receipt.terminal().clone(),
+                    deadline,
+                )?;
+                Ok(V5RuntimeReply::Prepared(publication.into_parts().1))
+            }
+            _ => Err(ReceiptLedgerError::ReceiptRowPresentUnsupported),
+        }
+    }
+
+    fn validate_receipt_key(&self, key: &ReceiptKey) -> Result<(), ReceiptLedgerError> {
+        if key.core_identity_digest() != self.core_identity.digest() {
+            return Err(ReceiptLedgerError::InvocationIdentityMismatch);
+        }
+        Ok(())
     }
 
     #[cfg(feature = "receipt-ledger-test-support")]
@@ -190,10 +619,7 @@ impl V5ReceiptRuntime {
         action: V5ExecutorReachabilityAction,
     ) -> Result<V5ExecutorReachability, String> {
         self.ensure_named_authority()?;
-        let observation = self
-            .receipt_ledger
-            .observe_stable_generation()
-            .map_err(|error| format!("observe protocol-v5 executor receipt generation: {error}"))?;
+        let observation = self.initial_receipt_observation.clone();
         Ok(self
             .invocation_executor
             .observe_missing_writer(action, observation))
@@ -205,12 +631,7 @@ impl V5ReceiptRuntime {
     ) -> Result<V5TaskProjectionReachability, String> {
         self.ensure_named_authority()?;
         self.task_projection.validate_named_identity()?;
-        let observation = self
-            .receipt_ledger
-            .observe_stable_generation()
-            .map_err(|error| {
-                format!("observe protocol-v5 task projection receipt generation: {error}")
-            })?;
+        let observation = self.initial_receipt_observation.clone();
         Ok(self
             .task_projection
             .observe_missing_seed_writer(observation))
@@ -241,18 +662,72 @@ impl V5ReceiptRuntime {
     }
 
     #[cfg(feature = "receipt-ledger-test-support")]
-    fn capture_missing_receipt(
+    fn capture_missing_submit_writer_after_reserve(
         &self,
-        observation: MissingReceiptObservation,
+        reply: &V5RuntimeReply,
+        deadline: Instant,
     ) -> Result<(), String> {
         let Some(capture) = &self.evidence_capture else {
             return Ok(());
         };
-        self.ensure_named_authority()?;
-        let evidence = ProductionMissingTransitionEvidence::receipt_row_absent(observation);
+        if !matches!(
+            reply,
+            V5RuntimeReply::Json(V5ServerResponse::Invocation {
+                outcome: V5InvocationResponse::ReceiptPending {
+                    phase: V5InvocationPhase::ReservedUnbound,
+                    ..
+                }
+            })
+        ) {
+            return Ok(());
+        }
+        self.ensure_named_authority_before(deadline)?;
+        let token = self.invocation_executor.observe_missing_writer(
+            V5ExecutorReachabilityAction::SubmitInvocation,
+            self.initial_receipt_observation.clone(),
+        );
+        let evidence = ProductionMissingTransitionEvidence::writer_path_unavailable(token);
         capture
             .try_send(evidence)
-            .map_err(|_| "capture protocol-v5 receipt evidence".to_string())
+            .map_err(|_| "capture protocol-v5 submit writer evidence".to_string())
+    }
+}
+
+enum V5RuntimeReply {
+    Json(V5ServerResponse),
+    Prepared(PreparedWireFrame),
+}
+
+fn pending_cancel_response(
+    receipt: &crate::application::receipt_ledger::CancelReservedReceipt,
+) -> V5ServerResponse {
+    V5ServerResponse::Invocation {
+        outcome: V5InvocationResponse::ReceiptPending {
+            receipt_key: receipt.key().clone(),
+            phase: V5InvocationPhase::CancelReserved,
+            accepted_epoch_ms: receipt.cancel_reserved_at_epoch_ms(),
+            original_budget_ms: 0,
+            cancel_requested: true,
+        },
+    }
+}
+
+fn pending_reserved_response(
+    receipt: &crate::application::receipt_ledger::ReservedReceipt,
+) -> V5ServerResponse {
+    let phase = match receipt.phase() {
+        ReservedPhase::Unbound => V5InvocationPhase::ReservedUnbound,
+        ReservedPhase::ActorBound { .. } => V5InvocationPhase::ReservedActorBound,
+        ReservedPhase::Begun { .. } => V5InvocationPhase::ReservedBegun,
+    };
+    V5ServerResponse::Invocation {
+        outcome: V5InvocationResponse::ReceiptPending {
+            receipt_key: receipt.key().clone(),
+            phase,
+            accepted_epoch_ms: receipt.original_cutoff().accepted_epoch_ms(),
+            original_budget_ms: receipt.original_cutoff().response_budget_ms(),
+            cancel_requested: receipt.cancel_requested(),
+        },
     }
 }
 
@@ -263,6 +738,14 @@ pub(crate) fn run_daemon(config: DaemonServerConfig) -> Result<(), String> {
 fn run_daemon_configured(
     config: DaemonServerConfig,
     configure_runtime: impl FnOnce(V5ReceiptRuntime) -> V5ReceiptRuntime,
+) -> Result<(), String> {
+    run_daemon_configured_until(config, configure_runtime, || false)
+}
+
+fn run_daemon_configured_until(
+    config: DaemonServerConfig,
+    configure_runtime: impl FnOnce(V5ReceiptRuntime) -> V5ReceiptRuntime,
+    stop_requested: impl Fn() -> bool,
 ) -> Result<(), String> {
     if config.core_identity != CoreIdentity::production_v5() {
         return Err(
@@ -282,7 +765,12 @@ fn run_daemon_configured(
     // Receipt ownership and the initial durable generation are established before
     // a listener can become discoverable.
     let runtime = configure_runtime(V5ReceiptRuntime::open(&state, &config)?);
-    runtime.ensure_named_authority()?;
+    if let Err(error) = runtime.ensure_named_authority() {
+        if runtime.restart_required() {
+            std::mem::forget(runtime);
+        }
+        return Err(error);
+    }
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
         .map_err(|error| daemon_io_error("bind protocol-v5 loopback endpoint", error))?;
     listener
@@ -295,13 +783,28 @@ fn run_daemon_configured(
     let record = V5EndpointRecord::new(config.core_identity.clone(), port)?;
     let published = state.publish_v5_endpoint_record(&record)?;
     if let Err(error) = runtime.ensure_named_authority() {
+        if runtime.restart_required() {
+            drop(listener);
+            std::mem::forget(runtime);
+            return Ok(());
+        }
         let _ = state.remove_v5_endpoint_if_owned(&published);
         return Err(error);
     }
+    #[cfg(feature = "receipt-ledger-test-support")]
+    let listener_telemetry = runtime.telemetry.listener_lease();
     let mut idle_since = Instant::now();
+    let mut restart_requested = false;
 
     loop {
+        if stop_requested() {
+            break;
+        }
         if let Err(error) = runtime.ensure_named_authority() {
+            if runtime.restart_required() {
+                restart_requested = true;
+                break;
+            }
             let _ = state.remove_v5_endpoint_if_owned(&published);
             return Err(error);
         }
@@ -309,6 +812,10 @@ fn run_daemon_configured(
             Ok((stream, address)) if address.ip().is_loopback() => {
                 if let Err(error) = runtime.ensure_named_authority() {
                     drop(stream);
+                    if runtime.restart_required() {
+                        restart_requested = true;
+                        break;
+                    }
                     let _ = state.remove_v5_endpoint_if_owned(&published);
                     return Err(error);
                 }
@@ -316,6 +823,10 @@ fn run_daemon_configured(
                 // This W0a shell deliberately handles one bounded probe synchronously. Full
                 // owner/session concurrency and invocation traffic remain separate W0b work.
                 let _ = handle_probe_connection(stream, &record, &runtime);
+                if runtime.restart_required() {
+                    restart_requested = true;
+                    break;
+                }
             }
             Ok((_stream, _)) => {}
             Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
@@ -332,6 +843,15 @@ fn run_daemon_configured(
     }
 
     drop(listener);
+    #[cfg(feature = "receipt-ledger-test-support")]
+    drop(listener_telemetry);
+    if restart_requested {
+        // INV.APP.DAEMON-STORE-FAIL-STOP: keep both the PID-bound endpoint and
+        // receipt authority alive until process death. A detached worker may
+        // still be inside an uninterruptible adapter or syscall.
+        std::mem::forget(runtime);
+        return Ok(());
+    }
     state.remove_v5_endpoint_if_owned(&published)?;
     Ok(())
 }
@@ -341,7 +861,8 @@ fn handle_probe_connection(
     record: &V5EndpointRecord,
     runtime: &V5ReceiptRuntime,
 ) -> Result<(), String> {
-    runtime.ensure_named_authority()?;
+    let handshake_deadline = Instant::now() + HANDSHAKE_READ_TIMEOUT;
+    runtime.ensure_named_authority_before(handshake_deadline)?;
     stream
         .set_nonblocking(false)
         .map_err(|error| daemon_io_error("configure protocol-v5 client stream", error))?;
@@ -349,9 +870,8 @@ fn handle_probe_connection(
         .try_clone()
         .map_err(|error| daemon_io_error("clone protocol-v5 client stream", error))?;
     let mut reader = BufReader::new(reader_stream);
-    let handshake_deadline = Instant::now() + HANDSHAKE_READ_TIMEOUT;
     let decoded = match read_v5_request_before(&mut reader, handshake_deadline) {
-        Ok(decoded) => decoded,
+        Ok((decoded, _)) => decoded,
         Err(V5RequestFrameError::InvalidRequest(_)) => {
             write_runtime_probe_error_before(
                 &mut stream,
@@ -407,12 +927,21 @@ fn handle_probe_connection(
         &V5HandshakeServerResponse::ready(record),
         handshake_deadline,
     )?;
-    let session_deadline = Instant::now() + SESSION_READ_TIMEOUT;
-    let decoded = match read_v5_request_before(&mut reader, session_deadline) {
-        Ok(decoded) => decoded,
-        Err(_) => return Ok(()),
-    };
-    runtime.ensure_named_authority()?;
+    #[cfg(feature = "receipt-ledger-test-support")]
+    let _actor_telemetry_lease = runtime.telemetry.actor_lease();
+    let session_read_deadline = Instant::now() + SESSION_READ_TIMEOUT;
+    let (decoded, request_received_at) =
+        match read_v5_request_before(&mut reader, session_read_deadline) {
+            Ok(observation) => observation,
+            Err(_) => return Ok(()),
+        };
+    let deadlines = v5_request_deadlines(&decoded, request_received_at)?;
+    #[cfg(feature = "receipt-ledger-test-support")]
+    runtime.telemetry.record_event(
+        V5ReceiptRuntimeEventKind::V5ReceiptRuntimeEntered,
+        runtime.epoch_ms(),
+    );
+    runtime.ensure_named_authority_before(deadlines.operation)?;
     let kind = decoded.request().kind();
     match kind {
         V5ClientRequestKind::Ping => {
@@ -422,55 +951,128 @@ fn handle_probe_connection(
                 &mut stream,
                 runtime,
                 &V5ProbeServerResponse::Pong {},
-                session_deadline,
+                deadlines.response,
             )
         }
-        V5ClientRequestKind::SubmitInvocation => match runtime.inspect_strict_submit(decoded) {
-            Ok(observation) => {
-                #[cfg(feature = "receipt-ledger-test-support")]
-                runtime.capture_missing_receipt(observation)?;
-                #[cfg(not(feature = "receipt-ledger-test-support"))]
-                drop(observation);
-                write_runtime_probe_error_before(
+        V5ClientRequestKind::SubmitInvocation => {
+            let epoch_ms = runtime.epoch_ms();
+            match runtime.submit_invocation(decoded, epoch_ms, deadlines.operation) {
+                Ok(reply) => {
+                    #[cfg(feature = "receipt-ledger-test-support")]
+                    runtime
+                        .capture_missing_submit_writer_after_reserve(&reply, deadlines.operation)?;
+                    write_runtime_reply_before(&mut stream, runtime, reply, deadlines.response)
+                }
+                Err(error) => write_runtime_ledger_error_before(
                     &mut stream,
                     runtime,
-                    V5DaemonErrorCode::ReceiptNotFound,
-                    session_deadline,
-                )
+                    &error,
+                    deadlines.response,
+                ),
             }
-            Err(_) => write_runtime_probe_error_before(
-                &mut stream,
-                runtime,
-                V5DaemonErrorCode::StoreFailed,
-                session_deadline,
-            ),
-        },
+        }
+        V5ClientRequestKind::CancelInvocation => {
+            let V5ClientRequest::CancelInvocation { receipt_key } = decoded.into_request() else {
+                unreachable!("request kind and decoded cancel variant diverged");
+            };
+            let epoch_ms = runtime.epoch_ms();
+            match runtime.cancel_invocation(receipt_key, epoch_ms, deadlines.operation) {
+                Ok(reply) => {
+                    write_runtime_reply_before(&mut stream, runtime, reply, deadlines.response)
+                }
+                Err(error) => write_runtime_ledger_error_before(
+                    &mut stream,
+                    runtime,
+                    &error,
+                    deadlines.response,
+                ),
+            }
+        }
+        V5ClientRequestKind::RecoverInvocationReceipt => {
+            let V5ClientRequest::RecoverInvocationReceipt { receipt_key } = decoded.into_request()
+            else {
+                unreachable!("request kind and decoded recover variant diverged");
+            };
+            let epoch_ms = runtime.epoch_ms();
+            match runtime.recover_invocation(receipt_key, epoch_ms, deadlines.operation) {
+                Ok(reply) => {
+                    write_runtime_reply_before(&mut stream, runtime, reply, deadlines.response)
+                }
+                Err(error) => write_runtime_ledger_error_before(
+                    &mut stream,
+                    runtime,
+                    &error,
+                    deadlines.response,
+                ),
+            }
+        }
+        V5ClientRequestKind::Release => write_runtime_json_line_before(
+            &mut stream,
+            runtime,
+            &V5ServerResponse::Released,
+            deadlines.response,
+        ),
         _ => write_runtime_probe_error_before(
             &mut stream,
             runtime,
             V5DaemonErrorCode::InvalidRequest,
-            session_deadline,
+            deadlines.response,
         ),
     }
+}
+
+struct V5RequestDeadlines {
+    operation: Instant,
+    response: Instant,
+}
+
+fn v5_request_deadlines(
+    decoded: &DecodedV5Request,
+    request_received_at: Instant,
+) -> Result<V5RequestDeadlines, String> {
+    let operation_budget = match decoded.request() {
+        V5ClientRequest::SubmitInvocation { invocation } => {
+            Duration::from_millis(invocation.response_budget_ms())
+        }
+        _ => SESSION_READ_TIMEOUT,
+    };
+    let operation = request_received_at
+        .checked_add(operation_budget)
+        .ok_or_else(|| "protocol-v5 operation deadline overflow".to_owned())?;
+    let response = operation
+        .checked_add(RESPONSE_SERIALIZATION_MARGIN)
+        .ok_or_else(|| "protocol-v5 response deadline overflow".to_owned())?
+        .min(
+            request_received_at
+                .checked_add(OWNER_RESPONSE_WRITE_TIMEOUT)
+                .ok_or_else(|| "protocol-v5 response safety deadline overflow".to_owned())?,
+        );
+    Ok(V5RequestDeadlines {
+        operation,
+        response,
+    })
 }
 
 fn read_v5_request_before(
     reader: &mut BufReader<TcpStream>,
     deadline: Instant,
-) -> Result<DecodedV5Request, V5RequestFrameError> {
-    let decoded = read_and_decode_v5_request_before(reader, |reader| {
+) -> Result<(DecodedV5Request, Instant), V5RequestFrameError> {
+    let raw_frame = read_bounded_v5_request_frame_before(reader, |reader| {
         let remaining = deadline
             .checked_duration_since(Instant::now())
             .filter(|remaining| !remaining.is_zero())
             .ok_or_else(|| io::Error::from(io::ErrorKind::TimedOut))?;
         reader.get_ref().set_read_timeout(Some(remaining))
-    })?;
-    if Instant::now() >= deadline {
+    })
+    .map_err(V5RequestFrameError::Read)?;
+    let request_received_at = Instant::now();
+    if request_received_at >= deadline {
         return Err(V5RequestFrameError::Read(io::Error::from(
             io::ErrorKind::TimedOut,
         )));
     }
-    Ok(decoded)
+    let decoded = decode_v5_request_frame(raw_frame)?;
+    Ok((decoded, request_received_at))
 }
 
 fn write_runtime_probe_error_before(
@@ -479,12 +1081,87 @@ fn write_runtime_probe_error_before(
     code: V5DaemonErrorCode,
     deadline: Instant,
 ) -> Result<(), String> {
-    write_runtime_json_line_before(
-        stream,
-        runtime,
-        &V5ProbeServerResponse::Error { code },
-        deadline,
-    )
+    write_runtime_json_line_before(stream, runtime, &V5ServerResponse::Error { code }, deadline)
+}
+
+fn write_runtime_ledger_error_before(
+    stream: &mut TcpStream,
+    runtime: &V5ReceiptRuntime,
+    error: &ReceiptLedgerError,
+    deadline: Instant,
+) -> Result<(), String> {
+    let response = V5ServerResponse::Error {
+        code: daemon_error_code(error),
+    };
+    if error.requires_reopen() {
+        // The actor has already latched fail-stop, so asking it for another
+        // generation check would turn the required closed response into EOF.
+        // The runtime still owns the authenticated stream, PID endpoint,
+        // listener and process-scoped authority at this point. The response
+        // deadline is the operation cutoff plus its one transport margin.
+        write_json_line_before(stream, &response, deadline)
+    } else {
+        write_runtime_json_line_before(stream, runtime, &response, deadline)
+    }
+}
+
+fn write_runtime_reply_before(
+    stream: &mut TcpStream,
+    runtime: &V5ReceiptRuntime,
+    reply: V5RuntimeReply,
+    deadline: Instant,
+) -> Result<(), String> {
+    match reply {
+        V5RuntimeReply::Json(response) => {
+            write_runtime_json_line_before(stream, runtime, &response, deadline)
+        }
+        V5RuntimeReply::Prepared(frame) => {
+            runtime.ensure_named_authority_before(deadline)?;
+            if frame.jsonl().len() > MAX_V5_RESPONSE_LINE_BYTES {
+                return Err("prepared protocol-v5 response exceeds the byte limit".to_string());
+            }
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .filter(|remaining| !remaining.is_zero())
+                .ok_or_else(|| "protocol-v5 response deadline expired".to_string())?;
+            stream.set_write_timeout(Some(remaining)).map_err(|error| {
+                daemon_io_error("configure prepared protocol-v5 response timeout", error)
+            })?;
+            stream
+                .write_all(frame.jsonl())
+                .map_err(|error| daemon_io_error("write prepared protocol-v5 response", error))?;
+            deadline
+                .checked_duration_since(Instant::now())
+                .filter(|remaining| !remaining.is_zero())
+                .map(|_| ())
+                .ok_or_else(|| "protocol-v5 response deadline expired".to_string())
+        }
+    }
+}
+
+fn daemon_error_code(error: &ReceiptLedgerError) -> V5DaemonErrorCode {
+    match error {
+        ReceiptLedgerError::InvocationIdentityMismatch
+        | ReceiptLedgerError::ReservedTaskIdentityMismatch => {
+            V5DaemonErrorCode::InvocationIdentityMismatch
+        }
+        ReceiptLedgerError::ReceiptNotFound => V5DaemonErrorCode::ReceiptNotFound,
+        ReceiptLedgerError::CapacityExceeded => V5DaemonErrorCode::ReceiptCapacity,
+        ReceiptLedgerError::CommitUncertain { .. } => V5DaemonErrorCode::DurabilityUncertain,
+        ReceiptLedgerError::DeadlineExceeded => V5DaemonErrorCode::Overloaded,
+        ReceiptLedgerError::AlreadyOwned => V5DaemonErrorCode::DuplicateLease,
+        ReceiptLedgerError::RecordTooLarge
+        | ReceiptLedgerError::TimestampOverflow
+        | ReceiptLedgerError::ReceiptVersionMismatch { .. }
+        | ReceiptLedgerError::ReceiptMutationSequenceMismatch { .. }
+        | ReceiptLedgerError::TerminalMismatch
+        | ReceiptLedgerError::ReceiptDigestCollision
+        | ReceiptLedgerError::StoreUnavailable
+        | ReceiptLedgerError::ConcurrentGenerationChange { .. }
+        | ReceiptLedgerError::Corrupt(_)
+        | ReceiptLedgerError::ReceiptRowPresentUnsupported
+        | ReceiptLedgerError::Storage { .. } => V5DaemonErrorCode::StoreFailed,
+    }
 }
 
 fn write_runtime_json_line_before<T: Serialize>(
@@ -493,7 +1170,7 @@ fn write_runtime_json_line_before<T: Serialize>(
     value: &T,
     deadline: Instant,
 ) -> Result<(), String> {
-    runtime.ensure_named_authority()?;
+    runtime.ensure_named_authority_before(deadline)?;
     write_json_line_before(stream, value, deadline)
 }
 
@@ -545,13 +1222,7 @@ fn daemon_io_error(operation: &str, error: io::Error) -> String {
 #[cfg(feature = "receipt-ledger-test-support")]
 pub(crate) fn run_protocol_ping_reachability_probe_for_test(
 ) -> Result<ProductionMissingTransitionEvidence, String> {
-    run_v5_reachability_probe_for_test(
-        V5ClientRequest::Ping {},
-        ReachabilityStoreFixture::Empty,
-        ReachabilityExpectedResponse::Pong,
-        ReachabilityEvidenceExpectation::Captured,
-    )?
-    .ok_or_else(|| "protocol-v5 reachability evidence was not captured".to_string())
+    run_v5_reachability_probe_for_test(V5ClientRequest::Ping {}, ReachabilityExpectedResponse::Pong)
 }
 
 #[cfg(feature = "receipt-ledger-test-support")]
@@ -559,11 +1230,8 @@ pub(crate) fn run_submit_reachability_probe_for_test(
 ) -> Result<ProductionMissingTransitionEvidence, String> {
     run_v5_reachability_probe_for_test(
         fixed_submit_request_for_test()?,
-        ReachabilityStoreFixture::Empty,
-        ReachabilityExpectedResponse::Error(V5DaemonErrorCode::ReceiptNotFound),
-        ReachabilityEvidenceExpectation::Captured,
-    )?
-    .ok_or_else(|| "protocol-v5 receipt evidence was not captured".to_string())
+        ReachabilityExpectedResponse::ReceiptPending(V5InvocationPhase::ReservedUnbound),
+    )
 }
 
 #[cfg(feature = "receipt-ledger-test-support")]
@@ -612,20 +1280,6 @@ fn run_executor_reachability_probe_for_test(
     Ok(ProductionMissingTransitionEvidence::writer_path_unavailable(token))
 }
 
-#[cfg(all(feature = "receipt-ledger-test-support", test))]
-fn run_present_submit_reachability_probe_for_test() -> Result<(), String> {
-    let evidence = run_v5_reachability_probe_for_test(
-        fixed_submit_request_for_test()?,
-        ReachabilityStoreFixture::PresentFixedSubmit,
-        ReachabilityExpectedResponse::Error(V5DaemonErrorCode::StoreFailed),
-        ReachabilityEvidenceExpectation::Absent,
-    )?;
-    if evidence.is_some() {
-        return Err("present receipt row minted missing-row evidence".to_string());
-    }
-    Ok(())
-}
-
 #[cfg(feature = "receipt-ledger-test-support")]
 fn fixed_submit_request_for_test() -> Result<V5ClientRequest, String> {
     use crate::application::receipt_ledger::V5ToolIdentity;
@@ -649,32 +1303,14 @@ fn fixed_submit_request_for_test() -> Result<V5ClientRequest, String> {
 #[derive(Clone, Copy)]
 enum ReachabilityExpectedResponse {
     Pong,
-    Error(V5DaemonErrorCode),
-}
-
-#[cfg(feature = "receipt-ledger-test-support")]
-#[derive(Clone, Copy)]
-enum ReachabilityStoreFixture {
-    Empty,
-    #[cfg(test)]
-    PresentFixedSubmit,
-}
-
-#[cfg(feature = "receipt-ledger-test-support")]
-#[derive(Clone, Copy)]
-enum ReachabilityEvidenceExpectation {
-    Captured,
-    #[cfg(test)]
-    Absent,
+    ReceiptPending(V5InvocationPhase),
 }
 
 #[cfg(feature = "receipt-ledger-test-support")]
 fn run_v5_reachability_probe_for_test(
     request: V5ClientRequest,
-    _store_fixture: ReachabilityStoreFixture,
     expected_response: ReachabilityExpectedResponse,
-    evidence_expectation: ReachabilityEvidenceExpectation,
-) -> Result<Option<ProductionMissingTransitionEvidence>, String> {
+) -> Result<ProductionMissingTransitionEvidence, String> {
     let root = tempfile::tempdir().map_err(|error| format!("create v5 probe state: {error}"))?;
     let state_root = std::fs::canonicalize(root.path())
         .map_err(|error| format!("canonicalize v5 probe state: {error}"))?;
@@ -700,11 +1336,6 @@ fn run_v5_reachability_probe_for_test(
         }
         thread::sleep(Duration::from_millis(5));
     };
-
-    #[cfg(test)]
-    if matches!(_store_fixture, ReachabilityStoreFixture::PresentFixedSubmit) {
-        seed_present_submit_receipt_for_test(&state_root, &identity, &request)?;
-    }
 
     let mut stream = TcpStream::connect(record.loopback_addr()?)
         .map_err(|error| daemon_io_error("connect protocol-v5 reachability endpoint", error))?;
@@ -741,32 +1372,24 @@ fn run_v5_reachability_probe_for_test(
     )?;
     let response_frame = read_bounded_v5_probe_response_frame(&mut reader)
         .map_err(|error| daemon_io_error("read protocol-v5 reachability response", error))?;
-    let response: V5ProbeServerResponse = serde_json::from_slice(&response_frame)
-        .map_err(|_| "protocol-v5 reachability response is not strict JSON".to_string())?;
+    let response = decode_v5_server_response(&response_frame).map_err(|error| {
+        format!("protocol-v5 reachability response is not strict JSON: {error}")
+    })?;
     let response_matches = match expected_response {
-        ReachabilityExpectedResponse::Pong => {
-            response.kind() == super::protocol_v5::V5ProbeResponseKind::Pong
-        }
-        ReachabilityExpectedResponse::Error(expected) => response.error_code() == Some(expected),
+        ReachabilityExpectedResponse::Pong => matches!(response, V5ServerResponse::Pong),
+        ReachabilityExpectedResponse::ReceiptPending(expected_phase) => matches!(
+            response,
+            V5ServerResponse::Invocation {
+                outcome: V5InvocationResponse::ReceiptPending { phase, .. }
+            } if phase == expected_phase
+        ),
     };
     if !response_matches {
         return Err("protocol-v5 reachability probe received an unexpected response".to_string());
     }
-    let evidence = match evidence_expectation {
-        ReachabilityEvidenceExpectation::Captured => Some(
-            evidence_rx
-                .recv_timeout(Duration::from_secs(2))
-                .map_err(|_| "protocol-v5 reachability evidence was not captured".to_string())?,
-        ),
-        #[cfg(test)]
-        ReachabilityEvidenceExpectation::Absent => {
-            match evidence_rx.recv_timeout(Duration::from_millis(100)) {
-                Ok(_) => return Err("unexpected protocol-v5 reachability evidence".to_string()),
-                Err(std::sync::mpsc::RecvTimeoutError::Timeout)
-                | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => None,
-            }
-        }
-    };
+    let evidence = evidence_rx
+        .recv_timeout(Duration::from_secs(2))
+        .map_err(|_| "protocol-v5 reachability evidence was not captured".to_string())?;
     drop(stream);
     server
         .join()
@@ -774,48 +1397,24 @@ fn run_v5_reachability_probe_for_test(
     Ok(evidence)
 }
 
-#[cfg(all(feature = "receipt-ledger-test-support", test))]
-fn seed_present_submit_receipt_for_test(
-    state_root: &std::path::Path,
-    identity: &CoreIdentity,
-    request: &V5ClientRequest,
-) -> Result<(), String> {
-    use crate::infrastructure::platform::filesystem::create_owner_only_file_child;
-    use std::ffi::OsStr;
-    use std::io::Cursor;
-
-    let mut frame = serde_json::to_vec(request)
-        .map_err(|_| "encode fixed present-receipt request".to_string())?;
-    frame.push(b'\n');
-    let mut reader = BufReader::new(Cursor::new(frame));
-    let strict = read_and_decode_v5_request(&mut reader)
-        .map_err(|error| format!("decode fixed present-receipt request: {error}"))?
-        .into_strict_submit(identity)
-        .map_err(|error| format!("derive fixed present-receipt identity: {error}"))?;
-    let state = DaemonStateDirectory::open(state_root, identity)?;
-    let receipts = state.create_private_retained_subdirectory("receipts")?;
-    let active = receipts
-        .retain_directory_child(OsStr::new("active"))
-        .map_err(|error| daemon_io_error("retain protocol-v5 receipt active fixture", error))?;
-    let active = active
-        .try_clone_directory()
-        .map_err(|error| daemon_io_error("clone protocol-v5 receipt active fixture", error))?;
-    let row_name = format!("{}.json", strict.receipt_key_digest().as_str());
-    let mut row = create_owner_only_file_child(&active, OsStr::new(&row_name))
-        .map_err(|error| daemon_io_error("create protocol-v5 receipt row fixture", error))?;
-    row.write_all(b"{}")
-        .map_err(|error| daemon_io_error("write protocol-v5 receipt row fixture", error))?;
-    row.sync_all()
-        .map_err(|error| daemon_io_error("sync protocol-v5 receipt row fixture", error))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::application::invocation::normalized_arguments_hash;
+    use crate::application::receipt_ledger::{
+        receipt_key_digest, request_scope_hash, CancelExpiryOutcome, CancelResolution,
+        CommittedDirectPublication, OriginalCutoffDescriptor, ReceiptKey, ReceiptLedgerPort,
+        ReceiptRecordHeader, ReceiptState, ReceiptTerminalOutcome, ReceiptVersion, RequestIdentity,
+        ReserveOutcome, ReservedPhase, ReservedReceipt, V5CanonicalTerminal, V5ToolIdentity,
+        CANCEL_RESERVATION_TTL_MS, MAX_RECEIPT_ENTITLEMENT_BYTES,
+    };
+    use crate::domain::invocation::{InvocationId, TaskId};
+    use crate::infrastructure::daemon::client_v5::V5DaemonProcessOwner;
     use crate::infrastructure::daemon::identity::{CoreIdentity, DaemonStateDirectory};
+    use crate::infrastructure::daemon::protocol_v5::V5InvocationRequest;
     use crate::infrastructure::daemon::protocol_v5::{
-        read_bounded_v5_probe_response_frame, V5EndpointRecord, V5ProbeResponseKind,
-        V5ProbeServerResponse,
+        decode_v5_server_response, read_bounded_v5_probe_response_frame, V5EndpointRecord,
+        V5ProbeResponseKind, V5ProbeServerResponse,
     };
     use crate::infrastructure::platform::testing::{
         attempt_retained_directory_replacement_for_test, RetainedDirectoryReplacementOutcome,
@@ -823,6 +1422,7 @@ mod tests {
     use serde_json::json;
     use std::io::{BufReader, Read, Write};
     use std::net::TcpStream;
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::mpsc;
     use std::thread;
     use std::time::{Duration, Instant};
@@ -831,6 +1431,689 @@ mod tests {
         let mut bytes = serde_json::to_vec(value).expect("serialize v5 frame");
         bytes.push(b'\n');
         stream.write_all(&bytes).expect("write v5 frame");
+    }
+
+    enum CancelPortFailure {
+        ImmediateCommitUncertain,
+        ImmediateStoreUnavailable,
+        WaitPastOperationDeadline,
+    }
+
+    struct FailingCancelPort {
+        failure: CancelPortFailure,
+    }
+
+    impl ReceiptLedgerPort for FailingCancelPort {
+        fn generation(&mut self, _deadline: Instant) -> Result<u64, ReceiptLedgerError> {
+            Ok(0)
+        }
+
+        fn reserve(
+            &mut self,
+            _key: ReceiptKey,
+            _original_cutoff: OriginalCutoffDescriptor,
+            _deadline: Instant,
+        ) -> Result<ReserveOutcome, ReceiptLedgerError> {
+            Err(ReceiptLedgerError::StoreUnavailable)
+        }
+
+        fn request_cancel_or_reserve(
+            &mut self,
+            key: ReceiptKey,
+            _cancel_reserved_at_epoch_ms: u64,
+            deadline: Instant,
+        ) -> Result<CancelResolution, ReceiptLedgerError> {
+            match self.failure {
+                CancelPortFailure::ImmediateCommitUncertain => {
+                    Err(ReceiptLedgerError::CommitUncertain {
+                        receipt_key_digest: receipt_key_digest(&key),
+                    })
+                }
+                CancelPortFailure::ImmediateStoreUnavailable => {
+                    Err(ReceiptLedgerError::StoreUnavailable)
+                }
+                CancelPortFailure::WaitPastOperationDeadline => {
+                    thread::sleep(
+                        deadline.saturating_duration_since(Instant::now())
+                            + Duration::from_millis(10),
+                    );
+                    Err(ReceiptLedgerError::StoreUnavailable)
+                }
+            }
+        }
+
+        fn expire_cancel_reserved(
+            &mut self,
+            _key: ReceiptKey,
+            _expected_version: ReceiptVersion,
+            _expected_mutation_sequence: u64,
+            _observed_at_epoch_ms: u64,
+            _deadline: Instant,
+        ) -> Result<CancelExpiryOutcome, ReceiptLedgerError> {
+            Err(ReceiptLedgerError::StoreUnavailable)
+        }
+
+        fn publish_direct_terminal(
+            &mut self,
+            _key: &ReceiptKey,
+            _expected_version: ReceiptVersion,
+            _terminal_epoch_ms: u64,
+            _terminal: V5CanonicalTerminal,
+            _deadline: Instant,
+        ) -> Result<CommittedDirectPublication, ReceiptLedgerError> {
+            Err(ReceiptLedgerError::StoreUnavailable)
+        }
+
+        fn recover(
+            &mut self,
+            _key: &ReceiptKey,
+            _deadline: Instant,
+        ) -> Result<ReceiptState, ReceiptLedgerError> {
+            Err(ReceiptLedgerError::StoreUnavailable)
+        }
+    }
+
+    struct SlowReservePort {
+        delay: Duration,
+    }
+
+    impl ReceiptLedgerPort for SlowReservePort {
+        fn generation(&mut self, _deadline: Instant) -> Result<u64, ReceiptLedgerError> {
+            Ok(0)
+        }
+
+        fn reserve(
+            &mut self,
+            key: ReceiptKey,
+            original_cutoff: OriginalCutoffDescriptor,
+            _deadline: Instant,
+        ) -> Result<ReserveOutcome, ReceiptLedgerError> {
+            thread::sleep(self.delay);
+            Ok(ReserveOutcome::Created(ReservedReceipt::new(
+                ReceiptRecordHeader::new(
+                    key.clone(),
+                    receipt_key_digest(&key),
+                    ReceiptVersion::initial(),
+                    1,
+                    512,
+                ),
+                original_cutoff.accepted_epoch_ms(),
+                original_cutoff,
+                ReservedPhase::Unbound,
+                false,
+                MAX_RECEIPT_ENTITLEMENT_BYTES - 512,
+            )))
+        }
+
+        fn request_cancel_or_reserve(
+            &mut self,
+            _key: ReceiptKey,
+            _cancel_reserved_at_epoch_ms: u64,
+            _deadline: Instant,
+        ) -> Result<CancelResolution, ReceiptLedgerError> {
+            Err(ReceiptLedgerError::StoreUnavailable)
+        }
+
+        fn expire_cancel_reserved(
+            &mut self,
+            _key: ReceiptKey,
+            _expected_version: ReceiptVersion,
+            _expected_mutation_sequence: u64,
+            _observed_at_epoch_ms: u64,
+            _deadline: Instant,
+        ) -> Result<CancelExpiryOutcome, ReceiptLedgerError> {
+            Err(ReceiptLedgerError::StoreUnavailable)
+        }
+
+        fn publish_direct_terminal(
+            &mut self,
+            _key: &ReceiptKey,
+            _expected_version: ReceiptVersion,
+            _terminal_epoch_ms: u64,
+            _terminal: V5CanonicalTerminal,
+            _deadline: Instant,
+        ) -> Result<CommittedDirectPublication, ReceiptLedgerError> {
+            Err(ReceiptLedgerError::StoreUnavailable)
+        }
+
+        fn recover(
+            &mut self,
+            _key: &ReceiptKey,
+            _deadline: Instant,
+        ) -> Result<ReceiptState, ReceiptLedgerError> {
+            Err(ReceiptLedgerError::StoreUnavailable)
+        }
+    }
+
+    #[test]
+    fn seven_second_submit_budget_is_not_truncated_by_transport_timeouts() {
+        let root = tempfile::tempdir().expect("temporary long-submit state root");
+        let state_root =
+            std::fs::canonicalize(root.path()).expect("physical long-submit state root");
+        let identity = CoreIdentity::production_v5();
+        let config = DaemonServerConfig::new(
+            state_root.clone(),
+            identity.clone(),
+            Duration::from_millis(80),
+        );
+        let server = thread::spawn(move || {
+            run_daemon_configured(config, |mut runtime| {
+                runtime.receipt_ledger = ReceiptLedgerActor::spawn(SlowReservePort {
+                    delay: Duration::from_millis(5_100),
+                });
+                runtime
+            })
+        });
+        let _record = wait_for_v5_record(&state_root, &identity);
+        let invocation = V5InvocationRequest::new(
+            InvocationId::new(),
+            TaskId::new(),
+            V5ToolIdentity::View,
+            serde_json::Map::new(),
+            "workspace-a".to_owned(),
+            7_000,
+        )
+        .expect("valid long-submit request");
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+            &state_root,
+            identity,
+            std::path::PathBuf::from("unused-existing-v5-endpoint"),
+            Duration::from_millis(300),
+        )
+        .expect("connect long-submit owner");
+        let response = owner.submit_invocation(invocation);
+        drop(owner);
+        let server_result = server.join().expect("join long-submit runtime");
+
+        assert!(matches!(
+            response,
+            Ok(V5ServerResponse::Invocation {
+                outcome: V5InvocationResponse::ReceiptPending {
+                    phase: V5InvocationPhase::ReservedUnbound,
+                    ..
+                }
+            })
+        ));
+        assert_eq!(server_result, Ok(()));
+    }
+
+    #[test]
+    fn commit_uncertain_is_returned_before_process_owned_fail_stop_retains_endpoint() {
+        let root = tempfile::tempdir().expect("temporary fail-stop state root");
+        let state_root = std::fs::canonicalize(root.path()).expect("physical fail-stop state root");
+        let identity = CoreIdentity::production_v5();
+        let config = DaemonServerConfig::new(
+            state_root.clone(),
+            identity.clone(),
+            Duration::from_secs(30),
+        );
+        let server = thread::spawn(move || {
+            run_daemon_configured(config, |mut runtime| {
+                runtime.receipt_ledger = ReceiptLedgerActor::spawn(FailingCancelPort {
+                    failure: CancelPortFailure::ImmediateCommitUncertain,
+                });
+                runtime
+            })
+        });
+        let record = wait_for_v5_record(&state_root, &identity);
+        let key = ReceiptKey::new(
+            InvocationId::new(),
+            TaskId::new(),
+            RequestIdentity::new(
+                identity.digest().clone(),
+                V5ToolIdentity::View,
+                normalized_arguments_hash(&serde_json::Map::new()),
+                request_scope_hash("workspace-a").expect("request scope"),
+            ),
+        );
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+            &state_root,
+            identity.clone(),
+            std::path::PathBuf::from("unused-existing-v5-endpoint"),
+            Duration::from_millis(300),
+        )
+        .expect("connect fail-stop owner");
+        let response = owner.cancel_invocation(key);
+        drop(owner);
+        let server_result = server.join().expect("join fail-stop runtime");
+        let state = DaemonStateDirectory::open(&state_root, &identity)
+            .expect("reopen fail-stop daemon state");
+        let retained = state
+            .read_v5_endpoint_record()
+            .expect("read retained fail-stop endpoint");
+        let competing_authority = state.acquire_receipt_authority(Duration::from_millis(30));
+
+        assert_eq!(
+            response,
+            Ok(V5ServerResponse::Error {
+                code: V5DaemonErrorCode::DurabilityUncertain,
+            })
+        );
+        assert_eq!(server_result, Ok(()));
+        assert_eq!(retained, Some(record));
+        assert!(
+            competing_authority.is_err(),
+            "fail-stop released receipt authority before process death"
+        );
+    }
+
+    #[test]
+    fn running_mutation_timeout_uses_a_separate_response_serialization_margin() {
+        let root = tempfile::tempdir().expect("temporary timeout fail-stop state root");
+        let state_root =
+            std::fs::canonicalize(root.path()).expect("physical timeout fail-stop state root");
+        let identity = CoreIdentity::production_v5();
+        let config = DaemonServerConfig::new(
+            state_root.clone(),
+            identity.clone(),
+            Duration::from_secs(30),
+        );
+        let server = thread::spawn(move || {
+            run_daemon_configured(config, |mut runtime| {
+                runtime.receipt_ledger = ReceiptLedgerActor::spawn(FailingCancelPort {
+                    failure: CancelPortFailure::WaitPastOperationDeadline,
+                });
+                runtime
+            })
+        });
+        let record = wait_for_v5_record(&state_root, &identity);
+        let key = ReceiptKey::new(
+            InvocationId::new(),
+            TaskId::new(),
+            RequestIdentity::new(
+                identity.digest().clone(),
+                V5ToolIdentity::View,
+                normalized_arguments_hash(&serde_json::Map::new()),
+                request_scope_hash("workspace-a").expect("request scope"),
+            ),
+        );
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+            &state_root,
+            identity.clone(),
+            std::path::PathBuf::from("unused-existing-v5-endpoint"),
+            Duration::from_millis(300),
+        )
+        .expect("connect timeout fail-stop owner");
+        let response = owner.cancel_invocation(key);
+        drop(owner);
+        let server_result = server.join().expect("join timeout fail-stop runtime");
+        let state = DaemonStateDirectory::open(&state_root, &identity)
+            .expect("reopen timeout fail-stop daemon state");
+        let retained = state
+            .read_v5_endpoint_record()
+            .expect("read retained timeout fail-stop endpoint");
+        let competing_authority = state.acquire_receipt_authority(Duration::from_millis(30));
+
+        assert_eq!(
+            response,
+            Ok(V5ServerResponse::Error {
+                code: V5DaemonErrorCode::DurabilityUncertain,
+            })
+        );
+        assert_eq!(server_result, Ok(()));
+        assert_eq!(retained, Some(record));
+        assert!(
+            competing_authority.is_err(),
+            "timed-out mutation released receipt authority before process death"
+        );
+    }
+
+    #[test]
+    fn every_fail_stop_store_error_is_written_without_reentering_the_actor() {
+        let root = tempfile::tempdir().expect("temporary store-failure state root");
+        let state_root =
+            std::fs::canonicalize(root.path()).expect("physical store-failure state root");
+        let identity = CoreIdentity::production_v5();
+        let config = DaemonServerConfig::new(
+            state_root.clone(),
+            identity.clone(),
+            Duration::from_secs(30),
+        );
+        let server = thread::spawn(move || {
+            run_daemon_configured(config, |mut runtime| {
+                runtime.receipt_ledger = ReceiptLedgerActor::spawn(FailingCancelPort {
+                    failure: CancelPortFailure::ImmediateStoreUnavailable,
+                });
+                runtime
+            })
+        });
+        let record = wait_for_v5_record(&state_root, &identity);
+        let key = ReceiptKey::new(
+            InvocationId::new(),
+            TaskId::new(),
+            RequestIdentity::new(
+                identity.digest().clone(),
+                V5ToolIdentity::View,
+                normalized_arguments_hash(&serde_json::Map::new()),
+                request_scope_hash("workspace-a").expect("request scope"),
+            ),
+        );
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+            &state_root,
+            identity.clone(),
+            std::path::PathBuf::from("unused-existing-v5-endpoint"),
+            Duration::from_millis(300),
+        )
+        .expect("connect store-failure owner");
+        let response = owner.cancel_invocation(key);
+        drop(owner);
+        let server_result = server.join().expect("join store-failure runtime");
+        let state = DaemonStateDirectory::open(&state_root, &identity)
+            .expect("reopen store-failure daemon state");
+        let retained = state
+            .read_v5_endpoint_record()
+            .expect("read retained store-failure endpoint");
+        let competing_authority = state.acquire_receipt_authority(Duration::from_millis(30));
+
+        assert_eq!(
+            response,
+            Ok(V5ServerResponse::Error {
+                code: V5DaemonErrorCode::StoreFailed,
+            })
+        );
+        assert_eq!(server_result, Ok(()));
+        assert_eq!(retained, Some(record));
+        assert!(
+            competing_authority.is_err(),
+            "store failure released receipt authority before process death"
+        );
+    }
+
+    #[test]
+    fn healthy_runtime_drops_the_actor_store_before_releasing_named_authority() {
+        let source = include_str!("runtime_v5.rs");
+        let start = source
+            .find("struct V5ReceiptRuntime {")
+            .expect("runtime owner declaration");
+        let body = source[start..]
+            .split_once("\n}")
+            .expect("runtime owner declaration end")
+            .0;
+
+        assert!(
+            body.find("receipt_ledger: ReceiptLedgerActor")
+                < body.find("_stable_authority: ReceiptAuthorityLock"),
+            "healthy Rust drop order must join actor/store before authority release"
+        );
+    }
+
+    #[test]
+    fn authenticated_release_closes_only_its_owner_session() {
+        let root = tempfile::tempdir().expect("temporary release state root");
+        let state_root = std::fs::canonicalize(root.path()).expect("physical state root");
+        let identity = CoreIdentity::production_v5();
+        let config = DaemonServerConfig::new(
+            state_root.clone(),
+            identity.clone(),
+            Duration::from_millis(500),
+        );
+        let server = thread::spawn(move || run_daemon(config));
+        let record = wait_for_v5_record(&state_root, &identity);
+        let mut stream = TcpStream::connect(record.loopback_addr().expect("loopback address"))
+            .expect("connect release owner");
+        let mut reader = BufReader::new(stream.try_clone().expect("clone release stream"));
+        write_json_line(
+            &mut stream,
+            &json!({
+                "kind": "hello",
+                "protocolVersion": 5,
+                "token": record.token(),
+                "coreIdentity": identity.as_str(),
+                "ownerLease": "77777777-7777-4777-8777-777777777777"
+            }),
+        );
+        read_bounded_v5_probe_response_frame(&mut reader).expect("read release ready");
+
+        write_json_line(&mut stream, &json!({"kind": "release"}));
+        let released =
+            read_bounded_v5_probe_response_frame(&mut reader).expect("read release response");
+        let released = decode_v5_server_response(&released).expect("decode release response");
+        drop(stream);
+
+        let mut successor = TcpStream::connect(record.loopback_addr().expect("loopback address"))
+            .expect("release must leave the daemon listener available");
+        successor
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .expect("bound successor session read");
+        let mut successor_reader =
+            BufReader::new(successor.try_clone().expect("clone successor stream"));
+        write_json_line(
+            &mut successor,
+            &json!({
+                "kind": "hello",
+                "protocolVersion": 5,
+                "token": record.token(),
+                "coreIdentity": identity.as_str(),
+                "ownerLease": "88888888-8888-4888-8888-888888888888"
+            }),
+        );
+        let successor_ready = read_bounded_v5_probe_response_frame(&mut successor_reader)
+            .expect("released owner must not close successor admission");
+        let successor_ready: V5HandshakeServerResponse =
+            serde_json::from_slice(&successor_ready).expect("decode successor ready response");
+        assert!(successor_ready.matches_record(&record));
+        write_json_line(&mut successor, &json!({"kind": "ping"}));
+        let successor_pong = read_bounded_v5_probe_response_frame(&mut successor_reader)
+            .expect("successor session ping");
+        let successor_pong: V5ProbeServerResponse =
+            serde_json::from_slice(&successor_pong).expect("decode successor pong");
+        assert_eq!(successor_pong.kind(), V5ProbeResponseKind::Pong);
+        drop(successor);
+
+        server
+            .join()
+            .expect("join released v5 runtime")
+            .expect("released v5 runtime");
+
+        assert_eq!(released, V5ServerResponse::Released);
+    }
+
+    struct ManualEpochClock {
+        epoch_ms: AtomicU64,
+    }
+
+    impl ManualEpochClock {
+        fn new(epoch_ms: u64) -> Self {
+            Self {
+                epoch_ms: AtomicU64::new(epoch_ms),
+            }
+        }
+
+        fn set(&self, epoch_ms: u64) {
+            self.epoch_ms.store(epoch_ms, Ordering::SeqCst);
+        }
+    }
+
+    impl EpochMillisClock for ManualEpochClock {
+        fn now_epoch_millis(&self) -> u64 {
+            self.epoch_ms.load(Ordering::SeqCst)
+        }
+    }
+
+    fn exchange_once_with_epoch(
+        state_root: &std::path::Path,
+        identity: &CoreIdentity,
+        clock: Arc<ManualEpochClock>,
+        exchange: impl FnOnce(&mut V5DaemonProcessOwner) -> Result<V5ServerResponse, String>,
+    ) -> V5ServerResponse {
+        let config = DaemonServerConfig::new(
+            state_root.to_path_buf(),
+            identity.clone(),
+            Duration::from_millis(80),
+        );
+        let server = thread::spawn(move || {
+            run_daemon_configured(config, move |mut runtime| {
+                runtime.epoch_clock = clock;
+                runtime
+            })
+        });
+        let _record = wait_for_v5_record(state_root, identity);
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+            state_root,
+            identity.clone(),
+            std::path::PathBuf::from("unused-existing-v5-endpoint"),
+            Duration::from_millis(300),
+        )
+        .expect("connect authenticated one-shot owner");
+        let response = exchange(&mut owner).expect("exchange one protocol-v5 request");
+        drop(owner);
+        server
+            .join()
+            .expect("join one-shot v5 runtime")
+            .expect("one-shot v5 runtime");
+        response
+    }
+
+    #[test]
+    fn receipt_digest_collision_is_a_fail_stop_store_error_not_caller_identity_mismatch() {
+        let error = ReceiptLedgerError::ReceiptDigestCollision;
+
+        assert!(error.requires_reopen());
+        assert_eq!(daemon_error_code(&error), V5DaemonErrorCode::StoreFailed);
+    }
+
+    #[test]
+    fn cancel_reserved_reopens_with_the_original_absolute_7125ms_expiry() {
+        let root = tempfile::tempdir().expect("temporary restart-stable receipt root");
+        let state_root = std::fs::canonicalize(root.path()).expect("physical state root");
+        let identity = CoreIdentity::production_v5();
+        let clock = Arc::new(ManualEpochClock::new(1_000));
+        let arguments = serde_json::Map::new();
+        let request_identity = RequestIdentity::new(
+            identity.digest().clone(),
+            V5ToolIdentity::View,
+            normalized_arguments_hash(&arguments),
+            request_scope_hash("workspace-a").expect("request scope"),
+        );
+        let key = ReceiptKey::new(InvocationId::new(), TaskId::new(), request_identity);
+
+        let initial =
+            exchange_once_with_epoch(&state_root, &identity, Arc::clone(&clock), |owner| {
+                owner.cancel_invocation(key.clone())
+            });
+        assert!(matches!(
+            initial,
+            V5ServerResponse::Invocation {
+                outcome: V5InvocationResponse::ReceiptPending {
+                    accepted_epoch_ms: 1_000,
+                    phase: V5InvocationPhase::CancelReserved,
+                    ..
+                }
+            }
+        ));
+
+        clock.set(4_000);
+        let duplicate =
+            exchange_once_with_epoch(&state_root, &identity, Arc::clone(&clock), |owner| {
+                owner.cancel_invocation(key.clone())
+            });
+        assert_eq!(duplicate, initial, "reopen extended the cancellation TTL");
+
+        clock.set(1_000 + CANCEL_RESERVATION_TTL_MS - 1);
+        let before_expiry =
+            exchange_once_with_epoch(&state_root, &identity, Arc::clone(&clock), |owner| {
+                owner.recover_invocation_receipt(key.clone())
+            });
+        assert_eq!(before_expiry, initial);
+
+        clock.set(1_000 + CANCEL_RESERVATION_TTL_MS);
+        let expired = exchange_once_with_epoch(&state_root, &identity, clock, |owner| {
+            owner.recover_invocation_receipt(key)
+        });
+        assert_eq!(
+            expired,
+            V5ServerResponse::Error {
+                code: V5DaemonErrorCode::ReceiptNotFound,
+            }
+        );
+    }
+
+    #[test]
+    fn authenticated_pre_cancel_submit_and_recover_cross_the_actor_owned_runtime() {
+        let root = tempfile::tempdir().expect("temporary state root");
+        let state_root = std::fs::canonicalize(root.path()).expect("physical state root");
+        let identity = CoreIdentity::production_v5();
+        let config = DaemonServerConfig::new(
+            state_root.clone(),
+            identity.clone(),
+            Duration::from_millis(300),
+        );
+        let server = thread::spawn(move || run_daemon(config));
+        let _record = wait_for_v5_record(&state_root, &identity);
+
+        let arguments = serde_json::Map::new();
+        let invocation_id = InvocationId::new();
+        let reserved_task_id = TaskId::new();
+        let request_identity = RequestIdentity::new(
+            identity.digest().clone(),
+            V5ToolIdentity::View,
+            normalized_arguments_hash(&arguments),
+            request_scope_hash("workspace-a").expect("request scope"),
+        );
+        let key = ReceiptKey::new(invocation_id, reserved_task_id, request_identity);
+        let invocation = V5InvocationRequest::new(
+            invocation_id,
+            reserved_task_id,
+            V5ToolIdentity::View,
+            arguments,
+            "workspace-a".to_string(),
+            7_000,
+        )
+        .expect("strict invocation");
+        let unused_executable = std::path::PathBuf::from("unused-existing-v5-endpoint");
+
+        let mut cancel_owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+            &state_root,
+            identity.clone(),
+            unused_executable.clone(),
+            Duration::from_millis(300),
+        )
+        .expect("connect authenticated cancel owner");
+        let cancel = cancel_owner
+            .cancel_invocation(key.clone())
+            .expect("durably reserve pre-submit cancellation");
+        assert!(matches!(
+            cancel,
+            V5ServerResponse::Invocation {
+                outcome: V5InvocationResponse::ReceiptPending {
+                    phase: V5InvocationPhase::CancelReserved,
+                    cancel_requested: true,
+                    ..
+                }
+            }
+        ));
+
+        let mut submit_owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+            &state_root,
+            identity.clone(),
+            unused_executable.clone(),
+            Duration::from_millis(300),
+        )
+        .expect("connect authenticated submit owner");
+        let submit = submit_owner
+            .submit_invocation(invocation)
+            .expect("terminalize exact pre-cancelled submit");
+        assert!(matches!(
+            &submit,
+            V5ServerResponse::Invocation {
+                outcome: V5InvocationResponse::Direct { receipt }
+            } if matches!(receipt.terminal(), ReceiptTerminalOutcome::Cancelled)
+                && receipt.receipt_key() == &key
+        ));
+
+        let mut recover_owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+            &state_root,
+            identity,
+            unused_executable,
+            Duration::from_millis(300),
+        )
+        .expect("connect authenticated recovery owner");
+        let recovered = recover_owner
+            .recover_invocation_receipt(key)
+            .expect("recover committed direct terminal");
+        assert_eq!(recovered, submit, "recovery changed the prepared response");
+
+        server.join().expect("join v5 runtime").expect("v5 runtime");
     }
 
     fn wait_for_v5_record(
@@ -848,28 +2131,6 @@ mod tests {
                 return record;
             }
             assert!(Instant::now() < deadline, "v5 endpoint was not published");
-            thread::sleep(Duration::from_millis(5));
-        }
-    }
-
-    fn wait_for_replacement_v5_record(
-        state_root: &std::path::Path,
-        core_identity: &CoreIdentity,
-        displaced_instance_id: &str,
-    ) -> V5EndpointRecord {
-        let deadline = Instant::now() + Duration::from_secs(5);
-        loop {
-            let state = DaemonStateDirectory::open(state_root, core_identity)
-                .expect("open v5 daemon state while waiting for successor");
-            if let Some(record) = state
-                .read_v5_endpoint_record()
-                .expect("read successor v5 endpoint record")
-            {
-                if record.instance_id() != displaced_instance_id {
-                    return record;
-                }
-            }
-            assert!(Instant::now() < deadline, "v5 successor was not published");
             thread::sleep(Duration::from_millis(5));
         }
     }
@@ -944,10 +2205,7 @@ mod tests {
         let state = DaemonStateDirectory::open(&state_root, &identity)
             .expect("open task projection daemon state");
         let encode_projection = |runtime: &V5ReceiptRuntime| {
-            let observation = runtime
-                .receipt_ledger
-                .observe_stable_generation()
-                .expect("observe production receipt generation");
+            let observation = runtime.initial_receipt_observation.clone();
             let token = runtime
                 .observe_missing_task_projection_writer()
                 .expect("observe production task projection boundary");
@@ -1182,7 +2440,7 @@ mod tests {
     }
 
     #[test]
-    fn displaced_receipt_authority_cannot_keep_accepting_beside_a_successor_owner() {
+    fn displaced_receipt_authority_fail_stops_until_process_death() {
         let root = tempfile::tempdir().expect("temporary state root");
         let state_root = std::fs::canonicalize(root.path()).expect("physical state root");
         let identity = CoreIdentity::production_v5();
@@ -1204,14 +2462,6 @@ mod tests {
                 server.join().expect("join v5 runtime").expect("v5 runtime");
             }
             RetainedDirectoryReplacementOutcome::Replaced => {
-                let successor_config = DaemonServerConfig::new(
-                    state_root.clone(),
-                    identity.clone(),
-                    Duration::from_millis(120),
-                );
-                let successor = thread::spawn(move || run_daemon(successor_config));
-                let successor_record =
-                    wait_for_replacement_v5_record(&state_root, &identity, record.instance_id());
                 let displaced_still_ready =
                     match TcpStream::connect(record.loopback_addr().expect("old v5 address")) {
                         Ok(mut stream) => {
@@ -1238,57 +2488,27 @@ mod tests {
                         }
                         Err(_) => false,
                     };
-
-                let mut successor_stream = TcpStream::connect(
-                    successor_record
-                        .loopback_addr()
-                        .expect("successor v5 loopback address"),
-                )
-                .expect("connect successor daemon");
-                successor_stream
-                    .set_read_timeout(Some(Duration::from_secs(2)))
-                    .expect("bound successor-daemon read");
-                write_json_line(
-                    &mut successor_stream,
-                    &json!({
-                        "kind": "hello",
-                        "protocolVersion": 5,
-                        "token": successor_record.token(),
-                        "coreIdentity": identity.as_str(),
-                        "ownerLease": "44444444-4444-4444-8444-444444444444"
-                    }),
-                );
-                let mut successor_reader = BufReader::new(
-                    successor_stream
-                        .try_clone()
-                        .expect("clone successor v5 stream"),
-                );
-                read_bounded_v5_probe_response_frame(&mut successor_reader)
-                    .expect("successor ready");
-                write_json_line(&mut successor_stream, &json!({"kind": "ping"}));
-                let successor_pong = read_bounded_v5_probe_response_frame(&mut successor_reader)
-                    .expect("successor pong");
-                assert_eq!(
-                    serde_json::from_slice::<V5ProbeServerResponse>(&successor_pong)
-                        .expect("decode successor pong")
-                        .kind(),
-                    V5ProbeResponseKind::Pong
-                );
-                drop(successor_stream);
-
                 let server_result = server.join().expect("join displaced v5 runtime");
-                let successor_result = successor.join().expect("join successor v5 runtime");
                 assert!(
                     !displaced_still_ready,
                     "displaced receipt owner still accepted a handshake"
                 );
                 assert!(
-                    server_result.is_err(),
-                    "displaced receipt owner exited as if its authority were still named"
+                    server_result.is_ok(),
+                    "process-owned fail-stop is a controlled daemon shutdown: {server_result:?}"
                 );
+                let retained_record = state
+                    .read_v5_endpoint_record()
+                    .expect("read fail-stop endpoint")
+                    .expect("fail-stop keeps the PID-bound endpoint until process death");
+                assert_eq!(retained_record, record);
                 assert!(
-                    successor_result.is_ok(),
-                    "successor failed: {successor_result:?}"
+                    V5ReceiptRuntime::open(
+                        &state,
+                        &DaemonServerConfig::new(state_root, identity, Duration::from_millis(120),),
+                    )
+                    .is_err(),
+                    "same-process successor bypassed the retained fail-stop authority"
                 );
             }
         }
@@ -1481,7 +2701,7 @@ mod tests {
 
     #[cfg(feature = "receipt-ledger-test-support")]
     #[test]
-    fn tcp_submit_missing_row_returns_runtime_evidence_after_exact_inspection() {
+    fn tcp_submit_reserves_before_reporting_the_missing_executor_writer() {
         let evidence =
             run_submit_reachability_probe_for_test().expect("run typed submit reachability probe");
         let encoded = evidence
@@ -1493,21 +2713,17 @@ mod tests {
         assert_eq!(encoded["kind"], "production_missing_transition");
         assert_eq!(encoded["payload"]["actionIndex"], 3);
         assert_eq!(encoded["payload"]["actionKind"], "submit");
-        assert_eq!(encoded["payload"]["reachedBoundary"], "v5_receipt_runtime");
+        assert_eq!(encoded["payload"]["reachedBoundary"], "v5_executor");
         assert_eq!(encoded["payload"]["currentProtocol"], "v5");
-        assert_eq!(encoded["payload"]["evidence"]["code"], "receipt_row_absent");
+        assert_eq!(
+            encoded["payload"]["evidence"]["code"],
+            "writer_path_unavailable"
+        );
         assert_eq!(
             encoded["payload"]["evidence"]["event"],
-            "v5_receipt_runtime_entered"
+            "v5_executor_entered"
         );
         assert_eq!(encoded["payload"]["evidence"]["generationBefore"], 0);
         assert_eq!(encoded["payload"]["evidence"]["generationAfter"], 0);
-    }
-
-    #[cfg(feature = "receipt-ledger-test-support")]
-    #[test]
-    fn present_exact_receipt_row_never_mints_receipt_row_absent() {
-        run_present_submit_reachability_probe_for_test()
-            .expect("run typed present-receipt reachability probe");
     }
 }

--- a/crates/unica-coder/src/infrastructure/daemon/runtime_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/runtime_v5.rs
@@ -1,9 +1,10 @@
 use super::identity::{CoreIdentity, DaemonStateDirectory, ReceiptAuthorityLock};
 use super::protocol_v5::{
     decode_v5_request_frame, read_bounded_v5_request_frame_before, DecodedV5Request,
-    V5ClientRequest, V5ClientRequestKind, V5DaemonErrorCode, V5EndpointRecord,
-    V5HandshakeServerResponse, V5InvocationPhase, V5InvocationResponse, V5ProbeServerResponse,
-    V5RequestFrameError, V5ServerResponse, DAEMON_PROTOCOL_VERSION, MAX_V5_RESPONSE_LINE_BYTES,
+    V5AcknowledgedReceipt, V5ClientRequest, V5ClientRequestKind, V5DaemonErrorCode,
+    V5EndpointRecord, V5HandshakeServerResponse, V5InvocationPhase, V5InvocationResponse,
+    V5ProbeServerResponse, V5RequestFrameError, V5ServerResponse, DAEMON_PROTOCOL_VERSION,
+    MAX_V5_RESPONSE_LINE_BYTES,
 };
 #[cfg(feature = "receipt-ledger-test-support")]
 use super::protocol_v5::{
@@ -19,7 +20,7 @@ use crate::application::invocation_v5::{
 };
 use crate::application::receipt_ledger::{
     OriginalCutoffDescriptor, PreparedWireFrame, ReceiptKey, ReceiptLedgerError, ReceiptState,
-    ReserveOutcome, ReservedPhase,
+    ReserveOutcome, ReservedPhase, TerminalDigest,
 };
 use crate::application::receipt_ledger_actor::ReceiptLedgerActor;
 use crate::infrastructure::platform::filesystem::RetainedDirectoryCapability;
@@ -58,6 +59,7 @@ enum V5ReceiptRuntimeEventKind {
     V5ReceiptRuntimeEntered,
     CancelReservationConverted,
     ReceiptTerminalCommitted,
+    AcknowledgementCommitted,
 }
 
 #[cfg(feature = "receipt-ledger-test-support")]
@@ -575,6 +577,29 @@ impl V5ReceiptRuntime {
         }
     }
 
+    fn acknowledge_invocation(
+        &self,
+        key: ReceiptKey,
+        terminal_digest: TerminalDigest,
+        epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<V5RuntimeReply, ReceiptLedgerError> {
+        self.validate_receipt_key(&key)?;
+        let acknowledged =
+            self.receipt_ledger
+                .acknowledge_direct(key, terminal_digest, epoch_ms, deadline)?;
+        #[cfg(feature = "receipt-ledger-test-support")]
+        self.telemetry.record_event(
+            V5ReceiptRuntimeEventKind::AcknowledgementCommitted,
+            epoch_ms,
+        );
+        Ok(V5RuntimeReply::Json(
+            V5ServerResponse::InvocationAcknowledged {
+                acknowledgement: V5AcknowledgedReceipt::from_receipt(&acknowledged),
+            },
+        ))
+    }
+
     fn reply_for_existing_state(
         &self,
         state: ReceiptState,
@@ -601,6 +626,13 @@ impl V5ReceiptRuntime {
                     deadline,
                 )?;
                 Ok(V5RuntimeReply::Prepared(publication.into_parts().1))
+            }
+            ReceiptState::AcknowledgedTombstone(receipt) => {
+                Ok(V5RuntimeReply::Json(V5ServerResponse::Invocation {
+                    outcome: V5InvocationResponse::Acknowledged {
+                        acknowledgement: V5AcknowledgedReceipt::from_receipt(&receipt),
+                    },
+                }))
             }
             _ => Err(ReceiptLedgerError::ReceiptRowPresentUnsupported),
         }
@@ -1007,6 +1039,41 @@ fn handle_probe_connection(
                 ),
             }
         }
+        V5ClientRequestKind::AcknowledgeInvocationReceipt => {
+            let V5ClientRequest::AcknowledgeInvocationReceipt {
+                receipt_key,
+                terminal_digest,
+            } = decoded.into_request()
+            else {
+                unreachable!("request kind and decoded acknowledgement variant diverged");
+            };
+            let epoch_ms = runtime.epoch_ms();
+            match runtime.acknowledge_invocation(
+                receipt_key,
+                terminal_digest,
+                epoch_ms,
+                deadlines.operation,
+            ) {
+                Ok(reply) => {
+                    write_runtime_reply_before(&mut stream, runtime, reply, deadlines.response)
+                }
+                Err(
+                    ReceiptLedgerError::TerminalMismatch
+                    | ReceiptLedgerError::ReceiptRowPresentUnsupported,
+                ) => write_runtime_probe_error_before(
+                    &mut stream,
+                    runtime,
+                    V5DaemonErrorCode::InvalidRequest,
+                    deadlines.response,
+                ),
+                Err(error) => write_runtime_ledger_error_before(
+                    &mut stream,
+                    runtime,
+                    &error,
+                    deadlines.response,
+                ),
+            }
+        }
         V5ClientRequestKind::Release => write_runtime_json_line_before(
             &mut stream,
             runtime,
@@ -1148,6 +1215,7 @@ fn daemon_error_code(error: &ReceiptLedgerError) -> V5DaemonErrorCode {
         }
         ReceiptLedgerError::ReceiptNotFound => V5DaemonErrorCode::ReceiptNotFound,
         ReceiptLedgerError::CapacityExceeded => V5DaemonErrorCode::ReceiptCapacity,
+        ReceiptLedgerError::TombstoneCapacityExceeded => V5DaemonErrorCode::TombstoneCapacity,
         ReceiptLedgerError::CommitUncertain { .. } => V5DaemonErrorCode::DurabilityUncertain,
         ReceiptLedgerError::DeadlineExceeded => V5DaemonErrorCode::Overloaded,
         ReceiptLedgerError::AlreadyOwned => V5DaemonErrorCode::DuplicateLease,

--- a/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5.rs
@@ -15,8 +15,8 @@ use crate::domain::invocation::{InvocationId, NormalizedArgumentsHash, SafeIdent
 use crate::infrastructure::daemon::client_v5::V5DaemonProcessOwner;
 use crate::infrastructure::daemon::identity::{CoreIdentity, DaemonStateDirectory};
 use crate::infrastructure::daemon::protocol_v5::{
-    decode_v5_request_frame, V5ClientRequest, V5DaemonErrorCode, V5InvocationRequest,
-    V5InvocationResponse, V5ServerResponse,
+    decode_v5_request_frame, V5ClientRequest, V5DaemonErrorCode, V5InvocationPhase,
+    V5InvocationRequest, V5InvocationResponse, V5ServerResponse,
 };
 use crate::infrastructure::daemon::server::DaemonServerConfig;
 use serde::{Deserialize, Serialize};
@@ -1104,12 +1104,19 @@ fn response_observation(
             outcome:
                 V5InvocationResponse::ReceiptPending {
                     receipt_key,
+                    phase,
                     accepted_epoch_ms,
                     original_budget_ms,
-                    ..
+                    cancel_requested,
                 },
         } => Ok(json!({
-            "kind": "cancelled",
+            "kind": match phase {
+                V5InvocationPhase::CancelReserved => "cancelled",
+                V5InvocationPhase::ReservedUnbound
+                | V5InvocationPhase::ReservedActorBound
+                | V5InvocationPhase::ReservedBegun => "pending",
+            },
+            "cancelRequested": cancel_requested,
             "error": null,
             "terminal": null,
             "key": receipt_key_observation(receipt_key),
@@ -1600,7 +1607,51 @@ mod tests {
     use crate::application::receipt_ledger::{
         OriginalCutoffDescriptor, ACKNOWLEDGED_TOMBSTONE_TTL_MS, MAX_RECEIPT_ENTITLEMENT_BYTES,
     };
+    use crate::infrastructure::daemon::protocol_v5::V5InvocationPhase as TestV5InvocationPhase;
     use crate::infrastructure::receipt_ledger::ReceiptLedgerStore;
+
+    #[test]
+    fn receipt_pending_observation_distinguishes_phase_and_projects_cancel_request() {
+        let identity = CoreIdentity::production_v5();
+        let key = fresh_key(&identity, &Map::new()).expect("construct pending receipt key");
+        let cases = [
+            (TestV5InvocationPhase::CancelReserved, true),
+            (TestV5InvocationPhase::ReservedUnbound, false),
+            (TestV5InvocationPhase::ReservedActorBound, true),
+            (TestV5InvocationPhase::ReservedBegun, false),
+        ];
+
+        let observed = cases
+            .into_iter()
+            .map(|(phase, cancel_requested)| {
+                let response = V5ServerResponse::Invocation {
+                    outcome: V5InvocationResponse::ReceiptPending {
+                        receipt_key: key.clone(),
+                        phase,
+                        accepted_epoch_ms: 1_000,
+                        original_budget_ms: 6_000,
+                        cancel_requested,
+                    },
+                };
+                let projected = response_observation(&response, None)
+                    .expect("project protocol-v5 pending response");
+                json!({
+                    "kind": projected["kind"],
+                    "cancelRequested": projected["cancelRequested"],
+                })
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            observed,
+            vec![
+                json!({ "kind": "cancelled", "cancelRequested": true }),
+                json!({ "kind": "pending", "cancelRequested": false }),
+                json!({ "kind": "pending", "cancelRequested": true }),
+                json!({ "kind": "pending", "cancelRequested": false }),
+            ]
+        );
+    }
 
     #[test]
     fn protocol_ack_loss_retry_and_duplicate_read_the_same_compact_tombstone() {

--- a/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5.rs
@@ -37,6 +37,7 @@ const SCENARIO_OPERATION_TIMEOUT: Duration = Duration::from_secs(2);
 pub(super) struct ReceiptScenarioControl {
     barrier: Mutex<CancelConversionBarrier>,
     changed: Condvar,
+    drop_ack_response_after_commit: AtomicBool,
 }
 
 #[derive(Default)]
@@ -51,7 +52,18 @@ impl ReceiptScenarioControl {
         Self {
             barrier: Mutex::new(CancelConversionBarrier::default()),
             changed: Condvar::new(),
+            drop_ack_response_after_commit: AtomicBool::new(false),
         }
+    }
+
+    fn arm_ack_response_disconnect(&self) {
+        self.drop_ack_response_after_commit
+            .store(true, Ordering::Release);
+    }
+
+    pub(super) fn take_ack_response_disconnect(&self) -> bool {
+        self.drop_ack_response_after_commit
+            .swap(false, Ordering::AcqRel)
     }
 
     fn install(&self) {
@@ -311,19 +323,36 @@ pub(crate) fn run_supported_receipt_scenario_for_test(
                     }
                     ScenarioDigest::TaskTerminal => return Ok(None),
                 };
-                let response = exchange_once(
-                    state.path(),
-                    &identity,
-                    Arc::clone(&clock),
-                    Arc::clone(&telemetry),
-                    |owner| {
-                        owner.acknowledge_invocation_receipt(exact_key.clone(), terminal_digest)
-                    },
-                )?;
-                if matches!(disconnect, ScenarioAckDisconnect::Never) {
-                    report
-                        .responses
-                        .insert(label, response_observation(&response, None)?);
+                match disconnect {
+                    ScenarioAckDisconnect::Never => {
+                        let response = exchange_once(
+                            state.path(),
+                            &identity,
+                            Arc::clone(&clock),
+                            Arc::clone(&telemetry),
+                            |owner| {
+                                owner.acknowledge_invocation_receipt(
+                                    exact_key.clone(),
+                                    terminal_digest,
+                                )
+                            },
+                        )?;
+                        report
+                            .responses
+                            .insert(label, response_observation(&response, None)?);
+                    }
+                    ScenarioAckDisconnect::AfterTombstoneCommit => {
+                        control.arm_ack_response_disconnect();
+                        exchange_ack_and_expect_disconnect(
+                            state.path(),
+                            &identity,
+                            Arc::clone(&clock),
+                            Arc::clone(&control),
+                            Arc::clone(&telemetry),
+                            exact_key.clone(),
+                            terminal_digest,
+                        )?;
+                    }
                 }
             }
             ReceiptScenarioAction::AdvanceEpoch { millis } => {
@@ -584,6 +613,47 @@ fn exchange_once(
     })();
     let cleanup = daemon.stop_and_join("protocol-v5 receipt scenario daemon panicked");
     finish_with_daemon_cleanup(response, cleanup)
+}
+
+fn exchange_ack_and_expect_disconnect(
+    state_root: &Path,
+    identity: &CoreIdentity,
+    clock: Arc<ScenarioEpochClock>,
+    control: Arc<ReceiptScenarioControl>,
+    telemetry: Arc<V5ReceiptRuntimeTelemetry>,
+    key: ReceiptKey,
+    terminal_digest: TerminalDigest,
+) -> Result<(), String> {
+    let config = DaemonServerConfig::new(
+        state_root.to_path_buf(),
+        identity.clone(),
+        SCENARIO_IDLE_GRACE,
+    );
+    let daemon = ScenarioDaemon::spawn(config, move |runtime| {
+        let mut runtime = runtime.with_shared_telemetry(telemetry);
+        runtime.epoch_clock = clock;
+        runtime.scenario_control = Some(control);
+        runtime
+    });
+    let result = (|| {
+        wait_for_endpoint(state_root, identity)?;
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+            state_root,
+            identity.clone(),
+            std::path::PathBuf::from("unused-existing-v5-scenario-endpoint"),
+            SCENARIO_IDLE_GRACE,
+        )?;
+        let result = owner.acknowledge_invocation_receipt(key, terminal_digest);
+        drop(owner);
+        match result {
+            Ok(_) => {
+                Err("ACK response was delivered instead of disconnecting after commit".to_owned())
+            }
+            Err(_) => Ok(()),
+        }
+    })();
+    let cleanup = daemon.stop_and_join("protocol-v5 receipt scenario ACK daemon panicked");
+    finish_with_daemon_cleanup(result, cleanup)
 }
 
 enum ScenarioWireRequest {

--- a/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5.rs
@@ -7,8 +7,8 @@ use crate::application::invocation_store::EpochMillisClock;
 use crate::application::receipt_ledger::{
     canonical_v5_terminal, receipt_key_digest, request_scope_hash, task_link_digest,
     CoreIdentityDigest, ReceiptKey, ReceiptKeyDigest, ReceiptLedgerError, ReceiptState,
-    ReceiptTerminalOutcome, RequestIdentity, ReservedPhase, TaskLinkIdentity, V5ToolIdentity,
-    DIRECT_TERMINAL_RETENTION_MS,
+    ReceiptTerminalOutcome, RequestIdentity, ReservedPhase, TaskLinkIdentity, TerminalDigest,
+    V5ToolIdentity, DIRECT_TERMINAL_RETENTION_MS,
 };
 use crate::application::receipt_ledger_actor::ReceiptLedgerActor;
 use crate::domain::invocation::{InvocationId, NormalizedArgumentsHash, SafeIdentityHash, TaskId};
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use std::collections::BTreeMap;
 use std::path::Path;
+use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc;
 use std::sync::{Arc, Condvar, Mutex};
@@ -285,6 +286,46 @@ pub(crate) fn run_supported_receipt_scenario_for_test(
                     .responses
                     .insert(label, response_observation(&response, None)?);
             }
+            ReceiptScenarioAction::Acknowledge {
+                key,
+                digest,
+                disconnect,
+                label,
+            } => {
+                let ScenarioKey::Exact = key else {
+                    return Ok(None);
+                };
+                let terminal_digest = match digest {
+                    ScenarioDigest::ExactTerminal => exact_terminal_digest(
+                        state.path(),
+                        &identity,
+                        Arc::clone(&clock),
+                        Arc::clone(&telemetry),
+                        &exact_key,
+                    )?,
+                    ScenarioDigest::Mismatched => TerminalDigest::from_str(&"a5".repeat(32))
+                        .expect("fixed mismatch digest is normalized"),
+                    ScenarioDigest::WellFormedCandidate => {
+                        TerminalDigest::from_str(&"00".repeat(32))
+                            .expect("fixed candidate digest is normalized")
+                    }
+                    ScenarioDigest::TaskTerminal => return Ok(None),
+                };
+                let response = exchange_once(
+                    state.path(),
+                    &identity,
+                    Arc::clone(&clock),
+                    Arc::clone(&telemetry),
+                    |owner| {
+                        owner.acknowledge_invocation_receipt(exact_key.clone(), terminal_digest)
+                    },
+                )?;
+                if matches!(disconnect, ScenarioAckDisconnect::Never) {
+                    report
+                        .responses
+                        .insert(label, response_observation(&response, None)?);
+                }
+            }
             ReceiptScenarioAction::AdvanceEpoch { millis } => {
                 clock.advance(millis)?;
             }
@@ -497,6 +538,7 @@ fn has_supported_shape(request: &str) -> Result<bool, String> {
                     "cancel"
                         | "submit"
                         | "recover"
+                        | "acknowledge"
                         | "advance_epoch"
                         | "restart"
                         | "checkpoint"
@@ -781,9 +823,16 @@ fn snapshot_with_actor(
     telemetry: &V5ReceiptRuntimeTelemetry,
     keys: &[ReceiptKey],
 ) -> Result<Value, String> {
+    actor
+        .reclaim_expired_tombstones(
+            clock.now_epoch_millis(),
+            Instant::now() + SCENARIO_OPERATION_TIMEOUT,
+        )
+        .map_err(|error| format!("reclaim protocol-v5 receipt tombstones: {error}"))?;
     let mut receipts = Vec::with_capacity(keys.len());
     for key in keys {
         match actor.recover(key.clone(), Instant::now() + SCENARIO_OPERATION_TIMEOUT) {
+            Ok(ReceiptState::AcknowledgedTombstone(_)) => {}
             Ok(receipt) => receipts.push(receipt_observation(receipt)?),
             Err(ReceiptLedgerError::ReceiptNotFound) => {}
             Err(error) => {
@@ -797,6 +846,11 @@ fn snapshot_with_actor(
     if u64::try_from(catalog.keys().len()).ok() != Some(catalog.live_count()) {
         return Err("sealed protocol-v5 receipt catalog count is inconsistent".to_owned());
     }
+    let tombstones = catalog
+        .tombstones()
+        .iter()
+        .map(tombstone_observation)
+        .collect::<Vec<_>>();
     let invocation_index = catalog
         .invocation_index()
         .iter()
@@ -812,7 +866,7 @@ fn snapshot_with_actor(
 
     Ok(json!({
         "receipts": receipts,
-        "tombstones": [],
+        "tombstones": tombstones,
         "tasks": [],
         "taskLinks": [],
         "invocationIndex": invocation_index,
@@ -824,8 +878,8 @@ fn snapshot_with_actor(
         "taskLinkBytes": 0,
         "taskLinkReservedCount": 0,
         "taskLinkReservedBytes": 0,
-        "tombstoneCount": 0,
-        "tombstoneBytes": 0,
+        "tombstoneCount": catalog.tombstones().len(),
+        "tombstoneBytes": catalog.tombstone_bytes(),
         "callbacks": runtime.callbacks,
         "listener": runtime.listener,
         "restartRequested": false,
@@ -843,6 +897,18 @@ fn snapshot_with_actor(
         "fallbackExecutions": 0,
         "stagedResponsesExposed": 0
     }))
+}
+
+fn tombstone_observation(
+    receipt: &crate::application::receipt_ledger::AcknowledgedTombstoneReceipt,
+) -> Value {
+    json!({
+        "key": receipt_key_observation(receipt.key()),
+        "terminalDigest": receipt.terminal_digest(),
+        "ackEpochMs": receipt.acknowledged_at_epoch_ms(),
+        "expiresEpochMs": receipt.expires_at_epoch_ms(),
+        "encodedBytes": receipt.encoded_bytes()
+    })
 }
 
 fn receipt_observation(state: ReceiptState) -> Result<Value, String> {
@@ -1007,6 +1073,30 @@ fn response_observation(
                 "latencyMs": 0
             }))
         }
+        V5ServerResponse::InvocationAcknowledged { acknowledgement } => Ok(json!({
+            "kind": "acknowledged",
+            "error": null,
+            "terminal": null,
+            "key": receipt_key_observation(acknowledgement.receipt_key()),
+            "task": null,
+            "acknowledgement": acknowledgement_observation(acknowledgement),
+            "cutoffEpochMs": null,
+            "originalBudgetMs": null,
+            "latencyMs": 0
+        })),
+        V5ServerResponse::Invocation {
+            outcome: V5InvocationResponse::Acknowledged { acknowledgement },
+        } => Ok(json!({
+            "kind": "tombstone",
+            "error": null,
+            "terminal": null,
+            "key": receipt_key_observation(acknowledgement.receipt_key()),
+            "task": null,
+            "acknowledgement": acknowledgement_observation(acknowledgement),
+            "cutoffEpochMs": null,
+            "originalBudgetMs": null,
+            "latencyMs": 0
+        })),
         V5ServerResponse::Error { code } => Ok(json!({
             "kind": if matches!(code, V5DaemonErrorCode::ReceiptNotFound) {
                 "not_found"
@@ -1025,6 +1115,42 @@ fn response_observation(
         })),
         other => Err(format!(
             "receipt scenario received unsupported protocol-v5 response: {other:?}"
+        )),
+    }
+}
+
+fn acknowledgement_observation(
+    acknowledgement: &crate::infrastructure::daemon::protocol_v5::V5AcknowledgedReceipt,
+) -> Value {
+    json!({
+        "ackEpochMs": acknowledgement.ack_epoch_ms(),
+        "expiresEpochMs": acknowledgement.expires_epoch_ms(),
+        "terminalDigest": acknowledgement.terminal_digest()
+    })
+}
+
+fn exact_terminal_digest(
+    state_root: &Path,
+    identity: &CoreIdentity,
+    clock: Arc<ScenarioEpochClock>,
+    telemetry: Arc<V5ReceiptRuntimeTelemetry>,
+    key: &ReceiptKey,
+) -> Result<TerminalDigest, String> {
+    let response = exchange_once(state_root, identity, clock, telemetry, |owner| {
+        owner.recover_invocation_receipt(key.clone())
+    })?;
+    match response {
+        V5ServerResponse::Invocation {
+            outcome: V5InvocationResponse::Direct { receipt },
+        } => Ok(receipt.terminal_digest().clone()),
+        V5ServerResponse::Invocation {
+            outcome: V5InvocationResponse::Acknowledged { acknowledgement },
+        }
+        | V5ServerResponse::InvocationAcknowledged { acknowledgement } => {
+            Ok(acknowledgement.terminal_digest().clone())
+        }
+        other => Err(format!(
+            "protocol-v5 scenario has no exact terminal digest: {other:?}"
         )),
     }
 }
@@ -1256,6 +1382,12 @@ enum ReceiptScenarioAction {
         key: ScenarioKey,
         label: String,
     },
+    Acknowledge {
+        key: ScenarioKey,
+        digest: ScenarioDigest,
+        disconnect: ScenarioAckDisconnect,
+        label: String,
+    },
     AdvanceEpoch {
         millis: u64,
     },
@@ -1303,6 +1435,15 @@ impl ReceiptScenarioAction {
                     && matches!(disconnect, ScenarioDisconnect::Never)
             }
             Self::Recover { key, .. } => matches!(key, ScenarioKey::Exact),
+            Self::Acknowledge {
+                key, disconnect, ..
+            } => {
+                matches!(key, ScenarioKey::Exact)
+                    && matches!(
+                        disconnect,
+                        ScenarioAckDisconnect::Never | ScenarioAckDisconnect::AfterTombstoneCommit
+                    )
+            }
             Self::AdvanceEpoch { .. }
             | Self::Restart
             | Self::Checkpoint { .. }
@@ -1326,6 +1467,22 @@ enum ScenarioRequest {
 #[serde(rename_all = "snake_case")]
 enum ScenarioDisconnect {
     Never,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ScenarioAckDisconnect {
+    Never,
+    AfterTombstoneCommit,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ScenarioDigest {
+    ExactTerminal,
+    Mismatched,
+    TaskTerminal,
+    WellFormedCandidate,
 }
 
 #[derive(Deserialize)]
@@ -1371,9 +1528,137 @@ enum ScenarioIdentityField {
 mod tests {
     use super::*;
     use crate::application::receipt_ledger::{
-        OriginalCutoffDescriptor, MAX_RECEIPT_ENTITLEMENT_BYTES,
+        OriginalCutoffDescriptor, ACKNOWLEDGED_TOMBSTONE_TTL_MS, MAX_RECEIPT_ENTITLEMENT_BYTES,
     };
     use crate::infrastructure::receipt_ledger::ReceiptLedgerStore;
+
+    #[test]
+    fn protocol_ack_loss_retry_and_duplicate_read_the_same_compact_tombstone() {
+        let request = json!({
+            "clock": "fake",
+            "actions": [
+                {
+                    "action": "cancel",
+                    "key": "exact",
+                    "lazy_session": true,
+                    "label": "cancel"
+                },
+                { "action": "checkpoint", "label": "premature-before" },
+                {
+                    "action": "acknowledge",
+                    "key": "exact",
+                    "digest": "well_formed_candidate",
+                    "disconnect": "never",
+                    "label": "premature"
+                },
+                { "action": "checkpoint", "label": "premature-after" },
+                {
+                    "action": "submit",
+                    "request": "canonical",
+                    "response_budget_ms": 6_000,
+                    "disconnect": "never",
+                    "label": "direct"
+                },
+                { "action": "checkpoint", "label": "mismatch-before" },
+                {
+                    "action": "acknowledge",
+                    "key": "exact",
+                    "digest": "mismatched",
+                    "disconnect": "never",
+                    "label": "mismatched"
+                },
+                { "action": "checkpoint", "label": "mismatch-after" },
+                {
+                    "action": "acknowledge",
+                    "key": "exact",
+                    "digest": "exact_terminal",
+                    "disconnect": "after_tombstone_commit",
+                    "label": "lost"
+                },
+                { "action": "checkpoint", "label": "after-lost" },
+                {
+                    "action": "acknowledge",
+                    "key": "exact",
+                    "digest": "exact_terminal",
+                    "disconnect": "never",
+                    "label": "retry"
+                },
+                {
+                    "action": "submit",
+                    "request": "canonical",
+                    "response_budget_ms": 6_000,
+                    "disconnect": "never",
+                    "label": "duplicate"
+                },
+                { "action": "advance_epoch", "millis": 899_999 },
+                { "action": "checkpoint", "label": "before-expiry" },
+                { "action": "advance_epoch", "millis": 1 },
+                { "action": "checkpoint", "label": "at-expiry" }
+            ]
+        });
+
+        let encoded = run_supported_receipt_scenario_for_test(&request.to_string())
+            .expect("run protocol-v5 acknowledgement scenario")
+            .expect("acknowledgement scenario is supported");
+        let report: Value = serde_json::from_str(&encoded).expect("decode scenario report");
+        let payload = &report["payload"];
+        let tombstones = payload["checkpoints"]["after-lost"]["tombstones"]
+            .as_array()
+            .expect("tombstone inventory");
+
+        assert_eq!(tombstones.len(), 1);
+        assert_eq!(
+            payload["responses"]["premature"]["error"].as_str(),
+            Some("invalid_request")
+        );
+        assert_eq!(
+            payload["checkpoints"]["premature-before"]["receipts"],
+            payload["checkpoints"]["premature-after"]["receipts"]
+        );
+        assert_eq!(
+            payload["responses"]["mismatched"]["error"].as_str(),
+            Some("invalid_request")
+        );
+        assert_eq!(
+            payload["checkpoints"]["mismatch-before"]["receipts"],
+            payload["checkpoints"]["mismatch-after"]["receipts"]
+        );
+        assert_eq!(
+            payload["checkpoints"]["after-lost"]["receiptLiveCount"].as_u64(),
+            Some(0)
+        );
+        assert_eq!(
+            payload["responses"]["retry"]["kind"].as_str(),
+            Some("acknowledged")
+        );
+        assert_eq!(
+            payload["responses"]["duplicate"]["kind"].as_str(),
+            Some("tombstone")
+        );
+        let first_ack_epoch = tombstones[0]["ackEpochMs"]
+            .as_u64()
+            .expect("first acknowledgement epoch");
+        assert_eq!(
+            tombstones[0]["expiresEpochMs"].as_u64(),
+            first_ack_epoch.checked_add(ACKNOWLEDGED_TOMBSTONE_TTL_MS)
+        );
+        assert_eq!(
+            payload["responses"]["retry"]["acknowledgement"]["ackEpochMs"].as_u64(),
+            Some(first_ack_epoch)
+        );
+        assert_eq!(
+            payload["responses"]["duplicate"]["acknowledgement"]["ackEpochMs"].as_u64(),
+            Some(first_ack_epoch)
+        );
+        assert_eq!(
+            payload["checkpoints"]["before-expiry"]["tombstoneCount"].as_u64(),
+            Some(1)
+        );
+        assert_eq!(
+            payload["checkpoints"]["at-expiry"]["tombstoneCount"].as_u64(),
+            Some(0)
+        );
+    }
 
     #[test]
     fn batch_client_failure_stops_and_joins_the_daemon_before_returning() {

--- a/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5.rs
@@ -19,7 +19,7 @@ use crate::infrastructure::daemon::protocol_v5::{
     V5InvocationResponse, V5ServerResponse,
 };
 use crate::infrastructure::daemon::server::DaemonServerConfig;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -846,23 +846,23 @@ fn snapshot_with_actor(
 }
 
 fn receipt_observation(state: ReceiptState) -> Result<Value, String> {
-    match state {
-        ReceiptState::CancelReserved(receipt) => Ok(json!({
-            "key": receipt_key_observation(receipt.key()),
-            "state": "cancel_reserved",
-            "cancelRequested": true,
-            "acceptedEpochMs": receipt.cancel_reserved_at_epoch_ms(),
-            "originalBudgetMs": 0,
-            "expiresEpochMs": receipt.expires_at_epoch_ms(),
-            "boundWorkspaceIdentity": null,
-            "stagedTerminal": null,
-            "terminal": null,
-            "encodedBytes": receipt.encoded_bytes(),
-            "reservedResultBytes": 0,
-            "version": receipt.record_version().get(),
-            "mutationSequence": receipt.mutation_sequence(),
-            "begun": false
-        })),
+    let observation = match state {
+        ReceiptState::CancelReserved(receipt) => ScenarioReceiptObservation {
+            key: receipt_key_observation(receipt.key()),
+            state: "cancel_reserved",
+            cancel_requested: true,
+            accepted_epoch_ms: receipt.cancel_reserved_at_epoch_ms(),
+            original_budget_ms: 0,
+            expires_epoch_ms: Some(receipt.expires_at_epoch_ms()),
+            bound_workspace_identity: None,
+            staged_terminal: None,
+            terminal: None,
+            encoded_bytes: receipt.encoded_bytes(),
+            reserved_result_bytes: 0,
+            version: receipt.record_version().get(),
+            mutation_sequence: receipt.mutation_sequence(),
+            begun: false,
+        },
         ReceiptState::Reserved(receipt) => {
             let (state, bound_workspace_identity, begun) = match receipt.phase() {
                 ReservedPhase::Unbound => ("reserved_unbound", None, false),
@@ -885,50 +885,78 @@ fn receipt_observation(state: ReceiptState) -> Result<Value, String> {
                     true,
                 ),
             };
-            Ok(json!({
-                "key": receipt_key_observation(receipt.key()),
-                "state": state,
-                "cancelRequested": receipt.cancel_requested(),
-                "acceptedEpochMs": receipt.original_cutoff().accepted_epoch_ms(),
-                "originalBudgetMs": receipt.original_cutoff().response_budget_ms(),
-                "expiresEpochMs": null,
-                "boundWorkspaceIdentity": bound_workspace_identity,
-                "stagedTerminal": null,
-                "terminal": null,
-                "encodedBytes": receipt.encoded_bytes(),
-                "reservedResultBytes": receipt.reserved_result_bytes(),
-                "version": receipt.record_version().get(),
-                "mutationSequence": receipt.mutation_sequence(),
-                "begun": begun
-            }))
+            ScenarioReceiptObservation {
+                key: receipt_key_observation(receipt.key()),
+                state,
+                cancel_requested: receipt.cancel_requested(),
+                accepted_epoch_ms: receipt.original_cutoff().accepted_epoch_ms(),
+                original_budget_ms: receipt.original_cutoff().response_budget_ms(),
+                expires_epoch_ms: None,
+                bound_workspace_identity,
+                staged_terminal: None,
+                terminal: None,
+                encoded_bytes: receipt.encoded_bytes(),
+                reserved_result_bytes: receipt.reserved_result_bytes(),
+                version: receipt.record_version().get(),
+                mutation_sequence: receipt.mutation_sequence(),
+                begun,
+            }
         }
-        ReceiptState::DirectTerminalUnacked(receipt) => Ok(json!({
-            "key": receipt_key_observation(receipt.key()),
-            "state": "direct_terminal_unacked",
-            "cancelRequested": matches!(
+        ReceiptState::DirectTerminalUnacked(receipt) => ScenarioReceiptObservation {
+            key: receipt_key_observation(receipt.key()),
+            state: "direct_terminal_unacked",
+            cancel_requested: matches!(
                 receipt.terminal().outcome(),
                 ReceiptTerminalOutcome::Cancelled
             ),
-            "acceptedEpochMs": receipt.original_cutoff().accepted_epoch_ms(),
-            "originalBudgetMs": receipt.original_cutoff().response_budget_ms(),
-            "expiresEpochMs": receipt.terminal_epoch_ms() + DIRECT_TERMINAL_RETENTION_MS,
-            "boundWorkspaceIdentity": null,
-            "stagedTerminal": null,
-            "terminal": terminal_observation(
+            accepted_epoch_ms: receipt.original_cutoff().accepted_epoch_ms(),
+            original_budget_ms: receipt.original_cutoff().response_budget_ms(),
+            expires_epoch_ms: Some(
+                receipt
+                    .terminal_epoch_ms()
+                    .checked_add(DIRECT_TERMINAL_RETENTION_MS)
+                    .ok_or_else(|| "direct terminal observation expiry overflow".to_owned())?,
+            ),
+            bound_workspace_identity: None,
+            staged_terminal: None,
+            terminal: Some(terminal_observation(
                 receipt.terminal().outcome(),
                 receipt.terminal_epoch_ms(),
-            )?,
-            "encodedBytes": receipt.encoded_bytes(),
-            "reservedResultBytes": receipt.reserved_result_bytes(),
-            "version": receipt.record_version().get(),
-            "mutationSequence": receipt.mutation_sequence(),
-            "begun": false
-        })),
-        other => Err(format!(
-            "receipt scenario cannot project unsupported state {}",
-            other.kind().diagnostic_name()
-        )),
-    }
+            )?),
+            encoded_bytes: receipt.encoded_bytes(),
+            reserved_result_bytes: receipt.reserved_result_bytes(),
+            version: receipt.record_version().get(),
+            mutation_sequence: receipt.mutation_sequence(),
+            begun: false,
+        },
+        other => {
+            return Err(format!(
+                "receipt scenario cannot project unsupported state {}",
+                other.kind().diagnostic_name()
+            ))
+        }
+    };
+    serde_json::to_value(observation)
+        .map_err(|error| format!("encode receipt scenario observation: {error}"))
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ScenarioReceiptObservation {
+    key: Value,
+    state: &'static str,
+    cancel_requested: bool,
+    accepted_epoch_ms: u64,
+    original_budget_ms: u64,
+    expires_epoch_ms: Option<u64>,
+    bound_workspace_identity: Option<String>,
+    staged_terminal: Option<Value>,
+    terminal: Option<Value>,
+    encoded_bytes: u64,
+    reserved_result_bytes: u64,
+    version: u64,
+    mutation_sequence: u64,
+    begun: bool,
 }
 
 fn response_observation(

--- a/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5.rs
@@ -1,0 +1,1507 @@
+use super::{
+    run_daemon_configured_until, V5ReceiptRuntime, V5ReceiptRuntimeEvent,
+    V5ReceiptRuntimeEventKind, V5ReceiptRuntimeTelemetry,
+};
+use crate::application::invocation::normalized_arguments_hash;
+use crate::application::invocation_store::EpochMillisClock;
+use crate::application::receipt_ledger::{
+    canonical_v5_terminal, receipt_key_digest, request_scope_hash, task_link_digest,
+    CoreIdentityDigest, ReceiptKey, ReceiptKeyDigest, ReceiptLedgerError, ReceiptState,
+    ReceiptTerminalOutcome, RequestIdentity, ReservedPhase, TaskLinkIdentity, V5ToolIdentity,
+    DIRECT_TERMINAL_RETENTION_MS,
+};
+use crate::application::receipt_ledger_actor::ReceiptLedgerActor;
+use crate::domain::invocation::{InvocationId, NormalizedArgumentsHash, SafeIdentityHash, TaskId};
+use crate::infrastructure::daemon::client_v5::V5DaemonProcessOwner;
+use crate::infrastructure::daemon::identity::{CoreIdentity, DaemonStateDirectory};
+use crate::infrastructure::daemon::protocol_v5::{
+    decode_v5_request_frame, V5ClientRequest, V5DaemonErrorCode, V5InvocationRequest,
+    V5InvocationResponse, V5ServerResponse,
+};
+use crate::infrastructure::daemon::server::DaemonServerConfig;
+use serde::Deserialize;
+use serde_json::{json, Map, Value};
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc;
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const SCENARIO_INITIAL_EPOCH_MS: u64 = 1;
+const SCENARIO_IDLE_GRACE: Duration = Duration::from_secs(2);
+const SCENARIO_OPERATION_TIMEOUT: Duration = Duration::from_secs(2);
+
+pub(super) struct ReceiptScenarioControl {
+    barrier: Mutex<CancelConversionBarrier>,
+    changed: Condvar,
+}
+
+#[derive(Default)]
+struct CancelConversionBarrier {
+    installed: bool,
+    reached: bool,
+    released: bool,
+}
+
+impl ReceiptScenarioControl {
+    fn new() -> Self {
+        Self {
+            barrier: Mutex::new(CancelConversionBarrier::default()),
+            changed: Condvar::new(),
+        }
+    }
+
+    fn install(&self) {
+        let mut barrier = self
+            .barrier
+            .lock()
+            .expect("scenario barrier mutex poisoned");
+        *barrier = CancelConversionBarrier {
+            installed: true,
+            reached: false,
+            released: false,
+        };
+    }
+
+    fn is_installed(&self) -> bool {
+        self.barrier
+            .lock()
+            .expect("scenario barrier mutex poisoned")
+            .installed
+    }
+
+    pub(super) fn pause_after_cancel_conversion(
+        &self,
+        deadline: Instant,
+    ) -> Result<(), ReceiptLedgerError> {
+        let mut barrier = self
+            .barrier
+            .lock()
+            .map_err(|_| ReceiptLedgerError::Corrupt("scenario barrier mutex was poisoned"))?;
+        if !barrier.installed {
+            return Ok(());
+        }
+        barrier.reached = true;
+        self.changed.notify_all();
+        while !barrier.released {
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                return Err(ReceiptLedgerError::DeadlineExceeded);
+            };
+            let (next, timeout) = self
+                .changed
+                .wait_timeout(barrier, remaining)
+                .map_err(|_| ReceiptLedgerError::Corrupt("scenario barrier mutex was poisoned"))?;
+            barrier = next;
+            if timeout.timed_out() && !barrier.released {
+                return Err(ReceiptLedgerError::DeadlineExceeded);
+            }
+        }
+        Ok(())
+    }
+
+    fn wait_until_reached(&self, deadline: Instant) -> Result<(), String> {
+        let mut barrier = self
+            .barrier
+            .lock()
+            .map_err(|_| "protocol-v5 receipt scenario barrier mutex was poisoned".to_owned())?;
+        while !barrier.reached {
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .ok_or_else(|| {
+                    "protocol-v5 cancel conversion barrier was not reached".to_owned()
+                })?;
+            let (next, timeout) = self.changed.wait_timeout(barrier, remaining).map_err(|_| {
+                "protocol-v5 receipt scenario barrier mutex was poisoned".to_owned()
+            })?;
+            barrier = next;
+            if timeout.timed_out() && !barrier.reached {
+                return Err("protocol-v5 cancel conversion barrier was not reached".to_owned());
+            }
+        }
+        Ok(())
+    }
+
+    fn release(&self) {
+        let mut barrier = self
+            .barrier
+            .lock()
+            .expect("scenario barrier mutex poisoned");
+        barrier.released = true;
+        self.changed.notify_all();
+    }
+}
+
+pub(crate) fn run_supported_receipt_scenario_for_test(
+    request: &str,
+) -> Result<Option<String>, String> {
+    if !has_supported_shape(request)? {
+        return Ok(None);
+    }
+    let Ok(scenario) = serde_json::from_str::<ReceiptScenario>(request) else {
+        return Ok(None);
+    };
+    if !matches!(scenario.clock, ScenarioClock::Fake)
+        || scenario.actions.iter().any(|action| !action.is_supported())
+    {
+        return Ok(None);
+    }
+
+    let mut state = ScenarioStateRoot::new()?;
+    let identity = CoreIdentity::production_v5();
+    let clock = Arc::new(ScenarioEpochClock::new(SCENARIO_INITIAL_EPOCH_MS));
+    let arguments = Map::new();
+    let invocation_id = InvocationId::new();
+    let reserved_task_id = TaskId::new();
+    let exact_key = ReceiptKey::new(
+        invocation_id,
+        reserved_task_id,
+        RequestIdentity::new(
+            identity.digest().clone(),
+            V5ToolIdentity::View,
+            normalized_arguments_hash(&arguments),
+            request_scope_hash("workspace-a")
+                .map_err(|error| format!("construct receipt scenario request scope: {error}"))?,
+        ),
+    );
+    let mismatched_arguments_key = {
+        let mut mismatched = Map::new();
+        mismatched.insert("mismatch".to_owned(), Value::Bool(true));
+        ReceiptKey::new(
+            invocation_id,
+            reserved_task_id,
+            RequestIdentity::new(
+                identity.digest().clone(),
+                V5ToolIdentity::View,
+                normalized_arguments_hash(&mismatched),
+                request_scope_hash("workspace-a").map_err(|error| {
+                    format!("construct mismatched receipt scenario request scope: {error}")
+                })?,
+            ),
+        )
+    };
+
+    let mut report = ScenarioReportBuilder::default();
+    let control = Arc::new(ReceiptScenarioControl::new());
+    let telemetry = Arc::new(V5ReceiptRuntimeTelemetry::new());
+    let mut known_keys = Vec::new();
+    let mut pending_submit: Option<PendingSubmit> = None;
+    for action in scenario.actions {
+        match action {
+            ReceiptScenarioAction::Cancel { key, label, .. } => {
+                let is_exact = matches!(&key, ScenarioKey::Exact);
+                let wire_key = match key {
+                    ScenarioKey::Exact => exact_key.clone(),
+                    ScenarioKey::Unknown => fresh_key(&identity, &arguments)?,
+                    ScenarioKey::Mismatch(ScenarioIdentityField::NormalizedArgumentsHash) => {
+                        mismatched_arguments_key.clone()
+                    }
+                    _ => return Ok(None),
+                };
+                let response = exchange_once(
+                    state.path(),
+                    &identity,
+                    Arc::clone(&clock),
+                    Arc::clone(&telemetry),
+                    |owner| owner.cancel_invocation(wire_key),
+                )?;
+                if !matches!(response, V5ServerResponse::Error { .. }) && is_exact {
+                    push_known_key(&mut known_keys, exact_key.clone());
+                }
+                report
+                    .responses
+                    .insert(label, response_observation(&response, None)?);
+            }
+            ReceiptScenarioAction::Submit {
+                response_budget_ms,
+                label,
+                ..
+            } => {
+                let invocation = V5InvocationRequest::new(
+                    invocation_id,
+                    reserved_task_id,
+                    V5ToolIdentity::View,
+                    arguments.clone(),
+                    "workspace-a".to_owned(),
+                    response_budget_ms,
+                )
+                .map_err(|error| format!("construct receipt scenario submit: {error}"))?;
+                push_known_key(&mut known_keys, exact_key.clone());
+                if control.is_installed() {
+                    if pending_submit.is_some() {
+                        return Err(
+                            "protocol-v5 receipt scenario already has a pending submit".to_owned()
+                        );
+                    }
+                    pending_submit = Some(start_blocked_submit(
+                        state.path(),
+                        &identity,
+                        Arc::clone(&clock),
+                        Arc::clone(&control),
+                        Arc::clone(&telemetry),
+                        invocation,
+                        label,
+                        clock.now_epoch_millis(),
+                        response_budget_ms,
+                    )?);
+                } else {
+                    let response = exchange_once(
+                        state.path(),
+                        &identity,
+                        Arc::clone(&clock),
+                        Arc::clone(&telemetry),
+                        |owner| owner.submit_invocation(invocation),
+                    )?;
+                    report.responses.insert(
+                        label,
+                        response_observation(
+                            &response,
+                            Some((clock.now_epoch_millis(), response_budget_ms)),
+                        )?,
+                    );
+                }
+            }
+            ReceiptScenarioAction::Recover { key, label } => {
+                let ScenarioKey::Exact = key else {
+                    return Ok(None);
+                };
+                let response = exchange_once(
+                    state.path(),
+                    &identity,
+                    Arc::clone(&clock),
+                    Arc::clone(&telemetry),
+                    |owner| owner.recover_invocation_receipt(exact_key.clone()),
+                )?;
+                if matches!(
+                    response,
+                    V5ServerResponse::Error {
+                        code: V5DaemonErrorCode::ReceiptNotFound
+                    }
+                ) {
+                    known_keys.retain(|known| known != &exact_key);
+                }
+                report
+                    .responses
+                    .insert(label, response_observation(&response, None)?);
+            }
+            ReceiptScenarioAction::AdvanceEpoch { millis } => {
+                clock.advance(millis)?;
+            }
+            ReceiptScenarioAction::Restart => {
+                // Every production action in this feature-only driver is a fresh authenticated
+                // daemon lifetime. The explicit marker therefore requires no synthetic state.
+            }
+            ReceiptScenarioAction::Checkpoint { label } => {
+                let snapshot = match &pending_submit {
+                    Some(pending) => {
+                        snapshot_with_actor(&pending.actor, &clock, &telemetry, &known_keys)?
+                    }
+                    None => snapshot_from_state(
+                        state.path(),
+                        &identity,
+                        Arc::clone(&clock),
+                        &telemetry,
+                        &known_keys,
+                    )?,
+                };
+                report.checkpoints.insert(label, snapshot);
+            }
+            ReceiptScenarioAction::Reset => {
+                if pending_submit.is_some() {
+                    return Err(
+                        "protocol-v5 receipt scenario cannot reset a live submit".to_owned()
+                    );
+                }
+                state = ScenarioStateRoot::new()?;
+                known_keys.clear();
+            }
+            ReceiptScenarioAction::FillReceiptPool { state: fill, count } => {
+                let mut requests = Vec::with_capacity(count as usize);
+                let mut added = Vec::with_capacity(count as usize);
+                for index in 0..count {
+                    let key = if matches!(fill, ScenarioSeedReceiptState::CancelReserved)
+                        && known_keys.is_empty()
+                        && index == 0
+                    {
+                        exact_key.clone()
+                    } else {
+                        fresh_key(&identity, &arguments)?
+                    };
+                    let request = match fill {
+                        ScenarioSeedReceiptState::CancelReserved => {
+                            ScenarioWireRequest::Cancel(key.clone())
+                        }
+                        ScenarioSeedReceiptState::ReservedUnbound => ScenarioWireRequest::Submit(
+                            invocation_for_key(&key, arguments.clone(), 7_000)?,
+                        ),
+                    };
+                    requests.push(request);
+                    added.push(key);
+                }
+                let responses = exchange_batch(
+                    state.path(),
+                    &identity,
+                    Arc::clone(&clock),
+                    Arc::clone(&telemetry),
+                    requests,
+                )?;
+                if let Some(error) = responses
+                    .iter()
+                    .find(|response| matches!(response, V5ServerResponse::Error { .. }))
+                {
+                    return Err(format!(
+                        "protocol-v5 receipt scenario pool fill was rejected: {error:?}"
+                    ));
+                }
+                for key in added {
+                    push_known_key(&mut known_keys, key);
+                }
+            }
+            ReceiptScenarioAction::InstallBarrier { point } => {
+                if !matches!(
+                    point,
+                    ScenarioBarrierPoint::AfterCancelReservationConvertedBeforeTerminal
+                ) {
+                    return Ok(None);
+                }
+                control.install();
+            }
+            ReceiptScenarioAction::WaitForEvent { event } => match event {
+                ScenarioEvent::CancelReservationConverted => {
+                    control.wait_until_reached(Instant::now() + SCENARIO_OPERATION_TIMEOUT)?;
+                    telemetry.wait_for_event(
+                        V5ReceiptRuntimeEventKind::CancelReservationConverted,
+                        Instant::now() + SCENARIO_OPERATION_TIMEOUT,
+                    )?;
+                }
+                ScenarioEvent::ReceiptTerminalCommitted => {
+                    if pending_submit.is_some() {
+                        return Err(
+                            "protocol-v5 receipt scenario terminal wait preceded barrier release"
+                                .to_owned(),
+                        );
+                    }
+                    telemetry.wait_for_event(
+                        V5ReceiptRuntimeEventKind::ReceiptTerminalCommitted,
+                        Instant::now() + SCENARIO_OPERATION_TIMEOUT,
+                    )?;
+                }
+            },
+            ReceiptScenarioAction::ReleaseBarrier { point } => {
+                if !matches!(
+                    point,
+                    ScenarioBarrierPoint::AfterCancelReservationConvertedBeforeTerminal
+                ) {
+                    return Ok(None);
+                }
+                control.release();
+                let pending = pending_submit.take().ok_or_else(|| {
+                    "protocol-v5 receipt scenario has no submit at the barrier".to_owned()
+                })?;
+                let (label, accepted_epoch_ms, response_budget_ms, response) = pending.finish()?;
+                report.responses.insert(
+                    label,
+                    response_observation(&response, Some((accepted_epoch_ms, response_budget_ms)))?,
+                );
+            }
+            ReceiptScenarioAction::CompareClientServerIdentity => {
+                report.identity = Some(compare_client_server_identity()?);
+            }
+        }
+    }
+
+    if pending_submit.is_some() {
+        return Err("protocol-v5 receipt scenario ended with a blocked submit".to_owned());
+    }
+
+    report.encode(telemetry.snapshot().events).map(Some)
+}
+
+struct ScenarioStateRoot {
+    _directory: tempfile::TempDir,
+    path: std::path::PathBuf,
+}
+
+impl ScenarioStateRoot {
+    fn new() -> Result<Self, String> {
+        let directory = tempfile::tempdir()
+            .map_err(|error| format!("create protocol-v5 receipt scenario state root: {error}"))?;
+        let path = std::fs::canonicalize(directory.path()).map_err(|error| {
+            format!("canonicalize protocol-v5 receipt scenario state root: {error}")
+        })?;
+        Ok(Self {
+            _directory: directory,
+            path,
+        })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+fn fresh_key(
+    identity: &CoreIdentity,
+    arguments: &Map<String, Value>,
+) -> Result<ReceiptKey, String> {
+    Ok(ReceiptKey::new(
+        InvocationId::new(),
+        TaskId::new(),
+        RequestIdentity::new(
+            identity.digest().clone(),
+            V5ToolIdentity::View,
+            normalized_arguments_hash(arguments),
+            request_scope_hash("workspace-a")
+                .map_err(|error| format!("construct receipt scenario request scope: {error}"))?,
+        ),
+    ))
+}
+
+fn invocation_for_key(
+    key: &ReceiptKey,
+    arguments: Map<String, Value>,
+    response_budget_ms: u64,
+) -> Result<V5InvocationRequest, String> {
+    V5InvocationRequest::new(
+        key.invocation_id(),
+        key.reserved_task_id(),
+        key.tool(),
+        arguments,
+        "workspace-a".to_owned(),
+        response_budget_ms,
+    )
+    .map_err(|error| format!("construct receipt scenario invocation: {error}"))
+}
+
+fn push_known_key(keys: &mut Vec<ReceiptKey>, key: ReceiptKey) {
+    if !keys.iter().any(|known| known == &key) {
+        keys.push(key);
+    }
+}
+
+fn has_supported_shape(request: &str) -> Result<bool, String> {
+    let value: Value = serde_json::from_str(request)
+        .map_err(|error| format!("decode receipt scenario shape: {error}"))?;
+    if value.get("clock").and_then(Value::as_str) != Some("fake") {
+        return Ok(false);
+    }
+    let Some(actions) = value.get("actions").and_then(Value::as_array) else {
+        return Ok(false);
+    };
+    Ok(!actions.is_empty()
+        && actions.iter().all(|action| {
+            matches!(
+                action.get("action").and_then(Value::as_str),
+                Some(
+                    "cancel"
+                        | "submit"
+                        | "recover"
+                        | "advance_epoch"
+                        | "restart"
+                        | "checkpoint"
+                        | "reset"
+                        | "fill_receipt_pool"
+                        | "install_barrier"
+                        | "wait_for_event"
+                        | "release_barrier"
+                        | "compare_client_server_identity"
+                )
+            )
+        }))
+}
+
+fn exchange_once(
+    state_root: &Path,
+    identity: &CoreIdentity,
+    clock: Arc<ScenarioEpochClock>,
+    telemetry: Arc<V5ReceiptRuntimeTelemetry>,
+    exchange: impl FnOnce(&mut V5DaemonProcessOwner) -> Result<V5ServerResponse, String>,
+) -> Result<V5ServerResponse, String> {
+    let config = DaemonServerConfig::new(
+        state_root.to_path_buf(),
+        identity.clone(),
+        SCENARIO_IDLE_GRACE,
+    );
+    let daemon = ScenarioDaemon::spawn(config, move |runtime| {
+        let mut runtime = runtime.with_shared_telemetry(telemetry);
+        runtime.epoch_clock = clock;
+        runtime
+    });
+    let response = (|| {
+        wait_for_endpoint(state_root, identity)?;
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+            state_root,
+            identity.clone(),
+            std::path::PathBuf::from("unused-existing-v5-scenario-endpoint"),
+            SCENARIO_IDLE_GRACE,
+        )?;
+        let response = exchange(&mut owner);
+        drop(owner);
+        response
+    })();
+    let cleanup = daemon.stop_and_join("protocol-v5 receipt scenario daemon panicked");
+    finish_with_daemon_cleanup(response, cleanup)
+}
+
+enum ScenarioWireRequest {
+    Cancel(ReceiptKey),
+    Submit(V5InvocationRequest),
+    #[cfg(test)]
+    InjectedClientFailure,
+}
+
+fn exchange_batch(
+    state_root: &Path,
+    identity: &CoreIdentity,
+    clock: Arc<ScenarioEpochClock>,
+    telemetry: Arc<V5ReceiptRuntimeTelemetry>,
+    requests: Vec<ScenarioWireRequest>,
+) -> Result<Vec<V5ServerResponse>, String> {
+    let config = DaemonServerConfig::new(
+        state_root.to_path_buf(),
+        identity.clone(),
+        SCENARIO_IDLE_GRACE,
+    );
+    let daemon = ScenarioDaemon::spawn(config, move |runtime| {
+        let mut runtime = runtime.with_shared_telemetry(telemetry);
+        runtime.epoch_clock = clock;
+        runtime
+    });
+    let responses = (|| {
+        wait_for_endpoint(state_root, identity)?;
+        let mut responses = Vec::with_capacity(requests.len());
+        for request in requests {
+            let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+                state_root,
+                identity.clone(),
+                std::path::PathBuf::from("unused-existing-v5-scenario-endpoint"),
+                SCENARIO_IDLE_GRACE,
+            )?;
+            let response = match request {
+                ScenarioWireRequest::Cancel(key) => owner.cancel_invocation(key),
+                ScenarioWireRequest::Submit(invocation) => owner.submit_invocation(invocation),
+                #[cfg(test)]
+                ScenarioWireRequest::InjectedClientFailure => {
+                    Err("injected protocol-v5 scenario client failure".to_owned())
+                }
+            }?;
+            responses.push(response);
+        }
+        Ok(responses)
+    })();
+    let cleanup = daemon.stop_and_join("protocol-v5 receipt scenario batch daemon panicked");
+    finish_with_daemon_cleanup(responses, cleanup)
+}
+
+struct ScenarioDaemon {
+    stop_requested: Arc<AtomicBool>,
+    server: Option<thread::JoinHandle<Result<(), String>>>,
+}
+
+impl ScenarioDaemon {
+    fn spawn(
+        config: DaemonServerConfig,
+        configure_runtime: impl FnOnce(V5ReceiptRuntime) -> V5ReceiptRuntime + Send + 'static,
+    ) -> Self {
+        let stop_requested = Arc::new(AtomicBool::new(false));
+        let server_stop = Arc::clone(&stop_requested);
+        let server = thread::spawn(move || {
+            run_daemon_configured_until(config, configure_runtime, || {
+                server_stop.load(Ordering::Acquire)
+            })
+        });
+        Self {
+            stop_requested,
+            server: Some(server),
+        }
+    }
+
+    fn request_stop(&self) {
+        self.stop_requested.store(true, Ordering::Release);
+    }
+
+    fn stop_and_join(mut self, panic_message: &'static str) -> Result<(), String> {
+        self.request_stop();
+        let server = self
+            .server
+            .take()
+            .expect("scenario daemon join handle must exist before explicit join");
+        if server.thread().id() == thread::current().id() {
+            return Err("protocol-v5 receipt scenario daemon cannot join itself".to_owned());
+        }
+        server.join().map_err(|_| panic_message.to_owned())?
+    }
+}
+
+impl Drop for ScenarioDaemon {
+    fn drop(&mut self) {
+        self.request_stop();
+        let Some(server) = self.server.take() else {
+            return;
+        };
+        if server.thread().id() != thread::current().id() {
+            let _ = server.join();
+        }
+    }
+}
+
+fn finish_with_daemon_cleanup<T>(
+    operation: Result<T, String>,
+    cleanup: Result<(), String>,
+) -> Result<T, String> {
+    match (operation, cleanup) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(_), Err(cleanup)) => Err(cleanup),
+        (Err(error), Err(cleanup)) => Err(format!("{error}; daemon cleanup failed: {cleanup}")),
+    }
+}
+
+struct PendingSubmit {
+    label: String,
+    accepted_epoch_ms: u64,
+    response_budget_ms: u64,
+    actor: ReceiptLedgerActor,
+    client: thread::JoinHandle<Result<V5ServerResponse, String>>,
+    daemon: ScenarioDaemon,
+}
+
+impl PendingSubmit {
+    fn finish(self) -> Result<(String, u64, u64, V5ServerResponse), String> {
+        let Self {
+            label,
+            accepted_epoch_ms,
+            response_budget_ms,
+            actor,
+            client,
+            daemon,
+        } = self;
+        let response = client
+            .join()
+            .map_err(|_| "protocol-v5 receipt scenario submit client panicked".to_owned())
+            .and_then(|response| response);
+        drop(actor);
+        let cleanup = daemon.stop_and_join("protocol-v5 receipt scenario blocked daemon panicked");
+        let response = finish_with_daemon_cleanup(response, cleanup)?;
+        Ok((label, accepted_epoch_ms, response_budget_ms, response))
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn start_blocked_submit(
+    state_root: &Path,
+    identity: &CoreIdentity,
+    clock: Arc<ScenarioEpochClock>,
+    control: Arc<ReceiptScenarioControl>,
+    telemetry: Arc<V5ReceiptRuntimeTelemetry>,
+    invocation: V5InvocationRequest,
+    label: String,
+    accepted_epoch_ms: u64,
+    response_budget_ms: u64,
+) -> Result<PendingSubmit, String> {
+    let config = DaemonServerConfig::new(
+        state_root.to_path_buf(),
+        identity.clone(),
+        SCENARIO_IDLE_GRACE,
+    );
+    let (actor_tx, actor_rx) = mpsc::sync_channel(1);
+    let daemon = ScenarioDaemon::spawn(config, move |runtime| {
+        let mut runtime = runtime.with_shared_telemetry(telemetry);
+        runtime.epoch_clock = clock;
+        runtime.scenario_control = Some(control);
+        actor_tx
+            .send(runtime.receipt_ledger.clone())
+            .expect("scenario actor observer receiver must remain live");
+        runtime
+    });
+    wait_for_endpoint(state_root, identity)?;
+    let actor = actor_rx
+        .recv_timeout(SCENARIO_OPERATION_TIMEOUT)
+        .map_err(|_| "protocol-v5 receipt scenario actor observer was not published".to_owned())?;
+    let client_state_root = state_root.to_path_buf();
+    let client_identity = identity.clone();
+    let client = thread::spawn(move || {
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+            &client_state_root,
+            client_identity.clone(),
+            std::path::PathBuf::from("unused-existing-v5-scenario-endpoint"),
+            SCENARIO_IDLE_GRACE,
+        )?;
+        let response = owner.submit_invocation(invocation)?;
+        drop(owner);
+        Ok(response)
+    });
+    Ok(PendingSubmit {
+        label,
+        accepted_epoch_ms,
+        response_budget_ms,
+        actor,
+        client,
+        daemon,
+    })
+}
+
+fn wait_for_endpoint(state_root: &Path, identity: &CoreIdentity) -> Result<(), String> {
+    let deadline = Instant::now() + SCENARIO_OPERATION_TIMEOUT;
+    loop {
+        let state = DaemonStateDirectory::open(state_root, identity)?;
+        if state.read_v5_endpoint_record()?.is_some() {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err("protocol-v5 receipt scenario endpoint was not published".to_owned());
+        }
+        thread::sleep(Duration::from_millis(5));
+    }
+}
+
+fn snapshot_from_state(
+    state_root: &Path,
+    identity: &CoreIdentity,
+    clock: Arc<ScenarioEpochClock>,
+    telemetry: &V5ReceiptRuntimeTelemetry,
+    keys: &[ReceiptKey],
+) -> Result<Value, String> {
+    let state = DaemonStateDirectory::open(state_root, identity)?;
+    let config = DaemonServerConfig::new(
+        state_root.to_path_buf(),
+        identity.clone(),
+        SCENARIO_IDLE_GRACE,
+    );
+    let runtime = V5ReceiptRuntime::open_with_epoch_clock(&state, &config, clock.clone())?;
+    let snapshot = snapshot_with_actor(&runtime.receipt_ledger, &clock, telemetry, keys);
+    drop(runtime);
+    snapshot
+}
+
+fn snapshot_with_actor(
+    actor: &ReceiptLedgerActor,
+    clock: &ScenarioEpochClock,
+    telemetry: &V5ReceiptRuntimeTelemetry,
+    keys: &[ReceiptKey],
+) -> Result<Value, String> {
+    let mut receipts = Vec::with_capacity(keys.len());
+    for key in keys {
+        match actor.recover(key.clone(), Instant::now() + SCENARIO_OPERATION_TIMEOUT) {
+            Ok(receipt) => receipts.push(receipt_observation(receipt)?),
+            Err(ReceiptLedgerError::ReceiptNotFound) => {}
+            Err(error) => {
+                return Err(format!("snapshot protocol-v5 receipt scenario: {error}"));
+            }
+        }
+    }
+    let catalog = actor
+        .snapshot_catalog(Instant::now() + SCENARIO_OPERATION_TIMEOUT)
+        .map_err(|error| format!("snapshot protocol-v5 receipt catalog: {error}"))?;
+    if u64::try_from(catalog.keys().len()).ok() != Some(catalog.live_count()) {
+        return Err("sealed protocol-v5 receipt catalog count is inconsistent".to_owned());
+    }
+    let invocation_index = catalog
+        .invocation_index()
+        .iter()
+        .map(receipt_key_observation)
+        .collect::<Vec<_>>();
+    let reserved_task_index = catalog
+        .reserved_task_index()
+        .iter()
+        .map(receipt_key_observation)
+        .collect::<Vec<_>>();
+    let generation = catalog.generation();
+    let runtime = telemetry.snapshot();
+
+    Ok(json!({
+        "receipts": receipts,
+        "tombstones": [],
+        "tasks": [],
+        "taskLinks": [],
+        "invocationIndex": invocation_index,
+        "reservedTaskIndex": reserved_task_index,
+        "receiptLiveCount": catalog.live_count(),
+        "receiptActualBytes": catalog.actual_bytes(),
+        "receiptReservedBytes": catalog.reserved_result_bytes(),
+        "taskLinkCount": 0,
+        "taskLinkBytes": 0,
+        "taskLinkReservedCount": 0,
+        "taskLinkReservedBytes": 0,
+        "tombstoneCount": 0,
+        "tombstoneBytes": 0,
+        "callbacks": runtime.callbacks,
+        "listener": runtime.listener,
+        "restartRequested": false,
+        "daemonRunning": runtime.daemon_running,
+        "actorLeases": runtime.actor_leases,
+        "sideEffectMarkers": 0,
+        "taskStoreCreateAttempts": 0,
+        "tokenSignals": 0,
+        "storeGeneration": generation,
+        "epochMs": clock.now_epoch_millis(),
+        "processExitElapsedMs": null,
+        "cancelAuthority": null,
+        "receiptStoreMutations": generation,
+        "taskStoreMutations": 0,
+        "fallbackExecutions": 0,
+        "stagedResponsesExposed": 0
+    }))
+}
+
+fn receipt_observation(state: ReceiptState) -> Result<Value, String> {
+    match state {
+        ReceiptState::CancelReserved(receipt) => Ok(json!({
+            "key": receipt_key_observation(receipt.key()),
+            "state": "cancel_reserved",
+            "cancelRequested": true,
+            "acceptedEpochMs": receipt.cancel_reserved_at_epoch_ms(),
+            "originalBudgetMs": 0,
+            "expiresEpochMs": receipt.expires_at_epoch_ms(),
+            "boundWorkspaceIdentity": null,
+            "stagedTerminal": null,
+            "terminal": null,
+            "encodedBytes": receipt.encoded_bytes(),
+            "reservedResultBytes": 0,
+            "version": receipt.record_version().get(),
+            "mutationSequence": receipt.mutation_sequence(),
+            "begun": false
+        })),
+        ReceiptState::Reserved(receipt) => {
+            let (state, bound_workspace_identity, begun) = match receipt.phase() {
+                ReservedPhase::Unbound => ("reserved_unbound", None, false),
+                ReservedPhase::ActorBound {
+                    bound_workspace_identity,
+                } => (
+                    "reserved_actor_bound",
+                    serde_json::to_value(bound_workspace_identity)
+                        .ok()
+                        .and_then(|value| value.as_str().map(str::to_owned)),
+                    false,
+                ),
+                ReservedPhase::Begun {
+                    bound_workspace_identity,
+                } => (
+                    "reserved_begun",
+                    serde_json::to_value(bound_workspace_identity)
+                        .ok()
+                        .and_then(|value| value.as_str().map(str::to_owned)),
+                    true,
+                ),
+            };
+            Ok(json!({
+                "key": receipt_key_observation(receipt.key()),
+                "state": state,
+                "cancelRequested": receipt.cancel_requested(),
+                "acceptedEpochMs": receipt.original_cutoff().accepted_epoch_ms(),
+                "originalBudgetMs": receipt.original_cutoff().response_budget_ms(),
+                "expiresEpochMs": null,
+                "boundWorkspaceIdentity": bound_workspace_identity,
+                "stagedTerminal": null,
+                "terminal": null,
+                "encodedBytes": receipt.encoded_bytes(),
+                "reservedResultBytes": receipt.reserved_result_bytes(),
+                "version": receipt.record_version().get(),
+                "mutationSequence": receipt.mutation_sequence(),
+                "begun": begun
+            }))
+        }
+        ReceiptState::DirectTerminalUnacked(receipt) => Ok(json!({
+            "key": receipt_key_observation(receipt.key()),
+            "state": "direct_terminal_unacked",
+            "cancelRequested": matches!(
+                receipt.terminal().outcome(),
+                ReceiptTerminalOutcome::Cancelled
+            ),
+            "acceptedEpochMs": receipt.original_cutoff().accepted_epoch_ms(),
+            "originalBudgetMs": receipt.original_cutoff().response_budget_ms(),
+            "expiresEpochMs": receipt.terminal_epoch_ms() + DIRECT_TERMINAL_RETENTION_MS,
+            "boundWorkspaceIdentity": null,
+            "stagedTerminal": null,
+            "terminal": terminal_observation(
+                receipt.terminal().outcome(),
+                receipt.terminal_epoch_ms(),
+            )?,
+            "encodedBytes": receipt.encoded_bytes(),
+            "reservedResultBytes": receipt.reserved_result_bytes(),
+            "version": receipt.record_version().get(),
+            "mutationSequence": receipt.mutation_sequence(),
+            "begun": false
+        })),
+        other => Err(format!(
+            "receipt scenario cannot project unsupported state {}",
+            other.kind().diagnostic_name()
+        )),
+    }
+}
+
+fn response_observation(
+    response: &V5ServerResponse,
+    submit_cutoff: Option<(u64, u64)>,
+) -> Result<Value, String> {
+    match response {
+        V5ServerResponse::Invocation {
+            outcome:
+                V5InvocationResponse::ReceiptPending {
+                    receipt_key,
+                    accepted_epoch_ms,
+                    original_budget_ms,
+                    ..
+                },
+        } => Ok(json!({
+            "kind": "cancelled",
+            "error": null,
+            "terminal": null,
+            "key": receipt_key_observation(receipt_key),
+            "task": null,
+            "acknowledgement": null,
+            "cutoffEpochMs": accepted_epoch_ms.checked_add(*original_budget_ms),
+            "originalBudgetMs": original_budget_ms,
+            "latencyMs": 0
+        })),
+        V5ServerResponse::Invocation {
+            outcome: V5InvocationResponse::Direct { receipt },
+        } => {
+            let (accepted_epoch_ms, original_budget_ms) = submit_cutoff
+                .map(|(accepted, budget)| (Some(accepted), Some(budget)))
+                .unwrap_or((None, None));
+            Ok(json!({
+                "kind": if matches!(receipt.terminal(), ReceiptTerminalOutcome::Cancelled) {
+                    "cancelled"
+                } else {
+                    "direct"
+                },
+                "error": null,
+                "terminal": terminal_observation(receipt.terminal(), receipt.terminal_epoch_ms())?,
+                "key": receipt_key_observation(receipt.receipt_key()),
+                "task": null,
+                "acknowledgement": null,
+                "cutoffEpochMs": accepted_epoch_ms
+                    .zip(original_budget_ms)
+                    .and_then(|(accepted, budget)| accepted.checked_add(budget)),
+                "originalBudgetMs": original_budget_ms,
+                "latencyMs": 0
+            }))
+        }
+        V5ServerResponse::Error { code } => Ok(json!({
+            "kind": if matches!(code, V5DaemonErrorCode::ReceiptNotFound) {
+                "not_found"
+            } else {
+                "rejected"
+            },
+            "error": serde_json::to_value(code)
+                .map_err(|error| format!("encode protocol-v5 scenario error code: {error}"))?,
+            "terminal": null,
+            "key": null,
+            "task": null,
+            "acknowledgement": null,
+            "cutoffEpochMs": null,
+            "originalBudgetMs": null,
+            "latencyMs": 0
+        })),
+        other => Err(format!(
+            "receipt scenario received unsupported protocol-v5 response: {other:?}"
+        )),
+    }
+}
+
+fn receipt_key_observation(key: &ReceiptKey) -> Value {
+    json!({
+        "invocationId": key.invocation_id(),
+        "reservedTaskId": key.reserved_task_id(),
+        "coreIdentityDigest": key.core_identity_digest(),
+        "tool": key.tool(),
+        "normalizedArgumentsHash": key.normalized_arguments_hash(),
+        "requestScopeHash": key.request_scope_hash(),
+        "keyDigest": receipt_key_digest(key)
+    })
+}
+
+fn terminal_observation(
+    outcome: &ReceiptTerminalOutcome,
+    terminal_epoch_ms: u64,
+) -> Result<Value, String> {
+    let terminal = canonical_v5_terminal(outcome)
+        .map_err(|error| format!("canonicalize protocol-v5 scenario terminal: {error}"))?;
+    let mut value = serde_json::to_value(outcome)
+        .map_err(|error| format!("encode protocol-v5 scenario terminal: {error}"))?;
+    let object = value
+        .as_object_mut()
+        .ok_or_else(|| "protocol-v5 scenario terminal is not an object".to_owned())?;
+    object.insert(
+        "canonical_payload_hex".to_owned(),
+        Value::String(lower_hex(terminal.payload())),
+    );
+    object.insert(
+        "terminal_digest".to_owned(),
+        Value::String(terminal.digest().to_string()),
+    );
+    object.insert(
+        "terminal_epoch_ms".to_owned(),
+        Value::Number(terminal_epoch_ms.into()),
+    );
+    Ok(value)
+}
+
+fn lower_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
+fn compare_client_server_identity() -> Result<Value, String> {
+    let production_identity = CoreIdentity::production_v5();
+    let invocation = V5InvocationRequest::new(
+        InvocationId::new(),
+        TaskId::new(),
+        V5ToolIdentity::View,
+        Map::new(),
+        "workspace-a".to_owned(),
+        7_000,
+    )?;
+    let client_key = ReceiptKey::new(
+        invocation.invocation_id(),
+        invocation.reserved_task_id(),
+        RequestIdentity::new(
+            production_identity.digest().clone(),
+            invocation.tool(),
+            normalized_arguments_hash(invocation.arguments()),
+            request_scope_hash(invocation.workspace_hint())
+                .map_err(|error| format!("derive client request scope: {error}"))?,
+        ),
+    );
+
+    let mut frame = serde_json::to_vec(&V5ClientRequest::SubmitInvocation { invocation })
+        .map_err(|error| format!("encode client identity probe: {error}"))?;
+    frame.push(b'\n');
+    let strict = decode_v5_request_frame(frame)
+        .map_err(|error| format!("decode daemon identity probe: {error}"))?
+        .into_strict_submit(&production_identity)
+        .map_err(|error| format!("derive daemon receipt identity: {error}"))?;
+    let (daemon_key, _) = strict.into_parts();
+
+    let caller_claimed_key = ReceiptKey::new(
+        client_key.invocation_id(),
+        client_key.reserved_task_id(),
+        RequestIdentity::new(
+            CoreIdentityDigest::from_sha256([0x7f; 32]),
+            client_key.tool(),
+            client_key.normalized_arguments_hash().clone(),
+            client_key.request_scope_hash().clone(),
+        ),
+    );
+
+    let frozen_vector_key = ReceiptKey::new(
+        "123e4567-e89b-42d3-a456-426614174000"
+            .parse()
+            .map_err(|error| format!("parse frozen invocation id: {error}"))?,
+        "123e4567-e89b-42d3-b456-426614174001"
+            .parse()
+            .map_err(|error| format!("parse frozen reserved task id: {error}"))?,
+        RequestIdentity::new(
+            CoreIdentityDigest::from_sha256([0x00; 32]),
+            V5ToolIdentity::View,
+            NormalizedArgumentsHash::from_sha256([0x11; 32]),
+            request_scope_hash("workspace-a")
+                .map_err(|error| format!("derive frozen request scope: {error}"))?,
+        ),
+    );
+    let frozen_task_link = TaskLinkIdentity::new(
+        "0".repeat(64)
+            .parse::<ReceiptKeyDigest>()
+            .map_err(|error| format!("parse frozen receipt key digest: {error}"))?,
+        "11111111-1111-4111-8111-111111111111"
+            .parse()
+            .map_err(|error| format!("parse frozen task id: {error}"))?,
+        "22222222-2222-4222-8222-222222222222"
+            .parse()
+            .map_err(|error| format!("parse frozen task invocation id: {error}"))?,
+        SafeIdentityHash::from_sha256([0xaa; 32]),
+    );
+
+    Ok(json!({
+        "clientKey": receipt_key_observation(&client_key),
+        "daemonKey": receipt_key_observation(&daemon_key),
+        "frozenVectorKey": receipt_key_observation(&frozen_vector_key),
+        "frozenTaskLinkVector": {
+            "receiptKeyDigest": "0".repeat(64),
+            "taskId": "11111111-1111-4111-8111-111111111111",
+            "invocationId": "22222222-2222-4222-8222-222222222222",
+            "workspaceIdentityHash": "a".repeat(64),
+            "taskLinkDigest": task_link_digest(&frozen_task_link).to_string(),
+        },
+        "callerClaimedKeyDigest": receipt_key_digest(&caller_claimed_key).to_string(),
+    }))
+}
+
+#[derive(Default)]
+struct ScenarioReportBuilder {
+    checkpoints: BTreeMap<String, Value>,
+    responses: BTreeMap<String, Value>,
+    identity: Option<Value>,
+}
+
+impl ScenarioReportBuilder {
+    fn encode(self, events: Vec<V5ReceiptRuntimeEvent>) -> Result<String, String> {
+        serde_json::to_string(&json!({
+            "kind": "observed",
+            "payload": {
+                "checkpoints": self.checkpoints,
+                "responses": self.responses,
+                "taskReads": {},
+                "events": events,
+                "gateEvents": [],
+                "operationEvents": [],
+                "actorBindings": [],
+                "actorAuthorizations": [],
+                "taskPublicationCapacity": [],
+                "taskStoreCapacityInvariantViolations": [],
+                "stagedTerminalPreparations": [],
+                "terminalPublications": [],
+                "protocol": [],
+                "identity": self.identity,
+                "crashCases": [],
+                "taskRetirementCases": [],
+                "loadRuns": {}
+            }
+        }))
+        .map_err(|error| format!("encode protocol-v5 receipt scenario report: {error}"))
+    }
+}
+
+struct ScenarioEpochClock {
+    epoch_ms: AtomicU64,
+}
+
+impl ScenarioEpochClock {
+    fn new(epoch_ms: u64) -> Self {
+        Self {
+            epoch_ms: AtomicU64::new(epoch_ms),
+        }
+    }
+
+    fn advance(&self, millis: u64) -> Result<(), String> {
+        self.epoch_ms
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |epoch_ms| {
+                epoch_ms.checked_add(millis)
+            })
+            .map(|_| ())
+            .map_err(|_| "protocol-v5 receipt scenario epoch overflow".to_owned())
+    }
+}
+
+impl EpochMillisClock for ScenarioEpochClock {
+    fn now_epoch_millis(&self) -> u64 {
+        self.epoch_ms.load(Ordering::SeqCst)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ReceiptScenario {
+    clock: ScenarioClock,
+    actions: Vec<ReceiptScenarioAction>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ScenarioClock {
+    Fake,
+    Wall,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case", deny_unknown_fields)]
+enum ReceiptScenarioAction {
+    Cancel {
+        key: ScenarioKey,
+        lazy_session: bool,
+        label: String,
+    },
+    Submit {
+        request: ScenarioRequest,
+        response_budget_ms: u64,
+        disconnect: ScenarioDisconnect,
+        label: String,
+    },
+    Recover {
+        key: ScenarioKey,
+        label: String,
+    },
+    AdvanceEpoch {
+        millis: u64,
+    },
+    Restart,
+    Checkpoint {
+        label: String,
+    },
+    Reset,
+    FillReceiptPool {
+        state: ScenarioSeedReceiptState,
+        count: u32,
+    },
+    InstallBarrier {
+        point: ScenarioBarrierPoint,
+    },
+    WaitForEvent {
+        event: ScenarioEvent,
+    },
+    ReleaseBarrier {
+        point: ScenarioBarrierPoint,
+    },
+    CompareClientServerIdentity,
+}
+
+impl ReceiptScenarioAction {
+    fn is_supported(&self) -> bool {
+        match self {
+            Self::Cancel {
+                key, lazy_session, ..
+            } => {
+                *lazy_session
+                    && matches!(
+                        key,
+                        ScenarioKey::Exact
+                            | ScenarioKey::Unknown
+                            | ScenarioKey::Mismatch(ScenarioIdentityField::NormalizedArgumentsHash)
+                    )
+            }
+            Self::Submit {
+                request,
+                disconnect,
+                ..
+            } => {
+                matches!(request, ScenarioRequest::Canonical)
+                    && matches!(disconnect, ScenarioDisconnect::Never)
+            }
+            Self::Recover { key, .. } => matches!(key, ScenarioKey::Exact),
+            Self::AdvanceEpoch { .. }
+            | Self::Restart
+            | Self::Checkpoint { .. }
+            | Self::Reset
+            | Self::FillReceiptPool { .. }
+            | Self::InstallBarrier { .. }
+            | Self::WaitForEvent { .. }
+            | Self::ReleaseBarrier { .. }
+            | Self::CompareClientServerIdentity => true,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ScenarioRequest {
+    Canonical,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ScenarioDisconnect {
+    Never,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ScenarioKey {
+    Exact,
+    Unknown,
+    Mismatch(ScenarioIdentityField),
+}
+
+#[derive(Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ScenarioSeedReceiptState {
+    CancelReserved,
+    ReservedUnbound,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ScenarioBarrierPoint {
+    AfterCancelReservationConvertedBeforeTerminal,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ScenarioEvent {
+    CancelReservationConverted,
+    ReceiptTerminalCommitted,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ScenarioIdentityField {
+    InvocationId,
+    ReservedTaskId,
+    CoreIdentity,
+    ToolIdentity,
+    NormalizedArgumentsHash,
+    RequestScopeHash,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::receipt_ledger::{
+        OriginalCutoffDescriptor, MAX_RECEIPT_ENTITLEMENT_BYTES,
+    };
+    use crate::infrastructure::receipt_ledger::ReceiptLedgerStore;
+
+    #[test]
+    fn batch_client_failure_stops_and_joins_the_daemon_before_returning() {
+        let root = tempfile::tempdir().expect("temporary failed-batch state root");
+        let state_root =
+            std::fs::canonicalize(root.path()).expect("physical failed-batch state root");
+        let identity = CoreIdentity::production_v5();
+
+        let error = exchange_batch(
+            &state_root,
+            &identity,
+            Arc::new(ScenarioEpochClock::new(SCENARIO_INITIAL_EPOCH_MS)),
+            Arc::new(V5ReceiptRuntimeTelemetry::new()),
+            vec![ScenarioWireRequest::InjectedClientFailure],
+        )
+        .expect_err("injected batch failure must reach the facade cleanup path");
+
+        assert_eq!(error, "injected protocol-v5 scenario client failure");
+        let state = DaemonStateDirectory::open(&state_root, &identity)
+            .expect("reopen failed-batch daemon state");
+        assert!(
+            state
+                .read_v5_endpoint_record()
+                .expect("inspect failed-batch endpoint")
+                .is_none(),
+            "scenario facade returned while its detached daemon was still discoverable"
+        );
+    }
+
+    #[test]
+    fn snapshot_accounting_and_indexes_cover_the_full_store_catalog() {
+        let root = tempfile::tempdir().expect("temporary full-catalog store");
+        let receipts = std::fs::canonicalize(root.path())
+            .expect("physical full-catalog root")
+            .join("receipts");
+        let store = ReceiptLedgerStore::open(&receipts).expect("open full-catalog store");
+        let actor = ReceiptLedgerActor::spawn(store);
+        let identity = CoreIdentity::production_v5();
+        let arguments = Map::new();
+        let cancel_key = fresh_key(&identity, &arguments).expect("cancel receipt key");
+        let reserved_key = fresh_key(&identity, &arguments).expect("reserved receipt key");
+
+        actor
+            .request_cancel_or_reserve(
+                cancel_key.clone(),
+                SCENARIO_INITIAL_EPOCH_MS,
+                Instant::now() + SCENARIO_OPERATION_TIMEOUT,
+            )
+            .expect("reserve cancellation receipt");
+        actor
+            .reserve(
+                reserved_key.clone(),
+                OriginalCutoffDescriptor::new(SCENARIO_INITIAL_EPOCH_MS, 7_000)
+                    .expect("valid cutoff"),
+                Instant::now() + SCENARIO_OPERATION_TIMEOUT,
+            )
+            .expect("reserve ordinary receipt");
+
+        let telemetry = V5ReceiptRuntimeTelemetry::new();
+        let snapshot = snapshot_with_actor(
+            &actor,
+            &ScenarioEpochClock::new(SCENARIO_INITIAL_EPOCH_MS),
+            &telemetry,
+            std::slice::from_ref(&cancel_key),
+        )
+        .expect("snapshot full catalog through actor");
+
+        assert_eq!(
+            snapshot["receipts"]
+                .as_array()
+                .expect("selected receipt rows")
+                .len(),
+            1,
+            "the scenario inventory remains a bounded row-selection input"
+        );
+        assert_eq!(snapshot["receiptLiveCount"].as_u64(), Some(2));
+        let selected_actual_bytes = snapshot["receipts"][0]["encodedBytes"]
+            .as_u64()
+            .expect("selected receipt encoded bytes");
+        assert_eq!(
+            snapshot["receiptActualBytes"]
+                .as_u64()
+                .expect("catalog actual bytes")
+                + snapshot["receiptReservedBytes"]
+                    .as_u64()
+                    .expect("catalog reserved bytes"),
+            selected_actual_bytes + MAX_RECEIPT_ENTITLEMENT_BYTES,
+            "store accounting must include the unselected reserved receipt"
+        );
+        let expected_digests = [
+            receipt_key_digest(&cancel_key).to_string(),
+            receipt_key_digest(&reserved_key).to_string(),
+        ];
+        for index_name in ["invocationIndex", "reservedTaskIndex"] {
+            let index = snapshot[index_name].as_array().expect("catalog index rows");
+            assert_eq!(index.len(), 2, "{index_name} must cover the full catalog");
+            for expected_digest in &expected_digests {
+                assert!(
+                    index
+                        .iter()
+                        .any(|key| { key["keyDigest"].as_str() == Some(expected_digest.as_str()) }),
+                    "{index_name} omitted {expected_digest}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn pending_submit_releases_actor_store_before_waiting_for_daemon_exit() {
+        let root = tempfile::tempdir().expect("temporary pending-submit store");
+        let receipts = std::fs::canonicalize(root.path())
+            .expect("physical pending-submit root")
+            .join("receipts");
+        let store = ReceiptLedgerStore::open(&receipts).expect("open pending-submit store");
+        let actor = ReceiptLedgerActor::spawn(store);
+        let client = thread::spawn(|| {
+            Ok(V5ServerResponse::Error {
+                code: V5DaemonErrorCode::ReceiptNotFound,
+            })
+        });
+        let reopen_path = receipts.clone();
+        let server = thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_millis(150);
+            loop {
+                match ReceiptLedgerStore::open(&reopen_path) {
+                    Ok(reopened) => {
+                        drop(reopened);
+                        return Ok(());
+                    }
+                    Err(ReceiptLedgerError::AlreadyOwned) if Instant::now() < deadline => {
+                        thread::sleep(Duration::from_millis(1));
+                    }
+                    Err(ReceiptLedgerError::AlreadyOwned) => {
+                        return Err(
+                            "pending-submit actor kept the receipt store owned while joining daemon"
+                                .to_owned(),
+                        );
+                    }
+                    Err(error) => return Err(format!("reopen pending-submit store: {error}")),
+                }
+            }
+        });
+        let pending = PendingSubmit {
+            label: "pending".to_owned(),
+            accepted_epoch_ms: 1,
+            response_budget_ms: 7_000,
+            actor,
+            client,
+            daemon: ScenarioDaemon {
+                stop_requested: Arc::new(AtomicBool::new(false)),
+                server: Some(server),
+            },
+        };
+
+        pending
+            .finish()
+            .expect("actor/store must be released before daemon join");
+    }
+}

--- a/crates/unica-coder/src/infrastructure/receipt_ledger.rs
+++ b/crates/unica-coder/src/infrastructure/receipt_ledger.rs
@@ -812,7 +812,7 @@ impl ReceiptLedgerStore {
         check_deadline(deadline)?;
         latch_catalog_result(&mut catalog, self.verify_named_authority())?;
 
-        if let Some(existing) = catalog.records.get(&key_digest) {
+        let expires_at_epoch_ms = if let Some(existing) = catalog.records.get(&key_digest) {
             if existing.record.key != key {
                 return self.reject_before_mutation(
                     &mut catalog,
@@ -829,11 +829,39 @@ impl ReceiptLedgerStore {
                 Ok(state) => state,
                 Err(error) => return latch_catalog_error(&mut catalog, error),
             };
-            return Ok(match state {
-                ReceiptState::CancelReserved(receipt) => CancelResolution::ExistingExact(receipt),
-                winner => CancelResolution::ExistingWinner(Box::new(winner)),
-            });
-        }
+            match state {
+                ReceiptState::CancelReserved(receipt)
+                    if cancel_reserved_at_epoch_ms < receipt.expires_at_epoch_ms() =>
+                {
+                    return Ok(CancelResolution::ExistingExact(receipt));
+                }
+                ReceiptState::CancelReserved(_) => {
+                    let expires_at_epoch_ms = cancel_reserved_at_epoch_ms
+                        .checked_add(CANCEL_RESERVATION_TTL_MS)
+                        .ok_or(ReceiptLedgerError::TimestampOverflow)?;
+                    self.expire_cancel_reserved_entry_under_writer_lock(
+                        &mut catalog,
+                        persisted,
+                        cancel_reserved_at_epoch_ms,
+                        deadline,
+                    )?;
+                    expires_at_epoch_ms
+                }
+                winner => return Ok(CancelResolution::ExistingWinner(Box::new(winner))),
+            }
+        } else {
+            cancel_reserved_at_epoch_ms
+                .checked_add(CANCEL_RESERVATION_TTL_MS)
+                .ok_or(ReceiptLedgerError::TimestampOverflow)?
+        };
+
+        self.reclaim_expired_cancel_reservations_under_writer_lock(
+            &mut catalog,
+            cancel_reserved_at_epoch_ms,
+            None,
+            deadline,
+        )?;
+
         if catalog.invocation_index.contains_key(&key.invocation_id()) {
             return self.reject_before_mutation(
                 &mut catalog,
@@ -858,10 +886,6 @@ impl ReceiptLedgerStore {
                 ReceiptLedgerError::CapacityExceeded,
             );
         }
-        let expires_at_epoch_ms = cancel_reserved_at_epoch_ms
-            .checked_add(CANCEL_RESERVATION_TTL_MS)
-            .ok_or(ReceiptLedgerError::TimestampOverflow)?;
-
         let generation = latch_catalog_result(&mut catalog, self.generation_under_writer_lock())?;
         let mutation_sequence = match generation.checked_add(1) {
             Some(sequence) => sequence,
@@ -1047,21 +1071,107 @@ impl ReceiptLedgerStore {
             return Ok(CancelExpiryOutcome::NotDue(cancel_reserved));
         }
 
+        self.expire_cancel_reserved_entry_under_writer_lock(
+            &mut catalog,
+            persisted,
+            observed_at_epoch_ms,
+            deadline,
+        )?;
+        Ok(CancelExpiryOutcome::Expired)
+    }
+
+    fn reclaim_expired_cancel_reservations_under_writer_lock(
+        &self,
+        catalog: &mut ReceiptCatalog,
+        observed_at_epoch_ms: u64,
+        except: Option<&ReceiptKeyDigest>,
+        deadline: Instant,
+    ) -> Result<(), ReceiptLedgerError> {
+        let mut expired = catalog
+            .records
+            .iter()
+            .filter_map(|(digest, entry)| match &entry.record.lifecycle {
+                StoredActiveLifecycleV1::CancelReserved {
+                    expires_at_epoch_ms,
+                    ..
+                } if observed_at_epoch_ms >= *expires_at_epoch_ms && except != Some(digest) => {
+                    Some(digest.clone())
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        expired.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+
+        for key_digest in expired {
+            check_deadline(deadline)?;
+            let expected =
+                catalog
+                    .records
+                    .get(&key_digest)
+                    .cloned()
+                    .ok_or(ReceiptLedgerError::Corrupt(
+                        "expired receipt disappeared while the writer lock was held",
+                    ))?;
+            let persisted = self
+                .read_entry_under_writer_lock(catalog, &key_digest, Some(deadline))?
+                .ok_or(ReceiptLedgerError::Corrupt(
+                    "catalogued expired receipt row is missing",
+                ))?;
+            if persisted != expected {
+                return latch_catalog_error(
+                    catalog,
+                    ReceiptLedgerError::Corrupt("catalogued expired receipt row changed on disk"),
+                );
+            }
+            match persisted.state() {
+                Ok(ReceiptState::CancelReserved(receipt))
+                    if observed_at_epoch_ms >= receipt.expires_at_epoch_ms() => {}
+                Ok(ReceiptState::CancelReserved(_)) => continue,
+                Ok(_) => {
+                    return latch_catalog_error(
+                        catalog,
+                        ReceiptLedgerError::Corrupt(
+                            "expired cancellation candidate changed lifecycle under writer lock",
+                        ),
+                    )
+                }
+                Err(error) => return latch_catalog_error(catalog, error),
+            }
+            self.expire_cancel_reserved_entry_under_writer_lock(
+                catalog,
+                persisted,
+                observed_at_epoch_ms,
+                deadline,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn expire_cancel_reserved_entry_under_writer_lock(
+        &self,
+        catalog: &mut ReceiptCatalog,
+        persisted: CatalogEntry,
+        observed_at_epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<(), ReceiptLedgerError> {
+        let key_digest = persisted.record.key_digest.clone();
+        let expected_version = persisted.record.record_version;
+
         let next_record_version = match expected_version.checked_next() {
             Some(version) => version,
             None => {
                 return latch_catalog_error(
-                    &mut catalog,
+                    catalog,
                     ReceiptLedgerError::Corrupt("receipt record version exhausted u64"),
                 )
             }
         };
-        let generation = latch_catalog_result(&mut catalog, self.generation_under_writer_lock())?;
+        let generation = latch_catalog_result(catalog, self.generation_under_writer_lock())?;
         let mutation_sequence = match generation.checked_add(1) {
             Some(sequence) => sequence,
             None => {
                 return latch_catalog_error(
-                    &mut catalog,
+                    catalog,
                     ReceiptLedgerError::Corrupt("receipt generation exhausted u64"),
                 )
             }
@@ -1073,18 +1183,18 @@ impl ReceiptLedgerStore {
             next_record_version,
         ) {
             Ok(record) => record,
-            Err(error) => return latch_catalog_error(&mut catalog, error),
+            Err(error) => return latch_catalog_error(catalog, error),
         };
         let (record, encoded) =
             match serialize_reserved_record(record, MAX_CANCEL_RESERVED_RECORD_BYTES) {
                 Ok(serialized) => serialized,
-                Err(error) => return self.reject_before_mutation(&mut catalog, deadline, error),
+                Err(error) => return self.reject_before_mutation(catalog, deadline, error),
             };
-        if let Err(error) = validate_catalog_remove(&catalog, &persisted) {
-            return latch_catalog_error(&mut catalog, error);
+        if let Err(error) = validate_catalog_remove(catalog, &persisted) {
+            return latch_catalog_error(catalog, error);
         }
         if let Err(error) = self.publish_replacement_record(&record, &encoded, deadline, || {
-            commit_catalog_remove(&mut catalog, &persisted);
+            commit_catalog_remove(catalog, &persisted);
         }) {
             if !matches!(error, ReceiptLedgerError::DeadlineExceeded) {
                 catalog.unavailable = true;
@@ -1107,7 +1217,7 @@ impl ReceiptLedgerStore {
                 receipt_key_digest: key_digest,
             });
         }
-        Ok(CancelExpiryOutcome::Expired)
+        Ok(())
     }
 
     pub(crate) fn reserve(
@@ -1129,6 +1239,13 @@ impl ReceiptLedgerStore {
         }
         check_deadline(deadline)?;
         latch_catalog_result(&mut catalog, self.verify_named_authority())?;
+
+        self.reclaim_expired_cancel_reservations_under_writer_lock(
+            &mut catalog,
+            original_cutoff.accepted_epoch_ms(),
+            Some(&key_digest),
+            deadline,
+        )?;
 
         if let Some(existing) = catalog.records.get(&key_digest) {
             if existing.record.key != key {
@@ -3854,18 +3971,21 @@ mod tests {
         };
         assert_eq!(duplicate, initial);
         assert_eq!(store.generation().expect("stable generation"), 1);
-        let duplicate_with_irrelevant_overflow = store
+        let expired_duplicate_with_overflow = store
             .request_cancel_or_reserve(
                 key.clone(),
                 u64::MAX - CANCEL_RESERVATION_TTL_MS + 1,
                 reserve_deadline(),
             )
-            .expect("an exact duplicate reuses the original timestamp before parsing a new one");
+            .expect_err("an expired duplicate must validate its new absolute expiry");
         assert_eq!(
-            duplicate_with_irrelevant_overflow,
-            crate::application::receipt_ledger::CancelResolution::ExistingExact(initial.clone())
+            expired_duplicate_with_overflow,
+            ReceiptLedgerError::TimestampOverflow
         );
-        assert_eq!(store.generation().expect("duplicate generation"), 1);
+        assert_eq!(
+            store.generation().expect("rejected duplicate generation"),
+            1
+        );
         assert_eq!(
             fs::read(&row).expect("reread exact CancelReserved row"),
             bytes_before_duplicate,
@@ -3884,6 +4004,49 @@ mod tests {
         );
         let catalog = reopened.writer.lock().expect("inspect reopened catalog");
         assert_eq!(catalog.reserved_result_bytes, 0);
+    }
+
+    #[test]
+    fn duplicate_cancel_at_expiry_reclaims_the_stale_row_before_new_admission() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("receipts");
+        let store = ReceiptLedgerStore::open(&receipts).expect("open receipt ledger");
+        let key = receipt_key(INVOCATION_A, TASK_A, "workspace-a");
+        let stale = match store
+            .request_cancel_or_reserve(key.clone(), 1_000, reserve_deadline())
+            .expect("reserve cancellation before submit")
+        {
+            CancelResolution::NewlyReserved(receipt) => receipt,
+            other => panic!("first cancel must create CancelReserved, got {other:?}"),
+        };
+
+        let current = match store
+            .request_cancel_or_reserve(key.clone(), stale.expires_at_epoch_ms(), reserve_deadline())
+            .expect("the boundary call reclaims stale state before admitting a new cancel")
+        {
+            CancelResolution::NewlyReserved(receipt) => receipt,
+            other => panic!("expired duplicate must become a new admission, got {other:?}"),
+        };
+
+        assert_eq!(current.key(), &key);
+        assert_eq!(current.cancel_reserved_at_epoch_ms(), 8_125);
+        assert_eq!(current.expires_at_epoch_ms(), 15_250);
+        assert_eq!(current.record_version(), ReceiptVersion::initial());
+        assert_eq!(current.mutation_sequence(), 3);
+        assert_eq!(
+            store
+                .generation()
+                .expect("expiry plus admission generation"),
+            3
+        );
+        assert_eq!(
+            store
+                .recover_exact(&key, reserve_deadline())
+                .expect("only the fresh reservation remains live"),
+            ReceiptState::CancelReserved(current)
+        );
     }
 
     #[test]
@@ -4552,6 +4715,60 @@ mod tests {
             .records
             .values()
             .all(|entry| entry.encoded_bytes <= 1_024 && entry.reserved_result_bytes() == 0));
+    }
+
+    #[test]
+    fn submit_admission_reclaims_a_full_pool_of_expired_cancel_reservations() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("receipts");
+        let store = ReceiptLedgerStore::open(&receipts).expect("open receipt ledger");
+
+        for index in 0..MAX_LIVE_RECEIPTS {
+            let key = receipt_key_with_ids(
+                InvocationId::new(),
+                TaskId::new(),
+                &format!("expired-cancel-workspace-{index}"),
+            );
+            assert!(matches!(
+                store.request_cancel_or_reserve(
+                    key,
+                    1_000,
+                    Instant::now() + Duration::from_secs(10),
+                ),
+                Ok(CancelResolution::NewlyReserved(_))
+            ));
+        }
+
+        let admitted_key = receipt_key_with_ids(
+            InvocationId::new(),
+            TaskId::new(),
+            "admitted-after-expired-cancel-pool",
+        );
+        let cutoff =
+            OriginalCutoffDescriptor::new(8_125, 7_000).expect("valid post-expiry submit cutoff");
+        let admitted = store
+            .reserve(
+                admitted_key.clone(),
+                cutoff,
+                Instant::now() + Duration::from_secs(10),
+            )
+            .expect("expired cancel reservations cannot deny later admission")
+            .into_reservation()
+            .expect("new submit remains reserved");
+
+        assert_eq!(admitted.key(), &admitted_key);
+        assert_eq!(admitted.mutation_sequence(), 129);
+        let catalog = store.writer.lock().expect("inspect reclaimed catalog");
+        assert_eq!(catalog.records.len(), 1);
+        assert_eq!(catalog.invocation_index.len(), 1);
+        assert_eq!(catalog.reserved_task_index.len(), 1);
+        assert_eq!(catalog.actual_bytes, admitted.encoded_bytes());
+        assert_eq!(
+            catalog.reserved_result_bytes,
+            admitted.reserved_result_bytes()
+        );
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/receipt_ledger.rs
+++ b/crates/unica-coder/src/infrastructure/receipt_ledger.rs
@@ -170,10 +170,13 @@ struct StoredActiveReceiptV1 {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(deny_unknown_fields)]
 struct StoredAcknowledgedTombstoneV1 {
+    #[serde(rename = "k")]
     key: ReceiptKey,
+    #[serde(rename = "d")]
     terminal_digest: TerminalDigest,
+    #[serde(rename = "a")]
     ack_epoch_ms: u64,
 }
 
@@ -213,6 +216,12 @@ enum StoredActiveLifecycleV1 {
         terminal_digest: crate::application::receipt_ledger::TerminalDigest,
         terminal: Arc<ReceiptTerminalOutcome>,
     },
+    AcknowledgementCommit {
+        terminal_digest: TerminalDigest,
+        acknowledged_at_epoch_ms: u64,
+        prior_record_version: ReceiptVersion,
+        prior_mutation_sequence: u64,
+    },
     AcknowledgedTombstone {
         terminal_digest: TerminalDigest,
         acknowledged_at_epoch_ms: u64,
@@ -241,6 +250,7 @@ impl CatalogEntry {
             StoredActiveLifecycleV1::CancelReserved { .. }
             | StoredActiveLifecycleV1::ExpiredDeletion { .. }
             | StoredActiveLifecycleV1::ExpiredTombstoneDeletion { .. }
+            | StoredActiveLifecycleV1::AcknowledgementCommit { .. }
             | StoredActiveLifecycleV1::AcknowledgedTombstone { .. } => 0,
             StoredActiveLifecycleV1::ReservedUnbound { .. }
             | StoredActiveLifecycleV1::DirectTerminalUnacked { .. } => {
@@ -330,6 +340,11 @@ impl CatalogEntry {
                     ),
                 ))
             }
+            StoredActiveLifecycleV1::AcknowledgementCommit { .. } => {
+                Err(ReceiptLedgerError::Corrupt(
+                    "acknowledgement commit witness is not a live receipt state",
+                ))
+            }
             StoredActiveLifecycleV1::AcknowledgedTombstone {
                 terminal_digest,
                 acknowledged_at_epoch_ms,
@@ -365,6 +380,13 @@ impl CatalogEntry {
             &self.record.lifecycle,
             StoredActiveLifecycleV1::ExpiredDeletion { .. }
                 | StoredActiveLifecycleV1::ExpiredTombstoneDeletion { .. }
+        )
+    }
+
+    fn is_acknowledgement_commit(&self) -> bool {
+        matches!(
+            &self.record.lifecycle,
+            StoredActiveLifecycleV1::AcknowledgementCommit { .. }
         )
     }
 }
@@ -428,6 +450,13 @@ struct RecoveredCatalog {
     staging: Vec<RecoveryStagingEntry>,
     expired_deletions: Vec<RecoveryStagingEntry>,
     expired_deletion_mutation_sequence: Option<u64>,
+    acknowledgement_recovery: Option<AcknowledgementRecovery>,
+}
+
+struct AcknowledgementRecovery {
+    compact_record: StoredActiveReceiptV1,
+    compact_encoded: Vec<u8>,
+    mutation_sequence: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -605,7 +634,7 @@ impl ReceiptLedgerStore {
                 ))
             }
         };
-        let recovered = if let Some((active, active_file)) = &existing_active {
+        let mut recovered = if let Some((active, active_file)) = &existing_active {
             Self::recover_existing_catalog(
                 &receipts,
                 &receipts_file,
@@ -620,6 +649,7 @@ impl ReceiptLedgerStore {
                 staging: Vec::new(),
                 expired_deletions: Vec::new(),
                 expired_deletion_mutation_sequence: None,
+                acknowledgement_recovery: None,
             }
         };
         check_deadline(deadline)?;
@@ -644,12 +674,25 @@ impl ReceiptLedgerStore {
                 "nonzero receipt generation is missing its active directory",
             ));
         }
-        if let Some(witness_sequence) = recovered.expired_deletion_mutation_sequence {
+        if recovered.expired_deletion_mutation_sequence.is_some()
+            && recovered.acknowledgement_recovery.is_some()
+        {
+            return Err(ReceiptLedgerError::Corrupt(
+                "receipt recovery contains more than one pending mutation witness",
+            ));
+        }
+        let pending_witness_sequence = recovered.expired_deletion_mutation_sequence.or_else(|| {
+            recovered
+                .acknowledgement_recovery
+                .as_ref()
+                .map(|recovery| recovery.mutation_sequence)
+        });
+        if let Some(witness_sequence) = pending_witness_sequence {
             let is_current_or_next = witness_sequence == persisted_generation
                 || persisted_generation.checked_add(1) == Some(witness_sequence);
             if !is_current_or_next || witness_sequence != recovered.maximum_mutation_sequence {
                 return Err(ReceiptLedgerError::Corrupt(
-                    "expired deletion witness is not the next persisted mutation",
+                    "pending receipt mutation witness is not the next persisted mutation",
                 ));
             }
         }
@@ -700,6 +743,22 @@ impl ReceiptLedgerStore {
         if persisted_generation < recovered.maximum_mutation_sequence {
             check_deadline(deadline)?;
             store.publish_generation(recovered.maximum_mutation_sequence, None, Some(deadline))?;
+        }
+        if let Some(recovery) = recovered.acknowledgement_recovery.take() {
+            store.publish_replacement_record(
+                &recovery.compact_record,
+                &recovery.compact_encoded,
+                deadline,
+                || {},
+            )?;
+            match store.read_active_record_bytes(&recovery.compact_record.key_digest) {
+                Ok(Some(committed)) if committed == recovery.compact_encoded => {}
+                Ok(Some(_)) | Ok(None) | Err(_) => {
+                    return Err(ReceiptLedgerError::CommitUncertain {
+                        receipt_key_digest: recovery.compact_record.key_digest,
+                    })
+                }
+            }
         }
         // An ExpiredDeletion row is the durable commit witness for logical
         // removal.  Its mutation sequence must become authoritative before the
@@ -941,6 +1000,20 @@ impl ReceiptLedgerStore {
                     self.expire_cancel_reserved_entry_under_writer_lock(
                         &mut catalog,
                         persisted,
+                        cancel_reserved_at_epoch_ms,
+                        deadline,
+                    )?;
+                    expires_at_epoch_ms
+                }
+                ReceiptState::AcknowledgedTombstone(receipt)
+                    if cancel_reserved_at_epoch_ms >= receipt.expires_at_epoch_ms() =>
+                {
+                    let expires_at_epoch_ms = cancel_reserved_at_epoch_ms
+                        .checked_add(CANCEL_RESERVATION_TTL_MS)
+                        .ok_or(ReceiptLedgerError::TimestampOverflow)?;
+                    self.reclaim_expired_tombstone_under_writer_lock(
+                        &mut catalog,
+                        &key_digest,
                         cancel_reserved_at_epoch_ms,
                         deadline,
                     )?;
@@ -2045,14 +2118,23 @@ impl ReceiptLedgerStore {
             };
         match persisted.state() {
             Ok(ReceiptState::AcknowledgedTombstone(tombstone)) => {
-                if tombstone.terminal_digest() == terminal_digest {
-                    return Ok(tombstone);
+                if tombstone.terminal_digest() != terminal_digest {
+                    return self.reject_before_mutation(
+                        &mut catalog,
+                        deadline,
+                        ReceiptLedgerError::TerminalMismatch,
+                    );
                 }
-                return self.reject_before_mutation(
-                    &mut catalog,
-                    deadline,
-                    ReceiptLedgerError::TerminalMismatch,
-                );
+                if acknowledged_at_epoch_ms >= tombstone.expires_at_epoch_ms() {
+                    self.reclaim_expired_tombstone_under_writer_lock(
+                        &mut catalog,
+                        &key_digest,
+                        acknowledged_at_epoch_ms,
+                        deadline,
+                    )?;
+                    return Err(ReceiptLedgerError::ReceiptNotFound);
+                }
+                return Ok(tombstone);
             }
             Ok(ReceiptState::DirectTerminalUnacked(receipt)) => {
                 if receipt.terminal().digest() != terminal_digest {
@@ -2073,28 +2155,12 @@ impl ReceiptLedgerStore {
             Err(error) => return latch_catalog_error(&mut catalog, error),
         }
 
-        // Reclamation is part of successful ACK-capacity preflight only.
-        // Premature or digest-mismatched ACK must remain reject-before-mutation,
-        // including with unrelated expired tombstones in the pool.
-        self.reclaim_expired_tombstones_under_writer_lock(
-            &mut catalog,
-            acknowledged_at_epoch_ms,
-            deadline,
-        )?;
-
-        let generation = latch_catalog_result(&mut catalog, self.generation_under_writer_lock())?;
-        let mutation_sequence = generation
-            .checked_add(1)
-            .ok_or(ReceiptLedgerError::Corrupt(
-                "receipt generation exhausted u64",
-            ))?;
         let record = StoredActiveReceiptV1 {
             schema_version: RECEIPT_RECORD_SCHEMA_VERSION,
-            // Compact tombstones persist only exact key, terminal digest and
-            // first-ACK epoch. The generation file remains the mutation fence.
             mutation_sequence: 0,
-            record_version: ReceiptVersion::new(3)
-                .expect("compact tombstone marker version is nonzero"),
+            record_version: persisted.record.record_version.checked_next().ok_or(
+                ReceiptLedgerError::Corrupt("receipt record version exhausted u64"),
+            )?,
             key: key.clone(),
             key_digest: key_digest.clone(),
             lifecycle: StoredActiveLifecycleV1::AcknowledgedTombstone {
@@ -2110,12 +2176,34 @@ impl ReceiptLedgerStore {
             record: record.clone(),
             encoded_bytes,
         };
+        // ACK owns only the minimum capacity work needed for this one
+        // transition. Bulk expiry remains a bounded maintenance command.
+        self.reclaim_expired_tombstones_for_ack_capacity_under_writer_lock(
+            &mut catalog,
+            &replacement,
+            acknowledged_at_epoch_ms,
+            deadline,
+        )?;
         if let Err(error) = validate_catalog_replace(&catalog, &persisted, &replacement) {
             return self.reject_before_mutation(&mut catalog, deadline, error);
         }
-        if let Err(error) = self.publish_replacement_record(&record, &encoded, deadline, || {
-            commit_catalog_replace(&mut catalog, replacement);
-        }) {
+        let generation = latch_catalog_result(&mut catalog, self.generation_under_writer_lock())?;
+        let mutation_sequence = generation
+            .checked_add(1)
+            .ok_or(ReceiptLedgerError::Corrupt(
+                "receipt generation exhausted u64",
+            ))?;
+        let witness = build_acknowledgement_commit_record(
+            &persisted,
+            terminal_digest.clone(),
+            acknowledged_at_epoch_ms,
+            mutation_sequence,
+        )?;
+        let (witness, witness_encoded) =
+            serialize_reserved_record(witness, MAX_CANCEL_RESERVED_RECORD_BYTES)?;
+        if let Err(error) =
+            self.publish_replacement_record(&witness, &witness_encoded, deadline, || {})
+        {
             if !matches!(error, ReceiptLedgerError::DeadlineExceeded) {
                 catalog.unavailable = true;
             }
@@ -2126,6 +2214,12 @@ impl ReceiptLedgerStore {
         {
             catalog.unavailable = true;
             return Err(error);
+        }
+        if let Err(error) = self.publish_replacement_record(&record, &encoded, deadline, || {
+            commit_catalog_replace(&mut catalog, replacement);
+        }) {
+            catalog.unavailable = true;
+            return Err(after_row_error(Some(&key_digest), error));
         }
         match self.read_active_record_bytes(&key_digest) {
             Ok(Some(committed)) if committed == encoded => {}
@@ -2204,6 +2298,39 @@ impl ReceiptLedgerStore {
             )?;
         }
         Ok(expired.len())
+    }
+
+    fn reclaim_expired_tombstones_for_ack_capacity_under_writer_lock(
+        &self,
+        catalog: &mut ReceiptCatalog,
+        replacement: &CatalogEntry,
+        observed_at_epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<(), ReceiptLedgerError> {
+        if ack_tombstone_has_capacity(catalog, replacement) {
+            return Ok(());
+        }
+
+        let mut expired = catalog
+            .records
+            .iter()
+            .filter(|(digest, _)| digest != &&replacement.record.key_digest)
+            .filter(|(_, entry)| entry_is_expired_tombstone(entry, observed_at_epoch_ms))
+            .map(|(digest, _)| digest.clone())
+            .collect::<Vec<_>>();
+        expired.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+        for digest in expired {
+            self.reclaim_expired_tombstone_under_writer_lock(
+                catalog,
+                &digest,
+                observed_at_epoch_ms,
+                deadline,
+            )?;
+            if ack_tombstone_has_capacity(catalog, replacement) {
+                return Ok(());
+            }
+        }
+        Err(ReceiptLedgerError::TombstoneCapacityExceeded)
     }
 
     fn reclaim_expired_tombstone_under_writer_lock(
@@ -2324,6 +2451,24 @@ impl ReceiptLedgerStore {
         key: &ReceiptKey,
         deadline: Instant,
     ) -> Result<ReceiptState, ReceiptLedgerError> {
+        self.recover_exact_inner(key, None, deadline)
+    }
+
+    fn recover_exact_at(
+        &self,
+        key: &ReceiptKey,
+        observed_at_epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<ReceiptState, ReceiptLedgerError> {
+        self.recover_exact_inner(key, Some(observed_at_epoch_ms), deadline)
+    }
+
+    fn recover_exact_inner(
+        &self,
+        key: &ReceiptKey,
+        observed_at_epoch_ms: Option<u64>,
+        deadline: Instant,
+    ) -> Result<ReceiptState, ReceiptLedgerError> {
         check_deadline(deadline)?;
         let key_digest = receipt_key_digest(key);
         let mut catalog = self
@@ -2361,6 +2506,18 @@ impl ReceiptLedgerStore {
                 )
             }
             Some(entry) => match entry.state() {
+                Ok(ReceiptState::AcknowledgedTombstone(receipt))
+                    if observed_at_epoch_ms
+                        .is_some_and(|observed| observed >= receipt.expires_at_epoch_ms()) =>
+                {
+                    self.reclaim_expired_tombstone_under_writer_lock(
+                        &mut catalog,
+                        &key_digest,
+                        observed_at_epoch_ms.expect("expiry guard requires an epoch"),
+                        deadline,
+                    )?;
+                    return Err(ReceiptLedgerError::ReceiptNotFound);
+                }
                 Ok(state) => Ok(state),
                 Err(error) => return latch_catalog_error(&mut catalog, error),
             },
@@ -2489,6 +2646,7 @@ impl ReceiptLedgerStore {
         let mut temporary_entries = Vec::new();
         let mut expired_deletions = Vec::new();
         let mut expired_deletion_mutation_sequence = None;
+        let mut acknowledgement_recovery = None;
         for name in names {
             check_deadline(deadline)?;
             let Some(name_text) = name.to_str() else {
@@ -2561,6 +2719,28 @@ impl ReceiptLedgerStore {
                 expired_deletions.push((name, identity, retained));
                 continue;
             }
+            if entry.is_acknowledgement_commit() {
+                if acknowledgement_recovery.is_some() {
+                    return Err(ReceiptLedgerError::Corrupt(
+                        "receipt recovery contains more than one acknowledgement witness",
+                    ));
+                }
+                let compact_record = build_acknowledged_tombstone_record_from_witness(&entry)?;
+                let (compact_record, compact_encoded) =
+                    serialize_reserved_record(compact_record, MAX_ACKNOWLEDGED_TOMBSTONE_BYTES)?;
+                let compact_entry = CatalogEntry {
+                    record: compact_record.clone(),
+                    encoded_bytes: u64::try_from(compact_encoded.len())
+                        .map_err(|_| ReceiptLedgerError::RecordTooLarge)?,
+                };
+                insert_catalog_entry(&mut catalog, compact_entry, true)?;
+                acknowledgement_recovery = Some(AcknowledgementRecovery {
+                    compact_record,
+                    compact_encoded,
+                    mutation_sequence: entry.record.mutation_sequence,
+                });
+                continue;
+            }
             insert_catalog_entry(&mut catalog, entry, true)?;
         }
         check_deadline(deadline)?;
@@ -2572,6 +2752,7 @@ impl ReceiptLedgerStore {
             staging: temporary_entries,
             expired_deletions,
             expired_deletion_mutation_sequence,
+            acknowledgement_recovery,
         })
     }
 
@@ -3247,6 +3428,15 @@ impl ReceiptLedgerPort for ReceiptLedgerStore {
     ) -> Result<ReceiptState, ReceiptLedgerError> {
         self.recover_exact(key, deadline)
     }
+
+    fn recover_at(
+        &mut self,
+        key: &ReceiptKey,
+        observed_at_epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<ReceiptState, ReceiptLedgerError> {
+        self.recover_exact_at(key, observed_at_epoch_ms, deadline)
+    }
 }
 
 fn verify_receipts_authority(
@@ -3322,6 +3512,7 @@ fn read_active_record_from_retained(
             | StoredActiveLifecycleV1::ExpiredDeletion { .. }
             | StoredActiveLifecycleV1::ExpiredTombstoneDeletion { .. }
             | StoredActiveLifecycleV1::ReservedUnbound { .. }
+            | StoredActiveLifecycleV1::AcknowledgementCommit { .. }
             | StoredActiveLifecycleV1::AcknowledgedTombstone { .. }
     ) {
         validate_persisted_reserved_record_bytes(&record, &bytes)?;
@@ -3681,6 +3872,71 @@ fn build_expired_tombstone_deletion_record(
     })
 }
 
+fn build_acknowledgement_commit_record(
+    expected: &CatalogEntry,
+    terminal_digest: TerminalDigest,
+    acknowledged_at_epoch_ms: u64,
+    mutation_sequence: u64,
+) -> Result<StoredActiveReceiptV1, ReceiptLedgerError> {
+    if !matches!(
+        &expected.record.lifecycle,
+        StoredActiveLifecycleV1::DirectTerminalUnacked { .. }
+    ) {
+        return Err(ReceiptLedgerError::Corrupt(
+            "acknowledgement commit witness requires a Direct predecessor",
+        ));
+    }
+    let record_version =
+        expected
+            .record
+            .record_version
+            .checked_next()
+            .ok_or(ReceiptLedgerError::Corrupt(
+                "receipt record version exhausted u64",
+            ))?;
+    Ok(StoredActiveReceiptV1 {
+        schema_version: RECEIPT_RECORD_SCHEMA_VERSION,
+        mutation_sequence,
+        record_version,
+        key: expected.record.key.clone(),
+        key_digest: expected.record.key_digest.clone(),
+        lifecycle: StoredActiveLifecycleV1::AcknowledgementCommit {
+            terminal_digest,
+            acknowledged_at_epoch_ms,
+            prior_record_version: expected.record.record_version,
+            prior_mutation_sequence: expected.record.mutation_sequence,
+        },
+    })
+}
+
+fn build_acknowledged_tombstone_record_from_witness(
+    witness: &CatalogEntry,
+) -> Result<StoredActiveReceiptV1, ReceiptLedgerError> {
+    let (terminal_digest, acknowledged_at_epoch_ms) = match &witness.record.lifecycle {
+        StoredActiveLifecycleV1::AcknowledgementCommit {
+            terminal_digest,
+            acknowledged_at_epoch_ms,
+            ..
+        } => (terminal_digest.clone(), *acknowledged_at_epoch_ms),
+        _ => {
+            return Err(ReceiptLedgerError::Corrupt(
+                "compact acknowledgement requires an acknowledgement witness",
+            ))
+        }
+    };
+    Ok(StoredActiveReceiptV1 {
+        schema_version: RECEIPT_RECORD_SCHEMA_VERSION,
+        mutation_sequence: 0,
+        record_version: witness.record.record_version,
+        key: witness.record.key.clone(),
+        key_digest: witness.record.key_digest.clone(),
+        lifecycle: StoredActiveLifecycleV1::AcknowledgedTombstone {
+            terminal_digest,
+            acknowledged_at_epoch_ms,
+        },
+    })
+}
+
 /// Sole serializer for active non-terminal receipt records.
 ///
 /// Direct terminal bytes are owned by `terminal_codec_v5`; accepting one here
@@ -3724,9 +3980,8 @@ fn validate_persisted_reserved_record_bytes(
     let maximum_encoded_bytes = match &record.lifecycle {
         StoredActiveLifecycleV1::CancelReserved { .. }
         | StoredActiveLifecycleV1::ExpiredDeletion { .. }
-        | StoredActiveLifecycleV1::ExpiredTombstoneDeletion { .. } => {
-            MAX_CANCEL_RESERVED_RECORD_BYTES
-        }
+        | StoredActiveLifecycleV1::ExpiredTombstoneDeletion { .. }
+        | StoredActiveLifecycleV1::AcknowledgementCommit { .. } => MAX_CANCEL_RESERVED_RECORD_BYTES,
         StoredActiveLifecycleV1::ReservedUnbound { .. } => MAX_TASK_RECORD_ENVELOPE_BYTES as u64,
         StoredActiveLifecycleV1::AcknowledgedTombstone { .. } => MAX_ACKNOWLEDGED_TOMBSTONE_BYTES,
         StoredActiveLifecycleV1::DirectTerminalUnacked { .. } => {
@@ -3971,6 +4226,30 @@ fn validate_active_record(
             )?;
             MAX_RECEIPT_ENTITLEMENT_BYTES
         }
+        StoredActiveLifecycleV1::AcknowledgementCommit {
+            acknowledged_at_epoch_ms,
+            prior_record_version,
+            prior_mutation_sequence,
+            ..
+        } => {
+            if prior_record_version.checked_next() != Some(record.record_version) {
+                return Err(ReceiptLedgerError::Corrupt(
+                    "acknowledgement witness does not advance its predecessor version",
+                ));
+            }
+            if *prior_mutation_sequence == 0 || *prior_mutation_sequence >= record.mutation_sequence
+            {
+                return Err(ReceiptLedgerError::Corrupt(
+                    "acknowledgement witness does not follow its predecessor mutation",
+                ));
+            }
+            acknowledged_at_epoch_ms
+                .checked_add(ACKNOWLEDGED_TOMBSTONE_TTL_MS)
+                .ok_or(ReceiptLedgerError::Corrupt(
+                    "acknowledgement witness expiry exceeds u64",
+                ))?;
+            MAX_CANCEL_RESERVED_RECORD_BYTES
+        }
         StoredActiveLifecycleV1::AcknowledgedTombstone {
             acknowledged_at_epoch_ms,
             ..
@@ -4150,6 +4429,17 @@ fn entry_is_expired_tombstone(entry: &CatalogEntry, observed_at_epoch_ms: u64) -
             .checked_add(ACKNOWLEDGED_TOMBSTONE_TTL_MS)
             .is_some_and(|expires_at_epoch_ms| observed_at_epoch_ms >= expires_at_epoch_ms)
     )
+}
+
+fn ack_tombstone_has_capacity(catalog: &ReceiptCatalog, replacement: &CatalogEntry) -> bool {
+    catalog
+        .tombstone_count()
+        .checked_add(usize::from(replacement.is_tombstone()))
+        .is_some_and(|count| count <= MAX_ACKNOWLEDGED_TOMBSTONES)
+        && catalog
+            .tombstone_bytes
+            .checked_add(replacement.tombstone_bytes())
+            .is_some_and(|bytes| bytes <= MAX_ACKNOWLEDGED_TOMBSTONE_POOL_BYTES)
 }
 
 fn validate_catalog_remove(
@@ -4456,6 +4746,35 @@ mod tests {
                 request_scope_hash(workspace_hint).expect("bounded request scope"),
             ),
         )
+    }
+
+    fn direct_terminal_fixture(
+        receipts: &Path,
+    ) -> (ReceiptLedgerStore, ReceiptKey, TerminalDigest) {
+        let store = ReceiptLedgerStore::open(receipts).expect("open receipt ledger");
+        let key = receipt_key(INVOCATION_A, TASK_A, "workspace-a");
+        let reserved = store
+            .reserve(
+                key.clone(),
+                OriginalCutoffDescriptor::new(1_000, 7_000).expect("valid cutoff"),
+                reserve_deadline(),
+            )
+            .expect("reserve exact receipt")
+            .into_reservation()
+            .expect("receipt remains reserved");
+        let terminal = canonical_v5_terminal(&ReceiptTerminalOutcome::Cancelled)
+            .expect("canonical direct terminal");
+        let terminal_digest = terminal.digest().clone();
+        store
+            .publish_direct_terminal(
+                &key,
+                reserved.record_version(),
+                2_000,
+                terminal,
+                reserve_deadline(),
+            )
+            .expect("publish direct terminal");
+        (store, key, terminal_digest)
     }
 
     fn reserve_deadline() -> Instant {
@@ -5162,7 +5481,7 @@ mod tests {
                 .err()
                 .expect("witness cannot skip the next persisted generation"),
             ReceiptLedgerError::Corrupt(
-                "expired deletion witness is not the next persisted mutation"
+                "pending receipt mutation witness is not the next persisted mutation"
             )
         );
     }
@@ -6009,6 +6328,198 @@ mod tests {
     }
 
     #[test]
+    fn compact_tombstone_fits_512_bytes_at_the_maximum_valid_epoch_and_longest_tool_name() {
+        let key = ReceiptKey::new(
+            InvocationId::from_str(INVOCATION_A).expect("canonical invocation id"),
+            TaskId::from_str(TASK_A).expect("canonical task id"),
+            RequestIdentity::new(
+                CoreIdentityDigest::from_sha256([0x55; 32]),
+                V5ToolIdentity::Search,
+                normalized_arguments_hash(&serde_json::Map::new()),
+                request_scope_hash("workspace-a").expect("bounded request scope"),
+            ),
+        );
+        let key_digest = receipt_key_digest(&key);
+        let acknowledged_at_epoch_ms = u64::MAX
+            .checked_sub(ACKNOWLEDGED_TOMBSTONE_TTL_MS)
+            .expect("bounded epoch");
+        let terminal_digest = canonical_v5_terminal(&ReceiptTerminalOutcome::Cancelled)
+            .expect("canonical terminal")
+            .digest()
+            .clone();
+        let record = StoredActiveReceiptV1 {
+            schema_version: RECEIPT_RECORD_SCHEMA_VERSION,
+            mutation_sequence: 0,
+            record_version: ReceiptVersion::new(3).expect("tombstone record version"),
+            key,
+            key_digest: key_digest.clone(),
+            lifecycle: StoredActiveLifecycleV1::AcknowledgedTombstone {
+                terminal_digest,
+                acknowledged_at_epoch_ms,
+            },
+        };
+
+        let (_, encoded) = serialize_reserved_record(record, MAX_ACKNOWLEDGED_TOMBSTONE_BYTES)
+            .expect("worst-case compact tombstone fits its contract");
+        assert!(encoded.len() <= MAX_ACKNOWLEDGED_TOMBSTONE_BYTES as usize);
+        let text = std::str::from_utf8(&encoded).expect("compact tombstone JSON is UTF-8");
+        assert!(text.starts_with("{\"k\":"));
+        assert!(text.contains("\"d\":"));
+        assert!(text.contains("\"a\":18446744073708651615"));
+        let mut persisted = tempfile::tempfile().expect("temporary file");
+        persisted
+            .write_all(&encoded)
+            .and_then(|()| persisted.sync_all())
+            .expect("persist compact tombstone fixture");
+        let decoded = read_active_record_from_retained(&mut persisted, &key_digest)
+            .expect("strict decoder accepts the worst-case compact tombstone");
+        assert!(matches!(
+            decoded.state(),
+            Ok(ReceiptState::AcknowledgedTombstone(_))
+        ));
+    }
+
+    #[test]
+    fn ack_crash_after_witness_row_before_generation_heals_and_compacts_on_reopen() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("receipts");
+        let (store, key, terminal_digest) = direct_terminal_fixture(&receipts);
+        set_after_receipt_row_rename_hook_for_test(|| panic!("simulated process crash"));
+
+        let crashed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            store
+                .acknowledge_direct(&key, &terminal_digest, 2_100, reserve_deadline())
+                .expect("crash hook interrupts ACK")
+        }));
+        assert!(crashed.is_err());
+        drop(store);
+        assert_eq!(
+            fs::read(receipts.join(GENERATION_FILE_NAME)).expect("read stale generation"),
+            b"2\n"
+        );
+
+        let reopened = ReceiptLedgerStore::open(&receipts)
+            .expect("reopen heals the durable acknowledgement witness");
+        assert_eq!(reopened.generation().expect("healed generation"), 3);
+        assert!(matches!(
+            reopened.recover_exact(&key, reserve_deadline()),
+            Ok(ReceiptState::AcknowledgedTombstone(_))
+        ));
+    }
+
+    #[test]
+    fn ack_generation_is_published_while_the_durable_witness_is_still_visible() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("receipts");
+        let (store, key, terminal_digest) = direct_terminal_fixture(&receipts);
+        let row_path = receipts
+            .join(ACTIVE_DIRECTORY_NAME)
+            .join(format!("{}.json", receipt_key_digest(&key).as_str()));
+        let observed = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        let hook_observed = std::sync::Arc::clone(&observed);
+        set_after_generation_replace_hook_for_test(move || {
+            *hook_observed.lock().expect("record observed ACK row") =
+                fs::read_to_string(&row_path).expect("read ACK row at generation publication");
+            panic!("simulated process crash");
+        });
+
+        assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            store
+                .acknowledge_direct(&key, &terminal_digest, 2_100, reserve_deadline())
+                .expect("generation crash hook interrupts ACK")
+        }))
+        .is_err());
+        assert!(
+            observed
+                .lock()
+                .expect("inspect observed ACK row")
+                .contains("\"state\":\"acknowledgement_commit\""),
+            "generation must not become authoritative while only a sequence-free tombstone is visible"
+        );
+        drop(store);
+
+        let reopened =
+            ReceiptLedgerStore::open(&receipts).expect("reopen finalizes the acknowledged witness");
+        assert_eq!(reopened.generation().expect("published generation"), 3);
+        assert!(matches!(
+            reopened.recover_exact(&key, reserve_deadline()),
+            Ok(ReceiptState::AcknowledgedTombstone(_))
+        ));
+    }
+
+    #[test]
+    fn ack_crash_after_compact_row_rename_reopens_the_same_tombstone() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("receipts");
+        let (store, key, terminal_digest) = direct_terminal_fixture(&receipts);
+        set_after_generation_replace_hook_for_test(|| {
+            set_after_receipt_row_rename_hook_for_test(|| panic!("simulated process crash"));
+        });
+
+        assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            store
+                .acknowledge_direct(&key, &terminal_digest, 2_100, reserve_deadline())
+                .expect("compact crash hook interrupts ACK")
+        }))
+        .is_err());
+        drop(store);
+
+        let reopened = ReceiptLedgerStore::open(&receipts)
+            .expect("reopen accepts the compact row after generation commit");
+        assert_eq!(reopened.generation().expect("published generation"), 3);
+        let recovered = reopened
+            .recover_exact(&key, reserve_deadline())
+            .expect("recover compact acknowledged tombstone");
+        let ReceiptState::AcknowledgedTombstone(tombstone) = recovered else {
+            panic!("ACK crash reopened as a non-tombstone lifecycle")
+        };
+        assert_eq!(tombstone.terminal_digest(), &terminal_digest);
+        assert_eq!(tombstone.acknowledged_at_epoch_ms(), 2_100);
+    }
+
+    #[test]
+    fn reopen_rejects_an_acknowledgement_witness_that_skips_generation() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("receipts");
+        let (store, key, terminal_digest) = direct_terminal_fixture(&receipts);
+        let key_digest = receipt_key_digest(&key);
+        let row_path = receipts
+            .join(ACTIVE_DIRECTORY_NAME)
+            .join(format!("{}.json", key_digest.as_str()));
+        let encoded = fs::read(&row_path).expect("read direct predecessor");
+        let record: StoredActiveReceiptV1 =
+            serde_json::from_slice(&encoded).expect("decode direct predecessor");
+        let predecessor = CatalogEntry {
+            record,
+            encoded_bytes: u64::try_from(encoded.len()).expect("bounded predecessor bytes"),
+        };
+        let witness = build_acknowledgement_commit_record(&predecessor, terminal_digest, 2_100, 4)
+            .expect("build forged ahead witness");
+        let (_, witness_encoded) =
+            serialize_reserved_record(witness, MAX_CANCEL_RESERVED_RECORD_BYTES)
+                .expect("encode forged ahead witness");
+        drop(store);
+        fs::write(&row_path, witness_encoded).expect("persist forged ahead witness");
+
+        assert_eq!(
+            ReceiptLedgerStore::open(&receipts)
+                .err()
+                .expect("witness may only be current or next generation"),
+            ReceiptLedgerError::Corrupt(
+                "pending receipt mutation witness is not the next persisted mutation"
+            )
+        );
+    }
+
+    #[test]
     fn acknowledged_tombstone_is_physically_reclaimed_at_its_absolute_expiry() {
         let root = tempfile::tempdir().expect("temporary root");
         let receipts = fs::canonicalize(root.path())
@@ -6067,6 +6578,232 @@ mod tests {
         let reopened = ReceiptLedgerStore::open(&receipts).expect("reopen after expiry");
         assert_eq!(
             reopened.recover_exact(&key, reserve_deadline()),
+            Err(ReceiptLedgerError::ReceiptNotFound)
+        );
+    }
+
+    #[test]
+    fn exact_cancel_request_reclaims_an_expired_tombstone_before_reserving_again() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("receipts");
+        let store = ReceiptLedgerStore::open(&receipts).expect("open receipt ledger");
+        let key = receipt_key(INVOCATION_A, TASK_A, "workspace-a");
+        let reserved = store
+            .reserve(
+                key.clone(),
+                OriginalCutoffDescriptor::new(1_000, 7_000).expect("valid cutoff"),
+                reserve_deadline(),
+            )
+            .expect("reserve exact receipt")
+            .into_reservation()
+            .expect("receipt remains reserved");
+        let terminal = canonical_v5_terminal(&ReceiptTerminalOutcome::Cancelled)
+            .expect("canonical direct terminal");
+        let terminal_digest = terminal.digest().clone();
+        store
+            .publish_direct_terminal(
+                &key,
+                reserved.record_version(),
+                2_000,
+                terminal,
+                reserve_deadline(),
+            )
+            .expect("publish direct terminal");
+        let tombstone = store
+            .acknowledge_direct(&key, &terminal_digest, 2_100, reserve_deadline())
+            .expect("acknowledge direct terminal");
+
+        assert!(matches!(
+            store
+                .request_cancel_or_reserve(
+                    key.clone(),
+                    tombstone.expires_at_epoch_ms() - 1,
+                    reserve_deadline(),
+                )
+                .expect("pre-expiry exact request returns the winner"),
+            CancelResolution::ExistingWinner(_)
+        ));
+        let replacement = store
+            .request_cancel_or_reserve(
+                key.clone(),
+                tombstone.expires_at_epoch_ms(),
+                reserve_deadline(),
+            )
+            .expect("expiry boundary releases the exact key");
+        let CancelResolution::NewlyReserved(replacement) = replacement else {
+            panic!("expired exact tombstone did not yield a new cancellation reservation")
+        };
+        assert_eq!(replacement.key(), &key);
+        assert_eq!(
+            store.generation().expect("reclaim plus reserve generation"),
+            5
+        );
+    }
+
+    #[test]
+    fn exact_ack_reclaims_its_tombstone_at_expiry_and_reports_absence() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("receipts");
+        let store = ReceiptLedgerStore::open(&receipts).expect("open receipt ledger");
+        let key = receipt_key(INVOCATION_A, TASK_A, "workspace-a");
+        let reserved = store
+            .reserve(
+                key.clone(),
+                OriginalCutoffDescriptor::new(1_000, 7_000).expect("valid cutoff"),
+                reserve_deadline(),
+            )
+            .expect("reserve exact receipt")
+            .into_reservation()
+            .expect("receipt remains reserved");
+        let terminal = canonical_v5_terminal(&ReceiptTerminalOutcome::Cancelled)
+            .expect("canonical direct terminal");
+        let terminal_digest = terminal.digest().clone();
+        store
+            .publish_direct_terminal(
+                &key,
+                reserved.record_version(),
+                2_000,
+                terminal,
+                reserve_deadline(),
+            )
+            .expect("publish direct terminal");
+        let tombstone = store
+            .acknowledge_direct(&key, &terminal_digest, 2_100, reserve_deadline())
+            .expect("acknowledge direct terminal");
+
+        assert_eq!(
+            store
+                .acknowledge_direct(
+                    &key,
+                    &terminal_digest,
+                    tombstone.expires_at_epoch_ms() - 1,
+                    reserve_deadline(),
+                )
+                .expect("pre-expiry retry is idempotent"),
+            tombstone
+        );
+        assert_eq!(
+            store.acknowledge_direct(
+                &key,
+                &terminal_digest,
+                tombstone.expires_at_epoch_ms(),
+                reserve_deadline(),
+            ),
+            Err(ReceiptLedgerError::ReceiptNotFound)
+        );
+        assert_eq!(store.generation().expect("expiry generation"), 4);
+    }
+
+    #[test]
+    fn exact_recovery_reclaims_its_tombstone_at_expiry_and_reports_absence() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("receipts");
+        let mut store = ReceiptLedgerStore::open(&receipts).expect("open receipt ledger");
+        let key = receipt_key(INVOCATION_A, TASK_A, "workspace-a");
+        let reserved = store
+            .reserve(
+                key.clone(),
+                OriginalCutoffDescriptor::new(1_000, 7_000).expect("valid cutoff"),
+                reserve_deadline(),
+            )
+            .expect("reserve exact receipt")
+            .into_reservation()
+            .expect("receipt remains reserved");
+        let terminal = canonical_v5_terminal(&ReceiptTerminalOutcome::Cancelled)
+            .expect("canonical direct terminal");
+        let terminal_digest = terminal.digest().clone();
+        store
+            .publish_direct_terminal(
+                &key,
+                reserved.record_version(),
+                2_000,
+                terminal,
+                reserve_deadline(),
+            )
+            .expect("publish direct terminal");
+        let tombstone = store
+            .acknowledge_direct(&key, &terminal_digest, 2_100, reserve_deadline())
+            .expect("acknowledge direct terminal");
+
+        assert_eq!(
+            ReceiptLedgerPort::recover_at(
+                &mut store,
+                &key,
+                tombstone.expires_at_epoch_ms() - 1,
+                reserve_deadline(),
+            ),
+            Ok(ReceiptState::AcknowledgedTombstone(tombstone.clone()))
+        );
+        assert_eq!(
+            ReceiptLedgerPort::recover_at(
+                &mut store,
+                &key,
+                tombstone.expires_at_epoch_ms(),
+                reserve_deadline(),
+            ),
+            Err(ReceiptLedgerError::ReceiptNotFound)
+        );
+        assert_eq!(store.generation().expect("expiry generation"), 4);
+    }
+
+    #[test]
+    fn all_exact_tombstone_paths_remain_absent_after_the_expiry_boundary() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("cancel-receipts");
+        let (store, key, terminal_digest) = direct_terminal_fixture(&receipts);
+        let tombstone = store
+            .acknowledge_direct(&key, &terminal_digest, 2_100, reserve_deadline())
+            .expect("acknowledge cancel fixture");
+        assert!(matches!(
+            store
+                .request_cancel_or_reserve(
+                    key,
+                    tombstone.expires_at_epoch_ms() + 1,
+                    reserve_deadline(),
+                )
+                .expect("post-expiry cancel reserves a new receipt"),
+            CancelResolution::NewlyReserved(_)
+        ));
+
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("ack-receipts");
+        let (store, key, terminal_digest) = direct_terminal_fixture(&receipts);
+        let tombstone = store
+            .acknowledge_direct(&key, &terminal_digest, 2_100, reserve_deadline())
+            .expect("acknowledge ACK fixture");
+        assert_eq!(
+            store.acknowledge_direct(
+                &key,
+                &terminal_digest,
+                tombstone.expires_at_epoch_ms() + 1,
+                reserve_deadline(),
+            ),
+            Err(ReceiptLedgerError::ReceiptNotFound)
+        );
+
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("recover-receipts");
+        let (mut store, key, terminal_digest) = direct_terminal_fixture(&receipts);
+        let tombstone = store
+            .acknowledge_direct(&key, &terminal_digest, 2_100, reserve_deadline())
+            .expect("acknowledge recovery fixture");
+        assert_eq!(
+            ReceiptLedgerPort::recover_at(
+                &mut store,
+                &key,
+                tombstone.expires_at_epoch_ms() + 1,
+                reserve_deadline(),
+            ),
             Err(ReceiptLedgerError::ReceiptNotFound)
         );
     }
@@ -7874,6 +8611,9 @@ mod tests {
             } => *reserved_at_epoch_ms = 1_001,
             StoredActiveLifecycleV1::DirectTerminalUnacked { .. } => {
                 panic!("reserved fixture decoded as a direct terminal")
+            }
+            StoredActiveLifecycleV1::AcknowledgementCommit { .. } => {
+                panic!("reserved fixture decoded as an acknowledgement witness")
             }
             StoredActiveLifecycleV1::AcknowledgedTombstone { .. } => {
                 panic!("reserved fixture decoded as an acknowledged tombstone")

--- a/crates/unica-coder/src/infrastructure/receipt_ledger.rs
+++ b/crates/unica-coder/src/infrastructure/receipt_ledger.rs
@@ -855,37 +855,12 @@ impl ReceiptLedgerStore {
                 .ok_or(ReceiptLedgerError::TimestampOverflow)?
         };
 
-        self.reclaim_expired_cancel_reservations_under_writer_lock(
+        self.prepare_new_admission_under_writer_lock(
             &mut catalog,
+            &key,
             cancel_reserved_at_epoch_ms,
-            None,
             deadline,
         )?;
-
-        if catalog.invocation_index.contains_key(&key.invocation_id()) {
-            return self.reject_before_mutation(
-                &mut catalog,
-                deadline,
-                ReceiptLedgerError::InvocationIdentityMismatch,
-            );
-        }
-        if catalog
-            .reserved_task_index
-            .contains_key(&key.reserved_task_id())
-        {
-            return self.reject_before_mutation(
-                &mut catalog,
-                deadline,
-                ReceiptLedgerError::ReservedTaskIdentityMismatch,
-            );
-        }
-        if catalog.records.len() >= MAX_LIVE_RECEIPTS {
-            return self.reject_before_mutation(
-                &mut catalog,
-                deadline,
-                ReceiptLedgerError::CapacityExceeded,
-            );
-        }
         let generation = latch_catalog_result(&mut catalog, self.generation_under_writer_lock())?;
         let mutation_sequence = match generation.checked_add(1) {
             Some(sequence) => sequence,
@@ -1080,71 +1055,147 @@ impl ReceiptLedgerStore {
         Ok(CancelExpiryOutcome::Expired)
     }
 
-    fn reclaim_expired_cancel_reservations_under_writer_lock(
+    fn prepare_new_admission_under_writer_lock(
         &self,
         catalog: &mut ReceiptCatalog,
+        key: &ReceiptKey,
         observed_at_epoch_ms: u64,
-        except: Option<&ReceiptKeyDigest>,
         deadline: Instant,
     ) -> Result<(), ReceiptLedgerError> {
-        let mut expired = catalog
-            .records
-            .iter()
-            .filter_map(|(digest, entry)| match &entry.record.lifecycle {
-                StoredActiveLifecycleV1::CancelReserved {
-                    expires_at_epoch_ms,
-                    ..
-                } if observed_at_epoch_ms >= *expires_at_epoch_ms && except != Some(digest) => {
-                    Some(digest.clone())
-                }
-                _ => None,
-            })
-            .collect::<Vec<_>>();
-        expired.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
-
-        for key_digest in expired {
-            check_deadline(deadline)?;
-            let expected =
-                catalog
-                    .records
-                    .get(&key_digest)
-                    .cloned()
-                    .ok_or(ReceiptLedgerError::Corrupt(
-                        "expired receipt disappeared while the writer lock was held",
-                    ))?;
-            let persisted = self
-                .read_entry_under_writer_lock(catalog, &key_digest, Some(deadline))?
-                .ok_or(ReceiptLedgerError::Corrupt(
-                    "catalogued expired receipt row is missing",
-                ))?;
-            if persisted != expected {
-                return latch_catalog_error(
+        let mut reclaim = Vec::with_capacity(2);
+        if let Some(digest) = catalog.invocation_index.get(&key.invocation_id()).cloned() {
+            let expired = match catalog_entry_is_expired_cancel_reserved(
+                catalog,
+                &digest,
+                observed_at_epoch_ms,
+            ) {
+                Ok(expired) => expired,
+                Err(error) => return latch_catalog_error(catalog, error),
+            };
+            if !expired {
+                return self.reject_before_mutation(
                     catalog,
-                    ReceiptLedgerError::Corrupt("catalogued expired receipt row changed on disk"),
+                    deadline,
+                    ReceiptLedgerError::InvocationIdentityMismatch,
                 );
             }
-            match persisted.state() {
-                Ok(ReceiptState::CancelReserved(receipt))
-                    if observed_at_epoch_ms >= receipt.expires_at_epoch_ms() => {}
-                Ok(ReceiptState::CancelReserved(_)) => continue,
-                Ok(_) => {
-                    return latch_catalog_error(
-                        catalog,
-                        ReceiptLedgerError::Corrupt(
-                            "expired cancellation candidate changed lifecycle under writer lock",
-                        ),
-                    )
-                }
-                Err(error) => return latch_catalog_error(catalog, error),
-            }
-            self.expire_cancel_reserved_entry_under_writer_lock(
+            reclaim.push(digest);
+        }
+        if let Some(digest) = catalog
+            .reserved_task_index
+            .get(&key.reserved_task_id())
+            .cloned()
+        {
+            let expired = match catalog_entry_is_expired_cancel_reserved(
                 catalog,
-                persisted,
+                &digest,
+                observed_at_epoch_ms,
+            ) {
+                Ok(expired) => expired,
+                Err(error) => return latch_catalog_error(catalog, error),
+            };
+            if !expired {
+                return self.reject_before_mutation(
+                    catalog,
+                    deadline,
+                    ReceiptLedgerError::ReservedTaskIdentityMismatch,
+                );
+            }
+            reclaim.push(digest);
+        }
+        reclaim.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+        reclaim.dedup();
+
+        let projected_count =
+            catalog
+                .records
+                .len()
+                .checked_sub(reclaim.len())
+                .ok_or(ReceiptLedgerError::Corrupt(
+                    "receipt reclamation exceeds the live catalog",
+                ))?;
+        if projected_count >= MAX_LIVE_RECEIPTS {
+            let capacity_candidate = catalog
+                .records
+                .iter()
+                .filter(|(digest, _)| !reclaim.contains(digest))
+                .filter(|(_, entry)| entry_is_expired_cancel_reserved(entry, observed_at_epoch_ms))
+                .map(|(digest, _)| digest.clone())
+                .min_by(|left, right| left.as_str().cmp(right.as_str()));
+            let Some(capacity_candidate) = capacity_candidate else {
+                return self.reject_before_mutation(
+                    catalog,
+                    deadline,
+                    ReceiptLedgerError::CapacityExceeded,
+                );
+            };
+            reclaim.push(capacity_candidate);
+            reclaim.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+        }
+
+        for digest in reclaim {
+            self.reclaim_expired_cancel_reservation_under_writer_lock(
+                catalog,
+                &digest,
                 observed_at_epoch_ms,
                 deadline,
             )?;
         }
         Ok(())
+    }
+
+    fn reclaim_expired_cancel_reservation_under_writer_lock(
+        &self,
+        catalog: &mut ReceiptCatalog,
+        key_digest: &ReceiptKeyDigest,
+        observed_at_epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<(), ReceiptLedgerError> {
+        check_deadline(deadline)?;
+        let expected =
+            catalog
+                .records
+                .get(key_digest)
+                .cloned()
+                .ok_or(ReceiptLedgerError::Corrupt(
+                    "expired receipt disappeared while the writer lock was held",
+                ))?;
+        let persisted = self
+            .read_entry_under_writer_lock(catalog, key_digest, Some(deadline))?
+            .ok_or(ReceiptLedgerError::Corrupt(
+                "catalogued expired receipt row is missing",
+            ))?;
+        if persisted != expected {
+            return latch_catalog_error(
+                catalog,
+                ReceiptLedgerError::Corrupt("catalogued expired receipt row changed on disk"),
+            );
+        }
+        match persisted.state() {
+            Ok(ReceiptState::CancelReserved(receipt))
+                if observed_at_epoch_ms >= receipt.expires_at_epoch_ms() => {}
+            Ok(ReceiptState::CancelReserved(_)) => {
+                return latch_catalog_error(
+                    catalog,
+                    ReceiptLedgerError::Corrupt("selected cancellation reservation is not expired"),
+                )
+            }
+            Ok(_) => {
+                return latch_catalog_error(
+                    catalog,
+                    ReceiptLedgerError::Corrupt(
+                        "expired cancellation candidate changed lifecycle under writer lock",
+                    ),
+                )
+            }
+            Err(error) => return latch_catalog_error(catalog, error),
+        }
+        self.expire_cancel_reserved_entry_under_writer_lock(
+            catalog,
+            persisted,
+            observed_at_epoch_ms,
+            deadline,
+        )
     }
 
     fn expire_cancel_reserved_entry_under_writer_lock(
@@ -1240,13 +1291,6 @@ impl ReceiptLedgerStore {
         check_deadline(deadline)?;
         latch_catalog_result(&mut catalog, self.verify_named_authority())?;
 
-        self.reclaim_expired_cancel_reservations_under_writer_lock(
-            &mut catalog,
-            original_cutoff.accepted_epoch_ms(),
-            Some(&key_digest),
-            deadline,
-        )?;
-
         if let Some(existing) = catalog.records.get(&key_digest) {
             if existing.record.key != key {
                 return self.reject_before_mutation(
@@ -1275,30 +1319,13 @@ impl ReceiptLedgerStore {
                 state => Ok(ReserveOutcome::ExistingExact(state)),
             };
         }
-        if catalog.invocation_index.contains_key(&key.invocation_id()) {
-            return self.reject_before_mutation(
-                &mut catalog,
-                deadline,
-                ReceiptLedgerError::InvocationIdentityMismatch,
-            );
-        }
-        if catalog
-            .reserved_task_index
-            .contains_key(&key.reserved_task_id())
-        {
-            return self.reject_before_mutation(
-                &mut catalog,
-                deadline,
-                ReceiptLedgerError::ReservedTaskIdentityMismatch,
-            );
-        }
-        if catalog.records.len() >= MAX_LIVE_RECEIPTS {
-            return self.reject_before_mutation(
-                &mut catalog,
-                deadline,
-                ReceiptLedgerError::CapacityExceeded,
-            );
-        }
+
+        self.prepare_new_admission_under_writer_lock(
+            &mut catalog,
+            &key,
+            original_cutoff.accepted_epoch_ms(),
+            deadline,
+        )?;
 
         let generation = latch_catalog_result(&mut catalog, self.generation_under_writer_lock())?;
         let mutation_sequence = match generation.checked_add(1) {
@@ -3471,6 +3498,33 @@ fn insert_catalog_entry(
     Ok(())
 }
 
+fn catalog_entry_is_expired_cancel_reserved(
+    catalog: &ReceiptCatalog,
+    digest: &ReceiptKeyDigest,
+    observed_at_epoch_ms: u64,
+) -> Result<bool, ReceiptLedgerError> {
+    let entry = catalog
+        .records
+        .get(digest)
+        .ok_or(ReceiptLedgerError::Corrupt(
+            "receipt identity index points outside the catalog",
+        ))?;
+    Ok(entry_is_expired_cancel_reserved(
+        entry,
+        observed_at_epoch_ms,
+    ))
+}
+
+fn entry_is_expired_cancel_reserved(entry: &CatalogEntry, observed_at_epoch_ms: u64) -> bool {
+    matches!(
+        &entry.record.lifecycle,
+        StoredActiveLifecycleV1::CancelReserved {
+            expires_at_epoch_ms,
+            ..
+        } if observed_at_epoch_ms >= *expires_at_epoch_ms
+    )
+}
+
 fn validate_catalog_remove(
     catalog: &ReceiptCatalog,
     expected: &CatalogEntry,
@@ -4718,7 +4772,7 @@ mod tests {
     }
 
     #[test]
-    fn submit_admission_reclaims_a_full_pool_of_expired_cancel_reservations() {
+    fn submit_admission_reclaims_one_slot_from_a_full_expired_cancel_pool() {
         let root = tempfile::tempdir().expect("temporary root");
         let receipts = fs::canonicalize(root.path())
             .expect("physical temporary root")
@@ -4735,7 +4789,7 @@ mod tests {
                 store.request_cancel_or_reserve(
                     key,
                     1_000,
-                    Instant::now() + Duration::from_secs(10),
+                    Instant::now() + Duration::from_secs(7),
                 ),
                 Ok(CancelResolution::NewlyReserved(_))
             ));
@@ -4752,23 +4806,141 @@ mod tests {
             .reserve(
                 admitted_key.clone(),
                 cutoff,
-                Instant::now() + Duration::from_secs(10),
+                Instant::now() + Duration::from_secs(7),
             )
             .expect("expired cancel reservations cannot deny later admission")
             .into_reservation()
             .expect("new submit remains reserved");
 
         assert_eq!(admitted.key(), &admitted_key);
-        assert_eq!(admitted.mutation_sequence(), 129);
+        assert_eq!(admitted.mutation_sequence(), 66);
+        assert_eq!(store.generation().expect("reclaim plus admission"), 66);
         let catalog = store.writer.lock().expect("inspect reclaimed catalog");
-        assert_eq!(catalog.records.len(), 1);
-        assert_eq!(catalog.invocation_index.len(), 1);
-        assert_eq!(catalog.reserved_task_index.len(), 1);
-        assert_eq!(catalog.actual_bytes, admitted.encoded_bytes());
+        assert_eq!(catalog.records.len(), MAX_LIVE_RECEIPTS);
+        assert_eq!(catalog.invocation_index.len(), MAX_LIVE_RECEIPTS);
+        assert_eq!(catalog.reserved_task_index.len(), MAX_LIVE_RECEIPTS);
+        assert_eq!(
+            catalog
+                .records
+                .values()
+                .filter(|entry| matches!(
+                    entry.record.lifecycle,
+                    StoredActiveLifecycleV1::CancelReserved { .. }
+                ))
+                .count(),
+            MAX_LIVE_RECEIPTS - 1
+        );
         assert_eq!(
             catalog.reserved_result_bytes,
             admitted.reserved_result_bytes()
         );
+    }
+
+    #[test]
+    fn partial_identity_rejection_does_not_reclaim_an_unrelated_expired_cancel() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("receipts");
+        let store = ReceiptLedgerStore::open(&receipts).expect("open receipt ledger");
+        let expired_key = receipt_key(INVOCATION_A, TASK_A, "expired-workspace");
+        store
+            .request_cancel_or_reserve(expired_key.clone(), 1_000, reserve_deadline())
+            .expect("seed expired cancellation reservation");
+        let live_key = receipt_key_with_ids(InvocationId::new(), TaskId::new(), "live-workspace");
+        let live_cutoff = OriginalCutoffDescriptor::new(1_000, 7_000).expect("valid live cutoff");
+        store
+            .reserve(live_key.clone(), live_cutoff, reserve_deadline())
+            .expect("seed live exact identity");
+        let mismatch = receipt_key_with_ids(
+            live_key.invocation_id(),
+            TaskId::new(),
+            "mismatching-workspace",
+        );
+
+        assert_eq!(
+            store
+                .request_cancel_or_reserve(mismatch, 8_125, reserve_deadline())
+                .expect_err("live partial identity must reject"),
+            ReceiptLedgerError::InvocationIdentityMismatch
+        );
+        assert_eq!(store.generation().expect("rejection generation"), 2);
+        assert!(matches!(
+            store
+                .recover_exact(&expired_key, reserve_deadline())
+                .expect("rejection cannot run unrelated housekeeping"),
+            ReceiptState::CancelReserved(_)
+        ));
+    }
+
+    #[test]
+    fn expired_partial_identity_is_reclaimed_before_new_admission() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("receipts");
+        let store = ReceiptLedgerStore::open(&receipts).expect("open receipt ledger");
+        let expired_key = receipt_key(INVOCATION_A, TASK_A, "expired-workspace");
+        store
+            .request_cancel_or_reserve(expired_key, 1_000, reserve_deadline())
+            .expect("seed expired cancellation reservation");
+        let admitted_key = receipt_key_with_ids(
+            InvocationId::from_str(INVOCATION_A).expect("canonical reused invocation"),
+            TaskId::new(),
+            "new-workspace",
+        );
+
+        let admitted = match store
+            .request_cancel_or_reserve(admitted_key.clone(), 8_125, reserve_deadline())
+            .expect("expired identity owner is reclaimable")
+        {
+            CancelResolution::NewlyReserved(receipt) => receipt,
+            other => panic!("reclaimed identity must admit a new receipt, got {other:?}"),
+        };
+
+        assert_eq!(admitted.key(), &admitted_key);
+        assert_eq!(admitted.mutation_sequence(), 3);
+        assert_eq!(store.generation().expect("reclaim plus admission"), 3);
+        let catalog = store
+            .writer
+            .lock()
+            .expect("inspect reused identity catalog");
+        assert_eq!(catalog.records.len(), 1);
+        assert_eq!(catalog.invocation_index.len(), 1);
+        assert_eq!(catalog.reserved_task_index.len(), 1);
+    }
+
+    #[test]
+    fn exact_reserve_winner_does_not_reclaim_an_unrelated_expired_cancel() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("receipts");
+        let store = ReceiptLedgerStore::open(&receipts).expect("open receipt ledger");
+        let expired_key = receipt_key(INVOCATION_A, TASK_A, "expired-workspace");
+        store
+            .request_cancel_or_reserve(expired_key.clone(), 1_000, reserve_deadline())
+            .expect("seed expired cancellation reservation");
+        let live_key = receipt_key_with_ids(InvocationId::new(), TaskId::new(), "live-workspace");
+        let initial_cutoff =
+            OriginalCutoffDescriptor::new(1_000, 7_000).expect("valid initial cutoff");
+        let initial = store
+            .reserve(live_key.clone(), initial_cutoff, reserve_deadline())
+            .expect("seed live exact identity");
+        let duplicate_cutoff =
+            OriginalCutoffDescriptor::new(8_125, 1).expect("irrelevant duplicate cutoff");
+
+        let duplicate = store
+            .reserve(live_key, duplicate_cutoff, reserve_deadline())
+            .expect("exact duplicate returns its original winner");
+        assert_eq!(duplicate.into_state(), initial.into_state());
+        assert_eq!(store.generation().expect("duplicate generation"), 2);
+        assert!(matches!(
+            store
+                .recover_exact(&expired_key, reserve_deadline())
+                .expect("duplicate cannot run unrelated housekeeping"),
+            ReceiptState::CancelReserved(_)
+        ));
     }
 
     #[test]

--- a/crates/unica-coder/src/infrastructure/receipt_ledger.rs
+++ b/crates/unica-coder/src/infrastructure/receipt_ledger.rs
@@ -1,11 +1,14 @@
 use crate::application::invocation_store::MAX_TASK_RECORD_ENVELOPE_BYTES;
 use crate::application::receipt_ledger::{
-    receipt_key_digest, CancelExpiryOutcome, CancelReservedReceipt, CancelResolution,
-    CommittedDirectPublication, DirectTerminalUnackedReceipt, OriginalCutoffDescriptor, ReceiptKey,
-    ReceiptKeyDigest, ReceiptLedgerError, ReceiptLedgerPort, ReceiptRecordHeader, ReceiptState,
-    ReceiptTerminalOutcome, ReceiptVersion, ReserveOutcome, ReservedPhase, ReservedReceipt,
-    V5CanonicalTerminal, CANCEL_RESERVATION_TTL_MS, DIRECT_TERMINAL_RETENTION_MS,
-    MAX_LIVE_RECEIPTS, MAX_LIVE_RECEIPT_BYTES, MAX_RECEIPT_ENTITLEMENT_BYTES,
+    receipt_key_digest, AcknowledgedTombstoneReceipt, CancelExpiryOutcome, CancelReservedReceipt,
+    CancelResolution, CommittedDirectPublication, DirectTerminalUnackedReceipt,
+    OriginalCutoffDescriptor, ReceiptKey, ReceiptKeyDigest, ReceiptLedgerError, ReceiptLedgerPort,
+    ReceiptRecordHeader, ReceiptState, ReceiptTerminalOutcome, ReceiptVersion, ReserveOutcome,
+    ReservedPhase, ReservedReceipt, TerminalDigest, V5CanonicalTerminal,
+    ACKNOWLEDGED_TOMBSTONE_TTL_MS, CANCEL_RESERVATION_TTL_MS, DIRECT_TERMINAL_RETENTION_MS,
+    MAX_ACKNOWLEDGED_TOMBSTONES, MAX_ACKNOWLEDGED_TOMBSTONE_BYTES,
+    MAX_ACKNOWLEDGED_TOMBSTONE_POOL_BYTES, MAX_LIVE_RECEIPTS, MAX_LIVE_RECEIPT_BYTES,
+    MAX_RECEIPT_ENTITLEMENT_BYTES,
 };
 #[cfg(feature = "receipt-ledger-test-support")]
 use crate::application::receipt_ledger::{
@@ -41,8 +44,9 @@ const LEDGER_LOCK_FILE_NAME: &str = ".receipt-ledger.lock";
 const MAX_GENERATION_FILE_BYTES: usize = 32;
 const RECEIPT_RECORD_SCHEMA_VERSION: u32 = 1;
 const MAX_CANCEL_RESERVED_RECORD_BYTES: u64 = 1_024;
-const MAX_ACTIVE_DIRECTORY_ENTRIES: usize = MAX_LIVE_RECEIPTS * 2;
-const MAX_GENERATION_STAGING_ENTRIES: usize = MAX_LIVE_RECEIPTS;
+const MAX_RETAINED_RECEIPT_ROWS: usize = MAX_LIVE_RECEIPTS + MAX_ACKNOWLEDGED_TOMBSTONES;
+const MAX_ACTIVE_DIRECTORY_ENTRIES: usize = MAX_RETAINED_RECEIPT_ROWS * 2;
+const MAX_GENERATION_STAGING_ENTRIES: usize = MAX_RETAINED_RECEIPT_ROWS;
 const MAX_RECEIPT_ROOT_DIRECTORY_ENTRIES: usize = MAX_GENERATION_STAGING_ENTRIES + 3;
 const DEFAULT_RECEIPT_RECOVERY_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -165,6 +169,14 @@ struct StoredActiveReceiptV1 {
     lifecycle: StoredActiveLifecycleV1,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct StoredAcknowledgedTombstoneV1 {
+    key: ReceiptKey,
+    terminal_digest: TerminalDigest,
+    ack_epoch_ms: u64,
+}
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(
     tag = "state",
@@ -185,6 +197,11 @@ enum StoredActiveLifecycleV1 {
         prior_cancel_reserved_at_epoch_ms: u64,
         prior_expires_at_epoch_ms: u64,
     },
+    ExpiredTombstoneDeletion {
+        observed_at_epoch_ms: u64,
+        prior_acknowledged_at_epoch_ms: u64,
+        prior_terminal_digest: TerminalDigest,
+    },
     ReservedUnbound {
         reserved_at_epoch_ms: u64,
         original_cutoff: OriginalCutoffDescriptor,
@@ -195,6 +212,10 @@ enum StoredActiveLifecycleV1 {
         terminal_epoch_ms: u64,
         terminal_digest: crate::application::receipt_ledger::TerminalDigest,
         terminal: Arc<ReceiptTerminalOutcome>,
+    },
+    AcknowledgedTombstone {
+        terminal_digest: TerminalDigest,
+        acknowledged_at_epoch_ms: u64,
     },
 }
 
@@ -218,13 +239,38 @@ impl CatalogEntry {
     fn reserved_result_bytes(&self) -> u64 {
         match &self.record.lifecycle {
             StoredActiveLifecycleV1::CancelReserved { .. }
-            | StoredActiveLifecycleV1::ExpiredDeletion { .. } => 0,
+            | StoredActiveLifecycleV1::ExpiredDeletion { .. }
+            | StoredActiveLifecycleV1::ExpiredTombstoneDeletion { .. }
+            | StoredActiveLifecycleV1::AcknowledgedTombstone { .. } => 0,
             StoredActiveLifecycleV1::ReservedUnbound { .. }
             | StoredActiveLifecycleV1::DirectTerminalUnacked { .. } => {
                 MAX_RECEIPT_ENTITLEMENT_BYTES
                     .checked_sub(self.encoded_bytes)
                     .expect("validated receipt record fits its exact byte entitlement")
             }
+        }
+    }
+
+    fn is_tombstone(&self) -> bool {
+        matches!(
+            &self.record.lifecycle,
+            StoredActiveLifecycleV1::AcknowledgedTombstone { .. }
+        )
+    }
+
+    fn live_actual_bytes(&self) -> u64 {
+        if self.is_tombstone() {
+            0
+        } else {
+            self.encoded_bytes
+        }
+    }
+
+    fn tombstone_bytes(&self) -> u64 {
+        if self.is_tombstone() {
+            self.encoded_bytes
+        } else {
+            0
         }
     }
 
@@ -250,9 +296,10 @@ impl CatalogEntry {
                 }
                 Ok(ReceiptState::CancelReserved(receipt))
             }
-            StoredActiveLifecycleV1::ExpiredDeletion { .. } => Err(ReceiptLedgerError::Corrupt(
-                "expired deletion witness is not a live receipt state",
-            )),
+            StoredActiveLifecycleV1::ExpiredDeletion { .. }
+            | StoredActiveLifecycleV1::ExpiredTombstoneDeletion { .. } => Err(
+                ReceiptLedgerError::Corrupt("expired deletion witness is not a live receipt state"),
+            ),
             StoredActiveLifecycleV1::ReservedUnbound {
                 reserved_at_epoch_ms,
                 original_cutoff,
@@ -283,13 +330,30 @@ impl CatalogEntry {
                     ),
                 ))
             }
+            StoredActiveLifecycleV1::AcknowledgedTombstone {
+                terminal_digest,
+                acknowledged_at_epoch_ms,
+            } => Ok(ReceiptState::AcknowledgedTombstone(
+                AcknowledgedTombstoneReceipt::new(
+                    self.record.key.clone(),
+                    self.record.key_digest.clone(),
+                    terminal_digest.clone(),
+                    *acknowledged_at_epoch_ms,
+                    self.encoded_bytes,
+                )
+                .map_err(|_| {
+                    ReceiptLedgerError::Corrupt("acknowledged tombstone expiry exceeds u64")
+                })?,
+            )),
         }
     }
 
     fn reservation(&self) -> Result<ReservedReceipt, ReceiptLedgerError> {
         match self.state()? {
             ReceiptState::Reserved(reservation) => Ok(reservation),
-            ReceiptState::CancelReserved(_) | ReceiptState::DirectTerminalUnacked(_) => {
+            ReceiptState::CancelReserved(_)
+            | ReceiptState::DirectTerminalUnacked(_)
+            | ReceiptState::AcknowledgedTombstone(_) => {
                 Err(ReceiptLedgerError::ReceiptRowPresentUnsupported)
             }
             _ => unreachable!("active receipt codec currently has three variants"),
@@ -300,6 +364,7 @@ impl CatalogEntry {
         matches!(
             &self.record.lifecycle,
             StoredActiveLifecycleV1::ExpiredDeletion { .. }
+                | StoredActiveLifecycleV1::ExpiredTombstoneDeletion { .. }
         )
     }
 }
@@ -321,7 +386,24 @@ struct ReceiptCatalog {
     reserved_task_index: HashMap<TaskId, ReceiptKeyDigest>,
     actual_bytes: u64,
     reserved_result_bytes: u64,
+    tombstone_bytes: u64,
     unavailable: bool,
+}
+
+impl ReceiptCatalog {
+    fn live_count(&self) -> usize {
+        self.records
+            .values()
+            .filter(|entry| !entry.is_tombstone())
+            .count()
+    }
+
+    fn tombstone_count(&self) -> usize {
+        self.records
+            .values()
+            .filter(|entry| entry.is_tombstone())
+            .count()
+    }
 }
 
 #[cfg(feature = "receipt-ledger-test-support")]
@@ -718,8 +800,19 @@ impl ReceiptLedgerStore {
                 records.sort_unstable_by(|(left, _), (right, _)| left.as_str().cmp(right.as_str()));
                 let keys = records
                     .iter()
+                    .filter(|(_, entry)| !entry.is_tombstone())
                     .map(|(_, entry)| entry.record.key.clone())
                     .collect::<Vec<_>>();
+                let tombstones = records
+                    .iter()
+                    .filter(|(_, entry)| entry.is_tombstone())
+                    .map(|(_, entry)| match entry.state()? {
+                        ReceiptState::AcknowledgedTombstone(receipt) => Ok(receipt),
+                        _ => Err(ReceiptLedgerError::Corrupt(
+                            "tombstone catalog entry decoded as a live receipt",
+                        )),
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
 
                 let mut invocation_index = Vec::with_capacity(catalog.invocation_index.len());
                 for (invocation_id, key_digest) in &catalog.invocation_index {
@@ -760,24 +853,28 @@ impl ReceiptLedgerStore {
                 Ok((
                     generation,
                     keys,
+                    tombstones,
                     invocation_index,
                     reserved_task_index,
-                    u64::try_from(catalog.records.len()).map_err(|_| {
+                    u64::try_from(catalog.live_count()).map_err(|_| {
                         ReceiptLedgerError::Corrupt("receipt catalog count does not fit telemetry")
                     })?,
                     catalog.actual_bytes,
                     catalog.reserved_result_bytes,
+                    catalog.tombstone_bytes,
                 ))
             },
         )?;
         let (
             generation,
             keys,
+            tombstones,
             invocation_index,
             reserved_task_index,
             live_count,
             actual_bytes,
             reserved_result_bytes,
+            tombstone_bytes,
         ) = match observed {
             Ok(observed) => observed,
             Err(error) => return latch_catalog_error(&mut catalog, error),
@@ -785,11 +882,13 @@ impl ReceiptLedgerStore {
         let snapshot = authority.seal(ReceiptLedgerCatalogSnapshotParts::new(
             generation,
             keys,
+            tombstones,
             invocation_index,
             reserved_task_index,
             live_count,
             actual_bytes,
             reserved_result_bytes,
+            tombstone_bytes,
         ));
         latch_catalog_result(&mut catalog, snapshot)
     }
@@ -1064,7 +1163,7 @@ impl ReceiptLedgerStore {
     ) -> Result<(), ReceiptLedgerError> {
         let mut reclaim = Vec::with_capacity(2);
         if let Some(digest) = catalog.invocation_index.get(&key.invocation_id()).cloned() {
-            let expired = match catalog_entry_is_expired_cancel_reserved(
+            let expired = match catalog_entry_is_expired_identity_reclaimable(
                 catalog,
                 &digest,
                 observed_at_epoch_ms,
@@ -1086,7 +1185,7 @@ impl ReceiptLedgerStore {
             .get(&key.reserved_task_id())
             .cloned()
         {
-            let expired = match catalog_entry_is_expired_cancel_reserved(
+            let expired = match catalog_entry_is_expired_identity_reclaimable(
                 catalog,
                 &digest,
                 observed_at_epoch_ms,
@@ -1106,11 +1205,19 @@ impl ReceiptLedgerStore {
         reclaim.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
         reclaim.dedup();
 
+        let reclaimed_live = reclaim
+            .iter()
+            .filter(|digest| {
+                catalog
+                    .records
+                    .get(*digest)
+                    .is_some_and(|entry| !entry.is_tombstone())
+            })
+            .count();
         let projected_count =
             catalog
-                .records
-                .len()
-                .checked_sub(reclaim.len())
+                .live_count()
+                .checked_sub(reclaimed_live)
                 .ok_or(ReceiptLedgerError::Corrupt(
                     "receipt reclamation exceeds the live catalog",
                 ))?;
@@ -1134,12 +1241,42 @@ impl ReceiptLedgerStore {
         }
 
         for digest in reclaim {
-            self.reclaim_expired_cancel_reservation_under_writer_lock(
-                catalog,
-                &digest,
-                observed_at_epoch_ms,
-                deadline,
-            )?;
+            match catalog
+                .records
+                .get(&digest)
+                .map(|entry| &entry.record.lifecycle)
+            {
+                Some(StoredActiveLifecycleV1::CancelReserved { .. }) => {
+                    self.reclaim_expired_cancel_reservation_under_writer_lock(
+                        catalog,
+                        &digest,
+                        observed_at_epoch_ms,
+                        deadline,
+                    )?;
+                }
+                Some(StoredActiveLifecycleV1::AcknowledgedTombstone { .. }) => {
+                    self.reclaim_expired_tombstone_under_writer_lock(
+                        catalog,
+                        &digest,
+                        observed_at_epoch_ms,
+                        deadline,
+                    )?;
+                }
+                Some(_) => {
+                    return latch_catalog_error(
+                        catalog,
+                        ReceiptLedgerError::Corrupt(
+                            "identity reclamation candidate changed lifecycle",
+                        ),
+                    )
+                }
+                None => {
+                    return latch_catalog_error(
+                        catalog,
+                        ReceiptLedgerError::Corrupt("identity reclamation candidate disappeared"),
+                    )
+                }
+            }
         }
         Ok(())
     }
@@ -1308,16 +1445,28 @@ impl ReceiptLedgerStore {
                 Ok(state) => state,
                 Err(error) => return latch_catalog_error(&mut catalog, error),
             };
-            return match state {
-                ReceiptState::CancelReserved(_) => self.convert_cancel_reserved_to_submit(
-                    &mut catalog,
-                    persisted,
-                    key,
-                    original_cutoff,
-                    deadline,
-                ),
-                state => Ok(ReserveOutcome::ExistingExact(state)),
-            };
+            match state {
+                ReceiptState::CancelReserved(_) => {
+                    return self.convert_cancel_reserved_to_submit(
+                        &mut catalog,
+                        persisted,
+                        key,
+                        original_cutoff,
+                        deadline,
+                    )
+                }
+                ReceiptState::AcknowledgedTombstone(receipt)
+                    if original_cutoff.accepted_epoch_ms() >= receipt.expires_at_epoch_ms() =>
+                {
+                    self.reclaim_expired_tombstone_under_writer_lock(
+                        &mut catalog,
+                        &key_digest,
+                        original_cutoff.accepted_epoch_ms(),
+                        deadline,
+                    )?;
+                }
+                state => return Ok(ReserveOutcome::ExistingExact(state)),
+            }
         }
 
         self.prepare_new_admission_under_writer_lock(
@@ -1836,6 +1985,316 @@ impl ReceiptLedgerStore {
         .map(|publication| publication.into_parts().0)
     }
 
+    pub(crate) fn acknowledge_direct(
+        &self,
+        key: &ReceiptKey,
+        terminal_digest: &TerminalDigest,
+        acknowledged_at_epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<AcknowledgedTombstoneReceipt, ReceiptLedgerError> {
+        check_deadline(deadline)?;
+        acknowledged_at_epoch_ms
+            .checked_add(ACKNOWLEDGED_TOMBSTONE_TTL_MS)
+            .ok_or(ReceiptLedgerError::TimestampOverflow)?;
+        let key_digest = receipt_key_digest(key);
+        let mut catalog = self
+            .writer
+            .lock()
+            .map_err(|_| ReceiptLedgerError::Corrupt("receipt catalog lock was poisoned"))?;
+        let classified =
+            self.inspect_catalog_under_stable_fence(&mut catalog, Some(deadline), |catalog| {
+                if let Some(existing) = catalog.records.get(&key_digest) {
+                    if &existing.record.key != key {
+                        return Err(ReceiptLedgerError::ReceiptDigestCollision);
+                    }
+                    return Ok(existing.clone());
+                }
+                if catalog.invocation_index.contains_key(&key.invocation_id()) {
+                    return Err(ReceiptLedgerError::InvocationIdentityMismatch);
+                }
+                if catalog
+                    .reserved_task_index
+                    .contains_key(&key.reserved_task_id())
+                {
+                    return Err(ReceiptLedgerError::ReservedTaskIdentityMismatch);
+                }
+                Err(ReceiptLedgerError::ReceiptNotFound)
+            })?;
+        let expected = match classified {
+            Ok(existing) => existing,
+            Err(error) if error.requires_reopen() => {
+                return latch_catalog_error(&mut catalog, error)
+            }
+            Err(error) => return Err(error),
+        };
+        let persisted =
+            match self.read_entry_under_writer_lock(&mut catalog, &key_digest, Some(deadline))? {
+                Some(persisted) if persisted == expected => persisted,
+                Some(_) => {
+                    return latch_catalog_error(
+                        &mut catalog,
+                        ReceiptLedgerError::Corrupt("catalogued receipt row changed on disk"),
+                    )
+                }
+                None => {
+                    return latch_catalog_error(
+                        &mut catalog,
+                        ReceiptLedgerError::Corrupt("catalogued receipt row is missing"),
+                    )
+                }
+            };
+        match persisted.state() {
+            Ok(ReceiptState::AcknowledgedTombstone(tombstone)) => {
+                if tombstone.terminal_digest() == terminal_digest {
+                    return Ok(tombstone);
+                }
+                return self.reject_before_mutation(
+                    &mut catalog,
+                    deadline,
+                    ReceiptLedgerError::TerminalMismatch,
+                );
+            }
+            Ok(ReceiptState::DirectTerminalUnacked(receipt)) => {
+                if receipt.terminal().digest() != terminal_digest {
+                    return self.reject_before_mutation(
+                        &mut catalog,
+                        deadline,
+                        ReceiptLedgerError::TerminalMismatch,
+                    );
+                }
+            }
+            Ok(_) => {
+                return self.reject_before_mutation(
+                    &mut catalog,
+                    deadline,
+                    ReceiptLedgerError::ReceiptRowPresentUnsupported,
+                )
+            }
+            Err(error) => return latch_catalog_error(&mut catalog, error),
+        }
+
+        // Reclamation is part of successful ACK-capacity preflight only.
+        // Premature or digest-mismatched ACK must remain reject-before-mutation,
+        // including with unrelated expired tombstones in the pool.
+        self.reclaim_expired_tombstones_under_writer_lock(
+            &mut catalog,
+            acknowledged_at_epoch_ms,
+            deadline,
+        )?;
+
+        let generation = latch_catalog_result(&mut catalog, self.generation_under_writer_lock())?;
+        let mutation_sequence = generation
+            .checked_add(1)
+            .ok_or(ReceiptLedgerError::Corrupt(
+                "receipt generation exhausted u64",
+            ))?;
+        let record = StoredActiveReceiptV1 {
+            schema_version: RECEIPT_RECORD_SCHEMA_VERSION,
+            // Compact tombstones persist only exact key, terminal digest and
+            // first-ACK epoch. The generation file remains the mutation fence.
+            mutation_sequence: 0,
+            record_version: ReceiptVersion::new(3)
+                .expect("compact tombstone marker version is nonzero"),
+            key: key.clone(),
+            key_digest: key_digest.clone(),
+            lifecycle: StoredActiveLifecycleV1::AcknowledgedTombstone {
+                terminal_digest: terminal_digest.clone(),
+                acknowledged_at_epoch_ms,
+            },
+        };
+        let (record, encoded) =
+            serialize_reserved_record(record, MAX_ACKNOWLEDGED_TOMBSTONE_BYTES)?;
+        let encoded_bytes =
+            u64::try_from(encoded.len()).map_err(|_| ReceiptLedgerError::RecordTooLarge)?;
+        let replacement = CatalogEntry {
+            record: record.clone(),
+            encoded_bytes,
+        };
+        if let Err(error) = validate_catalog_replace(&catalog, &persisted, &replacement) {
+            return self.reject_before_mutation(&mut catalog, deadline, error);
+        }
+        if let Err(error) = self.publish_replacement_record(&record, &encoded, deadline, || {
+            commit_catalog_replace(&mut catalog, replacement);
+        }) {
+            if !matches!(error, ReceiptLedgerError::DeadlineExceeded) {
+                catalog.unavailable = true;
+            }
+            return Err(error);
+        }
+        if let Err(error) =
+            self.publish_generation(mutation_sequence, Some(&key_digest), Some(deadline))
+        {
+            catalog.unavailable = true;
+            return Err(error);
+        }
+        match self.read_active_record_bytes(&key_digest) {
+            Ok(Some(committed)) if committed == encoded => {}
+            Ok(Some(_)) | Ok(None) | Err(_) => {
+                catalog.unavailable = true;
+                return Err(ReceiptLedgerError::CommitUncertain {
+                    receipt_key_digest: key_digest,
+                });
+            }
+        }
+        if check_deadline(deadline).is_err() || self.verify_named_authority().is_err() {
+            catalog.unavailable = true;
+            return Err(ReceiptLedgerError::CommitUncertain {
+                receipt_key_digest: key_digest,
+            });
+        }
+        AcknowledgedTombstoneReceipt::new(
+            key.clone(),
+            receipt_key_digest(key),
+            terminal_digest.clone(),
+            acknowledged_at_epoch_ms,
+            encoded_bytes,
+        )
+    }
+
+    pub(crate) fn reclaim_expired_tombstones(
+        &self,
+        observed_at_epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<usize, ReceiptLedgerError> {
+        check_deadline(deadline)?;
+        let mut catalog = self
+            .writer
+            .lock()
+            .map_err(|_| ReceiptLedgerError::Corrupt("receipt catalog lock was poisoned"))?;
+        if catalog.unavailable {
+            return Err(ReceiptLedgerError::StoreUnavailable);
+        }
+        latch_catalog_result(&mut catalog, self.verify_named_authority())?;
+        self.reclaim_expired_tombstones_under_writer_lock(
+            &mut catalog,
+            observed_at_epoch_ms,
+            deadline,
+        )
+    }
+
+    fn reclaim_expired_tombstones_under_writer_lock(
+        &self,
+        catalog: &mut ReceiptCatalog,
+        observed_at_epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<usize, ReceiptLedgerError> {
+        let mut expired = catalog
+            .records
+            .iter()
+            .filter_map(|(digest, entry)| match &entry.record.lifecycle {
+                StoredActiveLifecycleV1::AcknowledgedTombstone {
+                    acknowledged_at_epoch_ms,
+                    ..
+                } if acknowledged_at_epoch_ms
+                    .checked_add(ACKNOWLEDGED_TOMBSTONE_TTL_MS)
+                    .is_some_and(|expires| observed_at_epoch_ms >= expires) =>
+                {
+                    Some(digest.clone())
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        expired.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+        for digest in &expired {
+            self.reclaim_expired_tombstone_under_writer_lock(
+                catalog,
+                digest,
+                observed_at_epoch_ms,
+                deadline,
+            )?;
+        }
+        Ok(expired.len())
+    }
+
+    fn reclaim_expired_tombstone_under_writer_lock(
+        &self,
+        catalog: &mut ReceiptCatalog,
+        key_digest: &ReceiptKeyDigest,
+        observed_at_epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<(), ReceiptLedgerError> {
+        check_deadline(deadline)?;
+        let expected =
+            catalog
+                .records
+                .get(key_digest)
+                .cloned()
+                .ok_or(ReceiptLedgerError::Corrupt(
+                    "expired tombstone disappeared while the writer lock was held",
+                ))?;
+        let persisted = self
+            .read_entry_under_writer_lock(catalog, key_digest, Some(deadline))?
+            .ok_or(ReceiptLedgerError::Corrupt(
+                "catalogued expired tombstone row is missing",
+            ))?;
+        if persisted != expected {
+            return latch_catalog_error(
+                catalog,
+                ReceiptLedgerError::Corrupt("catalogued expired tombstone changed on disk"),
+            );
+        }
+        let expires_at_epoch_ms = match persisted.state() {
+            Ok(ReceiptState::AcknowledgedTombstone(receipt)) => receipt.expires_at_epoch_ms(),
+            Ok(_) => {
+                return latch_catalog_error(
+                    catalog,
+                    ReceiptLedgerError::Corrupt(
+                        "expired tombstone candidate changed lifecycle under writer lock",
+                    ),
+                )
+            }
+            Err(error) => return latch_catalog_error(catalog, error),
+        };
+        if observed_at_epoch_ms < expires_at_epoch_ms {
+            return latch_catalog_error(
+                catalog,
+                ReceiptLedgerError::Corrupt("selected acknowledged tombstone is not expired"),
+            );
+        }
+
+        let generation = latch_catalog_result(catalog, self.generation_under_writer_lock())?;
+        let mutation_sequence = generation
+            .checked_add(1)
+            .ok_or(ReceiptLedgerError::Corrupt(
+                "receipt generation exhausted u64",
+            ))?;
+        let record = build_expired_tombstone_deletion_record(
+            &persisted,
+            observed_at_epoch_ms,
+            mutation_sequence,
+        )?;
+        let (record, encoded) =
+            serialize_reserved_record(record, MAX_CANCEL_RESERVED_RECORD_BYTES)?;
+        if let Err(error) = validate_catalog_remove(catalog, &persisted) {
+            return latch_catalog_error(catalog, error);
+        }
+        if let Err(error) = self.publish_replacement_record(&record, &encoded, deadline, || {
+            commit_catalog_remove(catalog, &persisted);
+        }) {
+            if !matches!(error, ReceiptLedgerError::DeadlineExceeded) {
+                catalog.unavailable = true;
+            }
+            return Err(error);
+        }
+        if let Err(error) =
+            self.publish_generation(mutation_sequence, Some(key_digest), Some(deadline))
+        {
+            catalog.unavailable = true;
+            return Err(error);
+        }
+        if let Err(error) = self.remove_expired_deletion_witness(key_digest, &encoded, deadline) {
+            catalog.unavailable = true;
+            return Err(error);
+        }
+        if check_deadline(deadline).is_err() || self.verify_named_authority().is_err() {
+            catalog.unavailable = true;
+            return Err(ReceiptLedgerError::CommitUncertain {
+                receipt_key_digest: key_digest.clone(),
+            });
+        }
+        Ok(())
+    }
+
     fn reject_before_mutation<T>(
         &self,
         catalog: &mut ReceiptCatalog,
@@ -2081,13 +2540,15 @@ impl ReceiptLedgerStore {
                     "receipt catalog contains a duplicate reserved task id",
                 ));
             }
-            if !mutation_sequences.insert(entry.record.mutation_sequence) {
-                return Err(ReceiptLedgerError::Corrupt(
-                    "receipt recovery contains a duplicate mutation sequence",
-                ));
+            if !entry.is_tombstone() {
+                if !mutation_sequences.insert(entry.record.mutation_sequence) {
+                    return Err(ReceiptLedgerError::Corrupt(
+                        "receipt recovery contains a duplicate mutation sequence",
+                    ));
+                }
+                maximum_mutation_sequence =
+                    maximum_mutation_sequence.max(entry.record.mutation_sequence);
             }
-            maximum_mutation_sequence =
-                maximum_mutation_sequence.max(entry.record.mutation_sequence);
             if entry.is_expired_deletion() {
                 if expired_deletion_mutation_sequence
                     .replace(entry.record.mutation_sequence)
@@ -2755,6 +3216,30 @@ impl ReceiptLedgerPort for ReceiptLedgerStore {
         )
     }
 
+    fn acknowledge_direct(
+        &mut self,
+        key: &ReceiptKey,
+        terminal_digest: &TerminalDigest,
+        acknowledged_at_epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<AcknowledgedTombstoneReceipt, ReceiptLedgerError> {
+        ReceiptLedgerStore::acknowledge_direct(
+            self,
+            key,
+            terminal_digest,
+            acknowledged_at_epoch_ms,
+            deadline,
+        )
+    }
+
+    fn reclaim_expired_tombstones(
+        &mut self,
+        observed_at_epoch_ms: u64,
+        deadline: Instant,
+    ) -> Result<usize, ReceiptLedgerError> {
+        ReceiptLedgerStore::reclaim_expired_tombstones(self, observed_at_epoch_ms, deadline)
+    }
+
     fn recover(
         &mut self,
         key: &ReceiptKey,
@@ -2809,14 +3294,35 @@ fn read_active_record_from_retained(
     receipt_key_digest: &ReceiptKeyDigest,
 ) -> Result<CatalogEntry, ReceiptLedgerError> {
     let bytes = read_active_record_bytes_from_retained(file)?;
-    let record: StoredActiveReceiptV1 = serde_json::from_slice(&bytes)
-        .map_err(|_| ReceiptLedgerError::Corrupt("receipt row is not strict schema-v1 JSON"))?;
+    let record: StoredActiveReceiptV1 = match serde_json::from_slice(&bytes) {
+        Ok(record) => record,
+        Err(_) => {
+            let tombstone: StoredAcknowledgedTombstoneV1 =
+                serde_json::from_slice(&bytes).map_err(|_| {
+                    ReceiptLedgerError::Corrupt("receipt row is not a strict supported JSON record")
+                })?;
+            StoredActiveReceiptV1 {
+                schema_version: RECEIPT_RECORD_SCHEMA_VERSION,
+                mutation_sequence: 0,
+                record_version: ReceiptVersion::new(3)
+                    .expect("tombstone marker version is nonzero"),
+                key_digest: crate::application::receipt_ledger::receipt_key_digest(&tombstone.key),
+                key: tombstone.key,
+                lifecycle: StoredActiveLifecycleV1::AcknowledgedTombstone {
+                    terminal_digest: tombstone.terminal_digest,
+                    acknowledged_at_epoch_ms: tombstone.ack_epoch_ms,
+                },
+            }
+        }
+    };
     validate_active_record(&record, &bytes, receipt_key_digest)?;
     if matches!(
         &record.lifecycle,
         StoredActiveLifecycleV1::CancelReserved { .. }
             | StoredActiveLifecycleV1::ExpiredDeletion { .. }
+            | StoredActiveLifecycleV1::ExpiredTombstoneDeletion { .. }
             | StoredActiveLifecycleV1::ReservedUnbound { .. }
+            | StoredActiveLifecycleV1::AcknowledgedTombstone { .. }
     ) {
         validate_persisted_reserved_record_bytes(&record, &bytes)?;
     }
@@ -3144,6 +3650,37 @@ fn build_expired_deletion_record(
     })
 }
 
+fn build_expired_tombstone_deletion_record(
+    expected: &CatalogEntry,
+    observed_at_epoch_ms: u64,
+    mutation_sequence: u64,
+) -> Result<StoredActiveReceiptV1, ReceiptLedgerError> {
+    let (prior_acknowledged_at_epoch_ms, prior_terminal_digest) = match &expected.record.lifecycle {
+        StoredActiveLifecycleV1::AcknowledgedTombstone {
+            terminal_digest,
+            acknowledged_at_epoch_ms,
+        } => (*acknowledged_at_epoch_ms, terminal_digest.clone()),
+        _ => {
+            return Err(ReceiptLedgerError::Corrupt(
+                "expired tombstone deletion witness requires an acknowledged predecessor",
+            ))
+        }
+    };
+    Ok(StoredActiveReceiptV1 {
+        schema_version: RECEIPT_RECORD_SCHEMA_VERSION,
+        mutation_sequence,
+        record_version: ReceiptVersion::new(4)
+            .expect("expired tombstone witness version is nonzero"),
+        key: expected.record.key.clone(),
+        key_digest: expected.record.key_digest.clone(),
+        lifecycle: StoredActiveLifecycleV1::ExpiredTombstoneDeletion {
+            observed_at_epoch_ms,
+            prior_acknowledged_at_epoch_ms,
+            prior_terminal_digest,
+        },
+    })
+}
+
 /// Sole serializer for active non-terminal receipt records.
 ///
 /// Direct terminal bytes are owned by `terminal_codec_v5`; accepting one here
@@ -3160,8 +3697,18 @@ fn serialize_reserved_record(
             "Direct terminal rows must use the sole v5 terminal codec",
         ));
     }
-    let encoded = serde_json::to_vec(&record)
-        .map_err(|_| ReceiptLedgerError::Corrupt("receipt row serialization failed"))?;
+    let encoded = match &record.lifecycle {
+        StoredActiveLifecycleV1::AcknowledgedTombstone {
+            terminal_digest,
+            acknowledged_at_epoch_ms,
+        } => serde_json::to_vec(&StoredAcknowledgedTombstoneV1 {
+            key: record.key.clone(),
+            terminal_digest: terminal_digest.clone(),
+            ack_epoch_ms: *acknowledged_at_epoch_ms,
+        }),
+        _ => serde_json::to_vec(&record),
+    }
+    .map_err(|_| ReceiptLedgerError::Corrupt("receipt row serialization failed"))?;
     let encoded_bytes =
         u64::try_from(encoded.len()).map_err(|_| ReceiptLedgerError::RecordTooLarge)?;
     if encoded_bytes > maximum_encoded_bytes || encoded_bytes > MAX_RECEIPT_ENTITLEMENT_BYTES {
@@ -3176,8 +3723,12 @@ fn validate_persisted_reserved_record_bytes(
 ) -> Result<(), ReceiptLedgerError> {
     let maximum_encoded_bytes = match &record.lifecycle {
         StoredActiveLifecycleV1::CancelReserved { .. }
-        | StoredActiveLifecycleV1::ExpiredDeletion { .. } => MAX_CANCEL_RESERVED_RECORD_BYTES,
+        | StoredActiveLifecycleV1::ExpiredDeletion { .. }
+        | StoredActiveLifecycleV1::ExpiredTombstoneDeletion { .. } => {
+            MAX_CANCEL_RESERVED_RECORD_BYTES
+        }
         StoredActiveLifecycleV1::ReservedUnbound { .. } => MAX_TASK_RECORD_ENVELOPE_BYTES as u64,
+        StoredActiveLifecycleV1::AcknowledgedTombstone { .. } => MAX_ACKNOWLEDGED_TOMBSTONE_BYTES,
         StoredActiveLifecycleV1::DirectTerminalUnacked { .. } => {
             return Err(ReceiptLedgerError::Corrupt(
                 "non-terminal receipt validator received a Direct terminal lifecycle",
@@ -3275,7 +3826,12 @@ fn validate_active_record(
             "receipt row schema version is unsupported",
         ));
     }
-    if record.mutation_sequence == 0 {
+    if record.mutation_sequence == 0
+        && !matches!(
+            &record.lifecycle,
+            StoredActiveLifecycleV1::AcknowledgedTombstone { .. }
+        )
+    {
         return Err(ReceiptLedgerError::Corrupt(
             "receipt mutation sequence must be positive",
         ));
@@ -3351,6 +3907,28 @@ fn validate_active_record(
             }
             MAX_CANCEL_RESERVED_RECORD_BYTES
         }
+        StoredActiveLifecycleV1::ExpiredTombstoneDeletion {
+            observed_at_epoch_ms,
+            prior_acknowledged_at_epoch_ms,
+            ..
+        } => {
+            if record.record_version.get() != 4 {
+                return Err(ReceiptLedgerError::Corrupt(
+                    "expired tombstone deletion witness has an invalid record version",
+                ));
+            }
+            let expires_at_epoch_ms = prior_acknowledged_at_epoch_ms
+                .checked_add(ACKNOWLEDGED_TOMBSTONE_TTL_MS)
+                .ok_or(ReceiptLedgerError::Corrupt(
+                    "expired tombstone deletion witness expiry exceeds u64",
+                ))?;
+            if *observed_at_epoch_ms < expires_at_epoch_ms {
+                return Err(ReceiptLedgerError::Corrupt(
+                    "expired tombstone deletion witness predates the absolute expiry boundary",
+                ));
+            }
+            MAX_CANCEL_RESERVED_RECORD_BYTES
+        }
         StoredActiveLifecycleV1::ReservedUnbound {
             reserved_at_epoch_ms,
             original_cutoff,
@@ -3393,6 +3971,22 @@ fn validate_active_record(
             )?;
             MAX_RECEIPT_ENTITLEMENT_BYTES
         }
+        StoredActiveLifecycleV1::AcknowledgedTombstone {
+            acknowledged_at_epoch_ms,
+            ..
+        } => {
+            if record.record_version.get() < 3 {
+                return Err(ReceiptLedgerError::Corrupt(
+                    "acknowledged tombstone must follow a direct terminal record",
+                ));
+            }
+            acknowledged_at_epoch_ms
+                .checked_add(ACKNOWLEDGED_TOMBSTONE_TTL_MS)
+                .ok_or(ReceiptLedgerError::Corrupt(
+                    "acknowledged tombstone expiry exceeds u64",
+                ))?;
+            MAX_ACKNOWLEDGED_TOMBSTONE_BYTES
+        }
     };
     if u64::try_from(encoded.len()).map_or(true, |length| length > per_record_limit) {
         return Err(ReceiptLedgerError::Corrupt(
@@ -3407,11 +4001,18 @@ fn validate_catalog_insert(
     entry: &CatalogEntry,
     recovering: bool,
 ) -> Result<(), ReceiptLedgerError> {
-    if catalog.records.len() >= MAX_LIVE_RECEIPTS {
+    if !entry.is_tombstone() && catalog.live_count() >= MAX_LIVE_RECEIPTS {
         return Err(if recovering {
             ReceiptLedgerError::Corrupt("receipt catalog exceeds the live-record limit")
         } else {
             ReceiptLedgerError::CapacityExceeded
+        });
+    }
+    if entry.is_tombstone() && catalog.tombstone_count() >= MAX_ACKNOWLEDGED_TOMBSTONES {
+        return Err(if recovering {
+            ReceiptLedgerError::Corrupt("receipt catalog exceeds the tombstone-record limit")
+        } else {
+            ReceiptLedgerError::TombstoneCapacityExceeded
         });
     }
     if catalog.records.contains_key(&entry.record.key_digest) {
@@ -3441,10 +4042,12 @@ fn validate_catalog_insert(
             ReceiptLedgerError::ReservedTaskIdentityMismatch
         });
     }
-    if catalog
-        .records
-        .values()
-        .any(|stored| stored.record.mutation_sequence == entry.record.mutation_sequence)
+    if !entry.is_tombstone()
+        && catalog
+            .records
+            .values()
+            .filter(|stored| !stored.is_tombstone())
+            .any(|stored| stored.record.mutation_sequence == entry.record.mutation_sequence)
     {
         return Err(ReceiptLedgerError::Corrupt(
             "receipt catalog contains a duplicate mutation sequence",
@@ -3452,7 +4055,7 @@ fn validate_catalog_insert(
     }
     let next_actual_bytes = catalog
         .actual_bytes
-        .checked_add(entry.encoded_bytes)
+        .checked_add(entry.live_actual_bytes())
         .ok_or(ReceiptLedgerError::CapacityExceeded)?;
     let next_reserved_bytes = catalog
         .reserved_result_bytes
@@ -3469,12 +4072,24 @@ fn validate_catalog_insert(
             ReceiptLedgerError::CapacityExceeded
         });
     }
+    let next_tombstone_bytes = catalog
+        .tombstone_bytes
+        .checked_add(entry.tombstone_bytes())
+        .ok_or(ReceiptLedgerError::TombstoneCapacityExceeded)?;
+    if next_tombstone_bytes > MAX_ACKNOWLEDGED_TOMBSTONE_POOL_BYTES {
+        return Err(if recovering {
+            ReceiptLedgerError::Corrupt("receipt catalog exceeds the tombstone byte limit")
+        } else {
+            ReceiptLedgerError::TombstoneCapacityExceeded
+        });
+    }
     Ok(())
 }
 
 fn commit_catalog_insert(catalog: &mut ReceiptCatalog, entry: CatalogEntry) {
-    catalog.actual_bytes += entry.encoded_bytes;
+    catalog.actual_bytes += entry.live_actual_bytes();
     catalog.reserved_result_bytes += entry.reserved_result_bytes();
+    catalog.tombstone_bytes += entry.tombstone_bytes();
     catalog.invocation_index.insert(
         entry.record.key.invocation_id(),
         entry.record.key_digest.clone(),
@@ -3498,7 +4113,7 @@ fn insert_catalog_entry(
     Ok(())
 }
 
-fn catalog_entry_is_expired_cancel_reserved(
+fn catalog_entry_is_expired_identity_reclaimable(
     catalog: &ReceiptCatalog,
     digest: &ReceiptKeyDigest,
     observed_at_epoch_ms: u64,
@@ -3509,10 +4124,10 @@ fn catalog_entry_is_expired_cancel_reserved(
         .ok_or(ReceiptLedgerError::Corrupt(
             "receipt identity index points outside the catalog",
         ))?;
-    Ok(entry_is_expired_cancel_reserved(
-        entry,
-        observed_at_epoch_ms,
-    ))
+    Ok(
+        entry_is_expired_cancel_reserved(entry, observed_at_epoch_ms)
+            || entry_is_expired_tombstone(entry, observed_at_epoch_ms),
+    )
 }
 
 fn entry_is_expired_cancel_reserved(entry: &CatalogEntry, observed_at_epoch_ms: u64) -> bool {
@@ -3522,6 +4137,18 @@ fn entry_is_expired_cancel_reserved(entry: &CatalogEntry, observed_at_epoch_ms: 
             expires_at_epoch_ms,
             ..
         } if observed_at_epoch_ms >= *expires_at_epoch_ms
+    )
+}
+
+fn entry_is_expired_tombstone(entry: &CatalogEntry, observed_at_epoch_ms: u64) -> bool {
+    matches!(
+        &entry.record.lifecycle,
+        StoredActiveLifecycleV1::AcknowledgedTombstone {
+            acknowledged_at_epoch_ms,
+            ..
+        } if acknowledged_at_epoch_ms
+            .checked_add(ACKNOWLEDGED_TOMBSTONE_TTL_MS)
+            .is_some_and(|expires_at_epoch_ms| observed_at_epoch_ms >= expires_at_epoch_ms)
     )
 }
 
@@ -3555,7 +4182,7 @@ fn validate_catalog_remove(
     }
     catalog
         .actual_bytes
-        .checked_sub(expected.encoded_bytes)
+        .checked_sub(expected.live_actual_bytes())
         .ok_or(ReceiptLedgerError::Corrupt(
             "receipt catalog actual-byte accounting underflowed",
         ))?;
@@ -3565,13 +4192,20 @@ fn validate_catalog_remove(
         .ok_or(ReceiptLedgerError::Corrupt(
             "receipt catalog reserved-byte accounting underflowed",
         ))?;
+    catalog
+        .tombstone_bytes
+        .checked_sub(expected.tombstone_bytes())
+        .ok_or(ReceiptLedgerError::Corrupt(
+            "receipt catalog tombstone-byte accounting underflowed",
+        ))?;
     Ok(())
 }
 
 fn commit_catalog_remove(catalog: &mut ReceiptCatalog, expected: &CatalogEntry) {
     let digest = &expected.record.key_digest;
-    catalog.actual_bytes -= expected.encoded_bytes;
+    catalog.actual_bytes -= expected.live_actual_bytes();
     catalog.reserved_result_bytes -= expected.reserved_result_bytes();
+    catalog.tombstone_bytes -= expected.tombstone_bytes();
     catalog
         .invocation_index
         .remove(&expected.record.key.invocation_id());
@@ -3598,18 +4232,21 @@ fn validate_catalog_replace(
             "receipt replacement changed its exact identity",
         ));
     }
-    if catalog.records.iter().any(|(digest, stored)| {
-        digest != &expected.record.key_digest
-            && stored.record.mutation_sequence == replacement.record.mutation_sequence
-    }) {
+    if !replacement.is_tombstone()
+        && catalog.records.iter().any(|(digest, stored)| {
+            digest != &expected.record.key_digest
+                && !stored.is_tombstone()
+                && stored.record.mutation_sequence == replacement.record.mutation_sequence
+        })
+    {
         return Err(ReceiptLedgerError::Corrupt(
             "receipt replacement reuses a mutation sequence",
         ));
     }
     let next_actual_bytes = catalog
         .actual_bytes
-        .checked_sub(expected.encoded_bytes)
-        .and_then(|bytes| bytes.checked_add(replacement.encoded_bytes))
+        .checked_sub(expected.live_actual_bytes())
+        .and_then(|bytes| bytes.checked_add(replacement.live_actual_bytes()))
         .ok_or(ReceiptLedgerError::Corrupt(
             "receipt catalog actual-byte accounting underflowed",
         ))?;
@@ -3627,22 +4264,45 @@ fn validate_catalog_replace(
     {
         return Err(ReceiptLedgerError::CapacityExceeded);
     }
+    let next_tombstone_count = catalog
+        .tombstone_count()
+        .checked_sub(usize::from(expected.is_tombstone()))
+        .and_then(|count| count.checked_add(usize::from(replacement.is_tombstone())))
+        .ok_or(ReceiptLedgerError::Corrupt(
+            "receipt catalog tombstone count underflowed",
+        ))?;
+    if next_tombstone_count > MAX_ACKNOWLEDGED_TOMBSTONES {
+        return Err(ReceiptLedgerError::TombstoneCapacityExceeded);
+    }
+    let next_tombstone_bytes = catalog
+        .tombstone_bytes
+        .checked_sub(expected.tombstone_bytes())
+        .and_then(|bytes| bytes.checked_add(replacement.tombstone_bytes()))
+        .ok_or(ReceiptLedgerError::Corrupt(
+            "receipt catalog tombstone-byte accounting underflowed",
+        ))?;
+    if next_tombstone_bytes > MAX_ACKNOWLEDGED_TOMBSTONE_POOL_BYTES {
+        return Err(ReceiptLedgerError::TombstoneCapacityExceeded);
+    }
     Ok(())
 }
 
 fn commit_catalog_replace(catalog: &mut ReceiptCatalog, replacement: CatalogEntry) {
     let digest = replacement.record.key_digest.clone();
-    let replacement_encoded_bytes = replacement.encoded_bytes;
+    let replacement_live_actual_bytes = replacement.live_actual_bytes();
     let replacement_reserved_result_bytes = replacement.reserved_result_bytes();
+    let replacement_tombstone_bytes = replacement.tombstone_bytes();
     let previous = catalog
         .records
         .insert(digest, replacement)
         .expect("validated receipt replacement has an existing catalog entry");
     catalog.actual_bytes =
-        catalog.actual_bytes - previous.encoded_bytes + replacement_encoded_bytes;
+        catalog.actual_bytes - previous.live_actual_bytes() + replacement_live_actual_bytes;
     catalog.reserved_result_bytes = catalog.reserved_result_bytes
         - previous.reserved_result_bytes()
         + replacement_reserved_result_bytes;
+    catalog.tombstone_bytes =
+        catalog.tombstone_bytes - previous.tombstone_bytes() + replacement_tombstone_bytes;
 }
 
 fn latch_catalog_error<T>(
@@ -5278,6 +5938,315 @@ mod tests {
     }
 
     #[test]
+    fn direct_ack_compacts_payload_to_restart_stable_idempotent_tombstone() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("receipts");
+        let store = ReceiptLedgerStore::open(&receipts).expect("open receipt ledger");
+        let key = receipt_key(INVOCATION_A, TASK_A, "workspace-a");
+        let cutoff =
+            OriginalCutoffDescriptor::new(1_000, 7_000).expect("valid original response cutoff");
+        let reserved = store
+            .reserve(key.clone(), cutoff, reserve_deadline())
+            .expect("reserve exact receipt")
+            .into_reservation()
+            .expect("receipt remains reserved");
+        let terminal = canonical_v5_terminal(&ReceiptTerminalOutcome::Completed {
+            result: Box::new(DomainResult::success("direct result to compact")),
+        })
+        .expect("canonical direct terminal");
+        let terminal_digest = terminal.digest().clone();
+        let committed = store
+            .publish_direct_terminal(
+                &key,
+                reserved.record_version(),
+                2_000,
+                terminal,
+                reserve_deadline(),
+            )
+            .expect("publish exact direct terminal");
+
+        let acknowledged = store
+            .acknowledge_direct(&key, &terminal_digest, 2_100, reserve_deadline())
+            .expect("acknowledge committed direct terminal");
+        assert_eq!(acknowledged.key(), &key);
+        assert_eq!(acknowledged.terminal_digest(), &terminal_digest);
+        assert_eq!(acknowledged.acknowledged_at_epoch_ms(), 2_100);
+        assert_eq!(acknowledged.expires_at_epoch_ms(), 902_100);
+        assert!(acknowledged.encoded_bytes() <= MAX_ACKNOWLEDGED_TOMBSTONE_BYTES);
+        assert_eq!(store.generation().expect("generation after ack"), 3);
+        {
+            let catalog = store.writer.lock().expect("inspect acknowledged catalog");
+            assert_eq!(catalog.live_count(), 0);
+            assert_eq!(catalog.actual_bytes, 0);
+            assert_eq!(catalog.reserved_result_bytes, 0);
+            assert_eq!(catalog.tombstone_count(), 1);
+            assert_eq!(catalog.tombstone_bytes, acknowledged.encoded_bytes());
+        }
+        drop(store);
+
+        let reopened = ReceiptLedgerStore::open(&receipts).expect("reopen receipt ledger");
+        let recovered = reopened
+            .recover_exact(&key, reserve_deadline())
+            .expect("recover exact acknowledged tombstone");
+        assert_eq!(
+            recovered,
+            ReceiptState::AcknowledgedTombstone(acknowledged.clone())
+        );
+        let duplicate = reopened
+            .acknowledge_direct(&key, &terminal_digest, 9_999, reserve_deadline())
+            .expect("repeat exact acknowledgement");
+        assert_eq!(duplicate, acknowledged);
+        assert_eq!(
+            reopened
+                .generation()
+                .expect("generation after duplicate ack"),
+            3,
+            "duplicate ACK must not rewrite first-ACK epoch or generation"
+        );
+        assert!(committed.encoded_bytes() > acknowledged.encoded_bytes());
+    }
+
+    #[test]
+    fn acknowledged_tombstone_is_physically_reclaimed_at_its_absolute_expiry() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("receipts");
+        let store = ReceiptLedgerStore::open(&receipts).expect("open receipt ledger");
+        let key = receipt_key(INVOCATION_A, TASK_A, "workspace-a");
+        let reserved = store
+            .reserve(
+                key.clone(),
+                OriginalCutoffDescriptor::new(1_000, 7_000).expect("valid cutoff"),
+                reserve_deadline(),
+            )
+            .expect("reserve exact receipt")
+            .into_reservation()
+            .expect("receipt remains reserved");
+        let terminal = canonical_v5_terminal(&ReceiptTerminalOutcome::Cancelled)
+            .expect("canonical direct terminal");
+        let terminal_digest = terminal.digest().clone();
+        store
+            .publish_direct_terminal(
+                &key,
+                reserved.record_version(),
+                2_000,
+                terminal,
+                reserve_deadline(),
+            )
+            .expect("publish direct terminal");
+        store
+            .acknowledge_direct(&key, &terminal_digest, 2_100, reserve_deadline())
+            .expect("acknowledge direct terminal");
+
+        assert_eq!(
+            store
+                .reclaim_expired_tombstones(902_099, reserve_deadline())
+                .expect("inspect one millisecond before expiry"),
+            0
+        );
+        assert!(matches!(
+            store.recover_exact(&key, reserve_deadline()),
+            Ok(ReceiptState::AcknowledgedTombstone(_))
+        ));
+        assert_eq!(
+            store
+                .reclaim_expired_tombstones(902_100, reserve_deadline())
+                .expect("reclaim at absolute expiry"),
+            1
+        );
+        assert_eq!(
+            store.recover_exact(&key, reserve_deadline()),
+            Err(ReceiptLedgerError::ReceiptNotFound)
+        );
+        assert_eq!(store.generation().expect("generation after expiry"), 4);
+        drop(store);
+
+        let reopened = ReceiptLedgerStore::open(&receipts).expect("reopen after expiry");
+        assert_eq!(
+            reopened.recover_exact(&key, reserve_deadline()),
+            Err(ReceiptLedgerError::ReceiptNotFound)
+        );
+    }
+
+    #[test]
+    fn expired_tombstone_releases_partial_identity_for_new_admission_only_at_expiry() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("receipts");
+        let store = ReceiptLedgerStore::open(&receipts).expect("open receipt ledger");
+        let original = receipt_key(INVOCATION_A, TASK_A, "workspace-a");
+        let reserved = store
+            .reserve(
+                original.clone(),
+                OriginalCutoffDescriptor::new(1_000, 7_000).expect("valid cutoff"),
+                reserve_deadline(),
+            )
+            .expect("reserve original receipt")
+            .into_reservation()
+            .expect("original remains reserved");
+        let terminal =
+            canonical_v5_terminal(&ReceiptTerminalOutcome::Cancelled).expect("canonical terminal");
+        let terminal_digest = terminal.digest().clone();
+        store
+            .publish_direct_terminal(
+                &original,
+                reserved.record_version(),
+                2_000,
+                terminal,
+                reserve_deadline(),
+            )
+            .expect("publish original direct terminal");
+        store
+            .acknowledge_direct(&original, &terminal_digest, 2_100, reserve_deadline())
+            .expect("acknowledge original direct terminal");
+        let replacement = receipt_key(INVOCATION_A, TASK_B, "workspace-b");
+
+        assert_eq!(
+            store.reserve(
+                replacement.clone(),
+                OriginalCutoffDescriptor::new(902_099, 7_000).expect("pre-expiry cutoff"),
+                reserve_deadline(),
+            ),
+            Err(ReceiptLedgerError::InvocationIdentityMismatch)
+        );
+        assert_eq!(store.generation().expect("pre-expiry generation"), 3);
+
+        let admitted = store
+            .reserve(
+                replacement.clone(),
+                OriginalCutoffDescriptor::new(902_100, 7_000).expect("expiry cutoff"),
+                reserve_deadline(),
+            )
+            .expect("expired identity is reusable")
+            .into_reservation()
+            .expect("replacement is newly reserved");
+        assert_eq!(admitted.key(), &replacement);
+        assert_eq!(store.generation().expect("replacement generation"), 5);
+        assert_eq!(
+            store.recover_exact(&original, reserve_deadline()),
+            Err(ReceiptLedgerError::InvocationIdentityMismatch)
+        );
+        assert!(!receipts
+            .join(ACTIVE_DIRECTORY_NAME)
+            .join(format!("{}.json", receipt_key_digest(&original).as_str()))
+            .exists());
+    }
+
+    #[test]
+    fn tombstone_pool_does_not_consume_the_sixty_four_live_receipt_slots() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("receipts");
+        let store = ReceiptLedgerStore::open(&receipts).expect("open receipt ledger");
+        let terminal_digest = canonical_v5_terminal(&ReceiptTerminalOutcome::Cancelled)
+            .expect("canonical terminal")
+            .digest()
+            .clone();
+        let mut catalog = store.writer.lock().expect("inspect receipt catalog");
+        for _ in 0..65 {
+            let key = receipt_key_with_ids(InvocationId::new(), TaskId::new(), "workspace-a");
+            let key_digest = receipt_key_digest(&key);
+            insert_catalog_entry(
+                &mut catalog,
+                CatalogEntry {
+                    record: StoredActiveReceiptV1 {
+                        schema_version: RECEIPT_RECORD_SCHEMA_VERSION,
+                        mutation_sequence: 0,
+                        record_version: ReceiptVersion::new(3).expect("tombstone marker version"),
+                        key,
+                        key_digest,
+                        lifecycle: StoredActiveLifecycleV1::AcknowledgedTombstone {
+                            terminal_digest: terminal_digest.clone(),
+                            acknowledged_at_epoch_ms: 1_000,
+                        },
+                    },
+                    encoded_bytes: 256,
+                },
+                false,
+            )
+            .expect("insert synthetic tombstone telemetry fixture");
+        }
+        assert_eq!(catalog.live_count(), 0);
+        assert_eq!(catalog.tombstone_count(), 65);
+        let fresh = receipt_key_with_ids(InvocationId::new(), TaskId::new(), "workspace-fresh");
+
+        store
+            .prepare_new_admission_under_writer_lock(
+                &mut catalog,
+                &fresh,
+                1_001,
+                reserve_deadline(),
+            )
+            .expect("separate tombstone pool cannot block live admission");
+    }
+
+    #[test]
+    fn rejected_ack_does_not_reclaim_an_unrelated_expired_tombstone() {
+        let root = tempfile::tempdir().expect("temporary root");
+        let receipts = fs::canonicalize(root.path())
+            .expect("physical temporary root")
+            .join("receipts");
+        let store = ReceiptLedgerStore::open(&receipts).expect("open receipt ledger");
+        let tombstone_key = receipt_key(INVOCATION_A, TASK_A, "workspace-a");
+        let reserved = store
+            .reserve(
+                tombstone_key.clone(),
+                OriginalCutoffDescriptor::new(1_000, 7_000).expect("valid cutoff"),
+                reserve_deadline(),
+            )
+            .expect("reserve original receipt")
+            .into_reservation()
+            .expect("original remains reserved");
+        let terminal =
+            canonical_v5_terminal(&ReceiptTerminalOutcome::Cancelled).expect("canonical terminal");
+        let terminal_digest = terminal.digest().clone();
+        store
+            .publish_direct_terminal(
+                &tombstone_key,
+                reserved.record_version(),
+                2_000,
+                terminal,
+                reserve_deadline(),
+            )
+            .expect("publish original terminal");
+        let tombstone = store
+            .acknowledge_direct(&tombstone_key, &terminal_digest, 2_100, reserve_deadline())
+            .expect("acknowledge original terminal");
+        let premature_key = receipt_key(INVOCATION_B, TASK_B, "workspace-b");
+        store
+            .reserve(
+                premature_key.clone(),
+                OriginalCutoffDescriptor::new(3_000, 7_000).expect("valid second cutoff"),
+                reserve_deadline(),
+            )
+            .expect("reserve unrelated receipt");
+        let generation_before = store.generation().expect("generation before rejected ACK");
+
+        assert_eq!(
+            store.acknowledge_direct(
+                &premature_key,
+                &terminal_digest,
+                tombstone.expires_at_epoch_ms(),
+                reserve_deadline(),
+            ),
+            Err(ReceiptLedgerError::ReceiptRowPresentUnsupported)
+        );
+        assert_eq!(
+            store.generation().expect("generation after rejected ACK"),
+            generation_before
+        );
+        assert_eq!(
+            store.recover_exact(&tombstone_key, reserve_deadline()),
+            Ok(ReceiptState::AcknowledgedTombstone(tombstone))
+        );
+    }
+
+    #[test]
     fn direct_terminal_reopens_byte_equivalent_with_exact_state() {
         let root = tempfile::tempdir().expect("temporary root");
         let receipts = fs::canonicalize(root.path())
@@ -6896,12 +7865,18 @@ mod tests {
             StoredActiveLifecycleV1::ExpiredDeletion { .. } => {
                 panic!("reserved fixture decoded as an expiry deletion witness")
             }
+            StoredActiveLifecycleV1::ExpiredTombstoneDeletion { .. } => {
+                panic!("reserved fixture decoded as a tombstone deletion witness")
+            }
             StoredActiveLifecycleV1::ReservedUnbound {
                 reserved_at_epoch_ms,
                 ..
             } => *reserved_at_epoch_ms = 1_001,
             StoredActiveLifecycleV1::DirectTerminalUnacked { .. } => {
                 panic!("reserved fixture decoded as a direct terminal")
+            }
+            StoredActiveLifecycleV1::AcknowledgedTombstone { .. } => {
+                panic!("reserved fixture decoded as an acknowledged tombstone")
             }
         }
         let contradictory = serde_json::to_vec(&record).expect("encode contradictory row");

--- a/crates/unica-coder/src/infrastructure/receipt_ledger.rs
+++ b/crates/unica-coder/src/infrastructure/receipt_ledger.rs
@@ -7,6 +7,11 @@ use crate::application::receipt_ledger::{
     V5CanonicalTerminal, CANCEL_RESERVATION_TTL_MS, DIRECT_TERMINAL_RETENTION_MS,
     MAX_LIVE_RECEIPTS, MAX_LIVE_RECEIPT_BYTES, MAX_RECEIPT_ENTITLEMENT_BYTES,
 };
+#[cfg(feature = "receipt-ledger-test-support")]
+use crate::application::receipt_ledger::{
+    ReceiptLedgerCatalogSnapshot, ReceiptLedgerCatalogSnapshotAuthority,
+    ReceiptLedgerCatalogSnapshotParts,
+};
 use crate::domain::invocation::{InvocationId, TaskId};
 use crate::infrastructure::daemon::terminal_codec_v5::{
     prepare_committed_direct_wire, prepare_direct_terminal, restore_canonical_terminal,
@@ -317,6 +322,15 @@ struct ReceiptCatalog {
     actual_bytes: u64,
     reserved_result_bytes: u64,
     unavailable: bool,
+}
+
+#[cfg(feature = "receipt-ledger-test-support")]
+fn sort_receipt_keys_by_digest(keys: &mut [ReceiptKey]) {
+    keys.sort_unstable_by(|left, right| {
+        receipt_key_digest(left)
+            .as_str()
+            .cmp(receipt_key_digest(right).as_str())
+    });
 }
 
 struct GenerationState {
@@ -683,6 +697,101 @@ impl ReceiptLedgerStore {
             generation_before,
             generation_after,
         })
+    }
+
+    #[cfg(feature = "receipt-ledger-test-support")]
+    pub(crate) fn snapshot_catalog(
+        &self,
+        authority: ReceiptLedgerCatalogSnapshotAuthority,
+        deadline: Instant,
+    ) -> Result<ReceiptLedgerCatalogSnapshot, ReceiptLedgerError> {
+        check_deadline(deadline)?;
+        let mut catalog = self
+            .writer
+            .lock()
+            .map_err(|_| ReceiptLedgerError::Corrupt("receipt catalog lock was poisoned"))?;
+        let observed = self.inspect_catalog_with_generation_under_stable_fence(
+            &mut catalog,
+            Some(deadline),
+            |catalog, generation| {
+                let mut records = catalog.records.iter().collect::<Vec<_>>();
+                records.sort_unstable_by(|(left, _), (right, _)| left.as_str().cmp(right.as_str()));
+                let keys = records
+                    .iter()
+                    .map(|(_, entry)| entry.record.key.clone())
+                    .collect::<Vec<_>>();
+
+                let mut invocation_index = Vec::with_capacity(catalog.invocation_index.len());
+                for (invocation_id, key_digest) in &catalog.invocation_index {
+                    let entry =
+                        catalog
+                            .records
+                            .get(key_digest)
+                            .ok_or(ReceiptLedgerError::Corrupt(
+                                "receipt invocation index points outside the catalog",
+                            ))?;
+                    if entry.record.key.invocation_id() != *invocation_id {
+                        return Err(ReceiptLedgerError::Corrupt(
+                            "receipt invocation index contradicts its catalog key",
+                        ));
+                    }
+                    invocation_index.push(entry.record.key.clone());
+                }
+                sort_receipt_keys_by_digest(&mut invocation_index);
+
+                let mut reserved_task_index = Vec::with_capacity(catalog.reserved_task_index.len());
+                for (reserved_task_id, key_digest) in &catalog.reserved_task_index {
+                    let entry =
+                        catalog
+                            .records
+                            .get(key_digest)
+                            .ok_or(ReceiptLedgerError::Corrupt(
+                                "receipt reserved-task index points outside the catalog",
+                            ))?;
+                    if entry.record.key.reserved_task_id() != *reserved_task_id {
+                        return Err(ReceiptLedgerError::Corrupt(
+                            "receipt reserved-task index contradicts its catalog key",
+                        ));
+                    }
+                    reserved_task_index.push(entry.record.key.clone());
+                }
+                sort_receipt_keys_by_digest(&mut reserved_task_index);
+
+                Ok((
+                    generation,
+                    keys,
+                    invocation_index,
+                    reserved_task_index,
+                    u64::try_from(catalog.records.len()).map_err(|_| {
+                        ReceiptLedgerError::Corrupt("receipt catalog count does not fit telemetry")
+                    })?,
+                    catalog.actual_bytes,
+                    catalog.reserved_result_bytes,
+                ))
+            },
+        )?;
+        let (
+            generation,
+            keys,
+            invocation_index,
+            reserved_task_index,
+            live_count,
+            actual_bytes,
+            reserved_result_bytes,
+        ) = match observed {
+            Ok(observed) => observed,
+            Err(error) => return latch_catalog_error(&mut catalog, error),
+        };
+        let snapshot = authority.seal(ReceiptLedgerCatalogSnapshotParts::new(
+            generation,
+            keys,
+            invocation_index,
+            reserved_task_index,
+            live_count,
+            actual_bytes,
+            reserved_result_bytes,
+        ));
+        latch_catalog_result(&mut catalog, snapshot)
     }
 
     pub(crate) fn request_cancel_or_reserve(
@@ -1664,6 +1773,19 @@ impl ReceiptLedgerStore {
         deadline: Option<Instant>,
         inspect: impl FnOnce(&ReceiptCatalog) -> T,
     ) -> Result<T, ReceiptLedgerError> {
+        self.inspect_catalog_with_generation_under_stable_fence(
+            catalog,
+            deadline,
+            |catalog, _generation| inspect(catalog),
+        )
+    }
+
+    fn inspect_catalog_with_generation_under_stable_fence<T>(
+        &self,
+        catalog: &mut ReceiptCatalog,
+        deadline: Option<Instant>,
+        inspect: impl FnOnce(&ReceiptCatalog, u64) -> T,
+    ) -> Result<T, ReceiptLedgerError> {
         if catalog.unavailable {
             return Err(ReceiptLedgerError::StoreUnavailable);
         }
@@ -1672,7 +1794,7 @@ impl ReceiptLedgerStore {
         check_optional_deadline(deadline)?;
         let generation_before = latch_catalog_result(catalog, self.generation_under_writer_lock())?;
         check_optional_deadline(deadline)?;
-        let inspected = inspect(catalog);
+        let inspected = inspect(catalog, generation_before);
         check_optional_deadline(deadline)?;
         let generation_after = latch_catalog_result(catalog, self.generation_under_writer_lock())?;
         if generation_after != generation_before {
@@ -2414,6 +2536,22 @@ impl ReceiptLedgerStore {
 }
 
 impl ReceiptLedgerPort for ReceiptLedgerStore {
+    #[cfg(feature = "receipt-ledger-test-support")]
+    fn snapshot_catalog(
+        &mut self,
+        authority: ReceiptLedgerCatalogSnapshotAuthority,
+        deadline: Instant,
+    ) -> Result<ReceiptLedgerCatalogSnapshot, ReceiptLedgerError> {
+        ReceiptLedgerStore::snapshot_catalog(self, authority, deadline)
+    }
+
+    fn generation(&mut self, deadline: Instant) -> Result<u64, ReceiptLedgerError> {
+        check_deadline(deadline)?;
+        let generation = ReceiptLedgerStore::generation(self)?;
+        check_deadline(deadline)?;
+        Ok(generation)
+    }
+
     fn reserve(
         &mut self,
         key: ReceiptKey,

--- a/crates/unica-coder/src/infrastructure/receipt_ledger_test_evidence.rs
+++ b/crates/unica-coder/src/infrastructure/receipt_ledger_test_evidence.rs
@@ -120,7 +120,12 @@ impl ProductionMissingTransitionEvidence {
                 generation_after,
             },
             code: ProductionMissingTransitionCode::WriterPathUnavailable,
-            correlation: ActionCorrelation::Exact(action_kind),
+            correlation: match token.action() {
+                crate::infrastructure::daemon::runtime_v5::V5ExecutorReachabilityAction::SubmitInvocation => {
+                    ActionCorrelation::Submit
+                }
+                _ => ActionCorrelation::Exact(action_kind),
+            },
             fingerprint: executor_fingerprint(&token),
         }
     }
@@ -801,10 +806,7 @@ mod tests {
                 "strict_envelope_observation_unavailable",
                 Some("src/infrastructure/daemon/protocol_v5.rs"),
             ),
-            (
-                "receipt_row_absent",
-                Some("src/infrastructure/daemon/runtime_v5.rs"),
-            ),
+            ("receipt_row_absent", None),
             (
                 "protocol_behavior_unavailable",
                 Some("src/infrastructure/daemon/runtime_v5.rs"),

--- a/crates/unica-coder/src/receipt_ledger_test_support.rs
+++ b/crates/unica-coder/src/receipt_ledger_test_support.rs
@@ -16,7 +16,7 @@ use crate::infrastructure::daemon::protocol_v5::{
 use crate::infrastructure::daemon::runtime_v5::{
     run_direct_load_reachability_probe_for_test, run_lazy_cancel_storm_reachability_probe_for_test,
     run_protocol_ping_reachability_probe_for_test, run_seed_task_reachability_probe_for_test,
-    run_submit_reachability_probe_for_test,
+    run_submit_reachability_probe_for_test, run_supported_receipt_scenario_for_test,
 };
 use crate::infrastructure::receipt_ledger_reachability::{
     run_acknowledge_reachability_probe_for_test,
@@ -137,6 +137,11 @@ fn execute_scenario(request: &str) -> Result<String, ScenarioExecutionError> {
 
     let scenario: ScenarioInput = serde_json::from_str(request)
         .map_err(|error| ScenarioExecutionError::InvalidScenario(error.to_string()))?;
+    if let Some(observed) = run_supported_receipt_scenario_for_test(request)
+        .map_err(ScenarioExecutionError::ProductionProbe)?
+    {
+        return Ok(observed);
+    }
     let ScenarioInput { clock, actions } = scenario;
     let mut setup = StagedScenarioSetup::new(clock);
 
@@ -1069,19 +1074,52 @@ enum EventKindInput {
 mod tests {
     use super::*;
     use proc_macro2::{TokenStream, TokenTree};
-    use std::collections::BTreeSet;
+    use std::collections::{BTreeMap, BTreeSet};
     use syn::parse::Parser;
     use syn::visit::Visit;
+
+    const FACADE_PRODUCTION_SOURCES: &[(&str, &str)] = &[
+        (
+            "receipt_ledger_test_support.rs",
+            include_str!("receipt_ledger_test_support.rs"),
+        ),
+        (
+            "infrastructure/receipt_ledger_reachability.rs",
+            include_str!("infrastructure/receipt_ledger_reachability.rs"),
+        ),
+        (
+            "infrastructure/receipt_ledger_test_evidence.rs",
+            include_str!("infrastructure/receipt_ledger_test_evidence.rs"),
+        ),
+    ];
+
+    const OWNER_HELPER_PRODUCTION_SOURCES: &[(&str, &str)] = &[(
+        "infrastructure/daemon/runtime_v5/receipt_scenario_v5.rs",
+        include_str!("infrastructure/daemon/runtime_v5/receipt_scenario_v5.rs"),
+    )];
 
     fn facade_forbidden_authority_references(
         source: &str,
         forbidden: &[&str],
+    ) -> Result<BTreeSet<String>, String> {
+        facade_forbidden_authority_references_with_mode(
+            source,
+            forbidden,
+            FacadeAuthorityGuardMode::SealedRuntimeStrings,
+        )
+    }
+
+    fn facade_forbidden_authority_references_with_mode(
+        source: &str,
+        forbidden: &[&str],
+        mode: FacadeAuthorityGuardMode,
     ) -> Result<BTreeSet<String>, String> {
         let syntax = syn::parse_file(source).map_err(|error| error.to_string())?;
         let mut finder = FacadeAuthorityReferenceFinder {
             forbidden,
             references: BTreeSet::new(),
             unsupported_syntax: BTreeSet::new(),
+            mode,
         };
         finder.visit_file(&syntax);
         if finder.unsupported_syntax.is_empty() {
@@ -1095,10 +1133,40 @@ mod tests {
         }
     }
 
+    fn facade_forbidden_authority_references_by_source(
+        sources: &[(&str, &str)],
+        forbidden: &[&str],
+    ) -> Result<BTreeMap<String, BTreeSet<String>>, String> {
+        let mut source_paths = BTreeSet::new();
+        let mut references_by_source = BTreeMap::new();
+        for (path, source) in sources {
+            if !source_paths.insert(*path) {
+                return Err(format!("duplicate facade production source `{path}`"));
+            }
+            let references = facade_forbidden_authority_references_with_mode(
+                source,
+                forbidden,
+                FacadeAuthorityGuardMode::RustAuthorityOnly,
+            )
+            .map_err(|error| format!("{path}: {error}"))?;
+            if !references.is_empty() {
+                references_by_source.insert((*path).to_string(), references);
+            }
+        }
+        Ok(references_by_source)
+    }
+
     struct FacadeAuthorityReferenceFinder<'a> {
         forbidden: &'a [&'a str],
         references: BTreeSet<String>,
         unsupported_syntax: BTreeSet<String>,
+        mode: FacadeAuthorityGuardMode,
+    }
+
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum FacadeAuthorityGuardMode {
+        SealedRuntimeStrings,
+        RustAuthorityOnly,
     }
 
     impl FacadeAuthorityReferenceFinder<'_> {
@@ -1106,6 +1174,44 @@ mod tests {
             for authority in self.forbidden {
                 if text.contains(authority) {
                     self.references.insert((*authority).to_string());
+                }
+            }
+        }
+
+        fn scan_path(&mut self, path: &syn::Path) {
+            let path = path
+                .segments
+                .iter()
+                .map(|segment| segment.ident.to_string())
+                .collect::<Vec<_>>()
+                .join("::");
+            self.scan_text(&path);
+        }
+
+        fn scan_use_tree(&mut self, tree: &syn::UseTree, prefix: &mut Vec<String>) {
+            match tree {
+                syn::UseTree::Path(path) => {
+                    prefix.push(path.ident.to_string());
+                    self.scan_text(&prefix.join("::"));
+                    self.scan_use_tree(&path.tree, prefix);
+                    prefix.pop();
+                }
+                syn::UseTree::Name(name) => {
+                    prefix.push(name.ident.to_string());
+                    self.scan_text(&prefix.join("::"));
+                    prefix.pop();
+                }
+                syn::UseTree::Rename(rename) => {
+                    prefix.push(rename.ident.to_string());
+                    self.scan_text(&prefix.join("::"));
+                    self.scan_text(&rename.rename.to_string());
+                    prefix.pop();
+                }
+                syn::UseTree::Glob(_) => self.scan_text(&prefix.join("::")),
+                syn::UseTree::Group(group) => {
+                    for tree in &group.items {
+                        self.scan_use_tree(tree, prefix);
+                    }
                 }
             }
         }
@@ -1358,6 +1464,7 @@ mod tests {
                                 | "include_str"
                                 | "include_bytes"
                         )
+                            && self.mode != FacadeAuthorityGuardMode::RustAuthorityOnly
                             && tokens.get(index + 1).is_some_and(
                                 |token| matches!(token, TokenTree::Punct(punct) if punct.as_char() == '!'),
                             )
@@ -1494,6 +1601,16 @@ mod tests {
             self.scan_text(&identifier.to_string());
         }
 
+        fn visit_item_use(&mut self, item: &'ast syn::ItemUse) {
+            self.scan_use_tree(&item.tree, &mut Vec::new());
+            syn::visit::visit_item_use(self, item);
+        }
+
+        fn visit_path(&mut self, path: &'ast syn::Path) {
+            self.scan_path(path);
+            syn::visit::visit_path(self, path);
+        }
+
         fn visit_lit(&mut self, literal: &'ast syn::Lit) {
             self.scan_literal(literal);
         }
@@ -1503,6 +1620,14 @@ mod tests {
             match macro_.path.segments.last().map(|segment| &segment.ident) {
                 Some(identifier) if identifier == "concat" => {
                     self.scan_concat_tokens(macro_.tokens.clone());
+                }
+                Some(identifier)
+                    if matches!(
+                        identifier.to_string().as_str(),
+                        "format" | "format_args" | "write" | "writeln"
+                    ) && self.mode == FacadeAuthorityGuardMode::RustAuthorityOnly =>
+                {
+                    self.scan_macro_tokens(macro_.tokens.clone());
                 }
                 Some(identifier)
                     if matches!(
@@ -1656,6 +1781,163 @@ mod tests {
         }
 
         assert_eq!(fingerprints.len(), cases.len());
+    }
+
+    #[test]
+    fn facade_authority_guard_scans_every_named_production_source() {
+        let sources = [
+            ("receipt_ledger_test_support.rs", "fn entrypoint() {}"),
+            (
+                "infrastructure/receipt_ledger_reachability.rs",
+                r#"
+                    use crate::application::receipt_ledger::ReceiptLedgerPort;
+                    use crate::application::receipt_ledger_actor::ReceiptLedgerActor;
+                    use crate::infrastructure::daemon::identity::DaemonStateDirectory;
+                    use crate::infrastructure::receipt_ledger::ReceiptLedgerStore;
+
+                    fn bypass_the_owner() {}
+                "#,
+            ),
+            (
+                "infrastructure/receipt_ledger_test_evidence.rs",
+                r#"
+                    use std::{fs as retained_state_fs};
+                    use crate::infrastructure::platform::filesystem::RetainedDirectoryCapability;
+
+                    fn bypass_retained_state() {
+                        let _ = retained_state_fs::read("receipts");
+                    }
+                "#,
+            ),
+        ];
+        let forbidden = [
+            "ReceiptLedgerStore",
+            "ReceiptLedgerActor",
+            "ReceiptLedgerPort",
+            "DaemonStateDirectory",
+            "RetainedDirectoryCapability",
+            "::fs",
+            "filesystem",
+        ];
+
+        let references = facade_forbidden_authority_references_by_source(&sources, &forbidden)
+            .expect("synthetic facade sources parse");
+        assert_eq!(
+            references,
+            BTreeMap::from([
+                (
+                    "infrastructure/receipt_ledger_reachability.rs".to_string(),
+                    BTreeSet::from([
+                        "DaemonStateDirectory".to_string(),
+                        "ReceiptLedgerActor".to_string(),
+                        "ReceiptLedgerPort".to_string(),
+                        "ReceiptLedgerStore".to_string(),
+                    ]),
+                ),
+                (
+                    "infrastructure/receipt_ledger_test_evidence.rs".to_string(),
+                    BTreeSet::from([
+                        "::fs".to_string(),
+                        "RetainedDirectoryCapability".to_string(),
+                        "filesystem".to_string(),
+                    ]),
+                ),
+            ])
+        );
+    }
+
+    #[test]
+    fn facade_and_non_owner_helpers_have_no_direct_receipt_ledger_authority() {
+        assert_eq!(
+            FACADE_PRODUCTION_SOURCES
+                .iter()
+                .map(|(path, _)| *path)
+                .collect::<Vec<_>>(),
+            [
+                "receipt_ledger_test_support.rs",
+                "infrastructure/receipt_ledger_reachability.rs",
+                "infrastructure/receipt_ledger_test_evidence.rs",
+            ],
+            "every non-owner production helper belongs to the guard inventory"
+        );
+
+        let forbidden = [
+            "ReceiptLedgerStore",
+            "ReceiptLedgerActor",
+            "ReceiptLedgerPort",
+            "DaemonStateDirectory",
+            "ReceiptAuthorityLock",
+            "RetainedDirectoryCapability",
+            "RetainedRegularFileCapability",
+            "RetainedChildCapability",
+            "open_retained_directory",
+            "create_private_retained_subdirectory",
+            "::fs",
+            "filesystem",
+        ];
+        let references =
+            facade_forbidden_authority_references_by_source(FACADE_PRODUCTION_SOURCES, &forbidden)
+                .unwrap_or_else(|error| panic!("facade authority guard failed closed: {error}"));
+        assert!(
+            references.is_empty(),
+            "facade production sources contain direct receipt-ledger authority: {references:?}"
+        );
+    }
+
+    #[test]
+    fn scenario_owner_helpers_cannot_bypass_the_actor_store_boundary() {
+        assert_eq!(
+            OWNER_HELPER_PRODUCTION_SOURCES
+                .iter()
+                .map(|(path, _)| *path)
+                .collect::<Vec<_>>(),
+            ["infrastructure/daemon/runtime_v5/receipt_scenario_v5.rs"],
+            "every scenario owner helper belongs to the narrow authority inventory"
+        );
+
+        let forbidden = ["ReceiptLedgerStore", "ReceiptLedgerPort"];
+        let references = facade_forbidden_authority_references_by_source(
+            OWNER_HELPER_PRODUCTION_SOURCES,
+            &forbidden,
+        )
+        .unwrap_or_else(|error| panic!("scenario owner authority guard failed closed: {error}"));
+        assert!(
+            references.is_empty(),
+            "scenario owner helpers bypass the actor/store boundary: {references:?}"
+        );
+    }
+
+    #[test]
+    fn scenario_driver_cannot_mint_runtime_telemetry_events() {
+        let references = facade_forbidden_authority_references_by_source(
+            OWNER_HELPER_PRODUCTION_SOURCES,
+            &["record_runtime_entry", "record_event"],
+        )
+        .unwrap_or_else(|error| panic!("scenario telemetry guard failed closed: {error}"));
+        assert!(
+            references.is_empty(),
+            "scenario driver mints runtime telemetry instead of reading it: {references:?}"
+        );
+    }
+
+    #[test]
+    fn rust_authority_guard_finds_store_identifiers_inside_formatting_macros() {
+        let source = r#"
+            fn bypass() {
+                let _ = format!("{}", format!("{:?}", ReceiptLedgerStore::open));
+            }
+        "#;
+        let references = facade_forbidden_authority_references_with_mode(
+            source,
+            &["ReceiptLedgerStore", "ReceiptLedgerPort"],
+            FacadeAuthorityGuardMode::RustAuthorityOnly,
+        )
+        .expect("Rust authority scanning accepts dynamic formatting syntax");
+
+        assert_eq!(
+            references,
+            BTreeSet::from(["ReceiptLedgerStore".to_owned()])
+        );
     }
 
     #[test]

--- a/crates/unica-coder/tests/daemon_receipt_ledger.rs
+++ b/crates/unica-coder/tests/daemon_receipt_ledger.rs
@@ -10576,6 +10576,16 @@ fn cancel_before_submit_is_full_key_bounded_and_expires() {
         &reserved.key
     );
     assert_eq!(after_submit.callbacks.total_domain(), 0);
+    assert_eq!(
+        count_event(&report, EventKind::V5ReceiptRuntimeEntered),
+        4,
+        "one runtime-entry event must come from each authenticated action frame"
+    );
+    assert_eq!(
+        count_event(&report, EventKind::CancelReservationConverted),
+        1
+    );
+    assert_eq!(count_event(&report, EventKind::ReceiptTerminalCommitted), 1);
 }
 
 #[test]
@@ -10622,6 +10632,17 @@ fn cancel_reserved_reopens_with_original_7125ms_expiry() {
         response(&report, "after-expiry").error,
         Some(ErrorCode::ReceiptExpired | ErrorCode::ReceiptNotFound)
     ));
+    assert_eq!(checkpoint(&report, "expired").callbacks.total_domain(), 0);
+    assert_eq!(
+        count_event(&report, EventKind::V5ReceiptRuntimeEntered),
+        3,
+        "reopen markers and checkpoints must not invent action-frame events"
+    );
+    assert_eq!(
+        count_event(&report, EventKind::CancelReservationConverted),
+        0
+    );
+    assert_eq!(count_event(&report, EventKind::ReceiptTerminalCommitted), 0);
 }
 
 #[test]
@@ -10722,6 +10743,10 @@ fn cancel_reserved_shares_live_64_count_without_result_reservation() {
         converted_in_flight[0].state,
         SeedReceiptState::ReservedUnbound
     );
+    assert_eq!(converting.listener, ListenerState::Listening);
+    assert!(converting.daemon_running);
+    assert_eq!(converting.actor_leases, 1);
+    assert_eq!(converting.callbacks.total_domain(), 0);
     let after = checkpoint(&report, "after-conversion");
     assert_eq!(after.receipt_live_count, LIVE_RECEIPT_LIMIT - 1);
     assert!(after.receipt_actual_bytes + after.receipt_reserved_bytes <= LIVE_RECEIPT_BYTES_LIMIT);
@@ -10742,6 +10767,27 @@ fn cancel_reserved_shares_live_64_count_without_result_reservation() {
         response_terminal(response(&report, "converted-submit")),
         terminal_of_receipt(converted_terminal)
     );
+    assert_eq!(after.listener, ListenerState::Closed);
+    assert!(!after.daemon_running);
+    assert_eq!(after.actor_leases, 0);
+    assert_eq!(
+        count_event(&report, EventKind::V5ReceiptRuntimeEntered),
+        129,
+        "batched actions must report every authenticated action frame"
+    );
+    assert_event_order(
+        &report,
+        &[
+            EventKind::V5ReceiptRuntimeEntered,
+            EventKind::CancelReservationConverted,
+            EventKind::ReceiptTerminalCommitted,
+        ],
+    );
+    assert_eq!(
+        count_event(&report, EventKind::CancelReservationConverted),
+        1
+    );
+    assert_eq!(count_event(&report, EventKind::ReceiptTerminalCommitted), 1);
 }
 
 #[test]


### PR DESCRIPTION
## Scope

Partial CR0/W0 ReceiptLedger slice for #581. This PR intentionally does **not** activate S1/W0c, change the public `unica.*` MCP surface, or switch the default daemon protocol from v3. Execution and Task-backed lifecycle work remain out of scope.

Implemented:

- strict protocol-v5 submit/cancel/recover/acknowledge request and response algebra;
- runtime-owned canonical ReceiptKey derivation;
- actor-backed durable `CancelReserved` lifecycle with fixed absolute 7125 ms TTL;
- exact submit conversion to canonical cancelled Direct terminal;
- durable Direct ACK transition through a crash-recoverable generation witness;
- compact restart-stable acknowledged tombstones containing only exact key, terminal digest and first-ACK epoch;
- fixed 15-minute tombstone expiry across exact cancel, recover and repeated ACK paths;
- independent bounded tombstone accounting: 28,864 records, 512 bytes per record and 14,778,368 bytes total;
- minimal expired-only capacity reclaim on ACK rather than unbounded synchronous bulk GC;
- real transport-disconnect coverage after committed ACK and idempotent retry after lost response;
- shared 64-record live accounting without charging tombstones or pre-submit cancellation for result reservation;
- bounded admission-time reclamation of expired identity owners or one required capacity slot;
- reject-before-mutation and read-only exact-idempotency preflight;
- fail-stop authority behavior and typed scenario observations.

## Readiness boundary

The required-feature ReceiptLedger matrix remains intentionally **4/61 GREEN**. The execution-dependent and Task-backed contracts remain RED on missing executor, task projection, handoff, broader concurrency, and load boundaries. The ACK slice itself is covered through the production runtime/store path, including crash windows and real response loss, but the official full ACK scenario still depends on the excluded execution/provider harness. Therefore this is a partial foundation PR, not a claim that the v0.13 migration is complete or ready to activate.

## Verification

- ReceiptLedger/application/actor filtered suite — 200 passed;
- protocol-v5 runtime suite — 28 passed;
- ACK transport-loss scenario — passed with real EOF after durable commit;
- ACK crash recovery — old-generation witness, committed-generation witness and compact-row windows passed;
- worst-case compact tombstone (longest tool name, maximum valid epoch) — ≤512 bytes;
- `cargo clippy -p unica-coder --all-targets --all-features -- -D warnings` — passed;
- receipt terminal codec boundary — 22 passed;
- design/platform CI unit tests — 45 passed;
- `cargo fmt --all -- --check` and `git diff --check` — passed;
- full required-feature matrix — 4 passed / 57 expected functional RED.

Tracks #581.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added protocol v5 support for submitting, cancelling, recovering, and acknowledging invocations.
  * Added receipt responses for pending, direct, task, and acknowledged outcomes.
  * Added bounded tombstone storage with expiry, reclamation, and capacity protection.
  * Added deadline-aware processing and fail-stop behavior for daemon operations.
* **Tests**
  * Expanded scenario coverage for retries, restarts, cancellation, acknowledgements, expiry, capacity limits, and event ordering.
  * Added validation for response integrity and receipt state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

