### PR TITLE
docs: recommend context-engineering skills in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,49 @@ MCP Apps и интерактивных виджетов, `build-mcpb` — для
 поставки. Если нужны оба контура, применяйте навыки в порядке
 `build-mcp-server` → `build-mcp-app` → `build-mcpb`.
 
+## Навыки контекстной инженерии
+
+Рекомендуем установить набор навыков
+[Agent Skills for Context Engineering](https://github.com/muratcankoylan/agent-skills-for-context-engineering)
+Муратджана Кёйлана. Набор не обязателен для сборки и проверок, но полезен при
+работе над поверхностью инструментов Unica: описаниями `unica.*`, схемами,
+текстами ошибок, `SKILL.md` плагина и бюджетом токенов `tools/list`. Ключевые
+навыки для проекта:
+
+- `tool-design` — критерии оценки описаний инструментов, чек-лист и границы
+  консолидации поверхности;
+- `context-optimization` — стабильность префикса кеша и экономия токенов;
+- `evaluation` и `advanced-evaluation` — петля улучшения описаний по
+  наблюдаемым провалам маршрутизации.
+
+Остальные навыки набора (`context-fundamentals`, `context-degradation`,
+`context-compression`, `multi-agent-patterns`, `memory-systems` и другие)
+подключаются по контексту задачи и не мешают основной работе.
+
+### Claude Code
+
+Подключите репозиторий как marketplace и установите единый плагин со всеми
+навыками:
+
+```text
+/plugin marketplace add muratcankoylan/Agent-Skills-for-Context-Engineering
+/plugin install context-engineering@context-engineering-marketplace
+/reload-plugins
+```
+
+Навыки вызываются с префиксом плагина, например `/context-engineering:tool-design`.
+
+### Codex
+
+Навыки лежат в каталоге `skills/` репозитория, каждый — отдельный каталог с
+`SKILL.md` и `references/`. Установите нужные через `$skill-installer` из
+repository `muratcankoylan/Agent-Skills-for-Context-Engineering`, ref `main`,
+передав пути вида `skills/tool-design`, либо скопируйте каталоги целиком в
+`$CODEX_HOME/skills/` (по умолчанию `~/.codex/skills/`). Не сводите навык к
+одному файлу `SKILL.md`: относительные ссылки на `references/` перестанут
+работать. После установки завершите ход и на следующем проверьте, что навыки
+доступны для явного вызова.
+
 ## Самопроверка
 
 Перед началом работы проверьте Python командой для своей оболочки:


### PR DESCRIPTION
## Что меняется

В `CONTRIBUTING.md` добавлен раздел «Навыки контекстной инженерии» с рекомендацией установить набор [Agent Skills for Context Engineering](https://github.com/muratcankoylan/agent-skills-for-context-engineering). Описано назначение набора для работы над поверхностью инструментов Unica, выделены ключевые навыки (`tool-design`, `context-optimization`, `evaluation`, `advanced-evaluation`) и приведены инструкции установки для Claude Code и Codex в стиле соседнего раздела про `mcp-server-dev`.

## Архитектурный слой

- Затронутые записи реестра: нет
- Решение (`DEC.*`): нет

- [x] Прочитаны относящиеся к изменению записи из `arch/index.md`.

## Проверка

Изменение только документации. Выполнено `git diff --check`.

- [ ] Новое поведение покрыто тестом — не применимо, кода нет.
- [x] Документация обновлена в этом же PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Context Engineering Skills” section to the contributor guide.
  * Documented recommended skills for tool design, context optimization, and evaluation.
  * Added setup instructions for using these skills with Claude Code and Codex.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->