### PR TITLE
test(daemon): stabilize owner capacity fixture

### DIFF
--- a/crates/unica-coder/src/infrastructure/daemon/mod.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/mod.rs
@@ -343,21 +343,49 @@ mod tests {
         record: &EndpointRecord,
         identity: &CoreIdentity,
     ) -> (TcpStream, ServerResponse) {
+        try_connect_raw_owner(record, identity, Duration::from_secs(2)).unwrap()
+    }
+
+    fn try_connect_raw_owner(
+        record: &EndpointRecord,
+        identity: &CoreIdentity,
+        read_timeout: Duration,
+    ) -> io::Result<(TcpStream, ServerResponse)> {
         let mut stream = TcpStream::connect(record.loopback_addr().unwrap()).unwrap();
-        stream
-            .set_read_timeout(Some(Duration::from_secs(2)))
-            .unwrap();
+        stream.set_read_timeout(Some(read_timeout))?;
         let hello = ClientRequest::hello_with_owner_for_test(
             record.token().to_string(),
             identity.clone(),
             uuid::Uuid::new_v4().to_string(),
         );
         write_json_line(&mut stream, &hello);
-        let response = serde_json::from_slice(
-            &read_bounded_json_line(&mut BufReader::new(stream.try_clone().unwrap())).unwrap(),
-        )
-        .unwrap();
-        (stream, response)
+        let bytes = read_bounded_json_line(&mut BufReader::new(stream.try_clone()?))?;
+        let response = serde_json::from_slice(&bytes)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        Ok((stream, response))
+    }
+
+    fn connect_raw_owner_before(
+        record: &EndpointRecord,
+        identity: &CoreIdentity,
+        deadline: Instant,
+    ) -> (TcpStream, ServerResponse) {
+        loop {
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .filter(|remaining| !remaining.is_zero())
+                .expect("raw owner handshake retry deadline expired");
+            match try_connect_raw_owner(record, identity, remaining.min(Duration::from_secs(2))) {
+                Ok(owner) => return owner,
+                Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => {
+                    // A saturated test process can let the server-side handshake deadline
+                    // expire before its handler is scheduled. Retry only that silent close;
+                    // every protocol response is returned to the capacity assertions.
+                    thread::yield_now();
+                }
+                Err(error) => panic!("raw owner handshake failed before capacity result: {error}"),
+            }
+        }
     }
 
     struct BlockingCanonicalService {
@@ -3184,7 +3212,11 @@ mod tests {
         let mut owners = Vec::new();
 
         for owner_index in 0..EXPECTED_OWNER_SESSION_LIMIT {
-            let (stream, response) = connect_raw_owner(&record, &identity);
+            let (stream, response) = connect_raw_owner_before(
+                &record,
+                &identity,
+                Instant::now() + Duration::from_secs(10),
+            );
             assert!(
                 response.matches_record(&record),
                 "owner {owner_index} was rejected below the owner-session bound: {response:?}"


### PR DESCRIPTION
## Summary

- isolate the owner-capacity assertion from scheduler-sensitive silent handshake closes
- retry only UnexpectedEof under one bounded per-owner deadline
- preserve immediate assertions for every protocol response and leave production limits and deadlines unchanged

## Root cause

The full workspace suite reproduced one silent EOF while opening 64 owner sessions. Under suite load, a server handler can miss the existing two-second pre-auth deadline before it is scheduled. That closes the transport without a response and makes the capacity test fail before it reaches the capacity contract. The behavior and test predate PR #646 and PR #648, so this is an independent main-based fix.

## RED evidence

cargo test --workspace -- --test-threads=1

Result before the fix: 4456 passed, 1 failed, 3 ignored. Failure: infrastructure::daemon::tests::owner_session_capacity_is_distinct_and_retryable with UnexpectedEof.

## Verification

- cargo test --workspace -- --test-threads=1
- cargo test -p unica-coder infrastructure::daemon::tests::owner_session_capacity_is_distinct_and_retryable -- --exact
- 10 consecutive exact-test runs
- full daemon test subset: 51 passed
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- git diff --check

Unblocks the fresh merged-tree verification of #646.