### PR TITLE
test(daemon): isolate long-work contract processes

### DIFF
--- a/crates/unica-coder/src/infrastructure/daemon/server.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/server.rs
@@ -6180,46 +6180,53 @@ struct ActorLogicalReadLease {"#,
         );
     }
 
-    fn run_long_work_contract_obligation(name: &str, obligation: fn()) {
-        std::thread::Builder::new()
-            .name(name.to_owned())
-            // Each debug-only ownership oracle is independently valid on the
-            // test harness stack. Keep their stack frames isolated instead of
-            // compiling the whole named contract into one aggregate frame.
-            .stack_size(32 * 1024 * 1024)
-            .spawn(obligation)
-            .expect("long-work contract obligation thread should start")
-            .join()
-            .expect("long-work contract obligation thread should finish");
-    }
-
-    fn runtime_resource_tree_contract_obligation() {
-        crate::infrastructure::runtime_jobs::reset_runtime_resource_contract_executions_for_test();
-        crate::infrastructure::runtime_jobs::run_runtime_resource_tree_contract_for_test();
-        assert_eq!(
-            crate::infrastructure::runtime_jobs::runtime_resource_contract_executions_for_test(),
-            1,
-            "daemon CTR named check did not execute its runtime-tree obligations"
+    fn run_long_work_contract_obligation(test_name: &str) {
+        // These ownership oracles exercise independent global runtime fixtures.
+        // A larger child thread stack still shares the parent test process and
+        // can terminate that process on Windows before the aggregate reports a
+        // failure. Give each obligation an independent process boundary.
+        let output = std::process::Command::new(
+            std::env::current_exe().expect("current test executable should resolve"),
+        )
+        .args([
+            "--exact",
+            test_name,
+            "--nocapture",
+            "--test-threads=1",
+            "--color",
+            "never",
+        ])
+        // The parent harness has tests that temporarily change its process-wide
+        // current directory. Never inherit a fixture cwd that can disappear
+        // while this independent test process is starting.
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("long-work contract obligation process should start");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "long-work contract obligation {test_name} failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        assert!(
+            stdout.contains("running 1 test"),
+            "long-work contract obligation {test_name} matched no unique test\nstdout:\n{stdout}\nstderr:\n{stderr}"
         );
     }
 
     #[test]
     fn daemon_exact_long_work_ownership_contract() {
         run_long_work_contract_obligation(
-            "daemon-long-work-capabilities-contract",
-            daemon_long_work_capabilities_handoff_before_wait_and_preserve_exact_ownership,
+            "infrastructure::daemon::server::actor_capacity_tests::daemon_long_work_capabilities_handoff_before_wait_and_preserve_exact_ownership",
         );
         run_long_work_contract_obligation(
-            "daemon-index-revision-contract",
-            daemon_index_work_separates_worktrees_and_rejects_stale_revision_publication,
+            "infrastructure::daemon::server::actor_capacity_tests::daemon_index_work_separates_worktrees_and_rejects_stale_revision_publication",
         );
         run_long_work_contract_obligation(
-            "daemon-replaced-root-contract",
-            daemon_long_work_rejects_replaced_actor_root_before_reuse_or_publication,
+            "infrastructure::daemon::server::actor_capacity_tests::daemon_long_work_rejects_replaced_actor_root_before_reuse_or_publication",
         );
         run_long_work_contract_obligation(
-            "daemon-runtime-resource-contract",
-            runtime_resource_tree_contract_obligation,
+            "infrastructure::runtime_jobs::tests::runtime_resource_tree_lease_contract",
         );
     }
 

--- a/crates/unica-coder/src/infrastructure/runtime_jobs.rs
+++ b/crates/unica-coder/src/infrastructure/runtime_jobs.rs
@@ -53,22 +53,6 @@ const RUNTIME_STARTUP_CLEANUP_TIMEOUT: Duration = Duration::from_millis(500);
 #[cfg(test)]
 thread_local! {
     static STREAM_FINISH_ATTEMPTS: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
-    static RUNTIME_RESOURCE_CONTRACT_EXECUTIONS: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
-}
-
-#[cfg(test)]
-pub(crate) fn reset_runtime_resource_contract_executions_for_test() {
-    RUNTIME_RESOURCE_CONTRACT_EXECUTIONS.with(|slot| slot.set(0));
-}
-
-#[cfg(test)]
-pub(crate) fn runtime_resource_contract_executions_for_test() -> u32 {
-    RUNTIME_RESOURCE_CONTRACT_EXECUTIONS.with(std::cell::Cell::get)
-}
-
-#[cfg(test)]
-pub(crate) fn run_runtime_resource_tree_contract_for_test() {
-    tests::runtime_resource_tree_lease_contract();
 }
 #[cfg(test)]
 static INJECT_RUNTIME_RECORD_WRITE_FAILURE: std::sync::atomic::AtomicBool =
@@ -6983,9 +6967,6 @@ pub(crate) mod tests {
     #[test]
     pub(crate) fn runtime_resource_tree_lease_contract() {
         let supervisor_scope = TestSupervisorScope::new();
-        RUNTIME_RESOURCE_CONTRACT_EXECUTIONS.with(|slot| {
-            slot.set(slot.get().saturating_add(1));
-        });
         runtime_shared_work_joins_only_the_exact_active_resource_and_lease();
         runtime_shared_work_separates_physical_resources_and_distinct_v4_leases();
         stale_runtime_shared_work_authority_starts_no_producer_after_lock_replacement();


### PR DESCRIPTION
## Cause

The named long-work ownership contract still ran all four obligations inside one Rust test process. The 32 MiB child-thread workaround from #653 reduced the Windows failure rate but did not isolate process-wide stack/runtime state: CI job 100008829560 still terminated with STATUS_STACK_BUFFER_OVERRUN in daemon_exact_long_work_ownership_contract.

## Fix

- run each existing exact ownership oracle in its own test process;
- require both a successful exit and `running 1 test`, so a stale exact name cannot produce a false green;
- pin each child to CARGO_MANIFEST_DIR instead of inheriting a temporary process-wide fixture cwd;
- remove the process-local execution counter that no longer proves aggregation.

No production behavior or public contract changes.

## RED / GREEN

RED: #646 Windows CI job 100008829560 exited 0xc0000409 at the named contract. During implementation, the first full local run also exposed inherited fixture cwd as workspace actor admission failure.

GREEN locally:
- exact named contract: 1/1;
- actor_capacity_tests: 62/62;
- full unica-coder library: 4508 passed, 3 ignored;
- cargo clippy --workspace --all-targets --all-features -- -D warnings;
- cargo fmt --all -- --check;
- git diff --check.

Windows CI is the decisive merge gate.