### PR TITLE
test(project-health): keep the ceiling proof off the clock

### DIFF
--- a/crates/unica-coder/src/infrastructure/project_health/resources.rs
+++ b/crates/unica-coder/src/infrastructure/project_health/resources.rs
@@ -2438,8 +2438,9 @@ fn repository_regular_file_size(
 mod tests {
     use super::{
         classify_platform_xml_relative_path, inspect_working_eol, parse_attribute_records,
-        parse_eol_records, resource_check_ids, RepositoryResourceKind,
-        SourceResourcePolicyInspector, LFS_SINGLE_FILE_THRESHOLD_BYTES,
+        parse_eol_records, reserve_resource_owner_expansion, resource_check_ids,
+        RepositoryResourceKind, ResourceClassificationError, SourceResourcePolicyInspector,
+        LFS_SINGLE_FILE_THRESHOLD_BYTES, MAX_CLASSIFIED_RESOURCES,
     };
     use crate::domain::cancellation::CancellationToken;
     use crate::domain::code_intelligence::ProviderDeadline;
@@ -4071,5 +4072,28 @@ mod tests {
             stdout_had_invalid_utf8: false,
             stderr_had_invalid_utf8: false,
         }
+    }
+
+    #[test]
+    fn resource_owner_expansion_admits_the_ceiling_and_refuses_the_entry_after_it() {
+        let Ok((count, bytes)) =
+            reserve_resource_owner_expansion(MAX_CLASSIFIED_RESOURCES - 1, 0, 1, 0)
+        else {
+            panic!("the ceiling itself is a classified count, not an overflow");
+        };
+
+        assert_eq!(count, MAX_CLASSIFIED_RESOURCES);
+        assert_eq!(bytes, 0);
+
+        let Err(ResourceClassificationError::Incomplete(reason)) =
+            reserve_resource_owner_expansion(MAX_CLASSIFIED_RESOURCES, 0, 1, 0)
+        else {
+            panic!("one entry past the ceiling must fail closed as an incomplete classification");
+        };
+
+        assert!(
+            reason.contains(&format!("exceeds {MAX_CLASSIFIED_RESOURCES} entries")),
+            "{reason}"
+        );
     }
 }

--- a/crates/unica-coder/tests/platform/project_health.rs
+++ b/crates/unica-coder/tests/platform/project_health.rs
@@ -1473,7 +1473,14 @@ fn project_health_bounds_equal_root_resource_ownership_composition() {
         fs::write(root.join(format!("src/Module{index}.bsl")), "Процедура P()\nКонецПроцедуры\n")
             .unwrap();
     }
-    let source_sets = (0..1024)
+    // Every owner classifies the same 64 files, so the composition's cost is
+    // `owners x files` and the whole call has to fit the interactive invocation
+    // window. At 1024 owners that product is the classification ceiling itself,
+    // and the call sat close enough to the window to answer `deadline expired`
+    // on slower targets. The ceiling is proven exactly, and without a clock, by
+    // `resource_owner_expansion_admits_the_ceiling_and_refuses_the_entry_after_it`;
+    // what this test proves is that every equal-root owner is composed.
+    let source_sets = (0..256)
         .map(|index| {
             format!("  - name: owner-{index:04}\n    type: CONFIGURATION\n    path: src\n")
         })
@@ -1504,7 +1511,7 @@ fn project_health_bounds_equal_root_resource_ownership_composition() {
     assert_repository_check_status(
         &data,
         "repository.attributes",
-        Some("owner-1023"),
+        Some("owner-0255"),
         "notRun",
     );
     let owner_diagnostic = data["diagnostics"]

--- a/crates/unica-coder/tests/platform/project_health.rs
+++ b/crates/unica-coder/tests/platform/project_health.rs
@@ -1398,8 +1398,15 @@ fn project_health_full_portable_linked_worktree_is_ready_and_read_only() {
     let _ = fs::remove_dir_all(root);
 }
 
+/// The staged index must be larger than the generic stdout capture limit that
+/// the process facade applies by default: project health reads git through its
+/// own, much larger limit, and a routing regression would truncate a real
+/// repository's index and report the inspection as incomplete. The fixture is
+/// kept just past that limit rather than multiples above it, because the whole
+/// call has to answer inside the interactive invocation window, and git work on
+/// a large index is where a slow target spends that window.
 #[test]
-fn project_health_handles_real_index_with_43k_sibling_paths() {
+fn project_health_handles_a_real_index_past_the_generic_capture_limit() {
     let root = temp_root("large-index");
     git(&root, &["init"]);
     let workspace = root.join("workspace");
@@ -1425,8 +1432,8 @@ fn project_health_handles_real_index_with_43k_sibling_paths() {
         ],
     );
     let oid = git_with_input(&root, &["hash-object", "-w", "--stdin"], b"fixture\n");
-    let mut index_info = Vec::with_capacity(43_000 * 80);
-    for index in 0..43_000 {
+    let mut index_info = Vec::with_capacity(16_000 * 80);
+    for index in 0..16_000 {
         write!(
             index_info,
             "100644 {}\tlarge-sibling/{index:05}.txt\0",

--- a/crates/unica-coder/tests/platform/project_health.rs
+++ b/crates/unica-coder/tests/platform/project_health.rs
@@ -1475,9 +1475,7 @@ fn project_health_bounds_equal_root_resource_ownership_composition() {
     }
     let source_sets = (0..1024)
         .map(|index| {
-            format!(
-                "  - name: owner-{index:04}\n    type: CONFIGURATION\n    path: src\n"
-            )
+            format!("  - name: owner-{index:04}\n    type: CONFIGURATION\n    path: src\n")
         })
         .collect::<String>();
     fs::write(
@@ -1709,16 +1707,33 @@ fn status(workspace: &Path) -> StatusResult {
 
     let structured = response["result"]["structuredContent"].clone();
     let ok = structured["ok"] == Value::Bool(true);
-    let errors = structured["diagnostics"]
+    // Diagnostics live under `data`, and a call that fails before producing a
+    // structured answer carries none: reading them from the wrong place left
+    // every failure reporting an empty list. The JSON-RPC error is the
+    // fallback, so a refusal names itself instead of showing `[]`.
+    let errors = structured["data"]["diagnostics"]
         .as_array()
         .map(|items| {
             items
                 .iter()
-                .filter_map(|item| item.get("message").and_then(Value::as_str))
-                .map(str::to_string)
+                .map(|item| {
+                    let code = item.get("code").and_then(Value::as_str);
+                    let message = item.get("message").and_then(Value::as_str);
+                    match (code, message) {
+                        (Some(code), Some(message)) => format!("{code}: {message}"),
+                        (Some(code), None) => code.to_string(),
+                        (None, Some(message)) => message.to_string(),
+                        (None, None) => "diagnostic without code or message".to_string(),
+                    }
+                })
                 .collect()
         })
-        .unwrap_or_default();
+        .unwrap_or_else(|| {
+            response["error"]["message"]
+                .as_str()
+                .map(|message| vec![format!("jsonrpc error: {message}")])
+                .unwrap_or_default()
+        });
     StatusResult {
         ok,
         errors,


### PR DESCRIPTION
## Что меняется

`project_health_bounds_equal_root_resource_ownership_composition` падал на
`windows-latest` и не падал на двух других целях. Здесь две правки: тест снова
сообщает причину падения, а доказательство порога переезжает туда, где не
зависит от часов.

Closes #708.

## Причина

Тест ставил 1024 владельца на один и тот же `src` с 64 файлами:

```text
1024 × 64 = 65 536 = MAX_CLASSIFIED_RESOURCES
```

Это доказывало, что порог классификации включающий. Цена доказательства —
`владельцы × файлы` классификаций **внутри интерактивного окна вызова**
(`INVOCATION_HANDOFF_WINDOW`, 7 с). На macOS и Linux укладывалось, на Windows —
нет.

Воспроизведено локально сужением окна: при 1024 владельцах вызов проходит с
окном 2000 мс и падает с 1400 мс, то есть требует 1,4–2 с на этой машине. Ответ
при этом такой:

```text
errors=["jsonrpc error: daemon deadline expired during invocation submit response"]
```

Это ровно то, что видно на Windows: `unica.view` отвечает JSON-RPC ошибкой, а не
структурой, поэтому `ok` ложно. Запас в 3,5–5× от семисекундного окна на
быстрой машине не переживает раннер, который в несколько раз медленнее, — отсюда
и мерцание: [33805564901](https://github.com/IngvarConsulting/unica/actions/runs/33805564901)
и [33819933318](https://github.com/IngvarConsulting/unica/actions/runs/33819933318)
зелёные, [33824410701](https://github.com/IngvarConsulting/unica/actions/runs/33824410701)
(дважды) и [33829740878](https://github.com/IngvarConsulting/unica/actions/runs/33829740878)
на чистом `main` — красные.

## Почему причину не было видно

Хелпер читал диагностики из `structuredContent.diagnostics`, а они лежат под
`structuredContent.data`. Поэтому `errors` всегда был пуст, и любое падение
печатало `errors=[]` — независимо от того, что случилось. Плюс вызов, упавший до
структурированного ответа, диагностик не несёт вовсе.

Теперь диагностики читаются там, где лежат, каждая называется кодом и
сообщением, а JSON-RPC ошибка — запасной вариант. Информативность возвращается,
не возвращая то, на что ругался CodeQL в #695: печатается не весь результат, а
код и сообщение диагностики.

## Что с покрытием

Включающий порог теперь доказывает модульный тест на
`reserve_resource_owner_expansion`: запись, доводящая счёт ровно до
`MAX_CLASSIFIED_RESOURCES`, принимается, следующая — отклоняется как
`Incomplete`. Точно, мгновенно и без часов на любой цели.

Интеграционный тест оставляет за собой то, для чего нужен живой сервер: что
композиция покрывает **каждого** владельца с равным корнем (`owner-0000` и
`owner-0255`), и что на владельца приходится диагностика `git.inspection_incomplete`
с `count: 64`. Масштаб — 256 владельцев: после правки вызов проходит с окном
400 мс против семисекундного, то есть запас вырос с 3,5–5× до 17×.

## Архитектурный слой

- Decision: none — no architectural contract changed. Порог, окно вызова и
  поведение `unica.view` при исчерпании бюджета не трогаются: меняются тест и
  место, где доказывается порог.

## Проверка

- `cargo test -p unica-coder --test platform_project_health` — 30 из 30.
- `cargo test -p unica-coder --lib resource_owner_expansion` — новый тест.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`,
  `cargo fmt --all -- --check`.
- Замеры сужением `INVOCATION_HANDOFF_WINDOW` (в дерево не попадают): до правки
  2000 мс — зелено, 1400 мс — красно; после правки 400 мс — зелено.

## Смежное

Осталось за границей этой правки: `unica.view` на рабочем пространстве
масштаба порога отвечает отказом по дедлайну, а не результатом. Для CI это
больше не важно, но для реальной конфигурации такого размера — вопрос
продуктовый, и он не про тест.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for resource classification limits, including exact-boundary acceptance and over-limit rejection.
  - Improved validation of structured diagnostics and fallback error messages.
  - Reduced the size of a resource ownership test scenario to improve execution reliability while retaining coverage of the relevant behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->