### PR TITLE
fix(cfe.borrow): писать дескриптор расширения так, как его пишет платформа

### DIFF
--- a/crates/unica-coder/src/infrastructure/native_operations/cf.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/cf.rs
@@ -3930,17 +3930,12 @@ pub(crate) fn cf_edit_child_objects_xml(children: &[(String, String)]) -> String
     if children.is_empty() {
         return "<ChildObjects/>".to_string();
     }
-    let mut body = String::from("<ChildObjects>\n");
-    for (index, (type_name, obj_name)) in children.iter().enumerate() {
+    let mut body = String::from("<ChildObjects>\r\n");
+    for (type_name, obj_name) in children {
         body.push_str(&format!(
-            "\t\t\t<{type_name}>{}</{type_name}>",
+            "\t\t\t<{type_name}>{}</{type_name}>\r\n",
             escape_xml(obj_name)
         ));
-        if index + 1 == children.len() {
-            body.push('\n');
-        } else {
-            body.push_str("\r\n");
-        }
     }
     body.push_str("\t\t</ChildObjects>");
     body

--- a/crates/unica-coder/src/infrastructure/native_operations/cfe.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/cfe.rs
@@ -482,7 +482,7 @@ fn prepare_cfe_borrow_with_trace(
         }
     }
 
-    cfe_borrow_normalize_lxml_config_serialization(&mut ext_text);
+    cfe_borrow_normalize_empty_default_roles(&mut ext_text);
     write_plan.write_utf8_bom(&ext_path, &ext_text)?;
     registered_format_dependencies.extend(cfe_registered_xml_dependency_paths_with_reader(
         &ext_path,
@@ -2173,22 +2173,17 @@ pub(crate) fn cfe_borrow_add_to_child_objects(
     Ok(())
 }
 
-pub(crate) fn cfe_borrow_normalize_lxml_config_serialization(ext_text: &mut String) {
-    if ext_text.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>") {
-        *ext_text = ext_text.replacen(
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
-            1,
-        );
-    }
+/// Collapses an empty `DefaultRoles` pair to the self-closing form the platform
+/// emits.
+///
+/// This used to normalize the whole descriptor to the serialization of the
+/// retired Python writer: it lowercased the XML declaration, escaped every CRLF
+/// inside `ChildObjects` as `&#13;`, and appended a trailing newline. Platform
+/// dumps do none of that — `DumpConfigToFiles` writes `encoding="UTF-8"`, plain
+/// CRLF, and no newline after `</MetaDataObject>` — so those three rewrites made
+/// every borrow diverge from the format Designer round-trips.
+pub(crate) fn cfe_borrow_normalize_empty_default_roles(ext_text: &mut String) {
     *ext_text = ext_text.replace("<DefaultRoles></DefaultRoles>", "<DefaultRoles/>");
-    if let Some((start, end, _)) = cf_edit_element_range(ext_text, "ChildObjects") {
-        let child_objects = ext_text[start..end].replace("\r\n", "&#13;\n");
-        ext_text.replace_range(start..end, &child_objects);
-    }
-    if !ext_text.ends_with('\n') {
-        ext_text.push('\n');
-    }
 }
 
 pub(crate) fn cfe_borrow_form_shell(
@@ -3214,7 +3209,7 @@ pub(crate) fn cfe_borrow_register_form(
             1,
         );
     }
-    cfe_borrow_normalize_lxml_config_serialization(&mut text);
+    cfe_borrow_normalize_empty_default_roles(&mut text);
     write_plan.write_utf8_bom(&object_file, &text)?;
     Ok(())
 }
@@ -8422,6 +8417,72 @@ pub(crate) mod tests {
                 "every change names its effect: {change}"
             );
         }
+
+        let _ = fs::remove_dir_all(&context.cwd);
+    }
+
+    /// The extension descriptor keeps the serialization `DumpConfigToFiles`
+    /// emits, not the one the retired Python writer produced.
+    ///
+    /// Borrow used to post-process the descriptor into the shape of that old
+    /// writer: it lowercased the XML declaration, escaped every CRLF inside
+    /// `ChildObjects` as `&#13;`, and appended a newline the platform never
+    /// writes. Measured against `DumpConfigToFiles` output of two unrelated
+    /// production extensions, all three diverge — the platform writes
+    /// `encoding="UTF-8"`, plain CRLF, zero `&#13;`, and nothing after
+    /// `</MetaDataObject>`. A descriptor in the old shape still loads, so the
+    /// divergence is invisible until the next platform dump rewrites it and
+    /// the diff appears on untouched lines.
+    #[test]
+    fn borrow_cfe_writes_the_platform_serialization_of_the_extension_descriptor() {
+        let context = temp_context("borrow-canonical-descriptor");
+        let (_, _, extension_owner) =
+            write_minimal_borrow_fixture(&context, "2.20", "2.20", "2.20", None);
+        // A second registration is what makes the separator observable: the
+        // escaping only ever showed up between two `ChildObjects` entries.
+        write_file(
+            &extension_owner,
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n\
+<MetaDataObject xmlns=\"http://v8.1c.ru/8.3/MDClasses\" version=\"2.20\">\r\n\
+\t<Configuration uuid=\"66666666-6666-6666-6666-666666666666\">\r\n\
+\t\t<InternalInfo/>\r\n\
+\t\t<Properties>\r\n\
+\t\t\t<ObjectBelonging>Adopted</ObjectBelonging>\r\n\
+\t\t\t<Name>GuardedExtension</Name>\r\n\
+\t\t\t<ConfigurationExtensionPurpose>Customization</ConfigurationExtensionPurpose>\r\n\
+\t\t\t<NamePrefix>GE_</NamePrefix>\r\n\
+\t\t</Properties>\r\n\
+\t\t<ChildObjects>\r\n\t\t\t<Catalog>Already</Catalog>\r\n\t\t</ChildObjects>\r\n\
+\t</Configuration>\r\n\
+</MetaDataObject>",
+        );
+
+        let outcome = borrow_cfe(&minimal_borrow_args(), &context);
+        assert!(outcome.ok, "{:?}", outcome.errors);
+
+        let published = fs::read_to_string(&extension_owner)
+            .expect("the extension descriptor is published")
+            .trim_start_matches('\u{feff}')
+            .to_string();
+
+        assert!(
+            !published.contains("&#13;"),
+            "the platform never escapes a line break inside ChildObjects: {published}"
+        );
+        assert!(
+            published.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"),
+            "the declaration keeps the platform spelling: {published}"
+        );
+        assert!(
+            published.contains(
+                "<ChildObjects>\r\n\t\t\t<Catalog>Already</Catalog>\r\n\t\t\t<Catalog>Items</Catalog>\r\n\t\t</ChildObjects>"
+            ),
+            "registrations are separated by a plain CRLF: {published}"
+        );
+        assert!(
+            published.ends_with("</MetaDataObject>"),
+            "no newline is appended after the root element: {published:?}"
+        );
 
         let _ = fs::remove_dir_all(&context.cwd);
     }


### PR DESCRIPTION
`unica.cfe.borrow` пост-обрабатывает `Configuration.xml` расширения в сериализацию снятого Python-писателя. Семантически заимствование добавляет одну строку в `ChildObjects`, а файл на выходе расходится с тем, что пишет `DumpConfigToFiles`, по трём независимым признакам.

## Что расходится

Измерено на выгрузках двух не связанных между собой продуктовых расширений (платформа 8.3.27, формат 2.20), сделанных Конфигуратором:

| | Платформа пишет | `cfe.borrow` писал |
|---|---|---|
| Объявление XML | `encoding="UTF-8"` | `encoding="utf-8"` |
| Разделитель в `ChildObjects` | плайн CRLF | `&#13;` + LF |
| Конец файла | ничего после `</MetaDataObject>` | дописанный перевод строки |

В контрольных файлах: 204 и 132 CRLF, ноль одиночных LF, ноль `&#13;`, BOM на месте, завершающего перевода строки нет. Конфигурационный `Configuration.xml` того же продукта — 14734 CRLF, та же картина, `ChildObjects` вида `<ChildObjects>\r\n\t\t\t<Language>Русский</Language>\r\n…`.

## Почему это не косметика

Дескриптор в старой форме грузится, поэтому расхождение невидимо до следующей выгрузки платформой: она переписывает файл своей сериализацией, и diff появляется на строках, которых никто не трогал. Потребитель плагина ловил это как «добавили один объект — получили сотню изменённых строк», а следующий `DumpConfigToFiles` давал diff на пустом месте.

## Механизм оказался парным

Правки в двух местах, потому что одно без другого такого результата не даёт:

1. `cf_edit_child_objects_xml` (`cf.rs`) **намеренно** писал смешанные концы строк: `\n` после открывающего тега, `\r\n` между записями, `\n` перед закрывающим.
2. `cfe_borrow_normalize_lxml_config_serialization` (`cfe.rs`) затем превращал ровно эти `\r\n` в `&#13;\n`.

Вместе они воспроизводили вывод lxml — тот экранирует CR, потому что XML-парсер нормализовал бы литеральный `\r`. Удалить только шим было бы неполной починкой: остался бы смешанный профиль.

Эмиттер переведён на сплошной CRLF. Из шима сохранено единственное его верное действие — свёртка пустой пары `<DefaultRoles></DefaultRoles>` в самозакрывающуюся форму; функция сужена до него и переименована в `cfe_borrow_normalize_empty_default_roles`, история прежнего поведения записана в докблоке, чтобы следующий читатель не восстановил шим как «потерянную нормализацию».

## Радиус

`cf_edit_child_objects_xml` обслуживает и `unica.cf.edit` для конфигурации, а не только заимствование. Эталон там тот же сплошной CRLF (проверено на конфигурационном дескрипторе выше), поэтому изменение верно для обоих вызывающих. Это шире, чем «починить borrow», и я называю это явно: если предпочтительнее развести поведение по вызывающим, скажите — переделаю.

## Тест

`borrow_cfe_writes_the_platform_serialization_of_the_extension_descriptor` пинит все четыре свойства: отсутствие `&#13;`, спеллинг объявления, CRLF между двумя регистрациями, отсутствие приписанного перевода строки. Фикстура несёт две записи в `ChildObjects` намеренно: разделитель наблюдаем только между ними, на одной записи старый код `&#13;` не производил вовсе.

Тест проверен на красноту отдельно по каждой половине правки:

- старый эмиттер + новый шим → падает на `registrations are separated by a plain CRLF`;
- новый эмиттер + старый шим → падает на `the platform never escapes a line break inside ChildObjects`.

## Проверка

- `cargo test -p unica-coder --lib native_operations` — 1305 passed, 7 failed; **те же 7 падают и на чистом `a85ec846`** (1304 passed, 7 failed — разница ровно в новом тесте). Все семь — тесты символьных ссылок, требующие прав на создание symlink в Windows.
- `cargo test -p unica-coder --test format_8_3_27_xml_corpus` — 36/36 OK. Точный платформенный верификатор изменение принимает.
- `cargo test -p unica-coder --lib native_operations::cf` — 126/126 OK.

## Связь с уже поданным

Направление совпадает с epic #74: «одно смысловое изменение не трогает соседние строки, неизвестные узлы XML и существующие идентификаторы». Тот же вердикт по `&#13;` уже вынесен в закрытом #323 для `meta.edit` — здесь он доводится до writer-а расширений.

Расхождение нашёл потребитель плагина при работе над конвейером «хранилище 1С ↔ git». Подготовлено в соавторстве: Volodymyr Sydorenko и Claude (Anthropic Claude Code, Opus 5).

Refs #74, #323, #639.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XML export formatting with consistent CRLF line endings in child-object sections.
  * Prevented unnecessary XML-wide serialization changes during CFE processing.
  * Corrected handling of empty `DefaultRoles` elements.
  * Preserved platform-style UTF-8 declarations and prevented unwanted carriage-return escaping.
  * Removed unintended trailing newlines from generated XML.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->