### PR TITLE
feat(v13): execute A0 check and diff stream

### DIFF
--- a/crates/unica-coder/src/application/v13/check.rs
+++ b/crates/unica-coder/src/application/v13/check.rs
@@ -1,0 +1,412 @@
+use crate::domain::address::QualifiedAddress;
+use serde::Serialize;
+use serde_json::Value;
+use std::fmt;
+
+const SUPPORTED_PROFILES: &[CheckProfile] = &[
+    CheckProfile::Cf,
+    CheckProfile::Cfe,
+    CheckProfile::Form,
+    CheckProfile::Dcs,
+    CheckProfile::Mxl,
+    CheckProfile::Role,
+    CheckProfile::Subsystem,
+    CheckProfile::Interface,
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CheckProfile {
+    Cf,
+    Cfe,
+    Form,
+    Dcs,
+    Mxl,
+    Role,
+    Subsystem,
+    Interface,
+}
+
+impl CheckProfile {
+    pub(crate) fn parse(value: &str) -> Result<Self, CheckError> {
+        let profile = match value {
+            "cf" => Self::Cf,
+            "cfe" => Self::Cfe,
+            "form" => Self::Form,
+            "dcs" => Self::Dcs,
+            "mxl" => Self::Mxl,
+            "role" => Self::Role,
+            "subsystem" => Self::Subsystem,
+            "interface" => Self::Interface,
+            _ => {
+                return Err(CheckError::UnsupportedFilter {
+                    field: "validation.profile".to_string(),
+                    message: format!("unsupported validation profile `{value}`"),
+                })
+            }
+        };
+        Ok(profile)
+    }
+
+    fn for_address(at: &QualifiedAddress) -> Result<Self, CheckError> {
+        let kind = at
+            .segments()
+            .last()
+            .map(|segment| segment.kind().as_str())
+            .unwrap_or_default();
+        match kind {
+            "Configuration" => Ok(Self::Cf),
+            "Subsystem" => Ok(Self::Subsystem),
+            "Role" => Ok(Self::Role),
+            "Form" => Ok(Self::Form),
+            "Interface" => Ok(Self::Interface),
+            _ => Err(CheckError::UnsupportedFilter {
+                field: "filter".to_string(),
+                message: format!(
+                    "no default validator is registered for logical kind `{kind}`; provide validation.profile"
+                ),
+            }),
+        }
+    }
+
+    pub(crate) const fn name(self) -> &'static str {
+        match self {
+            Self::Cf => "cf",
+            Self::Cfe => "cfe",
+            Self::Form => "form",
+            Self::Dcs => "dcs",
+            Self::Mxl => "mxl",
+            Self::Role => "role",
+            Self::Subsystem => "subsystem",
+            Self::Interface => "interface",
+        }
+    }
+
+    pub(crate) const fn operation(self) -> &'static str {
+        match self {
+            Self::Cf => "cf-validate",
+            Self::Cfe => "cfe-validate",
+            Self::Form => "form-validate",
+            Self::Dcs => "dcs-validate",
+            Self::Mxl => "mxl-validate",
+            Self::Role => "role-validate",
+            Self::Subsystem => "subsystem-validate",
+            Self::Interface => "interface-validate",
+        }
+    }
+
+    pub(crate) fn supported() -> &'static [Self] {
+        SUPPORTED_PROFILES
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CheckRequest {
+    at: QualifiedAddress,
+    profile: CheckProfile,
+}
+
+impl CheckRequest {
+    pub(crate) fn new(at: &str, filter: Option<&Value>) -> Result<Self, CheckError> {
+        let at = QualifiedAddress::parse(at).map_err(|error| CheckError::BadValue {
+            field: "at".to_string(),
+            message: error.to_string(),
+        })?;
+        let profile = match filter {
+            Some(filter) => parse_filter(filter)?,
+            None => CheckProfile::for_address(&at)?,
+        };
+        Ok(Self { at, profile })
+    }
+
+    pub(crate) fn at(&self) -> &QualifiedAddress {
+        &self.at
+    }
+
+    pub(crate) const fn profile(&self) -> CheckProfile {
+        self.profile
+    }
+}
+
+fn parse_filter(filter: &Value) -> Result<CheckProfile, CheckError> {
+    let filter = filter.as_object().ok_or_else(|| CheckError::BadValue {
+        field: "filter".to_string(),
+        message: "check filter must be an object".to_string(),
+    })?;
+    if filter.len() != 1 || !filter.contains_key("validation") {
+        return Err(CheckError::UnsupportedFilter {
+            field: "filter".to_string(),
+            message: "check filter supports only validation.profile".to_string(),
+        });
+    }
+    let validation = filter["validation"]
+        .as_object()
+        .ok_or_else(|| CheckError::BadValue {
+            field: "validation".to_string(),
+            message: "check validation filter must be an object".to_string(),
+        })?;
+    if validation.len() != 1 || !validation.contains_key("profile") {
+        return Err(CheckError::UnsupportedFilter {
+            field: "validation".to_string(),
+            message: "check validation filter supports only profile".to_string(),
+        });
+    }
+    let profile = validation["profile"]
+        .as_str()
+        .ok_or_else(|| CheckError::BadValue {
+            field: "validation.profile".to_string(),
+            message: "validation profile must be a string".to_string(),
+        })?;
+    CheckProfile::parse(profile)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CheckError {
+    BadValue { field: String, message: String },
+    UnsupportedFilter { field: String, message: String },
+    DependencyUnavailable,
+}
+
+impl CheckError {
+    pub(crate) const fn code(&self) -> &'static str {
+        match self {
+            Self::BadValue { .. } => "bad_value",
+            Self::UnsupportedFilter { .. } => "unsupported_filter",
+            Self::DependencyUnavailable => "dependency_unavailable",
+        }
+    }
+}
+
+impl fmt::Display for CheckError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BadValue { field, message } | Self::UnsupportedFilter { field, message } => {
+                write!(formatter, "{field}: {message}")
+            }
+            Self::DependencyUnavailable => {
+                formatter.write_str("the selected validator dependency is unavailable")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct CheckDiagnostic {
+    severity: String,
+    code: String,
+    message: String,
+}
+
+impl CheckDiagnostic {
+    pub(crate) fn severity(&self) -> &str {
+        &self.severity
+    }
+
+    pub(crate) fn code(&self) -> &str {
+        &self.code
+    }
+
+    pub(crate) fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NativeCheckOutcome {
+    ok: bool,
+    diagnostics: Vec<CheckDiagnostic>,
+    unavailable: bool,
+}
+
+impl NativeCheckOutcome {
+    pub(crate) fn passed() -> Self {
+        Self {
+            ok: true,
+            diagnostics: Vec::new(),
+            unavailable: false,
+        }
+    }
+
+    pub(crate) fn failed(
+        diagnostics: impl IntoIterator<Item = (&'static str, &'static str, &'static str)>,
+    ) -> Self {
+        Self {
+            ok: false,
+            diagnostics: diagnostics
+                .into_iter()
+                .map(|(severity, code, message)| CheckDiagnostic {
+                    severity: severity.to_string(),
+                    code: code.to_string(),
+                    message: sanitize_message(message),
+                })
+                .collect(),
+            unavailable: false,
+        }
+    }
+
+    pub(crate) fn unavailable(_detail: &str) -> Self {
+        Self {
+            ok: false,
+            diagnostics: Vec::new(),
+            unavailable: true,
+        }
+    }
+
+    pub(crate) fn from_adapter(outcome: &crate::application::AdapterOutcome) -> Self {
+        let mut diagnostics = outcome
+            .errors
+            .iter()
+            .map(|message| CheckDiagnostic {
+                severity: "error".to_string(),
+                code: "native_validation_error".to_string(),
+                message: sanitize_message(message),
+            })
+            .collect::<Vec<_>>();
+        diagnostics.extend(outcome.warnings.iter().map(|message| CheckDiagnostic {
+            severity: "warning".to_string(),
+            code: "native_validation_warning".to_string(),
+            message: sanitize_message(message),
+        }));
+        Self {
+            ok: outcome.ok,
+            diagnostics,
+            unavailable: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct CheckResult {
+    at: String,
+    kind: String,
+    profile: String,
+    ok: bool,
+    diagnostics: Vec<CheckDiagnostic>,
+}
+
+impl CheckResult {
+    pub(crate) fn ok(&self) -> bool {
+        self.ok
+    }
+
+    pub(crate) fn diagnostics(&self) -> &[CheckDiagnostic] {
+        &self.diagnostics
+    }
+
+    pub(crate) fn raw_stream(&self) -> Option<&str> {
+        None
+    }
+}
+
+pub(crate) fn normalize_native_outcome(
+    request: &CheckRequest,
+    kind: &str,
+    native: NativeCheckOutcome,
+) -> Result<CheckResult, CheckError> {
+    if native.unavailable {
+        return Err(CheckError::DependencyUnavailable);
+    }
+    Ok(CheckResult {
+        at: request.at.to_string(),
+        kind: kind.to_string(),
+        profile: request.profile.name().to_string(),
+        ok: native.ok,
+        diagnostics: native.diagnostics,
+    })
+}
+
+fn sanitize_message(message: &str) -> String {
+    message
+        .split_whitespace()
+        .filter(|token| !token.contains('/') && !token.contains('\\'))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        normalize_native_outcome, CheckError, CheckProfile, CheckRequest, NativeCheckOutcome,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn check_registry_accepts_only_proven_validator_profiles() {
+        assert_eq!(
+            CheckProfile::parse("cf").unwrap().operation(),
+            "cf-validate"
+        );
+        assert_eq!(
+            CheckProfile::parse("form").unwrap().operation(),
+            "form-validate"
+        );
+        assert!(matches!(
+            CheckProfile::parse("meta"),
+            Err(CheckError::UnsupportedFilter { .. })
+        ));
+        assert!(matches!(
+            CheckProfile::parse("shell"),
+            Err(CheckError::UnsupportedFilter { .. })
+        ));
+    }
+
+    #[test]
+    fn check_request_rejects_unknown_filter_shape_before_native_dispatch() {
+        let error = CheckRequest::new(
+            "main:Configuration",
+            Some(&json!({"validation": {"profile": "cf"}, "paths": []})),
+        )
+        .unwrap_err();
+        assert!(matches!(error, CheckError::UnsupportedFilter { .. }));
+    }
+
+    #[test]
+    fn check_request_selects_a_closed_default_for_unfiltered_configuration() {
+        let request = CheckRequest::new("main:Configuration", None).unwrap();
+        assert_eq!(request.profile(), CheckProfile::Cf);
+    }
+
+    #[test]
+    fn check_result_normalizes_diagnostics_without_native_stream_or_path() {
+        let request = CheckRequest::new(
+            "main:Configuration",
+            Some(&json!({"validation": {"profile": "cf"}})),
+        )
+        .unwrap();
+        let native = NativeCheckOutcome::failed(vec![
+            (
+                "error",
+                "invalid_root",
+                "XML parse failed in /private/workspace/Configuration.xml",
+            ),
+            (
+                "warning",
+                "format_warning",
+                "provider /usr/local/bin/engine reported a warning",
+            ),
+        ]);
+        let result = normalize_native_outcome(&request, "Configuration", native).unwrap();
+        assert!(!result.ok());
+        assert_eq!(result.diagnostics().len(), 2);
+        assert_eq!(result.diagnostics()[0].code(), "invalid_root");
+        assert!(!result.diagnostics()[0].message().contains("/private/"));
+        assert!(!result.diagnostics()[1].message().contains("/usr/local/"));
+        assert!(result.raw_stream().is_none());
+    }
+
+    #[test]
+    fn unavailable_validator_is_typed_dependency_failure() {
+        let request = CheckRequest::new(
+            "main:Configuration",
+            Some(&json!({"validation": {"profile": "cf"}})),
+        )
+        .unwrap();
+        let error = normalize_native_outcome(
+            &request,
+            "Configuration",
+            NativeCheckOutcome::unavailable("validator engine is not installed"),
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "dependency_unavailable");
+        assert!(!error.to_string().contains("engine"));
+    }
+}

--- a/crates/unica-coder/src/application/v13/diff.rs
+++ b/crates/unica-coder/src/application/v13/diff.rs
@@ -436,22 +436,55 @@ fn project_data(data: &Value, filter: &Value) -> Result<Value, DiffError> {
             message: "diff paths must not be empty".to_string(),
         });
     }
-    for path in paths {
-        let path = path.as_str().ok_or_else(|| DiffError::BadValue {
-            field: "filter.paths".to_string(),
-            message: "diff paths must contain strings".to_string(),
-        })?;
-        if !path.starts_with('/') || path == "/" {
+    let mut paths = paths
+        .iter()
+        .map(|path| {
+            path.as_str().ok_or_else(|| DiffError::BadValue {
+                field: "filter.paths".to_string(),
+                message: "diff paths must contain strings".to_string(),
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    for path in &paths {
+        if !path.starts_with('/') || *path == "/" {
             return Err(DiffError::BadValue {
                 field: "filter.paths".to_string(),
                 message: "diff paths must be non-root JSON pointers".to_string(),
             });
         }
+    }
+    paths.sort_unstable_by(|left, right| {
+        pointer_depth(left)
+            .cmp(&pointer_depth(right))
+            .then_with(|| left.cmp(right))
+    });
+    let mut normalized: Vec<&str> = Vec::with_capacity(paths.len());
+    for path in paths {
+        if normalized
+            .iter()
+            .any(|ancestor| pointer_covers(ancestor, path))
+        {
+            continue;
+        }
+        normalized.push(path);
+    }
+    for path in normalized {
         if let Some(value) = data_value.pointer(path) {
             insert_pointer(&mut projected, path, value.clone())?;
         }
     }
     Ok(Value::Object(projected))
+}
+
+fn pointer_depth(pointer: &str) -> usize {
+    pointer.bytes().filter(|byte| *byte == b'/').count()
+}
+
+fn pointer_covers(ancestor: &str, candidate: &str) -> bool {
+    candidate == ancestor
+        || candidate
+            .strip_prefix(ancestor)
+            .is_some_and(|suffix| suffix.starts_with('/'))
 }
 
 fn insert_pointer(
@@ -629,5 +662,25 @@ mod tests {
             .unwrap();
         assert_eq!(page.changes()[0].path, "/props/value");
         assert!(!page.changes()[0].left.as_ref().unwrap().is_null());
+    }
+
+    #[test]
+    fn diff_overlapping_path_filters_are_order_independent() {
+        let handler = DiffHandler::default();
+        let parent_first = DiffRequest::new("main:Catalog.Items", "main:Catalog.Items")
+            .unwrap()
+            .with_filter(json!({"paths": ["/items", "/items/0"]}))
+            .unwrap();
+        let child_first = DiffRequest::new("main:Catalog.Items", "main:Catalog.Items")
+            .unwrap()
+            .with_filter(json!({"paths": ["/items/0", "/items"]}))
+            .unwrap();
+        let left = source("main:Catalog.Items", "Catalog", "left-1", 1);
+        let right = source("main:Catalog.Items", "Catalog", "right-1", 2);
+
+        let parent_first_page = handler.compare(&parent_first, &left, &right).unwrap();
+        let child_first_page = handler.compare(&child_first, &left, &right).unwrap();
+
+        assert_eq!(parent_first_page, child_first_page);
     }
 }

--- a/crates/unica-coder/src/application/v13/diff.rs
+++ b/crates/unica-coder/src/application/v13/diff.rs
@@ -1,0 +1,633 @@
+use crate::domain::address::QualifiedAddress;
+use serde::Serialize;
+use serde_json::{Map, Value};
+use std::collections::{BTreeSet, HashMap};
+use std::fmt;
+use std::sync::Mutex;
+use uuid::Uuid;
+
+const DEFAULT_LIMIT: usize = 100;
+const MAX_LIMIT: usize = 1_000;
+const MAX_CURSOR_ENTRIES: usize = 64;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct DiffRequest {
+    left: QualifiedAddress,
+    right: QualifiedAddress,
+    filter: Value,
+    limit: usize,
+    cursor: Option<String>,
+}
+
+impl DiffRequest {
+    pub(crate) fn new(left: &str, right: &str) -> Result<Self, DiffError> {
+        let left = QualifiedAddress::parse(left).map_err(|error| DiffError::BadValue {
+            field: "left".to_string(),
+            message: error.to_string(),
+        })?;
+        let right = QualifiedAddress::parse(right).map_err(|error| DiffError::BadValue {
+            field: "right".to_string(),
+            message: error.to_string(),
+        })?;
+        Ok(Self {
+            left,
+            right,
+            filter: Value::Object(Map::new()),
+            limit: DEFAULT_LIMIT,
+            cursor: None,
+        })
+    }
+
+    pub(crate) fn with_filter(mut self, filter: Value) -> Result<Self, DiffError> {
+        validate_filter(&filter)?;
+        self.filter = filter;
+        Ok(self)
+    }
+
+    pub(crate) fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = limit.clamp(1, MAX_LIMIT);
+        self
+    }
+
+    pub(crate) fn with_cursor(mut self, cursor: String) -> Self {
+        self.cursor = Some(cursor);
+        self
+    }
+
+    fn fingerprint(&self) -> String {
+        format!(
+            "{}|{}|{}|{}",
+            self.left,
+            self.right,
+            canonical_json(&self.filter),
+            self.limit
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct DiffSource {
+    at: QualifiedAddress,
+    kind: String,
+    revision: String,
+    data: Value,
+}
+
+impl DiffSource {
+    pub(crate) fn new(
+        at: QualifiedAddress,
+        kind: impl Into<String>,
+        revision: impl Into<String>,
+        data: Value,
+    ) -> Self {
+        Self {
+            at,
+            kind: kind.into(),
+            revision: revision.into(),
+            data,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct DiffChange {
+    path: String,
+    left: Option<Value>,
+    right: Option<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct DiffPage {
+    equal: bool,
+    changes: Vec<DiffChange>,
+    truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cursor: Option<String>,
+}
+
+impl DiffPage {
+    pub(crate) fn changes(&self) -> &[DiffChange] {
+        &self.changes
+    }
+
+    pub(crate) fn truncated(&self) -> bool {
+        self.truncated
+    }
+
+    pub(crate) fn cursor(&self) -> Option<&str> {
+        self.cursor.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DiffError {
+    BadValue { field: String, message: String },
+    UnsupportedFilter(String),
+    IncomparableNodes,
+    InvalidCursor,
+    StaleCursor,
+}
+
+impl DiffError {
+    pub(crate) const fn code(&self) -> &'static str {
+        match self {
+            Self::BadValue { .. } => "bad_value",
+            Self::UnsupportedFilter(_) => "unsupported_filter",
+            Self::IncomparableNodes => "incomparable_nodes",
+            Self::InvalidCursor => "invalid_cursor",
+            Self::StaleCursor => "stale_cursor",
+        }
+    }
+}
+
+impl fmt::Display for DiffError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BadValue { field, message } => write!(formatter, "{field}: {message}"),
+            Self::UnsupportedFilter(message) => formatter.write_str(message),
+            Self::IncomparableNodes => {
+                formatter.write_str("diff requires nodes of the same logical kind")
+            }
+            Self::InvalidCursor => {
+                formatter.write_str("diff cursor is invalid or belongs to another question")
+            }
+            Self::StaleCursor => {
+                formatter.write_str("a source revision changed after the diff cursor was issued")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CursorEntry {
+    fingerprint: String,
+    left_revision: String,
+    right_revision: String,
+    offset: usize,
+}
+
+#[derive(Debug, Default)]
+struct DiffCursorStore {
+    entries: Mutex<HashMap<String, CursorEntry>>,
+}
+
+impl DiffCursorStore {
+    fn issue(&self, entry: CursorEntry) -> Option<String> {
+        let mut entries = self.entries.lock().expect("diff cursor store poisoned");
+        if entries.len() >= MAX_CURSOR_ENTRIES {
+            let key = entries.keys().next()?.clone();
+            entries.remove(&key);
+        }
+        let token = format!("dc1.{}", Uuid::new_v4().simple());
+        entries.insert(token.clone(), entry);
+        Some(token)
+    }
+
+    fn read(&self, token: &str) -> Result<CursorEntry, DiffError> {
+        if token.len() != 36
+            || !token.starts_with("dc1.")
+            || !token[4..]
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        {
+            return Err(DiffError::InvalidCursor);
+        }
+        self.entries
+            .lock()
+            .expect("diff cursor store poisoned")
+            .get(token)
+            .cloned()
+            .ok_or(DiffError::InvalidCursor)
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct DiffHandler {
+    cursors: DiffCursorStore,
+}
+
+impl DiffHandler {
+    pub(crate) fn compare(
+        &self,
+        request: &DiffRequest,
+        left: &DiffSource,
+        right: &DiffSource,
+    ) -> Result<DiffPage, DiffError> {
+        if request.left != left.at || request.right != right.at {
+            return Err(DiffError::BadValue {
+                field: "source".to_string(),
+                message: "sources do not match the logical diff request".to_string(),
+            });
+        }
+        if left.kind != right.kind {
+            return Err(DiffError::IncomparableNodes);
+        }
+        let left_data = project_data(&left.data, &request.filter)?;
+        let right_data = project_data(&right.data, &request.filter)?;
+        if left_data.get("kind") != right_data.get("kind") {
+            return Err(DiffError::IncomparableNodes);
+        }
+
+        let fingerprint = request.fingerprint();
+        let offset = if let Some(token) = request.cursor.as_deref() {
+            let entry = self.cursors.read(token)?;
+            if entry.fingerprint != fingerprint {
+                return Err(DiffError::InvalidCursor);
+            }
+            if entry.left_revision != left.revision || entry.right_revision != right.revision {
+                return Err(DiffError::StaleCursor);
+            }
+            entry.offset
+        } else {
+            0
+        };
+        let mut skip = offset;
+        let mut changes = Vec::with_capacity(request.limit.saturating_add(1));
+        collect_changes(
+            "",
+            &left_data,
+            &right_data,
+            &mut skip,
+            request.limit.saturating_add(1),
+            &mut changes,
+        );
+        let truncated = changes.len() > request.limit;
+        changes.truncate(request.limit);
+        let next_cursor = truncated
+            .then(|| {
+                self.cursors.issue(CursorEntry {
+                    fingerprint,
+                    left_revision: left.revision.clone(),
+                    right_revision: right.revision.clone(),
+                    offset: offset.saturating_add(changes.len()),
+                })
+            })
+            .flatten();
+        Ok(DiffPage {
+            equal: changes.is_empty() && !truncated,
+            changes,
+            truncated,
+            cursor: next_cursor,
+        })
+    }
+}
+
+fn collect_changes(
+    path: &str,
+    left: &Value,
+    right: &Value,
+    skip: &mut usize,
+    limit: usize,
+    changes: &mut Vec<DiffChange>,
+) {
+    if left == right || changes.len() >= limit {
+        return;
+    }
+    match (left, right) {
+        (Value::Object(left), Value::Object(right)) => {
+            let keys = left
+                .keys()
+                .chain(right.keys())
+                .map(String::as_str)
+                .collect::<BTreeSet<_>>();
+            for key in keys {
+                let escaped = key.replace('~', "~0").replace('/', "~1");
+                let child_path = format!("{path}/{escaped}");
+                match (left.get(key), right.get(key)) {
+                    (Some(left), Some(right)) => {
+                        collect_changes(&child_path, left, right, skip, limit, changes)
+                    }
+                    (left, right) => emit_change(&child_path, left, right, skip, limit, changes),
+                }
+                if changes.len() >= limit {
+                    break;
+                }
+            }
+        }
+        (Value::Array(left), Value::Array(right)) => {
+            for index in 0..left.len().max(right.len()) {
+                let child_path = format!("{path}/{index}");
+                match (left.get(index), right.get(index)) {
+                    (Some(left), Some(right)) => {
+                        collect_changes(&child_path, left, right, skip, limit, changes)
+                    }
+                    (left, right) => emit_change(&child_path, left, right, skip, limit, changes),
+                }
+                if changes.len() >= limit {
+                    break;
+                }
+            }
+        }
+        _ => emit_change(
+            path_or_root(path),
+            Some(left),
+            Some(right),
+            skip,
+            limit,
+            changes,
+        ),
+    }
+}
+
+fn emit_change(
+    path: &str,
+    left: Option<&Value>,
+    right: Option<&Value>,
+    skip: &mut usize,
+    limit: usize,
+    changes: &mut Vec<DiffChange>,
+) {
+    if *skip > 0 {
+        *skip -= 1;
+        return;
+    }
+    if changes.len() < limit {
+        changes.push(DiffChange {
+            path: path.to_string(),
+            left: left.cloned(),
+            right: right.cloned(),
+        });
+    }
+}
+
+fn path_or_root(path: &str) -> &str {
+    if path.is_empty() {
+        "/"
+    } else {
+        path
+    }
+}
+
+fn validate_filter(filter: &Value) -> Result<(), DiffError> {
+    let Some(filter) = filter.as_object() else {
+        return Err(DiffError::BadValue {
+            field: "filter".to_string(),
+            message: "diff filter must be an object".to_string(),
+        });
+    };
+    if filter.keys().any(|key| key != "paths" && key != "sections") {
+        return Err(DiffError::UnsupportedFilter(
+            "diff filter supports only paths or sections".to_string(),
+        ));
+    }
+    if filter.contains_key("paths") && filter.contains_key("sections") {
+        return Err(DiffError::BadValue {
+            field: "filter".to_string(),
+            message: "diff filter accepts either paths or sections, not both".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn project_data(data: &Value, filter: &Value) -> Result<Value, DiffError> {
+    validate_filter(filter)?;
+    let Some(filter) = filter.as_object() else {
+        unreachable!()
+    };
+    if filter.is_empty() {
+        return Ok(data.clone());
+    }
+    let data_value = data.clone();
+    let data = data_value.as_object().ok_or_else(|| DiffError::BadValue {
+        field: "data".to_string(),
+        message: "diff source data must be an object".to_string(),
+    })?;
+    let mut projected = Map::new();
+    if let Some(kind) = data.get("kind") {
+        projected.insert("kind".to_string(), kind.clone());
+    }
+    if let Some(sections) = filter.get("sections") {
+        let sections = sections.as_array().ok_or_else(|| DiffError::BadValue {
+            field: "filter.sections".to_string(),
+            message: "diff sections must be an array of strings".to_string(),
+        })?;
+        const ALLOWED: &[&str] = &["at", "title", "props", "branches", "can", "limits", "items"];
+        if sections.is_empty() {
+            return Err(DiffError::BadValue {
+                field: "filter.sections".to_string(),
+                message: "diff sections must not be empty".to_string(),
+            });
+        }
+        for section in sections {
+            let section = section.as_str().ok_or_else(|| DiffError::BadValue {
+                field: "filter.sections".to_string(),
+                message: "diff sections must contain strings".to_string(),
+            })?;
+            if !ALLOWED.contains(&section) {
+                return Err(DiffError::UnsupportedFilter(format!(
+                    "unsupported diff section `{section}`"
+                )));
+            }
+            if let Some(value) = data.get(section) {
+                projected.insert(section.to_string(), value.clone());
+            }
+        }
+        return Ok(Value::Object(projected));
+    }
+    let paths = filter["paths"]
+        .as_array()
+        .ok_or_else(|| DiffError::BadValue {
+            field: "filter.paths".to_string(),
+            message: "diff paths must be an array of JSON pointers".to_string(),
+        })?;
+    if paths.is_empty() {
+        return Err(DiffError::BadValue {
+            field: "filter.paths".to_string(),
+            message: "diff paths must not be empty".to_string(),
+        });
+    }
+    for path in paths {
+        let path = path.as_str().ok_or_else(|| DiffError::BadValue {
+            field: "filter.paths".to_string(),
+            message: "diff paths must contain strings".to_string(),
+        })?;
+        if !path.starts_with('/') || path == "/" {
+            return Err(DiffError::BadValue {
+                field: "filter.paths".to_string(),
+                message: "diff paths must be non-root JSON pointers".to_string(),
+            });
+        }
+        if let Some(value) = data_value.pointer(path) {
+            insert_pointer(&mut projected, path, value.clone())?;
+        }
+    }
+    Ok(Value::Object(projected))
+}
+
+fn insert_pointer(
+    root: &mut Map<String, Value>,
+    pointer: &str,
+    value: Value,
+) -> Result<(), DiffError> {
+    let segments = pointer
+        .split('/')
+        .skip(1)
+        .map(|segment| segment.replace("~1", "/").replace("~0", "~"))
+        .collect::<Vec<_>>();
+    let Some((last, parents)) = segments.split_last() else {
+        return Err(DiffError::BadValue {
+            field: "filter.paths".to_string(),
+            message: "diff JSON pointer is empty".to_string(),
+        });
+    };
+    let mut current = root;
+    for segment in parents {
+        let entry = current
+            .entry(segment.clone())
+            .or_insert_with(|| Value::Object(Map::new()));
+        current = entry.as_object_mut().ok_or_else(|| DiffError::BadValue {
+            field: "filter.paths".to_string(),
+            message: "diff path crosses a non-object JSON value".to_string(),
+        })?;
+    }
+    current.insert(last.clone(), value);
+    Ok(())
+}
+
+fn canonical_json(value: &Value) -> String {
+    match value {
+        Value::Object(map) => map
+            .iter()
+            .map(|(key, value)| format!("{}:{}", key, canonical_json(value)))
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .join(","),
+        Value::Array(values) => values
+            .iter()
+            .map(canonical_json)
+            .collect::<Vec<_>>()
+            .join(","),
+        _ => value.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DiffError, DiffHandler, DiffRequest, DiffSource};
+    use crate::domain::address::QualifiedAddress;
+    use serde_json::json;
+
+    fn source(at: &str, kind: &str, revision: &str, value: i64) -> DiffSource {
+        DiffSource::new(
+            QualifiedAddress::parse(at).unwrap(),
+            kind,
+            revision,
+            json!({"kind": kind, "props": {"value": value}, "items": (0..50).map(|n| json!({"n": n + value})).collect::<Vec<_>>() }),
+        )
+    }
+
+    #[test]
+    fn diff_rejects_incomparable_logical_kinds() {
+        let handler = DiffHandler::default();
+        let request = DiffRequest::new("main:Catalog.Items", "main:Role.Manager").unwrap();
+        let error = handler
+            .compare(
+                &request,
+                &source("main:Catalog.Items", "Catalog", "left-1", 1),
+                &source("main:Role.Manager", "Role", "right-1", 1),
+            )
+            .unwrap_err();
+        assert_eq!(error.code(), "incomparable_nodes");
+    }
+
+    #[test]
+    fn diff_limit_bounds_materialized_changes_and_issues_a_cursor() {
+        let handler = DiffHandler::default();
+        let request = DiffRequest::new("main:Catalog.Items", "main:Catalog.Items")
+            .unwrap()
+            .with_limit(2);
+        let page = handler
+            .compare(
+                &request,
+                &source("main:Catalog.Items", "Catalog", "left-1", 1),
+                &source("main:Catalog.Items", "Catalog", "right-1", 2),
+            )
+            .unwrap();
+        assert_eq!(page.changes().len(), 2);
+        assert!(page.truncated());
+        assert!(page.cursor().is_some());
+    }
+
+    #[test]
+    fn diff_cursor_is_bound_to_both_source_revisions() {
+        let handler = DiffHandler::default();
+        let request = DiffRequest::new("main:Catalog.Items", "main:Catalog.Items")
+            .unwrap()
+            .with_limit(1);
+        let left = source("main:Catalog.Items", "Catalog", "left-1", 1);
+        let right = source("main:Catalog.Items", "Catalog", "right-1", 2);
+        let first = handler.compare(&request, &left, &right).unwrap();
+        let cursor = first.cursor().unwrap().to_string();
+        let stale_left = source("main:Catalog.Items", "Catalog", "left-2", 1);
+        let stale = handler
+            .compare(
+                &request.clone().with_cursor(cursor.clone()),
+                &stale_left,
+                &right,
+            )
+            .unwrap_err();
+        assert_eq!(stale.code(), "stale_cursor");
+        let stale_right = source("main:Catalog.Items", "Catalog", "right-2", 2);
+        let stale = handler
+            .compare(&request.with_cursor(cursor), &left, &stale_right)
+            .unwrap_err();
+        assert_eq!(stale.code(), "stale_cursor");
+    }
+
+    #[test]
+    fn diff_cursor_cannot_be_replayed_for_another_question() {
+        let handler = DiffHandler::default();
+        let request = DiffRequest::new("main:Catalog.Items", "main:Catalog.Items")
+            .unwrap()
+            .with_limit(1);
+        let left = source("main:Catalog.Items", "Catalog", "left-1", 1);
+        let right = source("main:Catalog.Items", "Catalog", "right-1", 2);
+        let first = handler.compare(&request, &left, &right).unwrap();
+        let cursor = first.cursor().unwrap();
+        let replay = request.with_cursor(cursor.to_string()).with_limit(2);
+        assert!(matches!(
+            handler.compare(&replay, &left, &right),
+            Err(DiffError::InvalidCursor)
+        ));
+    }
+
+    #[test]
+    fn diff_cursor_continues_from_the_bounded_change_offset() {
+        let handler = DiffHandler::default();
+        let request = DiffRequest::new("main:Catalog.Items", "main:Catalog.Items")
+            .unwrap()
+            .with_limit(2);
+        let left = source("main:Catalog.Items", "Catalog", "left-1", 1);
+        let right = source("main:Catalog.Items", "Catalog", "right-1", 2);
+        let first = handler.compare(&request, &left, &right).unwrap();
+        let second = handler
+            .compare(
+                &request.with_cursor(first.cursor().unwrap().to_string()),
+                &left,
+                &right,
+            )
+            .unwrap();
+        assert_eq!(first.changes()[0].path, "/items/0/n");
+        assert_eq!(second.changes()[0].path, "/items/2/n");
+        assert_ne!(first.changes()[0].path, second.changes()[0].path);
+    }
+
+    #[test]
+    fn diff_paths_filter_is_closed_and_preserves_kind_identity() {
+        let handler = DiffHandler::default();
+        let request = DiffRequest::new("main:Catalog.Items", "main:Catalog.Items")
+            .unwrap()
+            .with_filter(json!({"paths": ["/props/value"]}))
+            .unwrap();
+        let page = handler
+            .compare(
+                &request,
+                &source("main:Catalog.Items", "Catalog", "left-1", 1),
+                &source("main:Catalog.Items", "Catalog", "right-1", 2),
+            )
+            .unwrap();
+        assert_eq!(page.changes()[0].path, "/props/value");
+        assert!(!page.changes()[0].left.as_ref().unwrap().is_null());
+    }
+}

--- a/crates/unica-coder/src/application/v13/mod.rs
+++ b/crates/unica-coder/src/application/v13/mod.rs
@@ -1,4 +1,6 @@
 pub(crate) mod apply;
+pub(crate) mod check;
+pub(crate) mod diff;
 pub(crate) mod find;
 pub(crate) mod task_tools;
 pub(crate) mod tool_catalog;

--- a/crates/unica-coder/src/infrastructure/native_operations.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations.rs
@@ -30,6 +30,7 @@ pub(crate) mod support;
 pub(crate) mod template;
 pub(crate) mod text_snapshot;
 pub(crate) mod typed_result;
+pub(crate) mod v13_analysis;
 // The staged B4 XDTO planner/writer remains dormant until its W1B actor route.
 #[allow(dead_code)]
 pub(crate) mod xdto;

--- a/crates/unica-coder/src/infrastructure/native_operations.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations.rs
@@ -30,6 +30,9 @@ pub(crate) mod support;
 pub(crate) mod template;
 pub(crate) mod text_snapshot;
 pub(crate) mod typed_result;
+// The A0 validator adapter is consumed by the shared V13 dispatcher in J0.
+// Keep the seam compiled and tested before that wiring lands.
+#[allow(dead_code)]
 pub(crate) mod v13_analysis;
 // The staged B4 XDTO planner/writer remains dormant until its W1B actor route.
 #[allow(dead_code)]

--- a/crates/unica-coder/src/infrastructure/native_operations/v13_analysis.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/v13_analysis.rs
@@ -1,0 +1,133 @@
+use crate::application::v13::check::{CheckProfile, NativeCheckOutcome};
+use crate::domain::workspace::WorkspaceContext;
+use serde_json::{Map, Value};
+
+/// Closed native validator registry for the hidden A0 analysis seam. The
+/// family validators remain the source of validation truth; this adapter only
+/// translates their result into the bounded v0.13 diagnostic model.
+pub(crate) fn validate(
+    profile: CheckProfile,
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+) -> NativeCheckOutcome {
+    validate_with_availability(profile, args, context, ValidatorAvailability::Available)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ValidatorAvailability {
+    Available,
+    Unavailable,
+}
+
+pub(crate) fn validate_with_availability(
+    profile: CheckProfile,
+    args: &Map<String, Value>,
+    context: &WorkspaceContext,
+    availability: ValidatorAvailability,
+) -> NativeCheckOutcome {
+    if availability == ValidatorAvailability::Unavailable {
+        return unavailable_dependency();
+    }
+    let outcome = match profile {
+        CheckProfile::Cf => super::cf::validate_cf(args, context),
+        CheckProfile::Cfe => super::cfe::validate_cfe(args, context),
+        CheckProfile::Form => super::form::validate_form(args, context),
+        CheckProfile::Dcs => super::dcs::validate_dcs(args, context),
+        CheckProfile::Mxl => super::mxl::validate_mxl(args, context),
+        CheckProfile::Role => super::role::validate_role(args, context),
+        CheckProfile::Subsystem => super::subsystem::validate_subsystem(args, context),
+        CheckProfile::Interface => super::interface::validate_interface(args, context),
+    };
+    NativeCheckOutcome::from_adapter(&outcome)
+}
+
+/// A dependency that is not installed is not a validation failure and must be
+/// represented as a typed unavailable outcome by the caller.
+pub(crate) fn unavailable_dependency() -> NativeCheckOutcome {
+    NativeCheckOutcome::unavailable("native validator dependency is unavailable")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate, validate_with_availability, ValidatorAvailability};
+    use crate::application::v13::check::{normalize_native_outcome, CheckRequest};
+    use crate::domain::workspace::WorkspaceContext;
+    use serde_json::{json, Map};
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn context() -> (WorkspaceContext, std::path::PathBuf) {
+        let root = std::env::temp_dir().join(format!(
+            "unica-a0-check-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        (
+            WorkspaceContext {
+                cwd: root.clone(),
+                workspace_root: root.clone(),
+                cache_root: root.join(".build/unica"),
+                workspace_epoch: 1,
+            },
+            root,
+        )
+    }
+
+    #[test]
+    fn cf_validator_is_real_and_normalized_before_application_projection() {
+        let (context, root) = context();
+        fs::write(root.join("Configuration.xml"), "<not-configuration />").unwrap();
+        let request = CheckRequest::new(
+            "main:Configuration",
+            Some(&json!({"validation": {"profile": "cf"}})),
+        )
+        .unwrap();
+        let native = validate(
+            request.profile(),
+            &Map::from_iter([(
+                "ConfigPath".to_string(),
+                json!(root.join("Configuration.xml").display().to_string()),
+            )]),
+            &context,
+        );
+        let result = normalize_native_outcome(&request, "Configuration", native).unwrap();
+        assert!(!result.ok());
+        assert!(!result.diagnostics().is_empty());
+        for diagnostic in result.diagnostics() {
+            assert!(!diagnostic.message().contains(root.to_str().unwrap()));
+            assert!(!diagnostic.message().contains("stdout"));
+            assert!(!diagnostic.message().contains("stderr"));
+        }
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn unavailable_dependency_stays_typed_and_does_not_claim_success() {
+        let request = CheckRequest::new(
+            "main:Configuration",
+            Some(&json!({"validation": {"profile": "cf"}})),
+        )
+        .unwrap();
+        let error = normalize_native_outcome(
+            &request,
+            "Configuration",
+            validate_with_availability(
+                request.profile(),
+                &Map::new(),
+                &WorkspaceContext {
+                    cwd: std::path::PathBuf::new(),
+                    workspace_root: std::path::PathBuf::new(),
+                    cache_root: std::path::PathBuf::new(),
+                    workspace_epoch: 1,
+                },
+                ValidatorAvailability::Unavailable,
+            ),
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "dependency_unavailable");
+    }
+}

--- a/docs/plans/2026-09-01-a0-analysis-check-diff.md
+++ b/docs/plans/2026-09-01-a0-analysis-check-diff.md
@@ -1,0 +1,66 @@
+# A0 analysis handlers implementation plan
+
+**Goal:** Replace the provisional v0.13 `check` and `diff` behavior with independently testable typed handlers that run closed validator profiles, normalize diagnostics, and paginate revision-bound differences.
+
+**Architecture:** `application/v13/check.rs` and `application/v13/diff.rs` own request validation, result shapes, bounded traversal, and opaque cursor semantics. `infrastructure/native_operations/v13_analysis.rs` owns the closed native-validator registry and converts existing family validators into the application diagnostic model. The shared daemon dispatcher, public catalog, and coverage ledger remain untouched for J0.
+
+**Tech Stack:** Rust, serde/serde_json, existing native XML validators, UUID-backed process-local cursor capabilities.
+
+**Spec:** GitHub issue #581, stream A0 (`check` and `diff`).
+
+**Decision:** `none — no architectural contract changed`; this stream adds private typed seams and does not change the public dispatcher or tool catalog.
+
+## Global constraints
+
+- Start from `origin/main` at `8a13c2e711d0a31ed17d06f02bf08cd8eec36353`.
+- Do not edit `v13_service.rs`, `tool_catalog.rs`, `interfaces/*`, package metadata, or `arch/tool-implementation-coverage.json`; J0 owns shared wiring.
+- Keep validator profiles and filters closed; unknown profiles are typed unsupported errors.
+- Never expose physical paths, provider identities, raw commands, stdout, or stderr in typed results.
+- Apply the diff limit while traversing changes; do not materialize an unbounded change list.
+
+### Task 1: Typed check request, registry, and normalized result
+
+**Files:**
+
+- Create: `crates/unica-coder/src/application/v13/check.rs`
+- Modify: `crates/unica-coder/src/application/v13/mod.rs`
+
+- [ ] Write tests for the closed profile/filter registry, logical request parsing, normalized diagnostics, and unavailable-validator errors.
+- [ ] Run the focused tests and verify the new behavior fails because the module/types do not exist.
+- [ ] Implement the smallest typed request/result API and diagnostic normalization.
+- [ ] Run the focused tests and the v13 application test target.
+
+### Task 2: Native validator adapter
+
+**Files:**
+
+- Create: `crates/unica-coder/src/infrastructure/native_operations/v13_analysis.rs`
+- Modify: `crates/unica-coder/src/infrastructure/native_operations.rs`
+
+- [ ] Write tests that invoke a real existing validator through the closed registry and prove that paths/raw streams are absent from the normalized result.
+- [ ] Run the focused tests to record the RED state.
+- [ ] Implement profile-to-validator dispatch for the proven native validators and typed unavailable/unsupported outcomes.
+- [ ] Run the focused native-operation tests and the affected Rust suite.
+
+### Task 3: Revision-aware bounded diff handler
+
+**Files:**
+
+- Create: `crates/unica-coder/src/application/v13/diff.rs`
+- Modify: `crates/unica-coder/src/application/v13/mod.rs`
+
+- [ ] Write tests for incomparable kinds, bounded output, cursor binding to both revisions, stale cursors, and filter/request replay binding.
+- [ ] Run the focused tests to verify RED.
+- [ ] Implement deterministic JSON traversal with a bounded skip/collect window and opaque process-local cursors.
+- [ ] Run focused diff tests and the affected Rust suite.
+
+### Task 4: Fixture and exit evidence
+
+**Files:**
+
+- Modify: `tests/fixtures/v013/domain-parity/check-diff.json`
+- Add focused Rust tests only within the A0-owned modules.
+
+- [ ] Record the supported profile/filter and diff lifecycle cases in the existing fixture without changing public coverage wiring.
+- [ ] Run formatting, focused tests, full `cargo test -p unica-coder`, and repository architecture/source guards.
+- [ ] Review the final diff for ownership violations and report the exact verification results.

--- a/tests/fixtures/v013/domain-parity/check-diff.json
+++ b/tests/fixtures/v013/domain-parity/check-diff.json
@@ -2,6 +2,38 @@
   "schemaVersion": 2,
   "complete": false,
   "baselineDispositions": [],
-  "cases": [],
+  "cases": [
+    {
+      "caseId": "check-cf-real-validator",
+      "entry": "check",
+      "mode": "validation.profile=cf",
+      "fixture": "tests/fixtures/v013/domain-parity/check-diff.json",
+      "expected": {
+        "outcome": "normalized-diagnostics",
+        "rawStreams": false,
+        "physicalPaths": false
+      }
+    },
+    {
+      "caseId": "check-unavailable-dependency",
+      "entry": "check",
+      "mode": "validation.profile=cf;dependency=unavailable",
+      "fixture": "tests/fixtures/v013/domain-parity/check-diff.json",
+      "expected": {
+        "outcome": "dependency_unavailable"
+      }
+    },
+    {
+      "caseId": "diff-bounded-revision-cursor",
+      "entry": "diff",
+      "mode": "limit=2;cursor=both-revisions",
+      "fixture": "tests/fixtures/v013/domain-parity/check-diff.json",
+      "expected": {
+        "outcome": "stale_cursor_on_either_revision",
+        "boundedChanges": true,
+        "incomparableKinds": "rejected"
+      }
+    }
+  ],
   "newCapabilities": []
 }


### PR DESCRIPTION
## Summary

Implements stream A0 from issue #581 as an independently testable typed seam.

- adds closed `check` validator profiles and filter parsing
- normalizes native validator diagnostics without raw paths, provider identity, stdout, or stderr
- adds typed unavailable-dependency handling
- adds bounded JSON diff traversal with opaque cursors bound to both source revisions and the exact question
- records focused parity cases

## Ownership

- stream: A0
- owner: Codex (IngvarConsulting)
- branch: `codex/stream-a0-check-diff`
- base: `main` at `8a13c2e711d0a31ed17d06f02bf08cd8eec36353`
- shared daemon dispatcher, public catalog, and coverage wiring intentionally left for J0

## Supported boundary

Native profiles: `cf`, `cfe`, `form`, `dcs`, `mxl`, `role`, `subsystem`, `interface`. Unknown profiles and filters are typed unsupported results.

## Verification

- `cargo test -p unica-coder 'v13::' --lib` — 27 passed
- `cargo test -p unica-coder v13_analysis --lib` — 2 passed
- `python3 -m pytest -q tests/ci/test_v013_parity_inventory.py` — 39 passed
- `python3 -m pytest -q tests/ci/test_design_documents.py tests/ci/test_v013_parity_inventory.py tests/ci/test_v013_implementation_coverage.py` — 58 passed
- `python3 scripts/arch/registry.py --check` — passed
- `cargo test -p unica-coder --lib` — 4454 passed, 3 ignored, 1 pre-existing flaky baseline failure in `infrastructure::platform::process::tests::runtime_ownership_pipe_accepts_an_exact_quick_terminal_child`; isolated rerun passed 10/10

Closes no release gate; J0 owns public wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation checks for configuration, form, role, subsystem, interface, and related profiles.
  - Added structured diagnostics with sanitized messages and clear dependency-unavailable results.
  - Added comparison tools for compatible resources, including filtering, bounded result pages, and resumable cursors.

- **Bug Fixes**
  - Prevented stale or invalid comparison cursors from returning misleading results.
  - Added safeguards for incompatible comparisons and unsupported filters.

- **Tests**
  - Added coverage for validation, diagnostics, pagination, cursor handling, and unavailable dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->