### PR TITLE
build(runtime): pin v8-runner v0.6.0

### DIFF
--- a/crates/unica-bootstrap/tests/manifest_contract.rs
+++ b/crates/unica-bootstrap/tests/manifest_contract.rs
@@ -199,7 +199,7 @@ fn maintained_runner_target(target: &str) -> serde_json::Value {
         "asset": {
             "name": executable,
             "url": format!(
-                "https://github.com/IngvarConsulting/v8-runner-rust/releases/download/v0.5.2-ic.4/{executable}"
+                "https://github.com/IngvarConsulting/v8-runner-rust/releases/download/v0.6.0/{executable}"
             ),
             "mediaType": "application/octet-stream",
             "sha256": HASH
@@ -211,7 +211,7 @@ fn maintained_runner_target(target: &str) -> serde_json::Value {
 fn fixture_with_maintained_runner() -> serde_json::Value {
     let mut manifest = fixture();
     manifest["artifacts"]["v8-runner"] = serde_json::json!({
-        "version": "0.5.2-ic.4",
+        "version": "0.6.0",
         "role": "engine",
         "targets": {
             "darwin-arm64": maintained_runner_target("darwin-arm64"),
@@ -243,7 +243,7 @@ fn a_maintained_engine_source_is_approved_without_opening_other_origins() {
     let mut other = fixture_with_maintained_runner();
     other["artifacts"]["v8-runner"]["targets"]["linux-x64"]["asset"]["url"] =
         serde_json::json!(
-            "https://github.com/IngvarConsulting/another-project/releases/download/v0.5.2-ic.4/v8-runner-linux-x64"
+            "https://github.com/IngvarConsulting/another-project/releases/download/v0.6.0/v8-runner-linux-x64"
         );
     let error = parse(other)
         .validate("0.7.0")

--- a/plugins/unica/ATTRIBUTIONS.md
+++ b/plugins/unica/ATTRIBUTIONS.md
@@ -47,8 +47,8 @@ Unica поставляет LSP-бинарник `bsl-analyzer`. Его лице�
 - Репозиторий: [IngvarConsulting/v8-runner-rust](https://github.com/IngvarConsulting/v8-runner-rust)
 - Автор: [v8-runner contributors](https://github.com/alkoleft/v8-runner-rust/graphs/contributors)
 - Исходный проект: [alkoleft/v8-runner-rust](https://github.com/alkoleft/v8-runner-rust)
-- Закреплённая версия: `0.5.2-ic.4`, source tag и asset tag `v0.5.2-ic.4`,
-  commit `37b8dee0e057db07dc94722b6aa155bdfcabb51a`
+- Закреплённая версия: `0.6.0`, source tag и asset tag `v0.6.0`,
+  commit `344af6e87113feaf89c6b3c63f0e7bad17d73cbb`
 - Лицензия: [AGPL-3.0-only](third-party/licenses/v8-runner/LICENSE)
 
 `v8-runner` запускается Unica как отдельный внутренний процесс. На его

--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -58,27 +58,27 @@
     },
     {
       "name": "v8-runner",
-      "version": "0.5.2-ic.4",
+      "version": "0.6.0",
       "repository": "https://github.com/IngvarConsulting/v8-runner-rust",
-      "sourceTag": "v0.5.2-ic.4",
-      "sourceCommit": "37b8dee0e057db07dc94722b6aa155bdfcabb51a",
+      "sourceTag": "v0.6.0",
+      "sourceCommit": "344af6e87113feaf89c6b3c63f0e7bad17d73cbb",
       "assetRepository": "https://github.com/IngvarConsulting/v8-runner-rust",
-      "assetTag": "v0.5.2-ic.4",
+      "assetTag": "v0.6.0",
       "license": "AGPL-3.0-only",
       "assetStrategy": "direct-release-asset",
       "binaryName": "v8-runner",
       "assets": {
         "darwin-arm64": {
           "assetName": "v8-runner-darwin-arm64",
-          "sha256": "420cf6a2df47ddd9d12344454a0b36f4481dc1116d486b5e1319ef166162fe83"
+          "sha256": "b76e5c9e97828fe299a2f1d0f3b7b491fa1564b5f904ff4f68200d08c6fe75bf"
         },
         "linux-x64": {
           "assetName": "v8-runner-linux-x64",
-          "sha256": "00e71b5eb012fda07e029034a106b4fe4c1c77a15596039332596ef00b89f4d1"
+          "sha256": "65e5eb96d9372d217ec697f46a15acd0c2754aa4cc44db9657cab73296d49893"
         },
         "win-x64": {
           "assetName": "v8-runner-win-x64.exe",
-          "sha256": "f0c9943e55ef6dcb60bc04f730cbb835c28872f4e16a7fe22083e62d9ca4e574"
+          "sha256": "825a31d927969520806e3b2314766acd41c448bd265e38d6d6e0156ca0cacf70"
         }
       }
     },

--- a/tests/ci/test_build_unica_tools.py
+++ b/tests/ci/test_build_unica_tools.py
@@ -314,11 +314,11 @@ class BuildUnicaToolsTests(unittest.TestCase):
 
         self.assertEqual(runner["repository"], "https://github.com/IngvarConsulting/v8-runner-rust")
         self.assertEqual(runner["assetRepository"], runner["repository"])
-        self.assertEqual(runner["sourceTag"], "v0.5.2-ic.4")
+        self.assertEqual(runner["sourceTag"], "v0.6.0")
         self.assertEqual(runner["assetTag"], runner["sourceTag"])
         self.assertEqual(
             runner["sourceCommit"],
-            "37b8dee0e057db07dc94722b6aa155bdfcabb51a",
+            "344af6e87113feaf89c6b3c63f0e7bad17d73cbb",
         )
 
     def test_historical_build_2_release_provenance_is_immutable(self) -> None:

--- a/tests/ci/test_skill_provenance.py
+++ b/tests/ci/test_skill_provenance.py
@@ -639,10 +639,10 @@ class SkillProvenanceTests(unittest.TestCase):
 
         self.assertEqual(runtime_source["toolLockRef"], "v8-runner")
         self.assertIn(runtime_source["toolLockRef"], locked_tools)
-        self.assertEqual(locked_tools["v8-runner"]["sourceTag"], "v0.5.2-ic.4")
+        self.assertEqual(locked_tools["v8-runner"]["sourceTag"], "v0.6.0")
         self.assertEqual(
             locked_tools["v8-runner"]["sourceCommit"],
-            "37b8dee0e057db07dc94722b6aa155bdfcabb51a",
+            "344af6e87113feaf89c6b3c63f0e7bad17d73cbb",
         )
 
     def test_historical_rlm_build_2_review_is_immutable(self) -> None:


### PR DESCRIPTION
## Summary

- pin the maintained `v8-runner` fork at immutable release `v0.6.0`
- update all three direct native asset checksums and the exact source commit
- synchronize package attribution and contract fixtures

## Release evidence

- release: https://github.com/IngvarConsulting/v8-runner-rust/releases/tag/v0.6.0
- source commit: `344af6e87113feaf89c6b3c63f0e7bad17d73cbb`
- `gh release verify v0.6.0` succeeds
- direct darwin-arm64, linux-x64, and win-x64 assets were downloaded and their SHA-256 values independently recomputed
- all three assets pass GitHub build-attestation verification against the protected `master` source digest

## Validation

- `python3.12 tests/ci/test_build_unica_tools.py`
- `python3.12 tests/ci/test_skill_provenance.py`
- `python3.12 tests/ci/test_attributions.py`
- `PYTHONPATH=. <ci-python> tests/ci/test_product_contracts.py`
- `cargo test -p unica-bootstrap --test manifest_contract`
- JSON parse and `git diff --check`

## Architecture

No architectural contract changes. This advances the concrete lock under `DEC.2026-09-02.MAINTAINED-ENGINES-PUBLISH-AT-SOURCE` and preserves `INV.PKG.ENGINE-RELEASE-SOURCES`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the maintained v8 runner to release 0.6.0.
  * Refreshed platform-specific release metadata to support the updated runner across existing targets.

* **Quality Assurance**
  * Updated validation checks to confirm the new runner release, source, and published assets are correctly aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->