### PR TITLE
test(daemon): isolate ownership fixtures from fail-stop timing

### DIFF
--- a/crates/unica-coder/src/infrastructure/daemon/server.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/server.rs
@@ -6180,32 +6180,47 @@ struct ActorLogicalReadLease {"#,
         );
     }
 
+    fn run_long_work_contract_obligation(name: &str, obligation: fn()) {
+        std::thread::Builder::new()
+            .name(name.to_owned())
+            // Each debug-only ownership oracle is independently valid on the
+            // test harness stack. Keep their stack frames isolated instead of
+            // compiling the whole named contract into one aggregate frame.
+            .stack_size(32 * 1024 * 1024)
+            .spawn(obligation)
+            .expect("long-work contract obligation thread should start")
+            .join()
+            .expect("long-work contract obligation thread should finish");
+    }
+
+    fn runtime_resource_tree_contract_obligation() {
+        crate::infrastructure::runtime_jobs::reset_runtime_resource_contract_executions_for_test();
+        crate::infrastructure::runtime_jobs::run_runtime_resource_tree_contract_for_test();
+        assert_eq!(
+            crate::infrastructure::runtime_jobs::runtime_resource_contract_executions_for_test(),
+            1,
+            "daemon CTR named check did not execute its runtime-tree obligations"
+        );
+    }
+
     #[test]
     fn daemon_exact_long_work_ownership_contract() {
-        std::thread::Builder::new()
-            .name("daemon-exact-long-work-contract".to_owned())
-            // The aggregate exercises several deeply nested debug-only
-            // ownership oracles. Windows' test harness stack is too small,
-            // and 8 MiB remained close enough to the limit to be flaky under
-            // the full workspace run.
-            .stack_size(32 * 1024 * 1024)
-            .spawn(|| {
-                crate::infrastructure::runtime_jobs::reset_runtime_resource_contract_executions_for_test();
-
-                daemon_long_work_capabilities_handoff_before_wait_and_preserve_exact_ownership();
-                daemon_index_work_separates_worktrees_and_rejects_stale_revision_publication();
-                daemon_long_work_rejects_replaced_actor_root_before_reuse_or_publication();
-                crate::infrastructure::runtime_jobs::run_runtime_resource_tree_contract_for_test();
-
-                assert_eq!(
-                    crate::infrastructure::runtime_jobs::runtime_resource_contract_executions_for_test(),
-                    1,
-                    "daemon CTR named check did not execute its runtime-tree obligations"
-                );
-            })
-            .expect("long-work contract thread should start")
-            .join()
-            .expect("long-work contract thread should finish");
+        run_long_work_contract_obligation(
+            "daemon-long-work-capabilities-contract",
+            daemon_long_work_capabilities_handoff_before_wait_and_preserve_exact_ownership,
+        );
+        run_long_work_contract_obligation(
+            "daemon-index-revision-contract",
+            daemon_index_work_separates_worktrees_and_rejects_stale_revision_publication,
+        );
+        run_long_work_contract_obligation(
+            "daemon-replaced-root-contract",
+            daemon_long_work_rejects_replaced_actor_root_before_reuse_or_publication,
+        );
+        run_long_work_contract_obligation(
+            "daemon-runtime-resource-contract",
+            runtime_resource_tree_contract_obligation,
+        );
     }
 
     fn live_actor_capacity_reuses_alias_and_rejects_only_a_distinct_third_root() {

--- a/crates/unica-coder/src/infrastructure/daemon/server.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/server.rs
@@ -5658,6 +5658,24 @@ struct ActorLogicalReadLease {"#,
         Arc<(Mutex<bool>, Condvar)>,
     );
 
+    const OWNERSHIP_CONTRACT_RECONCILIATION_BUDGET: Duration = Duration::from_secs(15);
+    const OWNERSHIP_CONTRACT_WAIT_MS: u64 = 15_000;
+
+    fn ownership_contract_runtime(
+        store: Arc<dyn InvocationStore>,
+        service: Arc<dyn CanonicalInvocationService>,
+    ) -> DaemonInvocationRuntime {
+        // These fixtures assert capability and actor ownership, not the production
+        // fail-stop deadline. Keep a loaded Windows runner from turning scheduler
+        // delay into an unrelated RestartRequested result.
+        DaemonInvocationRuntime::new_with_reconciliation_budget_for_test(
+            store,
+            service,
+            Arc::new(TokioClock),
+            OWNERSHIP_CONTRACT_RECONCILIATION_BUDGET,
+        )
+    }
+
     fn shared_capability_service(kind: LongCapabilityKind) -> SharedCapabilityFixture {
         let producers = Arc::new(AtomicUsize::new(0));
         let (producer_entered, producer_wait) = mpsc::channel();
@@ -5942,8 +5960,7 @@ struct ActorLogicalReadLease {"#,
                     .unwrap();
             let (service, producers, producer_wait, joined_wait, release) =
                 shared_capability_service(kind.clone());
-            let runtime =
-                DaemonInvocationRuntime::new(Arc::new(store), service, Arc::new(TokioClock));
+            let runtime = ownership_contract_runtime(Arc::new(store), service);
             let runtime = if matches!(kind, LongCapabilityKind::Runtime { .. }) {
                 runtime.with_runtime_service_for_test(Arc::clone(&runtime_service))
             } else {
@@ -5990,8 +6007,16 @@ struct ActorLogicalReadLease {"#,
             let (released, wake) = &*release;
             *released.lock().unwrap() = true;
             wake.notify_all();
-            let first_result = runtime.wait(first, 7_000).unwrap().result.unwrap();
-            let second_result = runtime.wait(second, 7_000).unwrap().result.unwrap();
+            let first_result = runtime
+                .wait(first, OWNERSHIP_CONTRACT_WAIT_MS)
+                .unwrap()
+                .result
+                .unwrap();
+            let second_result = runtime
+                .wait(second, OWNERSHIP_CONTRACT_WAIT_MS)
+                .unwrap()
+                .result
+                .unwrap();
             if matches!(kind, LongCapabilityKind::Index) {
                 assert_eq!(first_result.summary, "index");
                 assert_eq!(second_result.summary, "index");
@@ -6019,7 +6044,7 @@ struct ActorLogicalReadLease {"#,
             FileInvocationStore::open(task_root.path(), Arc::new(SystemEpochMillisClock)).unwrap();
         let (service, producers, producer_wait, joined_wait, release) =
             shared_capability_service(LongCapabilityKind::Index);
-        let runtime = DaemonInvocationRuntime::new(Arc::new(store), service, Arc::new(TokioClock));
+        let runtime = ownership_contract_runtime(Arc::new(store), service);
         let request = |root: &std::path::Path| {
             InvocationRequest::new(
                 ToolIdentity::Run,
@@ -6045,7 +6070,10 @@ struct ActorLogicalReadLease {"#,
         *released.lock().unwrap() = true;
         wake.notify_all();
         assert_eq!(
-            runtime.wait(first, 7_000).unwrap().status,
+            runtime
+                .wait(first, OWNERSHIP_CONTRACT_WAIT_MS)
+                .unwrap()
+                .status,
             InvocationStatus::Completed
         );
         assert_eq!(
@@ -6081,7 +6109,7 @@ struct ActorLogicalReadLease {"#,
             mark_dirty: Mutex::new(dirty_request),
             dirty_done,
         });
-        let runtime = DaemonInvocationRuntime::new(Arc::new(store), service, Arc::new(TokioClock));
+        let runtime = ownership_contract_runtime(Arc::new(store), service);
         let first = task_id(submit_at_receipt(&runtime, request(&root)).unwrap());
         producer_wait.recv_timeout(Duration::from_secs(10)).unwrap();
         let old_key = joined_wait.recv_timeout(Duration::from_secs(10)).unwrap();
@@ -6098,10 +6126,13 @@ struct ActorLogicalReadLease {"#,
         *released.lock().unwrap() = true;
         wake.notify_all();
         assert_eq!(
-            runtime.wait(first, 7_000).unwrap().status,
+            runtime
+                .wait(first, OWNERSHIP_CONTRACT_WAIT_MS)
+                .unwrap()
+                .status,
             InvocationStatus::Failed
         );
-        let second = runtime.wait(second, 7_000).unwrap();
+        let second = runtime.wait(second, OWNERSHIP_CONTRACT_WAIT_MS).unwrap();
         assert_eq!(second.status, InvocationStatus::Completed);
         assert_eq!(second.result.unwrap().summary, "new");
     }
@@ -6118,7 +6149,7 @@ struct ActorLogicalReadLease {"#,
             FileInvocationStore::open(task_root.path(), Arc::new(SystemEpochMillisClock)).unwrap();
         let (service, _, producer_wait, joined_wait, release) =
             shared_capability_service(LongCapabilityKind::Index);
-        let runtime = DaemonInvocationRuntime::new(Arc::new(store), service, Arc::new(TokioClock));
+        let runtime = ownership_contract_runtime(Arc::new(store), service);
         let request = || {
             InvocationRequest::new(
                 ToolIdentity::Run,
@@ -6141,7 +6172,10 @@ struct ActorLogicalReadLease {"#,
         *released.lock().unwrap() = true;
         wake.notify_all();
         assert_eq!(
-            runtime.wait(first, 7_000).unwrap().status,
+            runtime
+                .wait(first, OWNERSHIP_CONTRACT_WAIT_MS)
+                .unwrap()
+                .status,
             InvocationStatus::Failed
         );
     }


### PR DESCRIPTION
## Summary

- give ownership/revision fixtures a test-only reconciliation budget
- align their bounded waits with that fixture budget
- execute each named contract obligation on an independent stack
- leave production reconciliation deadlines and runtime behavior unchanged

## Root causes

The expanded matrix on #646 exposed a Windows failure in `daemon_exact_long_work_ownership_contract`. The fixture releases two shared long-work tasks together and then verifies capability ownership. It used the production two-second terminal reconciliation budget even though fail-stop timing is outside this test contract. On the loaded Windows runner, one terminal worker missed that unrelated budget; the executor correctly entered `RestartRequested` and the ownership assertion failed.

After that timing dependency was removed, the forced full matrix on this PR exposed a second pre-existing defect in the same named witness: four independently valid, deeply nested obligations were compiled and run inside one aggregate 32 MiB thread. Windows aborted that process with `STATUS_STACK_BUFFER_OVERRUN`. Increasing the aggregate stack again would preserve the cause. The named architecture witness now orchestrates four sequential obligation threads instead, so their stack frames and lifetimes cannot accumulate. The runtime-resource execution counter is reset and asserted inside its own obligation thread because it is intentionally thread-local.

Both behaviors predate #646 and are outside its 17-file release-proof diff, so this fix is based independently on `main`.

## RED evidence

PR #646 exact head `06f051893ede0789441fd9ff01d3f18d57f7f0a0`, Windows Rust job `99954453553`:

- 4489 passed, 1 failed, 3 ignored
- `infrastructure::daemon::server::actor_capacity_tests::daemon_exact_long_work_ownership_contract`
- `Executor(RestartRequested)` at `server.rs:5993`

PR #653 exact head `25ba946aa69eb38d37e651c9301dcc614fb80dad`, forced Windows Rust job `99964741233`:

- process exit `0xc0000409` / `STATUS_STACK_BUFFER_OVERRUN`
- abort while running `daemon_exact_long_work_ownership_contract`
- Ubuntu and macOS full workspace jobs were green

## Local verification

- exact long-work ownership aggregate: passed
- complete `actor_capacity_tests` module: 62 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The `ci:full` label forces the Windows/macOS/Ubuntu workspace matrix for the exact PR head. Production reconciliation policy and deadline tests are unchanged. This PR unblocks an honest Windows recheck and P0 dry RC/package proof for #646.
