### PR TITLE
fix(v13): тело макета читается лениво, макеты AddIn адресуются без чтения

### DIFF
--- a/crates/unica-coder/src/application/ports.rs
+++ b/crates/unica-coder/src/application/ports.rs
@@ -166,6 +166,13 @@ pub(crate) enum MetadataTemplateType {
     SpreadsheetDocument,
     BinaryData,
     DataCompositionSchema,
+    /// External component archive. Same opaque payload as `BinaryData`; the
+    /// dedicated type exists so mobile builds can mark components. Logical
+    /// addressing stops at the template and never reads the payload.
+    AddIn,
+    /// Data composition appearance template: an opaque XML body whose
+    /// internals are not addressed.
+    DataCompositionAppearanceTemplate,
 }
 
 impl MetadataTemplateType {
@@ -176,7 +183,22 @@ impl MetadataTemplateType {
             "SpreadsheetDocument" => Some(Self::SpreadsheetDocument),
             "BinaryData" => Some(Self::BinaryData),
             "DataCompositionSchema" => Some(Self::DataCompositionSchema),
+            "AddIn" => Some(Self::AddIn),
+            "DataCompositionAppearanceTemplate" => Some(Self::DataCompositionAppearanceTemplate),
             _ => None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn descriptor_value(self) -> &'static str {
+        match self {
+            Self::HtmlDocument => "HTMLDocument",
+            Self::TextDocument => "TextDocument",
+            Self::SpreadsheetDocument => "SpreadsheetDocument",
+            Self::BinaryData => "BinaryData",
+            Self::DataCompositionSchema => "DataCompositionSchema",
+            Self::AddIn => "AddIn",
+            Self::DataCompositionAppearanceTemplate => "DataCompositionAppearanceTemplate",
         }
     }
 }

--- a/crates/unica-coder/src/infrastructure/native_operations/meta/edit.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta/edit.rs
@@ -1742,9 +1742,10 @@ pub(super) fn typed_template_primary_path(template_type: MetadataTemplateType) -
     match template_type {
         MetadataTemplateType::HtmlDocument
         | MetadataTemplateType::SpreadsheetDocument
-        | MetadataTemplateType::DataCompositionSchema => "Ext/Template.xml",
+        | MetadataTemplateType::DataCompositionSchema
+        | MetadataTemplateType::DataCompositionAppearanceTemplate => "Ext/Template.xml",
         MetadataTemplateType::TextDocument => "Ext/Template.txt",
-        MetadataTemplateType::BinaryData => "Ext/Template.bin",
+        MetadataTemplateType::BinaryData | MetadataTemplateType::AddIn => "Ext/Template.bin",
     }
 }
 
@@ -1772,7 +1773,10 @@ pub(super) fn typed_template_initial_content(template_type: MetadataTemplateType
                 .expect("closed template kind")
                 .into_bytes()
         }
-        MetadataTemplateType::TextDocument | MetadataTemplateType::BinaryData => Vec::new(),
+        MetadataTemplateType::TextDocument
+        | MetadataTemplateType::BinaryData
+        | MetadataTemplateType::AddIn
+        | MetadataTemplateType::DataCompositionAppearanceTemplate => Vec::new(),
     }
 }
 
@@ -2002,8 +2006,13 @@ fn typed_child_payload_role(
                 {
                     MetadataTemplateResourcePart::Primary
                 }
-                (MetadataTemplateType::BinaryData, path)
+                (MetadataTemplateType::BinaryData | MetadataTemplateType::AddIn, path)
                     if path == Path::new("Ext/Template.bin") =>
+                {
+                    MetadataTemplateResourcePart::Primary
+                }
+                (MetadataTemplateType::DataCompositionAppearanceTemplate, path)
+                    if path == Path::new("Ext/Template.xml") =>
                 {
                     MetadataTemplateResourcePart::Primary
                 }

--- a/crates/unica-coder/src/infrastructure/native_operations/meta/validation.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/meta/validation.rs
@@ -1576,7 +1576,12 @@ fn validate_template_resource(
                 .map(|_| ())
                 .map_err(|error| format!("text template is not UTF-8: {error}"))
         }
-        (MetadataTemplateType::BinaryData, MetadataTemplateResourcePart::Primary) => Ok(()),
+        (
+            MetadataTemplateType::BinaryData
+            | MetadataTemplateType::AddIn
+            | MetadataTemplateType::DataCompositionAppearanceTemplate,
+            MetadataTemplateResourcePart::Primary,
+        ) => Ok(()),
         (MetadataTemplateType::HtmlDocument, MetadataTemplateResourcePart::Primary) => {
             html_template_page_names(bytes).map(|_| ())
         }
@@ -4586,13 +4591,7 @@ mod tests {
         let child_address = address(child);
         let name = child_address.segments().last().unwrap().to_string();
         let template_type = resources.first().unwrap().0;
-        let template_type_value = match template_type {
-            MetadataTemplateType::HtmlDocument => "HTMLDocument",
-            MetadataTemplateType::TextDocument => "TextDocument",
-            MetadataTemplateType::SpreadsheetDocument => "SpreadsheetDocument",
-            MetadataTemplateType::BinaryData => "BinaryData",
-            MetadataTemplateType::DataCompositionSchema => "DataCompositionSchema",
-        };
+        let template_type_value = template_type.descriptor_value();
         let descriptor = typed_child_xml("Template", &name, Some(template_type_value));
         let directories = if template_type == MetadataTemplateType::HtmlDocument {
             vec![

--- a/crates/unica-coder/src/infrastructure/v13_read.rs
+++ b/crates/unica-coder/src/infrastructure/v13_read.rs
@@ -382,54 +382,6 @@ impl<'a> LogicalViewReadAuthority<'a> {
                 self.verify_registered_owner(&child, admitted)?;
             }
         }
-        let template_branches = local
-            .collections
-            .templates
-            .iter()
-            .map(|template| {
-                let child = MetadataAddress::parse(
-                    PLATFORM_XML_8_3_27_FORMAT_2_20,
-                    &format!("{}.Template.{}", target.as_str(), template.name),
-                )
-                .map_err(|error| ViewError::new("provider_unavailable", error.to_string()))?;
-                let branches = match self.read.metadata_child_profile(&child) {
-                    Ok(MetadataChildProfile::Template(
-                        MetadataTemplateType::DataCompositionSchema,
-                    )) => {
-                        let payload = self.read.dcs_payload(&child)?;
-                        vec![(
-                            NodeKind::DataSet,
-                            payload
-                                .get("dataSets")
-                                .and_then(Value::as_array)
-                                .map_or(0, Vec::len),
-                        )]
-                    }
-                    Ok(MetadataChildProfile::Template(
-                        MetadataTemplateType::SpreadsheetDocument,
-                    )) => {
-                        let payload = self.read.mxl_payload(&child)?;
-                        vec![(
-                            NodeKind::Area,
-                            payload
-                                .get("areas")
-                                .and_then(Value::as_array)
-                                .map_or(0, Vec::len),
-                        )]
-                    }
-                    Ok(MetadataChildProfile::Template(_)) => Vec::new(),
-                    Ok(MetadataChildProfile::Form | MetadataChildProfile::Command) => {
-                        return Err(ViewError::new(
-                            "provider_unavailable",
-                            "template registry points to a non-template descriptor",
-                        ));
-                    }
-                    Err(error) if error.code() == "not_found" => Vec::new(),
-                    Err(error) => return Err(error),
-                };
-                Ok((template.name.clone(), branches))
-            })
-            .collect::<Result<std::collections::BTreeMap<_, _>, ViewError>>()?;
         let mut payload = Map::new();
         payload.insert("name".to_string(), json!(local.name));
         payload.insert("synonym".to_string(), json!(local.synonym));
@@ -439,26 +391,8 @@ impl<'a> LogicalViewReadAuthority<'a> {
         insert_serialized(&mut payload, "properties", &local.properties)?;
         insert_serialized(&mut payload, "declarations", &local.declarations)?;
         insert_serialized(&mut payload, "relations", &local.relations)?;
-        let mut collections = serde_json::to_value(&local.collections)
+        let collections = serde_json::to_value(&local.collections)
             .map_err(|error| ViewError::new("provider_unavailable", error.to_string()))?;
-        if let Some(templates) = collections
-            .get_mut("templates")
-            .and_then(Value::as_array_mut)
-        {
-            for template in templates {
-                let Some(name) = template.get("name").and_then(Value::as_str) else {
-                    continue;
-                };
-                let Some(branches) = template_branches.get(name) else {
-                    continue;
-                };
-                template["logicalBranches"] = json!(branches
-                    .iter()
-                    .filter(|(_, count)| *count > 0)
-                    .map(|(kind, count)| json!({"kind": kind.as_str(), "count": count}))
-                    .collect::<Vec<_>>());
-            }
-        }
         payload.insert("collections".to_string(), collections);
         Ok(Value::Object(payload))
     }
@@ -1134,7 +1068,8 @@ impl ViewReadAuthority for LogicalViewReadAuthority<'_> {
             self.form_view(&route, admitted)?
         } else {
             let payload = self.typed_payload_for(&route, admitted)?;
-            project_typed_payload(&route, payload)?
+            let projected = project_typed_payload(&route, payload)?;
+            self.with_template_body_branches(projected, &route)?
         };
         let projected = self.with_module_branch(projected, at, admitted)?;
         self.read_checkpoint()?;
@@ -1149,6 +1084,88 @@ impl ViewReadAuthority for LogicalViewReadAuthority<'_> {
 }
 
 impl LogicalViewReadAuthority<'_> {
+    /// A template's own body (data sets of a DCS, areas of a spreadsheet) is
+    /// read only when the template node itself is addressed. Projecting the
+    /// owner or the template collection never opens template payloads, so a
+    /// large or unreadable body fails exactly one node instead of its owner.
+    fn with_template_body_branches(
+        &self,
+        projected: NodeViewData,
+        route: &LogicalTreeRoute,
+    ) -> Result<NodeViewData, ViewError> {
+        if route.reader() != LogicalReader::Metadata {
+            return Ok(projected);
+        }
+        let segments = route.at().segments();
+        let [owner, template] = segments else {
+            return Ok(projected);
+        };
+        if template.kind() != NodeKind::Template || template.name().is_none() {
+            return Ok(projected);
+        }
+        let Some(owner_name) = owner.name() else {
+            return Ok(projected);
+        };
+        let child = MetadataAddress::parse(
+            PLATFORM_XML_8_3_27_FORMAT_2_20,
+            &format!(
+                "{}.{owner_name}.Template.{}",
+                owner.kind().as_str(),
+                template.name().unwrap_or_default()
+            ),
+        )
+        .map_err(|error| ViewError::new("provider_unavailable", error.to_string()))?;
+        let mut projected = projected;
+        for (kind, count) in self.template_body_branches(&child)? {
+            if count > 0 {
+                projected = projected.with_branch(BranchRef::new(
+                    format!("{}.{}", route.at(), kind.as_str()),
+                    count,
+                ));
+            }
+        }
+        Ok(projected)
+    }
+
+    fn template_body_branches(
+        &self,
+        child: &MetadataAddress,
+    ) -> Result<Vec<(NodeKind, usize)>, ViewError> {
+        Ok(match self.read.metadata_child_profile(child) {
+            Ok(MetadataChildProfile::Template(MetadataTemplateType::DataCompositionSchema)) => {
+                let payload = self.read.dcs_payload(child)?;
+                vec![(
+                    NodeKind::DataSet,
+                    payload
+                        .get("dataSets")
+                        .and_then(Value::as_array)
+                        .map_or(0, Vec::len),
+                )]
+            }
+            Ok(MetadataChildProfile::Template(MetadataTemplateType::SpreadsheetDocument)) => {
+                let payload = self.read.mxl_payload(child)?;
+                vec![(
+                    NodeKind::Area,
+                    payload
+                        .get("areas")
+                        .and_then(Value::as_array)
+                        .map_or(0, Vec::len),
+                )]
+            }
+            // Text, HTML, binary, add-in and appearance templates have no
+            // addressable interior: addressing stops at the template.
+            Ok(MetadataChildProfile::Template(_)) => Vec::new(),
+            Ok(MetadataChildProfile::Form | MetadataChildProfile::Command) => {
+                return Err(ViewError::new(
+                    "provider_unavailable",
+                    "template registry points to a non-template descriptor",
+                ));
+            }
+            Err(error) if error.code() == "not_found" => Vec::new(),
+            Err(error) => return Err(error),
+        })
+    }
+
     fn with_module_branch(
         &self,
         projected: NodeViewData,

--- a/crates/unica-coder/src/infrastructure/v13_read/tests.rs
+++ b/crates/unica-coder/src/infrastructure/v13_read/tests.rs
@@ -2085,6 +2085,8 @@ fn logical_reader_parity_contract_is_complete() {
     crate::infrastructure::source_revision::tests::retained_revision_authority_contract_is_complete(
     );
     object_commands_are_registered_inline_without_descriptor_files();
+    template_bodies_are_read_only_when_the_template_node_is_addressed();
+    add_in_templates_stop_addressing_at_the_template_without_reading_the_payload();
     configuration_level_rights_are_readable_role_objects();
     actor_owned_reader_never_follows_a_source_set_remap_after_admission();
     actor_owned_configuration_support_and_home_page_sidecars_are_retained();
@@ -3562,6 +3564,109 @@ pub(crate) fn object_commands_are_registered_inline_without_descriptor_files() {
             "inline command identity is missing from find: {expected}: {found:?}"
         );
     }
+}
+
+#[test]
+pub(crate) fn template_bodies_are_read_only_when_the_template_node_is_addressed() {
+    let fixture = RealReaderFixture::new();
+    let body = fixture
+        .source
+        .join("Reports/ParityReport/Templates/Print/Ext/Template.xml");
+    let readable = fs::read(&body).unwrap();
+    // An unreadable spreadsheet body must not take the owner or the template
+    // collection down with it: only the template node opens the body.
+    fs::write(
+        &body,
+        "<document xmlns=\"http://v8.1c.ru/8.2/data/spreadsheet\"><unclosed>",
+    )
+    .unwrap();
+    let service = fixture.view_service();
+    for at in [
+        "main:Report.ParityReport",
+        "main:Report.ParityReport.Template",
+    ] {
+        let result = service.view(ViewRequest::new(at).unwrap());
+        assert!(result.ok, "{at}: {:?}", result.diagnostics);
+    }
+    let node = service.view(ViewRequest::new("main:Report.ParityReport.Template.Print").unwrap());
+    assert!(
+        !node.ok,
+        "an unreadable template body escaped through its own node"
+    );
+    assert_eq!(node.diagnostics[0]["code"], "provider_unavailable");
+
+    // A readable body still publishes its interior on the template node.
+    fs::write(&body, readable).unwrap();
+    let service = fixture.view_service();
+    let node = service.view(ViewRequest::new("main:Report.ParityReport.Template.Print").unwrap());
+    assert!(node.ok, "{:?}", node.diagnostics);
+    let branches = node.data.as_ref().unwrap()["branches"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        branches
+            .iter()
+            .any(|branch| branch["at"] == "main:Report.ParityReport.Template.Print.Area"),
+        "{branches:?}"
+    );
+}
+
+#[test]
+pub(crate) fn add_in_templates_stop_addressing_at_the_template_without_reading_the_payload() {
+    let fixture = RealReaderFixture::new();
+    let descriptor = fixture.source.join("Catalogs/Items.xml");
+    let owner = fs::read_to_string(&descriptor).unwrap();
+    let close = owner.rfind("</ChildObjects>").unwrap();
+    let owner = format!(
+        "{}<Template>Driver</Template>{}",
+        &owner[..close],
+        &owner[close..]
+    );
+    fs::write(&descriptor, owner).unwrap();
+    write(
+        &fixture.source.join("Catalogs/Items/Templates/Driver.xml"),
+        r#"<?xml version="1.0" encoding="UTF-8"?><MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" version="2.20"><Template uuid="10000000-0000-4000-8000-000000000081"><Properties><Name>Driver</Name><TemplateType>AddIn</TemplateType></Properties></Template></MetaDataObject>"#,
+    );
+    // The payload is an opaque archive; make it something no XML reader could parse.
+    fs::create_dir_all(fixture.source.join("Catalogs/Items/Templates/Driver/Ext")).unwrap();
+    fs::write(
+        fixture
+            .source
+            .join("Catalogs/Items/Templates/Driver/Ext/Template.bin"),
+        [0x50, 0x4b, 0x03, 0x04, 0xff, 0x00, 0x80],
+    )
+    .unwrap();
+    let service = fixture.view_service();
+    let node = service.view(ViewRequest::new("main:Catalog.Items.Template.Driver").unwrap());
+    assert!(node.ok, "{:?}", node.diagnostics);
+    let data = node.data.as_ref().unwrap();
+    assert_eq!(data["kind"], "Template");
+    assert!(
+        data.get("branches").is_none(),
+        "an add-in template has no addressable interior: {data}"
+    );
+
+    let authority = fixture.read_authority();
+    let index = WorkspaceFindIndexBuilder::default()
+        .build(
+            &[ActorFindSource::new("main", &authority)],
+            crate::domain::code_intelligence::ProviderDeadline::from_budget(
+                crate::application::v13::LOGICAL_READ_OPERATION_BUDGET,
+            ),
+            &fixture.cancellation,
+        )
+        .unwrap();
+    let expected = "main:Catalog.Items.Template.Driver";
+    let found = index.find(FindRequest::new(expected).unwrap());
+    assert!(
+        !found.is_nearest()
+            && found
+                .candidates()
+                .iter()
+                .any(|candidate| candidate.at() == expected),
+        "add-in template identity is missing from find: {found:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Что было

На дампе УТ `unica.find` падал на `Catalog.КлассификаторДОПОГЭПД` (макет табличного документа 9,5 МБ против лимита чтения 8 МиБ) и на `Catalog.СертификатыКлючейЭлектроннойПодписиИШифрования` (`Template descriptor has unsupported TemplateType` для `AddIn`).

## Причина

1. Проекция владельца читала тело каждого его макета (СКД и MXL) только ради счётчиков веток `DataSet`/`Area` у элементов коллекции. Большой или нечитаемый макет ронял владельца и всю операцию `find`, а лимит 8 МиБ, который защищает память демона, срабатывал там, где чтение вообще не требовалось.
2. Перечень типов макетов знал пять значений; `AddIn` (внешняя компонента, тот же двоичный `Template.bin`, что и `BinaryData`, но с разметкой для мобильной сборки) и `DataCompositionAppearanceTemplate` отвергались. В УТ 104 макета `AddIn` и 2 `DataCompositionAppearanceTemplate`.

## Что сделано

- Тело макета читается только когда адресован сам узел макета: владелец и коллекция `Template` тела не открывают. Нечитаемый макет теперь роняет ровно один узел, а `find` по-прежнему достигает `Template.<Имя>.DataSet.…` и `.Area.…` через узел макета.
- Добавлены типы `AddIn` и `DataCompositionAppearanceTemplate`: адресация останавливается на макете, полезная нагрузка не читается ни `view`, ни `find`; в `meta.add`/`meta.edit` `AddIn` пишется как `Ext/Template.bin`, `DataCompositionAppearanceTemplate` — как `Ext/Template.xml`.
- Лимит 8 МиБ на файл оставлен как граница памяти; после переноса чтения он касается только прямого обращения к телу макета.

## Тесты

Нечитаемое тело MXL: владелец и коллекция отвечают, узел макета — `provider_unavailable`, после починки тела узел публикует `Area`. Макет `AddIn` с двоичной нагрузкой: узел без веток, `find` находит адрес. Прогнано: `v13_read`, `v13_find`, template- и meta-тесты, `metadata_operations`, clippy `-D warnings`, fmt, `tests/arch`.
