### PR TITLE
fix(v13): расширение владеет своими корневыми модулями

### DIFF
--- a/crates/unica-coder/src/infrastructure/v13_read.rs
+++ b/crates/unica-coder/src/infrastructure/v13_read.rs
@@ -714,11 +714,11 @@ impl<'a> LogicalViewReadAuthority<'a> {
     ) -> Result<(), ViewError> {
         if capability.source_layout() == ModuleSourceLayout::Root {
             return match self.read.source_set_kind() {
-                SourceSetKind::Configuration => Ok(()),
-                SourceSetKind::Extension => Err(ViewError::new(
-                    "provider_unavailable",
-                    "extension root runtime module ownership is not proved",
-                )),
+                // An extension extends the configuration runtime modules from
+                // its own root (`Ext/ManagedApplicationModule.bsl` and the
+                // like), so its `Configuration.xml` owns them exactly as the
+                // main configuration does.
+                SourceSetKind::Configuration | SourceSetKind::Extension => Ok(()),
                 SourceSetKind::ExternalProcessor | SourceSetKind::ExternalReport => {
                     Err(ViewError::new(
                         "not_found",

--- a/crates/unica-coder/src/infrastructure/v13_read/tests.rs
+++ b/crates/unica-coder/src/infrastructure/v13_read/tests.rs
@@ -2017,8 +2017,12 @@ fn extension_platform_event_does_not_advertise_unproved_interception() {
 }
 
 #[test]
-fn extension_root_platform_module_remains_provider_unavailable() {
+fn extension_root_platform_modules_are_owned_by_the_extension_root() {
     let fixture = RealReaderFixture::new();
+    write(
+        &fixture.source.join("Ext/ManagedApplicationModule.bsl"),
+        "Procedure ПередНачаломРаботыСистемы(Отказ)\nEndProcedure\n\nProcedure РасширениеПриСтарте()\nEndProcedure\n",
+    );
     let cancellation = CancellationToken::new();
     let source_root = Arc::new(RetainedDirectoryCapability::open(&fixture.source).unwrap());
     let revisions = Arc::new(
@@ -2034,11 +2038,46 @@ fn extension_root_platform_module_remains_provider_unavailable() {
         PlatformProfile::v8_3_27(),
     );
 
-    let result = ViewService::new(authority, ViewCursorStore::default())
-        .view(ViewRequest::new("main:Module.ManagedApplication.Event.BeforeStart").unwrap());
+    let module = ViewService::new(authority, ViewCursorStore::default())
+        .view(ViewRequest::new("main:Module.ManagedApplication").unwrap());
+    assert!(module.ok, "{module:?}");
 
-    assert!(!result.ok, "{result:?}");
-    assert_eq!(result.diagnostics[0]["code"], "provider_unavailable");
+    let source_root = Arc::new(RetainedDirectoryCapability::open(&fixture.source).unwrap());
+    let revisions = Arc::new(
+        SourceRevisionService::new_reconciling_for_test(&fixture.context, &fixture.source).unwrap(),
+    );
+    let authority = LogicalViewReadAuthority::new(
+        &cancellation,
+        "main",
+        "actor-fixture-extension-root-find",
+        SourceSetKind::Extension,
+        revisions,
+        source_root,
+        PlatformProfile::v8_3_27(),
+    );
+    let index = WorkspaceFindIndexBuilder::default()
+        .build(
+            &[ActorFindSource::new("main", &authority)],
+            crate::domain::code_intelligence::ProviderDeadline::from_budget(
+                crate::application::v13::LOGICAL_READ_OPERATION_BUDGET,
+            ),
+            &cancellation,
+        )
+        .unwrap();
+    for expected in [
+        "main:Module.ManagedApplication",
+        "main:Module.ManagedApplication.Method.РасширениеПриСтарте",
+    ] {
+        let found = index.find(FindRequest::new(expected).unwrap());
+        assert!(
+            !found.is_nearest()
+                && found
+                    .candidates()
+                    .iter()
+                    .any(|candidate| candidate.at() == expected),
+            "extension root module identity is missing from find: {expected}: {found:?}"
+        );
+    }
 }
 
 #[test]
@@ -2092,7 +2131,7 @@ fn logical_reader_parity_contract_is_complete() {
     operation_lease_find_traversal_scans_once_then_confirms_once();
     websocket_client_source_view_is_an_explicit_provider_gap();
     extension_platform_event_does_not_advertise_unproved_interception();
-    extension_root_platform_module_remains_provider_unavailable();
+    extension_root_platform_modules_are_owned_by_the_extension_root();
     crate::application::invocation::tests::assert_operation_budget_survives_handoff_and_completes_once(
         crate::application::v13::LOGICAL_READ_OPERATION_BUDGET,
     );


### PR DESCRIPTION
## Что было

`unica.find` на workspace с расширением (Sendbox + `PrintWebDAV`) падал целиком: `find could not read logical identity PrintWebDAV:Module.ManagedApplication: extension root runtime module ownership is not proved`.

## Причина

Для корневых модулей платформы (`ManagedApplicationModule`, `SessionModule`, …) читатель принимал владельца только у основной конфигурации, а расширению отвечал `provider_unavailable`. Но расширение расширяет эти модули из собственного корня (`Ext/ManagedApplicationModule.bsl`), и его `Configuration.xml` владеет ими так же, как основная конфигурация (`1c-extension-spec.md`: формат аналогичен конфигурации).

## Что сделано

Корневые модули расширения доказываются как у конфигурации; внешние обработки и отчёты по-прежнему получают `not_found`. Контрактный тест `extension_root_platform_module_remains_provider_unavailable` заменён на позитивный: `view` корневого модуля расширения и `find` его методов.

Записей `arch/` не касается: `DEC.2026-08-25` и `INV.SOURCE.LOGICAL-READER-PARITY` запрещают runtime-модули только внешним source set.

## Тесты

`v13_read`, `v13_find`, clippy `-D warnings`, fmt, `tests/arch` (122 OK).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extension root modules are now correctly recognized as owned by their extension source.
  * Extension-root module methods can now be resolved and included in search results instead of returning an unavailable-provider error.
  * Terminal command owners can now be verified when their registration is provided inline, while invalid nested command ownership is rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->