### PR TITLE
test(check): compare normalized selector paths

### DIFF
--- a/crates/unica-coder/src/infrastructure/native_operations/v13_analysis.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/v13_analysis.rs
@@ -409,9 +409,12 @@ mod tests {
         fs::create_dir_all(root.join("src-ext")).unwrap();
         let root_address = QualifiedAddress::parse("ext:Configuration").unwrap();
         let selector = validator_selector(CheckValidator::Cfe, &root_address, &context).unwrap();
+        let extension_path =
+            crate::infrastructure::source_roots::normalize_path_identity(&root.join("src-ext"))
+                .unwrap();
         assert_eq!(
             selector["ExtensionPath"],
-            json!(root.join("src-ext").display().to_string())
+            json!(extension_path.display().to_string())
         );
         assert!(super::source_set_is_extension(&root_address, &context));
         let main_root = QualifiedAddress::parse("main:Configuration").unwrap();
@@ -420,12 +423,13 @@ mod tests {
         let interface = QualifiedAddress::parse("main:Subsystem.Sales.Interface").unwrap();
         let selector = validator_selector(CheckValidator::Interface, &interface, &context).unwrap();
         assert_eq!(selector["metadataPath"], "Subsystem.Sales");
+        let interface_path = crate::infrastructure::source_roots::normalize_path_identity(
+            &root.join("src/Subsystems/Sales/Ext/CommandInterface.xml"),
+        )
+        .unwrap();
         assert_eq!(
             selector["CIPath"],
-            json!(root
-                .join("src/Subsystems/Sales/Ext/CommandInterface.xml")
-                .display()
-                .to_string())
+            json!(interface_path.display().to_string())
         );
         let catalog = QualifiedAddress::parse("main:Catalog.Items").unwrap();
         assert!(validator_selector(CheckValidator::Interface, &catalog, &context).is_err());


### PR DESCRIPTION
## Причина

PR #676 forced the full Windows matrix and exposed a baseline failure introduced by #675 in `extension_and_interface_selectors_come_from_the_address`. `fs::canonicalize` returns an extended-length `\\?\` path on Windows, while the production source-root resolver deliberately strips that prefix according to the repository path-identity policy. The test compared those two different textual representations even though they name the same path.

## Исправление

Build both expected selector paths through `normalize_path_identity`, the same repository policy used by `resolve_named_source_set`. Production selector behavior is unchanged.

## RED → GREEN

RED: Windows full matrix run 33705831500, `4513 passed / 1 failed`; left `C:\...\src-ext`, right `\\?\C:\...\src-ext`.

GREEN locally:
- exact selector test: 1 passed
- `cargo clippy -p unica-coder --lib --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

This is independent of D0 #647 and corpus cleanup #676; it is based directly on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selector test reliability by normalizing filesystem paths before comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->