### PR TITLE
test(dev): убрать гонку уборки временного каталога с фоновым git maintenance

### DIFF
--- a/tests/dev/test_benchmark_rlm_index.py
+++ b/tests/dev/test_benchmark_rlm_index.py
@@ -3,6 +3,7 @@ import contextlib
 import importlib.util
 import io
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -23,7 +24,11 @@ SPEC.loader.exec_module(MODULE)
 
 class BenchmarkRlmIndexTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.temporary_directory = tempfile.TemporaryDirectory()
+        # Backstop, not the fix: git_fixture keeps the writer from existing.
+        # This only stops a stray cleanup error from failing a passing test.
+        self.temporary_directory = tempfile.TemporaryDirectory(
+            ignore_cleanup_errors=True
+        )
         self.addCleanup(self.temporary_directory.cleanup)
         self.root = Path(self.temporary_directory.name)
         self.fixture_number = 0
@@ -81,6 +86,15 @@ class BenchmarkRlmIndexTests(unittest.TestCase):
         configuration.write_text("<Configuration/>\n", encoding="utf-8")
 
         self.run_git(repo, "init", "-q")
+        # `git commit` otherwise spawns `git maintenance run --auto --detach`,
+        # which daemonizes: the commit returns, the fixture returns, and the
+        # grandchild keeps repacking `.git/objects` under the temporary
+        # directory this test is about to remove. A daemon is reparented to
+        # init, so nothing here can wait on it: the only sound fix is to keep it
+        # from being spawned. `gc.auto` covers Git older than 2.30, which
+        # detached `git gc --auto` directly instead.
+        self.run_git(repo, "config", "maintenance.auto", "false")
+        self.run_git(repo, "config", "gc.auto", "0")
         self.run_git(repo, "config", "user.email", "unica-test@example.invalid")
         self.run_git(repo, "config", "user.name", "Unica Test")
         self.run_git(repo, "add", ".")
@@ -139,6 +153,41 @@ class BenchmarkRlmIndexTests(unittest.TestCase):
             "bdf429e3a8dee1fb9b1f1af66adcc4280732cc4287c92c4fbe4effddc0f8492e"
         )
         return [packaged, source]
+
+    def trace2_events(self, path: Path) -> list[dict]:
+        events = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                # A detached grandchild appends to the same trace file while we
+                # read it, so a torn final line is expected noise, not a fact.
+                continue
+        return events
+
+    def test_fixture_leaves_no_detached_git_process_behind(self) -> None:
+        trace = self.root / "git-trace2.jsonl"
+
+        with patch.dict(os.environ, {"GIT_TRACE2_EVENT": str(trace)}):
+            self.git_fixture()
+
+        events = self.trace2_events(trace)
+        self.assertTrue(
+            any(event.get("event") == "start" for event in events),
+            "git wrote no trace2 events, so this probe proves nothing",
+        )
+        self.assertEqual(
+            [
+                event.get("argv")
+                for event in events
+                if event.get("event") == "child_start"
+                and "--detach" in (event.get("argv") or ())
+            ],
+            [],
+            "the fixture left a daemonized git process running; it keeps "
+            "writing into .git/objects after setUp returns and races the "
+            "TemporaryDirectory cleanup registered there",
+        )
 
     def test_refuses_a_dirty_tracked_tree(self) -> None:
         repo = self.git_fixture()

--- a/tests/dev/test_benchmark_rlm_index.py
+++ b/tests/dev/test_benchmark_rlm_index.py
@@ -156,13 +156,17 @@ class BenchmarkRlmIndexTests(unittest.TestCase):
 
     def trace2_events(self, path: Path) -> list[dict]:
         events = []
-        for line in path.read_text(encoding="utf-8").splitlines():
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
             try:
                 events.append(json.loads(line))
             except json.JSONDecodeError:
-                # A detached grandchild appends to the same trace file while we
-                # read it, so a torn final line is expected noise, not a fact.
-                continue
+                # A still-running grandchild appends to this file while we read
+                # it, so only the last line can be a torn write. Skipping an
+                # unparsable line anywhere else would let a `--detach` record
+                # go unseen and pass this test for the wrong reason.
+                if index != len(lines) - 1:
+                    raise
         return events
 
     def test_fixture_leaves_no_detached_git_process_behind(self) -> None:


### PR DESCRIPTION
## Что было

`test_selects_exact_deterministic_scenario_sizes` падал в CI на уборке
временного каталога, хотя сам тест проходил:

```
OSError: [Errno 39] Directory not empty: '/tmp/tmpds1enwo3/repo-1/.git/objects'
```

Ошибка приходила из `TemporaryDirectory.cleanup`, зарегистрированного в
`setUp`, поэтому валила уже прошедший тест.

## Причина

`git commit` порождает `git maintenance run --auto --quiet --detach`, и этот
процесс **демонизируется**. `subprocess.run(check=True)` дожидается только
запускающего процесса: `git_fixture` возвращает управление, а внучатый процесс,
переподчинённый init, продолжает перепаковывать `.git/objects` внутри
каталога, который тест уже удаляет.

Доказательство — `GIT_TRACE2_EVENT`. Родительский `git commit` пишет
`exit`/`atexit` **раньше**, чем вообще стартуют `git gc`, `git repack` и
`git pack-objects` (последний пишет `.git/objects/pack/.tmp-*-pack`):

```
start       git commit
child_start git maintenance run --auto --quiet --detach
exit 0 / atexit 0        <- родитель завершился, subprocess.run вернул управление
child_start git gc --auto --quiet --no-detach
child_start git repack -d -l -q --no-write-bitmap-index
child_start git pack-objects ... .git/objects/pack/.tmp-28265-pack
child_start git prune --expire 2.weeks.ago
```

Опрос дерева подтверждает окно: через 100 мс после возврата `subprocess.run`
`objects/pack` пуст и в `objects/17` лежит 7 свободных объектов, через 200 мс —
3 файла в `objects/pack` и `objects/17` пуст. Под нагрузкой CI это окно
растягивается и попадает в `rmtree`.

## Правка

Демона нельзя дождаться: он переподчинён init, и `wait()` на него не бывает.
Поэтому фикстура не даёт ему появиться — `maintenance.auto=false` в конфиге
репозитория (плюс `gc.auto=0` для git старше 2.30, который отсоединял
`git gc --auto` напрямую). Конфиг ставится сразу после `git init`, поэтому
покрывает и вызовы git из самого `benchmark-rlm-index.py`.

`ignore_cleanup_errors=True` добавлен **только как страховка**, чтобы случайная
ошибка уборки не валила прошедший тест, а не как решение.

## Тест

`test_fixture_leaves_no_detached_git_process_behind` закрепляет причину, а не
тайминг: через `GIT_TRACE2_EVENT` проверяется, что фикстура не запускает ни
одного дочернего процесса с `--detach`. Тест детерминированный в обе стороны.

- RED на текущем коде:
  `AssertionError: Lists differ: [['git', 'maintenance', 'run', '--auto', '--quiet', '--detach']] != []`
- GREEN после правки.

Отдельно проверено, что `.git/objects` после возврата `git_fixture` больше не
меняется: снимок сразу и через 1,5 с совпадают (266 файлов, ничего не появилось
и не исчезло).

## Проверка

- `python3.12 -m unittest discover -s tests/dev` — 256 тестов, OK
  (255 прежних + новый).
- `python3.12 -m py_compile scripts/dev/*.py tests/dev/*.py` — OK.

## Граница

База — актуальный `origin/main` (156a9ae9). С #704 не смешано: тот PR снимает
агрегаторы в `tests/arch`, здесь затронут один файл `tests/dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test cleanup to prevent detached Git maintenance processes from remaining after test execution.
  * Added coverage to verify that Git operations do not leave behind unintended background processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->