### PR TITLE
ci(gate): снять windows, сборку и холодный старт с pull request

### DIFF
--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -119,7 +119,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ubuntu-latest, windows-latest, macos-14]
+        # windows-latest снят: раннер валил разные тесты от прогона к прогону
+        # при 4366 зелёных, и гейт краснел не по предмету правки. Вернётся
+        # отдельно, вместе с разбором дедлайнов и Job Object.
+        runner: [ubuntu-latest, macos-14]
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -164,6 +167,7 @@ jobs:
         (needs.test-rust-primary.result == 'success' || needs.test-rust-primary.result == 'skipped') &&
         (needs.test-rust-platforms.result == 'success' || needs.test-rust-platforms.result == 'skipped') &&
         (needs.test-search-integration.result == 'success' || needs.test-search-integration.result == 'skipped') &&
+        github.event_name != 'pull_request' &&
         (needs.classify-changes.outputs.release_required == 'true' ||
          needs.classify-changes.outputs.ci_changed == 'true')
       }}
@@ -551,7 +555,7 @@ jobs:
         needs.build-tools.result == 'success' &&
         needs.package-thin.result == 'success' &&
         needs.release-assessment.result == 'success' &&
-        (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+        github.event_name == 'workflow_dispatch'
       }}
     permissions:
       contents: read
@@ -616,7 +620,7 @@ jobs:
       ${{
         always() &&
         needs.package-thin.result == 'success' &&
-        (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
+        github.event_name == 'workflow_dispatch'
       }}
     strategy:
       fail-fast: false
@@ -656,6 +660,7 @@ jobs:
         always() &&
         needs.classify-changes.result == 'success' &&
         needs.build-tools.result == 'success' &&
+        github.event_name != 'pull_request' &&
         needs.classify-changes.outputs.assessment_required == 'true'
       }}
     steps:

--- a/scripts/ci/evaluate-ci-gate.py
+++ b/scripts/ci/evaluate-ci-gate.py
@@ -111,7 +111,10 @@ def expected_results(
 
     full_matrix = values["platform_changed"] or values["toolchain_changed"] or values["ci_changed"]
     primary_rust = values["rust_changed"] and not full_matrix
-    package_pipeline = values["release_required"] or values["ci_changed"]
+    # Сборка пакета и холодные старты сняты с pull request до пересборки системы
+    # тестирования: прослеживаемости они не давали, а гейт красили. Тег и ручной
+    # запуск их сохраняют — выпуск обязан собираться.
+    package_pipeline = (values["release_required"] or values["ci_changed"]) and not is_pr
 
     expected["test-rust-primary"] = "success" if primary_rust else "skipped"
     expected["test-rust-platforms"] = "success" if full_matrix else "skipped"
@@ -121,15 +124,13 @@ def expected_results(
         else "skipped"
     )
     expected.update({job: "success" if package_pipeline else "skipped" for job in PACKAGE_JOBS})
-    expected[ASSESSMENT_JOB] = "success" if values["assessment_required"] else "skipped"
+    expected[ASSESSMENT_JOB] = (
+        "success" if values["assessment_required"] and not is_pr else "skipped"
+    )
     expected[P0_PROOF_JOB] = (
-        "success"
-        if values["assessment_required"] and (is_pr or is_manual)
-        else "skipped"
+        "success" if values["assessment_required"] and is_manual else "skipped"
     )
-    expected["probe-thin-bootstrap"] = (
-        "success" if package_pipeline and (is_pr or is_manual) else "skipped"
-    )
+    expected["probe-thin-bootstrap"] = "success" if package_pipeline and is_manual else "skipped"
     expected.update({job: "success" if is_tag else "skipped" for job in PUBLISH_JOBS})
 
     if is_tag:

--- a/tests/ci/test_evaluate_ci_gate.py
+++ b/tests/ci/test_evaluate_ci_gate.py
@@ -62,28 +62,29 @@ def source_results() -> dict[str, str]:
 
 
 class EvaluateCiGateTests(unittest.TestCase):
-    def test_p0_release_proof_runs_for_assessed_pr_without_publication(self) -> None:
+    def test_pull_request_skips_package_pipeline_even_when_classified(self) -> None:
+        """Тяжёлые контуры сняты с pull request, а не выключены везде.
+
+        Классификация продолжает честно говорить, что правка задела упаковку и
+        оценку; гейт при этом ждёт от них пропуска, потому что на pull request
+        они больше не запускаются.
+        """
         module = load_gate_module()
         outputs = classification(
             package_changed=True,
             release_required=True,
             assessment_required=True,
         )
-        results = {
-            **source_results(),
-            "build-tools": "success",
-            "package-thin": "success",
-            "p0-release-proof": "success",
-            "release-assessment": "success",
-            "probe-thin-bootstrap": "success",
-        }
 
         evaluation = module.evaluate_gate(
-            "pull_request", "refs/pull/581/merge", outputs, results
+            "pull_request", "refs/pull/581/merge", outputs, source_results()
         )
 
         self.assertTrue(evaluation.ok)
-        self.assertEqual("success", evaluation.expected["p0-release-proof"])
+        for job in ("build-tools", "package-thin", "probe-thin-bootstrap"):
+            self.assertEqual("skipped", evaluation.expected[job], job)
+        self.assertEqual("skipped", evaluation.expected["release-assessment"])
+        self.assertEqual("skipped", evaluation.expected["p0-release-proof"])
 
     def test_source_only_pr_accepts_only_classified_skips(self) -> None:
         module = load_gate_module()
@@ -96,14 +97,12 @@ class EvaluateCiGateTests(unittest.TestCase):
         self.assertEqual("source", evaluation.contour)
         self.assertEqual(set(results) - set(ALWAYS_SUCCESS), set(evaluation.skipped_jobs))
 
-    def test_platform_independent_rust_uses_primary_macos_and_package_pipeline(self) -> None:
+    def test_platform_independent_rust_uses_primary_macos_without_package_pipeline(self) -> None:
         module = load_gate_module()
         outputs = classification(rust_changed=True, release_required=True)
         results = {
             **source_results(),
             "test-rust-primary": "success",
-            **PACKAGE_SUCCESS,
-            "probe-thin-bootstrap": "success",
         }
 
         evaluation = module.evaluate_gate("pull_request", "refs/pull/155/merge", outputs, results)
@@ -118,8 +117,6 @@ class EvaluateCiGateTests(unittest.TestCase):
         results = {
             **source_results(),
             "test-rust-platforms": "success",
-            **PACKAGE_SUCCESS,
-            "probe-thin-bootstrap": "success",
         }
 
         evaluation = module.evaluate_gate("pull_request", "refs/pull/155/merge", outputs, results)
@@ -128,38 +125,15 @@ class EvaluateCiGateTests(unittest.TestCase):
         self.assertEqual("platform", evaluation.contour)
         self.assertEqual("skipped", evaluation.expected["test-rust-primary"])
 
-    def test_long_assessment_requires_affected_mechanism_or_full_contour(self) -> None:
-        module = load_gate_module()
-        ordinary_outputs = classification(rust_changed=True, release_required=True)
-        ordinary_results = {
-            **source_results(),
-            "test-rust-primary": "success",
-            **PACKAGE_SUCCESS,
-            "probe-thin-bootstrap": "success",
-        }
-        affected_outputs = classification(
-            rust_changed=True,
-            release_required=True,
-            assessment_required=True,
-        )
-        affected_results = {**ordinary_results, **ASSESSMENT_SUCCESS, **P0_SUCCESS}
+    def test_long_assessment_runs_outside_pull_request_only(self) -> None:
+        """Оценка на BSP осталась у ручного запуска и тега.
 
-        ordinary = module.evaluate_gate(
-            "pull_request", "refs/pull/155/merge", ordinary_outputs, ordinary_results
-        )
-        affected = module.evaluate_gate(
-            "pull_request", "refs/pull/155/merge", affected_outputs, affected_results
-        )
-
-        self.assertTrue(ordinary.ok)
-        self.assertEqual("skipped", ordinary.expected["release-assessment"])
-        self.assertTrue(affected.ok)
-        self.assertEqual("success", affected.expected["release-assessment"])
-
-    def test_ci_full_pr_runs_all_validation_and_package_jobs_without_publication(self) -> None:
+        На pull request её нет ни при какой классификации: это и есть снятие
+        тяжёлого контура, а не отключение оценки вообще.
+        """
         module = load_gate_module()
         outputs = classification(**{name: True for name in OUTPUT_NAMES})
-        results = {
+        manual_results = {
             **source_results(),
             "test-rust-platforms": "success",
             "test-search-integration": "success",
@@ -169,11 +143,50 @@ class EvaluateCiGateTests(unittest.TestCase):
             "probe-thin-bootstrap": "success",
         }
 
+        manual = module.evaluate_gate(
+            "workflow_dispatch", "refs/heads/main", outputs, manual_results
+        )
+        request = module.evaluate_gate(
+            "pull_request",
+            "refs/pull/155/merge",
+            outputs,
+            {
+                **source_results(),
+                "test-rust-platforms": "success",
+                "test-search-integration": "success",
+            },
+        )
+
+        self.assertTrue(manual.ok)
+        self.assertEqual("success", manual.expected["release-assessment"])
+        self.assertTrue(request.ok)
+        self.assertEqual("skipped", request.expected["release-assessment"])
+
+    def test_ci_full_pr_runs_validation_but_no_package_jobs(self) -> None:
+        module = load_gate_module()
+        outputs = classification(**{name: True for name in OUTPUT_NAMES})
+        results = {
+            **source_results(),
+            "test-rust-platforms": "success",
+            "test-search-integration": "success",
+        }
+
         evaluation = module.evaluate_gate("pull_request", "refs/pull/155/merge", outputs, results)
 
         self.assertTrue(evaluation.ok)
         self.assertEqual("full", evaluation.contour)
-        self.assertEqual({"test-rust-primary", *PUBLISH_SKIPPED}, set(evaluation.skipped_jobs))
+        self.assertEqual(
+            {
+                "test-rust-primary",
+                "build-tools",
+                "package-thin",
+                "probe-thin-bootstrap",
+                "release-assessment",
+                "p0-release-proof",
+                *PUBLISH_SKIPPED,
+            },
+            set(evaluation.skipped_jobs),
+        )
 
     def test_ci_change_requires_the_search_integration_job(self) -> None:
         module = load_gate_module()
@@ -182,8 +195,6 @@ class EvaluateCiGateTests(unittest.TestCase):
             **source_results(),
             "test-rust-platforms": "success",
             "test-search-integration": "success",
-            **PACKAGE_SUCCESS,
-            "probe-thin-bootstrap": "success",
         }
 
         evaluation = module.evaluate_gate(
@@ -272,10 +283,9 @@ class EvaluateCiGateTests(unittest.TestCase):
             "verify-source": "cancelled",
             "test-rust-platforms": "failure",
             "test-search-integration": "success",
-            **PACKAGE_SUCCESS,
-            **ASSESSMENT_SUCCESS,
-            "package-thin": "skipped",
-            "probe-thin-bootstrap": "success",
+            # Снятый с pull request контур, который всё-таки отработал, — тоже
+            # расхождение: гейт обязан заметить и лишнюю работу.
+            "build-tools": "success",
         }
 
         evaluation = module.evaluate_gate("pull_request", "refs/pull/155/merge", outputs, results)
@@ -285,8 +295,7 @@ class EvaluateCiGateTests(unittest.TestCase):
             {
                 "verify-source": ("cancelled", "success"),
                 "test-rust-platforms": ("failure", "success"),
-                "package-thin": ("skipped", "success"),
-                "p0-release-proof": ("skipped", "success"),
+                "build-tools": ("success", "skipped"),
             },
             {key: value for key, value in evaluation.unexpected.items() if key != "classification"},
         )

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -279,7 +279,9 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         self.assertIn("runs-on: macos-14", primary)
         self.assertIn("rust_changed == 'true'", primary)
         self.assertIn("platform_changed == 'false'", primary)
-        self.assertIn("runner: [ubuntu-latest, windows-latest, macos-14]", platforms)
+        # windows-latest снят с матрицы до разбора нестабильности раннера;
+        # список закреплён целиком, поэтому вернуть его молча не получится.
+        self.assertIn("runner: [ubuntu-latest, macos-14]", platforms)
         self.assertIn("platform_changed == 'true'", platforms)
         self.assertIn("toolchain_changed == 'true'", platforms)
         self.assertIn("ci_changed == 'true'", platforms)
@@ -313,8 +315,11 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
 
         self.assertIn("release_required == 'true'", build)
         self.assertIn("ci_changed == 'true'", build)
-        self.assertIn("github.event_name == 'pull_request'", probe)
+        # Сборка и холодный старт сняты с pull request: там они не давали
+        # прослеживаемости, а гейт красили. Тег и ручной запуск их сохраняют.
+        self.assertIn("github.event_name != 'pull_request'", build)
         self.assertIn("github.event_name == 'workflow_dispatch'", probe)
+        self.assertNotIn("github.event_name == 'pull_request'", probe)
         self.assertIn("startsWith(github.ref, 'refs/tags/')", publish)
 
     def test_release_assessment_uses_affected_mechanism_contour(self) -> None:


### PR DESCRIPTION
## Зачем

Система тестирования сейчас не даёт прослеживаемости. Windows-раннер валит **разные** тесты от прогона к прогону при 4366 зелёных в том же прогоне: на одном коммите сначала `DurabilityUncertain` в ожидании задачи, при перезапуске — контракт ёмкости акторов, рядом `TimedOut: "Windows runtime leader did not exit while its Job Object descendant lived"`. Сборка пакета и холодные старты добавляют к этому минуты и свои падения.

Пока нет опубликованных отчётов, разбирать это нечем. Поэтому контуры снимаются с pull request и будут возвращаться по одному, вместе с разбором, а не свалкой.

## Что снято с pull request

- `windows-latest` из матрицы Rust-тестов;
- `build-tools` и `package-thin`;
- `probe-thin-bootstrap` — холодный старт;
- `release-assessment` и `p0-release-proof`.

## Что сохранено

Тег и ручной запуск собирают и проверяют всё как раньше: выпуск обязан собираться. `ubuntu-latest` и `macos-14` в Rust-матрице остались, `Verify source guardrails` и `Search integration` — тоже.

## Гейт по-прежнему говорит правду

`evaluate-ci-gate.py` знает новое распределение и продолжает сверять ожидаемое с фактическим в обе стороны: снятый контур, который вдруг отработал, — такое же расхождение, как упавшая джоба. Это закреплено тестом.

Тесты гейта переписаны под новый контракт, а не ослаблены: появился `test_pull_request_skips_package_pipeline_even_when_classified` — классификация продолжает честно говорить, что правка задела упаковку, а гейт ждёт от неё пропуска.

## Проверено

`tests/ci` целиком — 759 тестов, `OK (skipped=11)`.
