### PR TITLE
fix(bootstrap): align required skills after runner removal

### DIFF
--- a/crates/unica-bootstrap/src/main.rs
+++ b/crates/unica-bootstrap/src/main.rs
@@ -201,12 +201,7 @@ fn verify_installed_skill_package(plugin_root: &Path) -> Result<()> {
         }
         visible.insert(entry.file_name().to_string_lossy().into_owned());
     }
-    for required in [
-        "code-search",
-        "platform-help",
-        "release-support",
-        "v8-runner",
-    ] {
+    for required in ["code-search", "platform-help", "release-support"] {
         if !visible.contains(required) {
             return Err(unica_bootstrap::BootstrapError::new(format!(
                 "installed prompt-visible skill is missing: {required}"

--- a/scripts/dev/install-local-unica.sh
+++ b/scripts/dev/install-local-unica.sh
@@ -228,7 +228,7 @@ if [ "$DO_INSTALL" -eq 1 ]; then
 
   if [ "$DO_VERIFY" -eq 1 ]; then
     codex debug prompt-input 'test' > "$PROMPT_PROOF"
-    for needle in "Unica" "v8-runner" "db-auth-check"; do
+    for needle in "Unica" "db-auth-check"; do
       if ! grep -q "$needle" "$PROMPT_PROOF"; then
         echo "Codex prompt verification did not contain '$needle'." >&2
         echo "Saved prompt proof: $PROMPT_PROOF" >&2

--- a/tests/ci/test_local_dev_installer.py
+++ b/tests/ci/test_local_dev_installer.py
@@ -167,6 +167,14 @@ class LocalDevInstallerTests(unittest.TestCase):
         )
         self.assertLess(create_home, first_codex_call)
 
+    def test_prompt_verification_requires_only_installed_visible_skills(self) -> None:
+        installer = INSTALLER.read_text(encoding="utf-8")
+
+        self.assertIn('for needle in "Unica" "db-auth-check"; do', installer)
+        self.assertNotIn(
+            'for needle in "Unica" "v8-runner" "db-auth-check"; do', installer
+        )
+
     def test_installer_preserves_persistent_cargo_work_and_writes_metrics(self) -> None:
         installer = INSTALLER.read_text(encoding="utf-8")
         workflow = (


### PR DESCRIPTION
## Причина

#670 удалил prompt-visible skill `v8-runner`, но bootstrap package contract продолжил требовать этот каталог, а Windows local-installer prompt proof — строку `v8-runner`. Поэтому exact `main` `72c004e7` падает в `tests::source_plugin_exposes_required_prompt_visible_skills` с `installed prompt-visible skill is missing: v8-runner`; после первого исправления Windows package smoke также доказал второй stale contract: `Codex prompt verification did not contain 'v8-runner'`. Тот же baseline defect блокирует CI #647.

## Исправление

Удаляет устаревшее обязательное имя `v8-runner` из `verify_installed_skill_package` и из local-installer prompt needles. Проверка остальных обязательных prompt-visible skills и непустого каталога сохраняется. Добавлен focused тест, который не даёт installer снова потребовать удалённый skill.

## RED / GREEN

RED на exact `main`:

```text
cargo test -p unica-bootstrap --bin unica-bootstrap source_plugin_exposes_required_prompt_visible_skills -- --nocapture
installed prompt-visible skill is missing: v8-runner
```

GREEN на этом head:

```text
cargo fmt --all -- --check
cargo test -p unica-bootstrap --bin unica-bootstrap source_plugin_exposes_required_prompt_visible_skills -- --nocapture
cargo test -p unica-bootstrap --all-targets
python3.12 -m unittest tests.ci.test_local_dev_installer
```

- focused: 1 passed;
- bootstrap all-targets: 57 lib + 1 bin + 4 CLI + 19 manifest + 34 runtime install + 6 verification passed.
- local installer: 12 passed.

Regression follow-up for #670. Unblocks #647; no D0 files changed.
