### PR TITLE
fix(windows): keep persistent daemon outside workspace

### DIFF
--- a/crates/unica-coder/src/infrastructure/daemon/client.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/client.rs
@@ -9,7 +9,6 @@ use crate::infrastructure::platform::ManagedStartupChild;
 use std::io::{self, BufReader, Write};
 use std::net::TcpStream;
 use std::path::PathBuf;
-use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -255,18 +254,12 @@ impl DaemonClient {
             .as_ref()
             .ok_or_else(|| "daemon spawning is disabled for this client".to_string())?;
         deadline.checkpoint("child spawn")?;
-        let mut command = Command::new(executable);
-        command
-            .arg("--daemon")
-            .arg("--state-root")
-            .arg(&self.config.state_root)
-            .arg("--core-identity")
-            .arg(self.config.core_identity.as_str())
-            .arg("--idle-grace-ms")
-            .arg(self.config.idle_grace.as_millis().to_string())
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null());
+        let command = super::daemon_process_command(
+            executable,
+            &self.config.state_root,
+            &self.config.core_identity,
+            self.config.idle_grace,
+        );
         let mut child = ManagedStartupChild::spawn_configured(command)
             .map_err(|error| format!("failed to spawn daemon: {error}"))?;
         if let Err(error) = deadline.checkpoint("child spawn") {

--- a/crates/unica-coder/src/infrastructure/daemon/client_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/client_v5.rs
@@ -10,7 +10,6 @@ use crate::infrastructure::platform::ManagedStartupChild;
 use std::io::{self, BufReader, Write};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
@@ -137,18 +136,8 @@ impl V5DaemonProcessOwner {
             }
         }
 
-        let mut command = Command::new(executable);
-        command
-            .arg("--daemon")
-            .arg("--state-root")
-            .arg(state_root)
-            .arg("--core-identity")
-            .arg(core_identity.as_str())
-            .arg("--idle-grace-ms")
-            .arg(idle_grace.as_millis().to_string())
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null());
+        let command =
+            super::daemon_process_command(&executable, state_root, &core_identity, idle_grace);
         let mut child = ManagedStartupChild::spawn_configured(command)
             .map_err(|error| format!("failed to spawn protocol-v5 daemon: {error}"))?;
         let expected_pid = child.id();

--- a/crates/unica-coder/src/infrastructure/daemon/mod.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/mod.rs
@@ -13,6 +13,33 @@ mod v13_service;
 mod v13_workspace_bootstrap;
 mod v13_workspace_initialize;
 
+use identity::CoreIdentity;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+fn daemon_process_command(
+    executable: &Path,
+    state_root: &Path,
+    core_identity: &CoreIdentity,
+    idle_grace: Duration,
+) -> Command {
+    let mut command = Command::new(executable);
+    command
+        .arg("--daemon")
+        .arg("--state-root")
+        .arg(state_root)
+        .arg("--core-identity")
+        .arg(core_identity.as_str())
+        .arg("--idle-grace-ms")
+        .arg(idle_grace.as_millis().to_string())
+        .current_dir(state_root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    command
+}
+
 #[cfg(test)]
 mod tests {
     use super::client::{
@@ -65,6 +92,19 @@ mod tests {
     const INTEGRATION_COORDINATION_TIMEOUT: Duration = Duration::from_secs(10);
     const INTEGRATION_TASK_WAIT_MS: u64 = 7_000;
     const FAIL_STOP_PROCESS_FIXTURE: &str = "UNICA_FAIL_STOP_PROCESS_FIXTURE";
+
+    #[test]
+    fn daemon_process_is_anchored_outside_the_caller_workspace() {
+        let state_root = std::env::temp_dir().join("unica-daemon-command-state");
+        let command = super::daemon_process_command(
+            PathBuf::from("unica").as_path(),
+            &state_root,
+            &CoreIdentity::production(),
+            Duration::from_secs(30),
+        );
+
+        assert_eq!(command.get_current_dir(), Some(state_root.as_path()));
+    }
 
     struct FailStopFixtureChild {
         child: Child,

--- a/crates/unica-coder/src/infrastructure/native_operations/v13_analysis.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/v13_analysis.rs
@@ -409,9 +409,12 @@ mod tests {
         fs::create_dir_all(root.join("src-ext")).unwrap();
         let root_address = QualifiedAddress::parse("ext:Configuration").unwrap();
         let selector = validator_selector(CheckValidator::Cfe, &root_address, &context).unwrap();
+        let extension_path =
+            crate::infrastructure::source_roots::normalize_path_identity(&root.join("src-ext"))
+                .unwrap();
         assert_eq!(
             selector["ExtensionPath"],
-            json!(root.join("src-ext").display().to_string())
+            json!(extension_path.display().to_string())
         );
         assert!(super::source_set_is_extension(&root_address, &context));
         let main_root = QualifiedAddress::parse("main:Configuration").unwrap();
@@ -420,12 +423,13 @@ mod tests {
         let interface = QualifiedAddress::parse("main:Subsystem.Sales.Interface").unwrap();
         let selector = validator_selector(CheckValidator::Interface, &interface, &context).unwrap();
         assert_eq!(selector["metadataPath"], "Subsystem.Sales");
+        let interface_path = crate::infrastructure::source_roots::normalize_path_identity(
+            &root.join("src/Subsystems/Sales/Ext/CommandInterface.xml"),
+        )
+        .unwrap();
         assert_eq!(
             selector["CIPath"],
-            json!(root
-                .join("src/Subsystems/Sales/Ext/CommandInterface.xml")
-                .display()
-                .to_string())
+            json!(interface_path.display().to_string())
         );
         let catalog = QualifiedAddress::parse("main:Catalog.Items").unwrap();
         assert!(validator_selector(CheckValidator::Interface, &catalog, &context).is_err());

--- a/crates/unica-coder/src/infrastructure/runtime_jobs.rs
+++ b/crates/unica-coder/src/infrastructure/runtime_jobs.rs
@@ -4040,6 +4040,8 @@ pub(crate) mod tests {
         },
     };
 
+    const PROCESS_TREE_STARTUP_BUDGET: Duration = Duration::from_secs(15);
+
     #[test]
     fn atomic_write_replaces_an_existing_runtime_job_record() {
         let cache = TestCache::new();
@@ -5011,7 +5013,7 @@ pub(crate) mod tests {
         );
         let mut process = runner.spawn(&request).expect("spawn process group");
         let descendant = scenario
-            .wait_for_descendant(Duration::from_secs(5))
+            .wait_for_descendant(PROCESS_TREE_STARTUP_BUDGET)
             .expect("observe runtime-job descendant");
 
         cancel_and_reap(&mut *process).expect("cancel and reap process group");
@@ -5042,7 +5044,7 @@ pub(crate) mod tests {
         );
         let started = service.start(request).expect("start runtime process tree");
         let descendant = scenario
-            .wait_for_descendant(Duration::from_secs(5))
+            .wait_for_descendant(PROCESS_TREE_STARTUP_BUDGET)
             .expect("observe runtime descendant");
 
         // Poll until the platform handle has reaped the leader. Reaching
@@ -6944,7 +6946,7 @@ pub(crate) mod tests {
         );
         let process = runner.spawn(&request).expect("spawn owned process tree");
         let descendant = scenario
-            .wait_for_descendant(Duration::from_secs(5))
+            .wait_for_descendant(PROCESS_TREE_STARTUP_BUDGET)
             .expect("observe drop-test descendant");
         assert!(
             descendant.is_alive().expect("probe live process tree"),

--- a/crates/unica-coder/tests/format_8_3_27_xml_corpus.rs
+++ b/crates/unica-coder/tests/format_8_3_27_xml_corpus.rs
@@ -1,14 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-#[cfg(windows)]
-use std::io;
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
-#[cfg(windows)]
-use std::thread;
-#[cfg(windows)]
-use std::time::{Duration, Instant};
 
 use roxmltree::Document;
 use serde::{Deserialize, Serialize};
@@ -1517,47 +1511,8 @@ fn unique_temp_dir(label: &str) -> PathBuf {
     ))
 }
 
-#[cfg(windows)]
-fn is_windows_sharing_violation(error: &io::Error) -> bool {
-    const WINDOWS_SHARING_VIOLATION: i32 = 32;
-    error.raw_os_error() == Some(WINDOWS_SHARING_VIOLATION)
-}
-
-#[cfg(windows)]
 fn remove_temp_tree(root: &Path) {
-    const RETRY_BUDGET: Duration = Duration::from_secs(15);
-    const RETRY_DELAY: Duration = Duration::from_millis(50);
-
-    let deadline = Instant::now() + RETRY_BUDGET;
-    loop {
-        match fs::remove_dir_all(root) {
-            Ok(()) => return,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => return,
-            Err(error) if is_windows_sharing_violation(&error) && Instant::now() < deadline => {
-                thread::sleep(RETRY_DELAY);
-            }
-            Err(error) => panic!("cannot remove temporary tree {}: {error}", root.display()),
-        }
-    }
-}
-
-#[cfg(not(windows))]
-fn remove_temp_tree(root: &Path) {
-    if let Err(error) = fs::remove_dir_all(root) {
-        assert_eq!(
-            error.kind(),
-            std::io::ErrorKind::NotFound,
-            "cannot remove temporary tree {}: {error}",
-            root.display()
-        );
-    }
-}
-
-#[cfg(windows)]
-#[test]
-fn windows_corpus_cleanup_recognizes_the_observed_sharing_violation() {
-    let error = io::Error::from_raw_os_error(32);
-    assert!(is_windows_sharing_violation(&error));
+    platform_support::remove_temp_tree(root);
 }
 
 fn write_designer_project(

--- a/crates/unica-coder/tests/format_8_3_27_xml_corpus.rs
+++ b/crates/unica-coder/tests/format_8_3_27_xml_corpus.rs
@@ -1,8 +1,14 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
+#[cfg(windows)]
+use std::io;
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
+#[cfg(windows)]
+use std::thread;
+#[cfg(windows)]
+use std::time::{Duration, Instant};
 
 use roxmltree::Document;
 use serde::{Deserialize, Serialize};
@@ -1509,6 +1515,49 @@ fn unique_temp_dir(label: &str) -> PathBuf {
         std::process::id(),
         TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
     ))
+}
+
+#[cfg(windows)]
+fn is_windows_sharing_violation(error: &io::Error) -> bool {
+    const WINDOWS_SHARING_VIOLATION: i32 = 32;
+    error.raw_os_error() == Some(WINDOWS_SHARING_VIOLATION)
+}
+
+#[cfg(windows)]
+fn remove_temp_tree(root: &Path) {
+    const RETRY_BUDGET: Duration = Duration::from_secs(15);
+    const RETRY_DELAY: Duration = Duration::from_millis(50);
+
+    let deadline = Instant::now() + RETRY_BUDGET;
+    loop {
+        match fs::remove_dir_all(root) {
+            Ok(()) => return,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return,
+            Err(error) if is_windows_sharing_violation(&error) && Instant::now() < deadline => {
+                thread::sleep(RETRY_DELAY);
+            }
+            Err(error) => panic!("cannot remove temporary tree {}: {error}", root.display()),
+        }
+    }
+}
+
+#[cfg(not(windows))]
+fn remove_temp_tree(root: &Path) {
+    if let Err(error) = fs::remove_dir_all(root) {
+        assert_eq!(
+            error.kind(),
+            std::io::ErrorKind::NotFound,
+            "cannot remove temporary tree {}: {error}",
+            root.display()
+        );
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_corpus_cleanup_recognizes_the_observed_sharing_violation() {
+    let error = io::Error::from_raw_os_error(32);
+    assert!(is_windows_sharing_violation(&error));
 }
 
 fn write_designer_project(
@@ -4182,7 +4231,7 @@ fn meta_edit_structural_resource_insertions_build_exact_platform_cases() {
             "{case_id}: {descriptor}"
         );
 
-        fs::remove_dir_all(root).unwrap();
+        remove_temp_tree(&root);
     }
 }
 
@@ -4334,7 +4383,7 @@ fn source_resource_reads_preserve_every_corpus_byte() {
         capture_workspace_payloads_for_source_test(&workspace),
         before
     );
-    fs::remove_dir_all(&root).unwrap();
+    remove_temp_tree(&root);
 }
 
 fn capture_workspace_payloads_for_source_test(root: &Path) -> BTreeMap<String, Vec<u8>> {
@@ -4416,7 +4465,7 @@ fn cf_init_public_case_creates_real_xml() {
     let delta = enforce_xml_impact(entry.impact, &before, &after).unwrap();
     assert!(delta.created.contains(&"src/Configuration.xml".to_string()));
     assert_eq!(gate.completed_target_calls, 1);
-    fs::remove_dir_all(root).unwrap();
+    remove_temp_tree(&root);
 }
 
 #[test]
@@ -4470,7 +4519,7 @@ fn managed_form_corpus_cases_mutate_content_without_overwriting_metadata_wrapper
     }
 
     assert_eq!(gate.completed_target_calls, 2);
-    fs::remove_dir_all(root).unwrap();
+    remove_temp_tree(&root);
 }
 
 #[test]
@@ -4513,7 +4562,7 @@ fn pre_snapshot_materializes_only_immutable_pre_call_bytes() {
         require_xml_payloads_unchanged(&workspace, &captured_post, "post-workspace").unwrap_err();
     assert!(error.contains("changed after"), "{error}");
 
-    fs::remove_dir_all(root).unwrap();
+    remove_temp_tree(&root);
 }
 
 #[test]
@@ -4596,7 +4645,7 @@ fn non_xml_manifest_inventory_binds_bsl_tampering_for_none_impact_case() {
         require_non_xml_payloads_unchanged(case, &workspace, &post_payloads, "tampered workspace")
             .unwrap_err();
     assert!(error.contains("changed after"), "{error}");
-    fs::remove_dir_all(root).unwrap();
+    remove_temp_tree(&root);
 }
 
 fn assert_platform_canonical_bsl(bytes: &[u8]) {
@@ -4655,7 +4704,7 @@ fn meta_reference_cases_seed_platform_canonical_event_handlers_bsl() {
             fs::read(workspace.join("src/CommonModules/EventHandlers/Ext/Module.bsl")).unwrap();
         assert_platform_canonical_bsl(&module);
         assert_eq!(module, expected, "{case_id}");
-        fs::remove_dir_all(root).unwrap();
+        remove_temp_tree(&root);
     }
 }
 
@@ -4690,7 +4739,7 @@ fn code_patch_case_seeds_and_preserves_platform_canonical_bsl_bytes() {
         "inserted code must use the surrounding platform CRLF convention"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    remove_temp_tree(&root);
 }
 
 #[test]
@@ -4757,7 +4806,7 @@ fn cfe_patch_method_case_seeds_a_registered_adopted_common_module() {
         "the borrowed interceptor target must exist in the base CommonModule"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    remove_temp_tree(&root);
 }
 
 #[test]
@@ -4822,7 +4871,7 @@ fn non_xml_inventory_covers_every_xml_none_impact_case() {
                 .unwrap(),
             );
         }
-        fs::remove_dir_all(root).unwrap();
+        remove_temp_tree(&root);
     }
 }
 
@@ -4867,7 +4916,7 @@ fn managed_form_cases_address_logform_content_and_spare_the_descriptor() {
             "{case_id} did not change exactly the managed form content"
         );
 
-        fs::remove_dir_all(root).unwrap();
+        remove_temp_tree(&root);
     }
 }
 
@@ -5044,7 +5093,7 @@ fn cfe_patch_method_inventory_covers_atomic_xml_and_bsl_change() {
         assert_platform_canonical_bsl(&fs::read(workspace.join(extension_module)).unwrap());
         assert_platform_canonical_bsl(&fs::read(workspace.join(base_module)).unwrap());
         assert_exact_extended_property_state(&workspace.join(descriptor), property);
-        fs::remove_dir_all(root).unwrap();
+        remove_temp_tree(&root);
     }
 }
 
@@ -5162,7 +5211,7 @@ fn meta_edit_event_source_case_executes_public_writer_and_binds_exact_delta() {
         "two isolated generations must have byte-identical auxiliary artifacts"
     );
 
-    fs::remove_dir_all(root).unwrap();
+    remove_temp_tree(&root);
 }
 
 #[test]
@@ -5199,7 +5248,7 @@ fn html_template_case_inventories_the_platform_page_set_layout() {
     assert_eq!(page["seed"], false);
     assert_eq!(page["delta"], "created");
 
-    fs::remove_dir_all(root).unwrap();
+    remove_temp_tree(&root);
 }
 
 #[test]
@@ -5229,7 +5278,7 @@ fn corpus_case_inventories_stable_files_outside_platform_boundaries() {
     );
     assert!(paths.iter().all(|path| !path.contains("/workspace/src/")));
 
-    fs::remove_dir_all(root).unwrap();
+    remove_temp_tree(&root);
 }
 
 #[test]
@@ -5401,7 +5450,7 @@ fn tracked_xdto_package_fixture_executes_public_corpus_preview_apply_and_noop() 
         Some("cases/xdto-add-nested-property/workspace/src/Configuration.xml")
     );
 
-    fs::remove_dir_all(root).unwrap();
+    remove_temp_tree(&root);
 }
 
 #[test]
@@ -5454,7 +5503,7 @@ fn output_directory_refusal_rules_are_fail_closed() {
         root.canonicalize().unwrap().join("explicit-absent-target")
     );
     assert!(!absent.exists());
-    fs::remove_dir_all(root).unwrap();
+    remove_temp_tree(&root);
 }
 
 #[test]
@@ -5473,7 +5522,7 @@ fn empty_directory_inventory_detects_added_and_removed_paths() {
 
     assert_eq!(after, vec!["added-empty"]);
     assert_ne!(before, after);
-    fs::remove_dir_all(root).unwrap();
+    remove_temp_tree(&root);
 }
 
 #[test]

--- a/crates/unica-coder/tests/platform/format_8_3_27_xml_corpus.rs
+++ b/crates/unica-coder/tests/platform/format_8_3_27_xml_corpus.rs
@@ -1,5 +1,55 @@
 use std::path::Path;
 
+#[cfg(windows)]
+use std::io;
+#[cfg(windows)]
+use std::thread;
+#[cfg(windows)]
+use std::time::{Duration, Instant};
+
+#[cfg(windows)]
+fn is_windows_sharing_violation(error: &io::Error) -> bool {
+    const WINDOWS_SHARING_VIOLATION: i32 = 32;
+    error.raw_os_error() == Some(WINDOWS_SHARING_VIOLATION)
+}
+
+#[cfg(windows)]
+pub(super) fn remove_temp_tree(root: &Path) {
+    const RETRY_BUDGET: Duration = Duration::from_secs(15);
+    const RETRY_DELAY: Duration = Duration::from_millis(50);
+
+    let deadline = Instant::now() + RETRY_BUDGET;
+    loop {
+        match std::fs::remove_dir_all(root) {
+            Ok(()) => return,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return,
+            Err(error) if is_windows_sharing_violation(&error) && Instant::now() < deadline => {
+                thread::sleep(RETRY_DELAY);
+            }
+            Err(error) => panic!("cannot remove temporary tree {}: {error}", root.display()),
+        }
+    }
+}
+
+#[cfg(not(windows))]
+pub(super) fn remove_temp_tree(root: &Path) {
+    if let Err(error) = std::fs::remove_dir_all(root) {
+        assert_eq!(
+            error.kind(),
+            std::io::ErrorKind::NotFound,
+            "cannot remove temporary tree {}: {error}",
+            root.display()
+        );
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_corpus_cleanup_recognizes_the_observed_sharing_violation() {
+    let error = io::Error::from_raw_os_error(32);
+    assert!(is_windows_sharing_violation(&error));
+}
+
 #[cfg(unix)]
 pub(super) fn require_single_link(path: &Path) -> Result<(), String> {
     use std::os::unix::fs::MetadataExt;


### PR DESCRIPTION
## Что исправлено

Полный Windows Rust matrix выявил три переносимых дефекта, которые на Unix маскировались различиями файловой системы и представления путей:

- persistent user daemon наследовал `current_dir` вызывающего workspace и удерживал временный проект от удаления на Windows;
- corpus cleanup не учитывал кратковременный Windows sharing violation `os error 32`;
- selector-test сравнивал текстовые пути `\\?\C:` и `C:` без нормализации;
- process-tree tests требовали публикацию PID потомка за жёсткие 5 секунд даже на загруженном hosted runner.

Основное исправление причины: команды запуска daemon v3 и v5 теперь собираются единым helper и запускаются с `current_dir = provider state root`. Persistent daemon больше не привязан к одному workspace, что восстанавливает `INV.APP.HIDDEN-SERVICES`. Публичная MCP-поверхность и форматы результатов не меняются.

Дополнительно:

- все corpus cleanup-точки используют единый платформенный helper; Windows повторяет только `raw_os_error() == 32` в ограниченном бюджете, остальные ошибки остаются fail-fast;
- ожидаемые selector paths проходят ту же path-identity нормализацию, что и production result;
- три process-tree сценария используют единый тестовый startup budget 15 секунд; production deadlines не меняются.

## RED → GREEN

Windows RED:

- runs `33701111938` и `33703083264`: corpus cleanup падал с `os error 32`;
- run `33707684264`: selector identity mismatch, затем runtime descendant startup timeout;
- run `33726730185`: process contract прошёл `4514/4514`, но четыре corpus case доказали, что retry не устраняет persistent daemon cwd — удаление не удавалось весь 15-секундный бюджет.

Локальный GREEN на head:

```sh
cargo test -p unica-coder --test format_8_3_27_xml_corpus -- --test-threads=1
cargo test -p unica-coder --test daemon_process -- --test-threads=1
cargo test -p unica-coder --lib infrastructure::daemon::tests::daemon_process_is_anchored_outside_the_caller_workspace -- --exact --test-threads=1
cargo test -p unica-coder --lib infrastructure::daemon::server::actor_capacity_tests::daemon_exact_long_work_ownership_contract -- --exact --test-threads=1
cargo clippy -p unica-coder --lib --tests -- -D warnings
cargo fmt --check
git diff --check
```

Windows matrix нового head является terminal evidence для освобождения workspace.

Unblocks #647.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved cross-platform cleanup of temporary test files, including handling briefly locked files on Windows.
  * Improved path comparison consistency in extension and interface analysis.
  * Standardized process-tree startup wait limits across runtime tests.

* **Refactor**
  * Standardized daemon startup configuration to provide consistent launch behavior across supported clients.
  * Added validation that daemon processes run from the intended state location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->