### PR TITLE
ci: одна точка входа для прогона тестов

### DIFF
--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -66,9 +66,9 @@ jobs:
         with:
           python-version: "3.12"
       - run: python -m pip install -r tests/ci/requirements.txt
-      - run: python -m unittest discover -s tests/ci --durations 20
-      - run: python -m unittest discover -s tests/arch
-      - run: python -m unittest discover -s tests/dev --durations 20
+      # Наборы гоняет одна точка входа: профиль ворот меняется в ней, а не в
+      # трёх строках здесь. Сегодня `all` повторяет прежние команды один в один.
+      - run: python scripts/ci/run-tests.py --profile all --ecosystem python
       - run: python -m py_compile scripts/ci/*.py tests/ci/*.py
       - run: python -m py_compile scripts/arch/*.py tests/arch/*.py
       - run: python -m py_compile scripts/dev/*.py tests/dev/*.py
@@ -103,7 +103,7 @@ jobs:
           components: rustfmt, clippy
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-      - run: cargo test --workspace -- --test-threads=1
+      - run: python3 scripts/ci/run-tests.py --profile all --ecosystem rust
 
   test-rust-platforms:
     name: Rust tests (${{ matrix.runner }})
@@ -135,7 +135,7 @@ jobs:
       - if: matrix.runner == 'macos-14'
         run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
-      - run: cargo test --workspace -- --test-threads=1
+      - run: python3 scripts/ci/run-tests.py --profile all --ecosystem rust
 
   test-search-integration:
     name: Search integration (macos-14)

--- a/scripts/ci/run-tests.py
+++ b/scripts/ci/run-tests.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Одна точка входа для прогона тестов обеих экосистем.
+
+Workflow называет только этот скрипт — не `cargo test` и не `unittest`. Пока
+профиль один, `all`, и он повторяет прежние команды один в один: тот же
+набор, тот же порядок, тот же цвет гейта. Смысл шага не в отборе, а в том,
+что место для отбора появилось: профиль ворот меняет одну функцию здесь, а
+не шесть мест в YAML.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+PROFILES = ("all",)
+ECOSYSTEMS = ("rust", "python", "all")
+
+# Наборы Python идут в том же порядке, что шли шагами workflow: сначала стражи
+# CI, потом реестр, потом инструменты разработчика. `--durations` там, где
+# набор длинный и стоит видеть, кто тянет время. Набор `tests/arch` идёт без
+# `-t .`: его модули не пакет, и верхний уровень ему не нужен.
+PYTHON_SUITES = (
+    ("tests/ci", ("--durations", "20")),
+    ("tests/arch", ()),
+    ("tests/dev", ("--durations", "20")),
+)
+
+
+def rust_commands(profile: str) -> list[list[str]]:
+    """Команды Rust для профиля. Сегодня — весь набор, одним потоком."""
+    if profile == "all":
+        # `--test-threads=1` — не выбор, а необходимость: тесты делят состояние
+        # процесса. Снимается, когда исполнитель даст процесс на тест.
+        return [["cargo", "test", "--workspace", "--", "--test-threads=1"]]
+    raise ValueError(f"профиль {profile!r} для Rust не описан")
+
+
+def python_commands(profile: str, interpreter: str = sys.executable) -> list[list[str]]:
+    """Команды Python для профиля. Сегодня — три набора целиком."""
+    if profile == "all":
+        return [
+            [interpreter, "-m", "unittest", "discover", "-s", suite, *extra]
+            for suite, extra in PYTHON_SUITES
+        ]
+    raise ValueError(f"профиль {profile!r} для Python не описан")
+
+
+def commands(profile: str, ecosystem: str, interpreter: str = sys.executable) -> list[list[str]]:
+    if profile not in PROFILES:
+        raise ValueError(f"неизвестный профиль {profile!r}; известны: {', '.join(PROFILES)}")
+    if ecosystem not in ECOSYSTEMS:
+        raise ValueError(f"неизвестная экосистема {ecosystem!r}; известны: {', '.join(ECOSYSTEMS)}")
+    planned: list[list[str]] = []
+    if ecosystem in ("rust", "all"):
+        planned.extend(rust_commands(profile))
+    if ecosystem in ("python", "all"):
+        planned.extend(python_commands(profile, interpreter))
+    return planned
+
+
+def run(planned: list[list[str]]) -> int:
+    """Выполнить команды по очереди; первая упавшая останавливает прогон.
+
+    Так вели себя и шаги workflow: упавший шаг валит джобу, следующие не
+    идут. Менять это здесь значило бы менять смысл гейта под видом переезда.
+    """
+    for command in planned:
+        print("+ " + " ".join(command), flush=True)
+        completed = subprocess.run(command, cwd=REPO_ROOT)
+        if completed.returncode != 0:
+            return completed.returncode
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--profile", required=True, choices=PROFILES, help="профиль ворот")
+    parser.add_argument("--ecosystem", default="all", choices=ECOSYSTEMS)
+    parser.add_argument("--dry-run", action="store_true", help="напечатать команды и выйти")
+    args = parser.parse_args(argv)
+
+    planned = commands(args.profile, args.ecosystem)
+    if args.dry_run:
+        for command in planned:
+            print(" ".join(command))
+        return 0
+    return run(planned)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_run_tests.py
+++ b/tests/ci/test_run_tests.py
@@ -1,0 +1,88 @@
+"""Шов прогона тестов повторяет прежние команды и не пропускает ничего."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "run-tests.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("run_tests", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load {MODULE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class RunTestsSeamTests(unittest.TestCase):
+    def test_profile_all_repeats_the_former_workflow_commands_verbatim(self) -> None:
+        """Шаг переезда обязан быть неотличим от того, что было.
+
+        Команды ниже — ровно те строки, что стояли в workflow. Если шов их
+        меняет, это уже не переезд, а правка гейта под чужим именем.
+        """
+        module = load_module()
+
+        rust = module.commands("all", "rust", interpreter="python")
+        python = module.commands("all", "python", interpreter="python")
+
+        self.assertEqual(rust, [["cargo", "test", "--workspace", "--", "--test-threads=1"]])
+        self.assertEqual(
+            python,
+            [
+                ["python", "-m", "unittest", "discover", "-s", "tests/ci", "--durations", "20"],
+                ["python", "-m", "unittest", "discover", "-s", "tests/arch"],
+                ["python", "-m", "unittest", "discover", "-s", "tests/dev", "--durations", "20"],
+            ],
+        )
+
+    def test_arch_suite_is_discovered_without_a_top_level_directory(self) -> None:
+        """Модули `tests/arch` — не пакет: `-t .` сломал бы их импорт."""
+        module = load_module()
+
+        arch = next(
+            command
+            for command in module.commands("all", "python", interpreter="python")
+            if "tests/arch" in command
+        )
+
+        self.assertNotIn("-t", arch)
+
+    def test_all_ecosystems_keep_rust_before_python(self) -> None:
+        module = load_module()
+
+        planned = module.commands("all", "all", interpreter="python")
+
+        self.assertEqual(planned[0][0], "cargo")
+        self.assertTrue(all(command[0] == "python" for command in planned[1:]))
+        self.assertEqual(len(planned), 4)
+
+    def test_unknown_profile_or_ecosystem_is_a_refusal_not_an_empty_run(self) -> None:
+        """Пустой прогон зелёный по устройству; отказ — единственный честный ответ."""
+        module = load_module()
+
+        with self.assertRaises(ValueError):
+            module.commands("pr", "rust")
+        with self.assertRaises(ValueError):
+            module.commands("all", "go")
+
+    def test_dry_run_prints_commands_and_runs_nothing(self) -> None:
+        module = load_module()
+        import contextlib
+        import io
+
+        captured = io.StringIO()
+        with contextlib.redirect_stdout(captured):
+            code = module.main(["--profile", "all", "--ecosystem", "rust", "--dry-run"])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(captured.getvalue().strip(), "cargo test --workspace -- --test-threads=1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -133,9 +133,11 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         text = self.release_text()
 
         self.assertIn("cargo clippy --workspace --all-targets --all-features -- -D warnings", text)
-        self.assertIn("cargo test --workspace -- --test-threads=1", text)
-        self.assertIn("python -m unittest discover -s tests/ci --durations 20", text)
-        self.assertIn("python -m unittest discover -s tests/dev --durations 20", text)
+        # Наборы гоняет шов; сами команды закреплены тестом `test_run_tests`.
+        self.assertIn("python3 scripts/ci/run-tests.py --profile all --ecosystem rust", text)
+        self.assertIn("python scripts/ci/run-tests.py --profile all --ecosystem python", text)
+        self.assertNotIn("cargo test --workspace", text)
+        self.assertNotIn("unittest discover", text)
         self.assertIn("python -m py_compile scripts/dev/*.py tests/dev/*.py", text)
         self.assertIn("python scripts/ci/check-version-contract.py", text)
 
@@ -451,8 +453,7 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
     def test_registry_guards_run_in_the_source_contour(self) -> None:
         verify = job_block(self.release_text(), "verify-source")
 
-        self.assertIn("python -m unittest discover -s tests/arch", verify)
-        self.assertNotIn("python -m unittest discover -s tests/arch -t .", verify)
+        self.assertIn("python scripts/ci/run-tests.py --profile all --ecosystem python", verify)
         self.assertIn("python -m py_compile scripts/arch/*.py tests/arch/*.py", verify)
 
     def test_platform_build_uses_exact_cargo_cache_and_reports_outcome(self) -> None:


### PR DESCRIPTION
Шаг 1 порядка приведения из [замысла площадки тестирования](https://github.com/IngvarConsulting/unica/pull/719): шов, а не отбор.

Workflow больше не называет ни `cargo test`, ни `unittest` — он зовёт `scripts/ci/run-tests.py --profile all` с экосистемой. Профиль пока один, и он повторяет прежние команды **один в один**: тот же набор, тот же порядок, `--test-threads=1` на месте, `tests/arch` без `-t .`. Первая упавшая команда останавливает прогон — так вели себя и шаги workflow.

Смысл шага не в поведении, которое не изменилось, а в том, что место для отбора появилось: профиль ворот на следующих шагах меняет одну функцию здесь, а не три строки в трёх джобах.

## Как проверяется

- `tests/ci/test_run_tests.py` закрепляет команды дословно — теми строками, что стояли в YAML. Если шов их меняет, тест краснеет: это уже не переезд.
- Неизвестный профиль или экосистема — отказ, не пустой зелёный прогон.
- `test_unica_workflow.py` теперь требует вызова шва и запрещает прямые `cargo test --workspace` и `unittest discover` в workflow.
- Гейт должен остаться того же цвета с тем же счётом тестов. Правка трогает `.github/`, поэтому контур полный.