### PR TITLE
ci: джобы отдают результаты в формате Allure

### DIFF
--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -68,7 +68,15 @@ jobs:
       - run: python -m pip install -r tests/ci/requirements.txt
       # Наборы гоняет одна точка входа: профиль ворот меняется в ней, а не в
       # трёх строках здесь. Сегодня `all` повторяет прежние команды один в один.
-      - run: python scripts/ci/run-tests.py --profile all --ecosystem python
+      - run: python scripts/ci/run-tests.py --profile all --ecosystem python --results .build/results --runner ubuntu-latest
+      # Результаты едут артефактом и при красном прогоне: ради них он и шёл.
+      - if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: results-python
+          path: .build/results
+          retention-days: 7
+          overwrite: true
       - run: python -m py_compile scripts/ci/*.py tests/ci/*.py
       - run: python -m py_compile scripts/arch/*.py tests/arch/*.py
       - run: python -m py_compile scripts/dev/*.py tests/dev/*.py
@@ -107,7 +115,23 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest@0.9.143
-      - run: python3 scripts/ci/run-tests.py --profile all --ecosystem rust
+      # План выгружается до тестов: упавший раннер не унесёт его с собой,
+      # и недошедшие тесты попадут в отчёт как `skipped`, а не исчезнут.
+      - run: python3 scripts/ci/run-tests.py --profile all --ecosystem rust --plan-only --results .build/results --runner macos-14
+      - uses: actions/upload-artifact@v7
+        with:
+          name: plan-rust-macos-14-primary
+          path: .build/results/plan.json
+          retention-days: 7
+          overwrite: true
+      - run: python3 scripts/ci/run-tests.py --profile all --ecosystem rust --results .build/results --runner macos-14
+      - if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: results-rust-macos-14-primary
+          path: .build/results
+          retention-days: 7
+          overwrite: true
 
   test-rust-platforms:
     name: Rust tests (${{ matrix.runner }})
@@ -143,7 +167,23 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest@0.9.143
-      - run: python3 scripts/ci/run-tests.py --profile all --ecosystem rust
+      # План выгружается до тестов: упавший раннер не унесёт его с собой,
+      # и недошедшие тесты попадут в отчёт как `skipped`, а не исчезнут.
+      - run: python3 scripts/ci/run-tests.py --profile all --ecosystem rust --plan-only --results .build/results --runner ${{ matrix.runner }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: plan-rust-${{ matrix.runner }}
+          path: .build/results/plan.json
+          retention-days: 7
+          overwrite: true
+      - run: python3 scripts/ci/run-tests.py --profile all --ecosystem rust --results .build/results --runner ${{ matrix.runner }}
+      - if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: results-rust-${{ matrix.runner }}
+          path: .build/results
+          retention-days: 7
+          overwrite: true
 
   test-search-integration:
     name: Search integration (macos-14)

--- a/scripts/ci/allure_results.py
+++ b/scripts/ci/allure_results.py
@@ -1,0 +1,220 @@
+"""Результаты прогона в формате Allure, написанные нами.
+
+Одна запись — один файл `{uuid}-result.json`. Формат описан у Allure как
+«файл результата теста»; здесь — ровно те поля, которые читает отчёт: имя,
+полное имя, статус, подробности, время, метки.
+
+Почему пишем сами, а не адаптером и не JUnit напрямую, — в замысле площадки:
+адаптер для Rust не видит отключённых и ломается под процессом на тест, а
+тесты из JUnit приходят без меток и в чужом дереве. Здесь у двух языков
+равные права: одно дерево, одни метки, один набор состояний.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import time
+import uuid
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+# Причина `#[ignore]` — конструкция языка, а не наше имя: nextest её не отдаёт
+# ни в JUnit, ни в списке, а в атрибуте она есть всегда.
+IGNORE_ATTRIBUTE = re.compile(
+    r'#\[ignore\s*=\s*"((?:[^"\\]|\\.)*)"\]\s*(?:#\[[^\]]*\]\s*)*fn\s+(\w+)\s*\(', re.S
+)
+# Паника из assert — дефект продукта; любая другая — поломка самого теста.
+# JUnit от nextest этого не различает, различаем по тексту.
+ASSERTION = re.compile(r"assertion|assert_eq|assert_ne|left == right|left != right", re.I)
+
+
+def now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def history_id(full_name: str, runner: str) -> str:
+    """Один тест на двух раннерах — два теста, две истории.
+
+    С одним `historyId` Allure счёл бы их повторами одного теста и показал бы
+    только последний; результат второго раннера исчез бы.
+    """
+    return hashlib.md5(f"{full_name}@{runner}".encode("utf-8")).hexdigest()
+
+
+def record(
+    *,
+    name: str,
+    full_name: str,
+    status: str,
+    runner: str,
+    labels: dict[str, str],
+    tags: tuple[str, ...] = (),
+    message: str | None = None,
+    trace: str | None = None,
+    start: int | None = None,
+    stop: int | None = None,
+) -> dict:
+    """Запись результата. Метки — словарь плюс теги, потому что `tag` повторяется."""
+    details: dict[str, str] = {}
+    if message:
+        details["message"] = message
+    if trace:
+        details["trace"] = trace
+    return {
+        "uuid": str(uuid.uuid4()),
+        "historyId": history_id(full_name, runner),
+        "name": name,
+        "fullName": full_name,
+        "status": status,
+        "statusDetails": details,
+        "start": start if start is not None else now_ms(),
+        "stop": stop if stop is not None else now_ms(),
+        "labels": [
+            *({"name": key, "value": value} for key, value in labels.items()),
+            {"name": "host", "value": runner},
+            *({"name": "tag", "value": tag} for tag in tags),
+        ],
+    }
+
+
+def write(out: Path, entry: dict) -> Path:
+    out.mkdir(parents=True, exist_ok=True)
+    path = out / f"{entry['uuid']}-result.json"
+    path.write_text(json.dumps(entry, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+def write_run(out: Path, *, profile: str, runner: str, ecosystem: str) -> Path:
+    """Подпись прогона: кто, когда и на чём собрал эти результаты.
+
+    Сайт читает её оттуда, а не из события: у прогона по расписанию
+    `head_branch` всегда `main`, даже когда он проверяет релизную линию.
+    """
+    env = os.environ.get
+    repository = env("GITHUB_REPOSITORY", "")
+    run_id = env("GITHUB_RUN_ID", "")
+    signature = {
+        "sha": env("GITHUB_SHA", ""),
+        "ref": env("GITHUB_REF_NAME", ""),
+        "run_id": run_id,
+        "run_attempt": env("GITHUB_RUN_ATTEMPT", ""),
+        "run_url": f"https://github.com/{repository}/actions/runs/{run_id}" if repository and run_id else "",
+        "runner": runner,
+        "os": env("RUNNER_OS", ""),
+        "profile": profile,
+        "ecosystem": ecosystem,
+        "at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    out.mkdir(parents=True, exist_ok=True)
+    path = out / "run.json"
+    path.write_text(json.dumps(signature, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def ignore_reasons(root: Path) -> dict[str, str]:
+    """Имя функции → причина `#[ignore]`, по всем исходникам крейтов."""
+    found: dict[str, str] = {}
+    for path in (root / "crates").rglob("*.rs"):
+        if "target" in path.parts:
+            continue
+        for reason, name in IGNORE_ATTRIBUTE.findall(path.read_text(encoding="utf-8", errors="replace")):
+            found[name] = reason
+    return found
+
+
+def nextest_list(root: Path, profile: str) -> list[dict]:
+    """Состав прогона по nextest: двоичный файл, имя, признак `ignored`.
+
+    Это и план прогона, и источник дерева для отчёта. Проигнорированные
+    перечисляются тоже: план обязан знать всё, что дерево знает.
+    """
+    completed = subprocess.run(
+        ["cargo", "nextest", "list", "--workspace", "--profile", profile,
+         "--run-ignored", "all", "--message-format", "json"],
+        cwd=root, capture_output=True, text=True, check=True,
+    )
+    listed = json.loads(completed.stdout)
+    entries = []
+    for suite in listed["rust-suites"].values():
+        for name, case in suite["testcases"].items():
+            entries.append({"binary": suite["binary-id"], "name": name, "ignored": bool(case.get("ignored"))})
+    return entries
+
+
+def write_plan(out: Path, entries: list[dict]) -> Path:
+    out.mkdir(parents=True, exist_ok=True)
+    path = out / "plan.json"
+    path.write_text(json.dumps(entries, ensure_ascii=False, indent=1) + "\n", encoding="utf-8")
+    return path
+
+
+def rust_labels(binary: str, name: str, profile: str) -> dict[str, str]:
+    module = name.rsplit("::", 1)[0] if "::" in name else binary
+    return {
+        "language": "rust",
+        "framework": "nextest",
+        "parentSuite": "rust",
+        "suite": binary,
+        "subSuite": module,
+        "profile": profile,
+    }
+
+
+def junit_records(
+    junit: Path, *, runner: str, profile: str, reasons: dict[str, str], stop: int | None = None
+) -> list[dict]:
+    """Перевести JUnit от nextest в записи Allure.
+
+    Статус и трейс — из JUnit; причина `#[ignore]` — из атрибута; полное имя
+    — двоичный файл и путь теста. Паника из assert — `failed`, прочая —
+    `broken`; отключённый — `skipped` с причиной автора.
+    """
+    root = ET.parse(junit).getroot()
+    finished = stop if stop is not None else now_ms()
+    entries = []
+    for suite in root.iter("testsuite"):
+        binary = suite.get("name", "")
+        for case in suite.findall("testcase"):
+            name = case.get("name", "")
+            full_name = f"{binary}::{name}"
+            seconds = float(case.get("time", "0") or 0)
+            start = finished - int(seconds * 1000)
+            failure = case.find("failure")
+            error = case.find("error")
+            skipped = case.find("skipped")
+            message = trace = None
+            if skipped is not None:
+                fn = name.rsplit("::", 1)[-1]
+                reason = reasons.get(fn)
+                status = "skipped"
+                message = f"отключён автором: {reason}" if reason else (skipped.get("message") or "пропущен")
+            elif failure is not None or error is not None:
+                node = failure if failure is not None else error
+                body = (node.text or "").strip()
+                err = case.find("system-err")
+                stderr = ((err.text or "") if err is not None else "").strip()
+                # Первая содержательная строка — сообщение; всё остальное — трейс.
+                message = body.splitlines()[0] if body else (node.get("message") or "тест упал")
+                trace = "\n".join(part for part in (body, stderr) if part)
+                status = "failed" if ASSERTION.search(trace or message) else "broken"
+            else:
+                status = "passed"
+            entries.append(
+                record(
+                    name=name,
+                    full_name=full_name,
+                    status=status,
+                    runner=runner,
+                    labels=rust_labels(binary, name, profile),
+                    tags=(profile,),
+                    message=message,
+                    trace=trace,
+                    start=start,
+                    stop=finished,
+                )
+            )
+    return entries

--- a/scripts/ci/classify-workflow-changes.py
+++ b/scripts/ci/classify-workflow-changes.py
@@ -65,7 +65,10 @@ CI_CONTRACT_PATHS = {
     # Шов прогона решает, что именно гоняет каждая джоба; его правка — правка
     # конвейера, а не исходников, и обязана ехать полным контуром.
     "scripts/ci/run-tests.py",
+    "scripts/ci/run-unittest.py",
+    "scripts/ci/allure_results.py",
     "tests/ci/test_run_tests.py",
+    "tests/ci/test_allure_results.py",
     "tests/ci/test_classify_workflow_changes.py",
     "tests/ci/test_evaluate_ci_gate.py",
     "tests/ci/test_unica_workflow.py",

--- a/scripts/ci/run-tests.py
+++ b/scripts/ci/run-tests.py
@@ -177,6 +177,10 @@ def execute(
         allure_results.write_run(results, profile=profile, runner=runner, ecosystem=ecosystem)
     code = 0
     if ecosystem in ("rust", "all"):
+        # Старый JUnit от прошлого прогона — не результат этого. Если nextest
+        # упадёт до отчёта, файл на месте выдал бы чужие записи за свежие.
+        if junit.is_file():
+            junit.unlink()
         code = run_commands(rust_commands(profile))
         if results is not None and junit.is_file():
             print(f"результаты Rust: {emit_rust(results, profile, runner, junit)} записей")

--- a/scripts/ci/run-tests.py
+++ b/scripts/ci/run-tests.py
@@ -11,11 +11,17 @@ Workflow называет только этот скрипт — не `cargo tes
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import allure_results  # noqa: E402
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
+RUN_UNITTEST = Path(__file__).with_name("run-unittest.py")
+NEXTEST_JUNIT = REPO_ROOT / "target" / "nextest" / "default" / "junit.xml"
 
 PROFILES = ("all",)
 ECOSYSTEMS = ("rust", "python", "all")
@@ -31,27 +37,56 @@ PYTHON_SUITES = (
 )
 
 
+# Профиль ворот и профиль nextest — разные имена: ворота описывают, когда
+# гоняем, профиль nextest — как. Пока ворота одни, они ложатся на `default`.
+NEXTEST_PROFILES = {"all": "default"}
+
+
+def nextest_profile(profile: str) -> str:
+    try:
+        return NEXTEST_PROFILES[profile]
+    except KeyError:
+        raise ValueError(f"профиль {profile!r} для Rust не описан") from None
+
+
 def rust_commands(profile: str) -> list[list[str]]:
     """Команды Rust для профиля. Сегодня — весь набор, одним потоком."""
-    if profile == "all":
-        # nextest: процесс на тест и JUnit из коробки. Число потоков, повторы
-        # и отчёт описаны в `.config/nextest.toml`, а не здесь: конвейер и
-        # локальный прогон обязаны идти одной настройкой.
-        return [["cargo", "nextest", "run", "--workspace", "--profile", "default"]]
-    raise ValueError(f"профиль {profile!r} для Rust не описан")
+    # nextest: процесс на тест и JUnit из коробки. Число потоков, повторы
+    # и отчёт описаны в `.config/nextest.toml`, а не здесь: конвейер и
+    # локальный прогон обязаны идти одной настройкой.
+    return [["cargo", "nextest", "run", "--workspace", "--profile", nextest_profile(profile)]]
 
 
-def python_commands(profile: str, interpreter: str = sys.executable) -> list[list[str]]:
-    """Команды Python для профиля. Сегодня — три набора целиком."""
+def python_commands(
+    profile: str,
+    interpreter: str = sys.executable,
+    results: Path | None = None,
+    runner: str = "local",
+) -> list[list[str]]:
+    """Команды Python для профиля. Сегодня — три набора целиком.
+
+    Идут через `run-unittest.py`: это тот же `discover` и тот же текстовый
+    вывод, но с классом результата, который пишет `allure-results`, когда
+    указан каталог. Без каталога набор идёт как раньше и ничего не пишет.
+    """
     if profile == "all":
+        tail: list[str] = []
+        if results is not None:
+            tail = ["--results", str(results), "--runner", runner, "--profile", profile]
         return [
-            [interpreter, "-m", "unittest", "discover", "-s", suite, *extra]
+            [interpreter, str(RUN_UNITTEST), "-s", suite, *extra, *tail]
             for suite, extra in PYTHON_SUITES
         ]
     raise ValueError(f"профиль {profile!r} для Python не описан")
 
 
-def commands(profile: str, ecosystem: str, interpreter: str = sys.executable) -> list[list[str]]:
+def commands(
+    profile: str,
+    ecosystem: str,
+    interpreter: str = sys.executable,
+    results: Path | None = None,
+    runner: str = "local",
+) -> list[list[str]]:
     if profile not in PROFILES:
         raise ValueError(f"неизвестный профиль {profile!r}; известны: {', '.join(PROFILES)}")
     if ecosystem not in ECOSYSTEMS:
@@ -60,8 +95,24 @@ def commands(profile: str, ecosystem: str, interpreter: str = sys.executable) ->
     if ecosystem in ("rust", "all"):
         planned.extend(rust_commands(profile))
     if ecosystem in ("python", "all"):
-        planned.extend(python_commands(profile, interpreter))
+        planned.extend(python_commands(profile, interpreter, results, runner))
     return planned
+
+
+def write_rust_plan(results: Path, profile: str) -> int:
+    """План прогона — до тестов, чтобы упавший раннер не унёс его с собой."""
+    entries = allure_results.nextest_list(REPO_ROOT, nextest_profile(profile))
+    allure_results.write_plan(results, entries)
+    return len(entries)
+
+
+def emit_rust(results: Path, profile: str, runner: str) -> int:
+    """JUnit от nextest + причины `#[ignore]` из атрибутов → allure-results."""
+    reasons = allure_results.ignore_reasons(REPO_ROOT)
+    entries = allure_results.junit_records(NEXTEST_JUNIT, runner=runner, profile=profile, reasons=reasons)
+    for entry in entries:
+        allure_results.write(results, entry)
+    return len(entries)
 
 
 def run(planned: list[list[str]]) -> int:
@@ -69,6 +120,8 @@ def run(planned: list[list[str]]) -> int:
 
     Так вели себя и шаги workflow: упавший шаг валит джобу, следующие не
     идут. Менять это здесь значило бы менять смысл гейта под видом переезда.
+    Исключение одно: прогон nextest с упавшими тестами всё равно доводится до
+    записи результатов — именно ради них он и шёл.
     """
     for command in planned:
         print("+ " + " ".join(command), flush=True)
@@ -83,14 +136,38 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--profile", required=True, choices=PROFILES, help="профиль ворот")
     parser.add_argument("--ecosystem", default="all", choices=ECOSYSTEMS)
     parser.add_argument("--dry-run", action="store_true", help="напечатать команды и выйти")
+    parser.add_argument("--results", type=Path, default=None, help="куда писать allure-results")
+    parser.add_argument("--runner", default=os.environ.get("RUNNER_NAME_LABEL", "local"),
+                        help="имя раннера для меток и истории")
+    parser.add_argument("--plan-only", action="store_true", help="записать план и выйти")
     args = parser.parse_args(argv)
 
-    planned = commands(args.profile, args.ecosystem)
+    planned = commands(args.profile, args.ecosystem, results=args.results, runner=args.runner)
     if args.dry_run:
         for command in planned:
             print(" ".join(command))
         return 0
-    return run(planned)
+
+    if args.plan_only:
+        if args.results is None:
+            parser.error("--plan-only требует --results")
+        if args.ecosystem in ("rust", "all"):
+            print(f"план Rust: {write_rust_plan(args.results, args.profile)} тестов")
+        return 0
+
+    code = 0
+    if args.ecosystem in ("rust", "all"):
+        code = run(rust_commands(args.profile))
+        if args.results is not None and NEXTEST_JUNIT.is_file():
+            print(f"результаты Rust: {emit_rust(args.results, args.profile, args.runner)} записей")
+            allure_results.write_run(args.results, profile=args.profile, runner=args.runner, ecosystem="rust")
+        if code != 0:
+            return code
+    if args.ecosystem in ("python", "all"):
+        code = run(python_commands(args.profile, results=args.results, runner=args.runner))
+        if args.results is not None:
+            allure_results.write_run(args.results, profile=args.profile, runner=args.runner, ecosystem="python")
+    return code
 
 
 if __name__ == "__main__":

--- a/scripts/ci/run-tests.py
+++ b/scripts/ci/run-tests.py
@@ -106,10 +106,10 @@ def write_rust_plan(results: Path, profile: str) -> int:
     return len(entries)
 
 
-def emit_rust(results: Path, profile: str, runner: str) -> int:
+def emit_rust(results: Path, profile: str, runner: str, junit: Path = NEXTEST_JUNIT) -> int:
     """JUnit от nextest + причины `#[ignore]` из атрибутов → allure-results."""
     reasons = allure_results.ignore_reasons(REPO_ROOT)
-    entries = allure_results.junit_records(NEXTEST_JUNIT, runner=runner, profile=profile, reasons=reasons)
+    entries = allure_results.junit_records(junit, runner=runner, profile=profile, reasons=reasons)
     for entry in entries:
         allure_results.write(results, entry)
     return len(entries)
@@ -155,18 +155,35 @@ def main(argv: list[str] | None = None) -> int:
             print(f"план Rust: {write_rust_plan(args.results, args.profile)} тестов")
         return 0
 
+    return execute(args.profile, args.ecosystem, args.results, args.runner)
+
+
+def execute(
+    profile: str,
+    ecosystem: str,
+    results: Path | None,
+    runner: str,
+    run_commands=None,
+    junit: Path = NEXTEST_JUNIT,
+) -> int:
+    """Прогнать экосистемы и оставить результаты.
+
+    Подпись прогона пишется один раз на вызов и до тестов: она описывает
+    вызов, а не исход, и обязана остаться даже когда nextest упал раньше, чем
+    успел написать JUnit. Результаты Rust пишутся, только если JUnit есть.
+    """
+    run_commands = run if run_commands is None else run_commands
+    if results is not None:
+        allure_results.write_run(results, profile=profile, runner=runner, ecosystem=ecosystem)
     code = 0
-    if args.ecosystem in ("rust", "all"):
-        code = run(rust_commands(args.profile))
-        if args.results is not None and NEXTEST_JUNIT.is_file():
-            print(f"результаты Rust: {emit_rust(args.results, args.profile, args.runner)} записей")
-            allure_results.write_run(args.results, profile=args.profile, runner=args.runner, ecosystem="rust")
+    if ecosystem in ("rust", "all"):
+        code = run_commands(rust_commands(profile))
+        if results is not None and junit.is_file():
+            print(f"результаты Rust: {emit_rust(results, profile, runner, junit)} записей")
         if code != 0:
             return code
-    if args.ecosystem in ("python", "all"):
-        code = run(python_commands(args.profile, results=args.results, runner=args.runner))
-        if args.results is not None:
-            allure_results.write_run(args.results, profile=args.profile, runner=args.runner, ecosystem="python")
+    if ecosystem in ("python", "all"):
+        code = run_commands(python_commands(profile, results=results, runner=runner))
     return code
 
 

--- a/scripts/ci/run-unittest.py
+++ b/scripts/ci/run-unittest.py
@@ -18,6 +18,11 @@ import traceback
 import unittest
 from pathlib import Path
 
+# `python -m unittest` ставит текущий каталог первым в `sys.path`, и модули
+# тестов импортируют `scripts.ci.*` от корня. Скрипт по умолчанию ставит
+# свой каталог, а не корень, — восстанавливаем то, что было у `-m`.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import allure_results  # noqa: E402
 

--- a/scripts/ci/run-unittest.py
+++ b/scripts/ci/run-unittest.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Прогон набора `unittest` с записью результатов в формате Allure.
+
+Замена `python -m unittest discover` один в один: тот же поиск, тот же
+текстовый вывод, тот же код выхода. Сверх того — свой класс результата,
+который пишет `{uuid}-result.json` на каждый тест, когда указан `--results`.
+Без него набор идёт как раньше и ничего не пишет.
+
+JUnit здесь не нужен: `unittest` принимает свой класс результата, он в
+процессе и знает про тест всё.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import traceback
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import allure_results  # noqa: E402
+
+
+class AllureResult(unittest.TextTestResult):
+    """Пишет запись в момент завершения теста; текстовый вывод не трогает."""
+
+    out: Path | None = None
+    runner_name = "local"
+    profile = "all"
+    suite_name = ""
+
+    def startTest(self, test):
+        super().startTest(test)
+        self._started = allure_results.now_ms()
+
+    def _emit(self, test, status, message=None, trace=None):
+        if self.out is None:
+            return
+        cls = test.__class__
+        full_name = f"{cls.__module__}.{cls.__qualname__}.{test._testMethodName}"
+        doc = (test._testMethodDoc or "").strip().splitlines()
+        allure_results.write(
+            self.out,
+            allure_results.record(
+                name=doc[0] if doc else test._testMethodName,
+                full_name=full_name,
+                status=status,
+                runner=self.runner_name,
+                labels={
+                    "language": "python",
+                    "framework": "unittest",
+                    "parentSuite": "python",
+                    "suite": self.suite_name,
+                    "subSuite": cls.__qualname__,
+                    "profile": self.profile,
+                },
+                tags=(self.profile,),
+                message=message,
+                trace=trace,
+                start=self._started,
+                stop=allure_results.now_ms(),
+            ),
+        )
+
+    def addSuccess(self, test):
+        super().addSuccess(test)
+        self._emit(test, "passed")
+
+    def addFailure(self, test, err):
+        super().addFailure(test, err)
+        self._emit(test, "failed", str(err[1]), "".join(traceback.format_exception(*err)))
+
+    def addError(self, test, err):
+        super().addError(test, err)
+        self._emit(test, "broken", f"{err[0].__name__}: {err[1]}", "".join(traceback.format_exception(*err)))
+
+    def addSkip(self, test, reason):
+        super().addSkip(test, reason)
+        self._emit(test, "skipped", reason)
+
+    def addExpectedFailure(self, test, err):
+        super().addExpectedFailure(test, err)
+        self._emit(test, "passed", "ожидаемое падение")
+
+    def addUnexpectedSuccess(self, test):
+        super().addUnexpectedSuccess(test)
+        self._emit(test, "failed", "неожиданный успех")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("-s", "--start-directory", required=True)
+    parser.add_argument("--durations", type=int, default=None)
+    parser.add_argument("--results", type=Path, default=None, help="каталог allure-results")
+    parser.add_argument("--runner", default="local")
+    parser.add_argument("--profile", default="all")
+    parser.add_argument("--plan-only", action="store_true", help="перечислить тесты и выйти")
+    args = parser.parse_args(argv)
+
+    suite = unittest.defaultTestLoader.discover(args.start_directory)
+    if args.plan_only:
+        for case in iter_cases(suite):
+            print(case.id())
+        return 0
+
+    AllureResult.out = args.results
+    AllureResult.runner_name = args.runner
+    AllureResult.profile = args.profile
+    AllureResult.suite_name = args.start_directory
+    options = {"resultclass": AllureResult, "verbosity": 1}
+    if args.durations is not None:
+        options["durations"] = args.durations
+    result = unittest.TextTestRunner(**options).run(suite)
+    return 0 if result.wasSuccessful() else 1
+
+
+def iter_cases(suite):
+    for item in suite:
+        if isinstance(item, unittest.TestSuite):
+            yield from iter_cases(item)
+        else:
+            yield item
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci/test_allure_results.py
+++ b/tests/ci/test_allure_results.py
@@ -1,0 +1,151 @@
+"""Перевод результатов в формат Allure: статусы, причины, история по раннеру."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "allure_results.py"
+
+JUNIT = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="unica" tests="4" failures="2" errors="0">
+  <testsuite name="unica-coder" tests="4" failures="2" errors="0" skipped="1">
+    <testcase name="address::resolves_catalog" classname="unica-coder" time="0.010"/>
+    <testcase name="address::wrong_expectation" classname="unica-coder" time="0.020">
+      <failure message="test failed">assertion `left == right` failed: нарочно</failure>
+      <system-err>thread 'address::wrong_expectation' panicked</system-err>
+    </testcase>
+    <testcase name="daemon::index_out_of_bounds" classname="unica-coder" time="0.030">
+      <failure message="test failed">index out of bounds: the len is 0 but the index is 3</failure>
+    </testcase>
+    <testcase name="daemon::spawns_daemon" classname="unica-coder" time="0">
+      <skipped message="Skipped: test does not match the run-ignored option"/>
+    </testcase>
+  </testsuite>
+</testsuites>
+"""
+
+RUST_SOURCE = '''
+#[cfg(test)]
+mod daemon {
+    #[test]
+    #[ignore = "daemon tier: raises a daemon process; disabled on purpose"]
+    fn spawns_daemon() {}
+}
+'''
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("allure_results", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load {MODULE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class JunitTranslationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module = load_module()
+        self.root = Path(tempfile.mkdtemp(prefix="allure-results-"))
+        (self.root / "crates" / "unica-coder" / "src").mkdir(parents=True)
+        (self.root / "crates" / "unica-coder" / "src" / "lib.rs").write_text(RUST_SOURCE, encoding="utf-8")
+        self.junit = self.root / "junit.xml"
+        self.junit.write_text(JUNIT, encoding="utf-8")
+
+    def entries(self, runner: str = "ubuntu-latest") -> dict[str, dict]:
+        reasons = self.module.ignore_reasons(self.root)
+        records = self.module.junit_records(self.junit, runner=runner, profile="all", reasons=reasons)
+        return {entry["name"]: entry for entry in records}
+
+    def test_statuses_distinguish_product_defect_from_broken_test(self) -> None:
+        """JUnit от nextest пишет `<failure>` на любую панику; различаем по тексту."""
+        entries = self.entries()
+
+        self.assertEqual(entries["address::resolves_catalog"]["status"], "passed")
+        self.assertEqual(entries["address::wrong_expectation"]["status"], "failed")
+        self.assertEqual(entries["daemon::index_out_of_bounds"]["status"], "broken")
+
+    def test_ignored_test_carries_the_authors_reason_not_nextests_phrase(self) -> None:
+        entries = self.entries()
+
+        skipped = entries["daemon::spawns_daemon"]
+        self.assertEqual(skipped["status"], "skipped")
+        self.assertEqual(
+            skipped["statusDetails"]["message"],
+            "отключён автором: daemon tier: raises a daemon process; disabled on purpose",
+        )
+
+    def test_failure_keeps_the_trace_for_the_report(self) -> None:
+        entries = self.entries()
+
+        self.assertIn("panicked", entries["address::wrong_expectation"]["statusDetails"]["trace"])
+
+    def test_labels_place_rust_tests_in_one_tree_with_python(self) -> None:
+        entry = self.entries()["address::resolves_catalog"]
+        labels = {label["name"]: label["value"] for label in entry["labels"]}
+
+        self.assertEqual(labels["language"], "rust")
+        self.assertEqual(labels["parentSuite"], "rust")
+        self.assertEqual(labels["suite"], "unica-coder")
+        self.assertEqual(labels["subSuite"], "address")
+        self.assertEqual(labels["host"], "ubuntu-latest")
+        self.assertEqual(entry["fullName"], "unica-coder::address::resolves_catalog")
+
+    def test_history_id_separates_runners_so_neither_result_vanishes(self) -> None:
+        """Один `historyId` на два раннера — Allure покажет только последний."""
+        ubuntu = self.entries("ubuntu-latest")["address::resolves_catalog"]
+        macos = self.entries("macos-14")["address::resolves_catalog"]
+
+        self.assertNotEqual(ubuntu["historyId"], macos["historyId"])
+        self.assertEqual(
+            ubuntu["historyId"], self.entries("ubuntu-latest")["address::resolves_catalog"]["historyId"]
+        )
+
+    def test_write_produces_one_uuid_named_file_per_record(self) -> None:
+        out = self.root / "allure-results"
+        module = self.module
+
+        paths = [module.write(out, entry) for entry in self.entries().values()]
+
+        self.assertEqual(len(paths), 4)
+        self.assertEqual(len({path.name for path in paths}), 4)
+        for path in paths:
+            self.assertTrue(path.name.endswith("-result.json"))
+            json.loads(path.read_text(encoding="utf-8"))
+
+    def test_run_signature_is_written_from_the_environment(self) -> None:
+        import os
+
+        env = {
+            "GITHUB_REPOSITORY": "IngvarConsulting/unica",
+            "GITHUB_SHA": "abcdef0123456789",
+            "GITHUB_REF_NAME": "release-v0.12",
+            "GITHUB_RUN_ID": "42",
+            "GITHUB_RUN_ATTEMPT": "2",
+            "RUNNER_OS": "Linux",
+        }
+        saved = {key: os.environ.get(key) for key in env}
+        os.environ.update(env)
+        try:
+            path = self.module.write_run(self.root / "out", profile="all", runner="ubuntu-latest", ecosystem="rust")
+        finally:
+            for key, value in saved.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+        signature = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(signature["ref"], "release-v0.12")
+        self.assertEqual(signature["run_attempt"], "2")
+        self.assertEqual(signature["run_url"], "https://github.com/IngvarConsulting/unica/actions/runs/42")
+        self.assertEqual(signature["runner"], "ubuntu-latest")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci/test_classify_workflow_changes.py
+++ b/tests/ci/test_classify_workflow_changes.py
@@ -244,7 +244,13 @@ class ClassifyWorkflowChangesTests(unittest.TestCase):
         Иначе правка одного `run-tests.py` ехала бы контуром исходников и
         могла бы тихо сузить прогон, который сама и должна была запустить.
         """
-        for path in ("scripts/ci/run-tests.py", "tests/ci/test_run_tests.py"):
+        for path in (
+            "scripts/ci/run-tests.py",
+            "scripts/ci/run-unittest.py",
+            "scripts/ci/allure_results.py",
+            "tests/ci/test_run_tests.py",
+            "tests/ci/test_allure_results.py",
+        ):
             with self.subTest(path=path):
                 self.assert_classification([path], ci_changed=True)
 

--- a/tests/ci/test_run_tests.py
+++ b/tests/ci/test_run_tests.py
@@ -133,6 +133,28 @@ class RunTestsSeamTests(unittest.TestCase):
         self.assertTrue((out / "run.json").is_file())
         self.assertEqual(list(out.glob("*-result.json")), [])
 
+    def test_stale_junit_from_an_earlier_run_is_never_emitted_as_fresh(self) -> None:
+        """nextest упал до отчёта, а от прошлого прогона остался JUnit — он не результат."""
+        import tempfile
+        from pathlib import Path as P
+
+        module = load_module()
+        out = P(tempfile.mkdtemp(prefix="run-tests-"))
+        stale = out / "junit.xml"
+        stale.write_text(
+            '<testsuites name="unica"><testsuite name="unica-coder">'
+            '<testcase name="old::passed" classname="unica-coder" time="0.1"/>'
+            "</testsuite></testsuites>",
+            encoding="utf-8",
+        )
+
+        code = module.execute("all", "rust", out, "ubuntu-latest",
+                              run_commands=lambda planned: 101, junit=stale)
+
+        self.assertEqual(code, 101)
+        self.assertFalse(stale.exists(), "старый отчёт обязан быть снят до прогона")
+        self.assertEqual(list(out.glob("*-result.json")), [])
+
     def test_unknown_profile_or_ecosystem_is_a_refusal_not_an_empty_run(self) -> None:
         """Пустой прогон зелёный по устройству; отказ — единственный честный ответ."""
         module = load_module()

--- a/tests/ci/test_run_tests.py
+++ b/tests/ci/test_run_tests.py
@@ -79,6 +79,24 @@ class RunTestsSeamTests(unittest.TestCase):
             self.assertIn("--results", command)
             self.assertIn("macos-14", command)
 
+    def test_own_runner_imports_every_module_the_module_runner_could(self) -> None:
+        """`python -m unittest` видит `scripts.ci.*` от корня; наш раннер обязан тоже.
+
+        Иначе модуль, импортирующий скрипт конвейера, падает на импорте и
+        считается упавшим тестом — так и было на первом прогоне.
+        """
+        import subprocess
+        import sys
+
+        runner = MODULE_PATH.with_name("run-unittest.py")
+        listing = subprocess.run(
+            [sys.executable, str(runner), "-s", "tests/ci", "--plan-only"],
+            cwd=MODULE_PATH.parents[2], capture_output=True, text=True, check=True,
+        ).stdout
+
+        self.assertNotIn("_FailedTest", listing)
+        self.assertIn("test_donor_parity_contract", listing)
+
     def test_unknown_profile_or_ecosystem_is_a_refusal_not_an_empty_run(self) -> None:
         """Пустой прогон зелёный по устройству; отказ — единственный честный ответ."""
         module = load_module()

--- a/tests/ci/test_run_tests.py
+++ b/tests/ci/test_run_tests.py
@@ -97,6 +97,42 @@ class RunTestsSeamTests(unittest.TestCase):
         self.assertNotIn("_FailedTest", listing)
         self.assertIn("test_donor_parity_contract", listing)
 
+    def test_run_signature_is_written_once_per_invocation_and_names_the_ecosystem(self) -> None:
+        """`--ecosystem all` — одна подпись с `all`, а не две, где вторая стирает первую."""
+        import json
+        import tempfile
+        from pathlib import Path as P
+
+        module = load_module()
+        out = P(tempfile.mkdtemp(prefix="run-tests-"))
+        calls = []
+
+        code = module.execute("all", "all", out, "ubuntu-latest",
+                              run_commands=lambda planned: calls.append(planned) or 0,
+                              junit=out / "no-such-junit.xml")
+
+        self.assertEqual(code, 0)
+        self.assertEqual(len(calls), 2)
+        signature = json.loads((out / "run.json").read_text(encoding="utf-8"))
+        self.assertEqual(signature["ecosystem"], "all")
+        self.assertEqual(signature["runner"], "ubuntu-latest")
+
+    def test_rust_failure_before_junit_still_leaves_the_signature(self) -> None:
+        """Подпись описывает вызов, а не исход: nextest упал до JUnit — она всё равно есть."""
+        import tempfile
+        from pathlib import Path as P
+
+        module = load_module()
+        out = P(tempfile.mkdtemp(prefix="run-tests-"))
+
+        code = module.execute("all", "rust", out, "macos-14",
+                              run_commands=lambda planned: 101,
+                              junit=out / "no-such-junit.xml")
+
+        self.assertEqual(code, 101)
+        self.assertTrue((out / "run.json").is_file())
+        self.assertEqual(list(out.glob("*-result.json")), [])
+
     def test_unknown_profile_or_ecosystem_is_a_refusal_not_an_empty_run(self) -> None:
         """Пустой прогон зелёный по устройству; отказ — единственный честный ответ."""
         module = load_module()

--- a/tests/ci/test_run_tests.py
+++ b/tests/ci/test_run_tests.py
@@ -34,12 +34,13 @@ class RunTestsSeamTests(unittest.TestCase):
         self.assertEqual(
             rust, [["cargo", "nextest", "run", "--workspace", "--profile", "default"]]
         )
+        runner_script = str(MODULE_PATH.with_name("run-unittest.py"))
         self.assertEqual(
             python,
             [
-                ["python", "-m", "unittest", "discover", "-s", "tests/ci", "--durations", "20"],
-                ["python", "-m", "unittest", "discover", "-s", "tests/arch"],
-                ["python", "-m", "unittest", "discover", "-s", "tests/dev", "--durations", "20"],
+                ["python", runner_script, "-s", "tests/ci", "--durations", "20"],
+                ["python", runner_script, "-s", "tests/arch"],
+                ["python", runner_script, "-s", "tests/dev", "--durations", "20"],
             ],
         )
 
@@ -62,7 +63,21 @@ class RunTestsSeamTests(unittest.TestCase):
 
         self.assertEqual(planned[0][0], "cargo")
         self.assertTrue(all(command[0] == "python" for command in planned[1:]))
+        self.assertTrue(all(command[1].endswith("run-unittest.py") for command in planned[1:]))
         self.assertEqual(len(planned), 4)
+
+    def test_results_directory_turns_emission_on_for_python_suites(self) -> None:
+        """Без `--results` набор идёт как раньше; с ним пишет результаты и знает раннер."""
+        module = load_module()
+        from pathlib import Path as P
+
+        quiet = module.commands("all", "python", interpreter="python")
+        emitting = module.commands("all", "python", interpreter="python", results=P("out"), runner="macos-14")
+
+        self.assertTrue(all("--results" not in command for command in quiet))
+        for command in emitting:
+            self.assertIn("--results", command)
+            self.assertIn("macos-14", command)
 
     def test_unknown_profile_or_ecosystem_is_a_refusal_not_an_empty_run(self) -> None:
         """Пустой прогон зелёный по устройству; отказ — единственный честный ответ."""

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -134,8 +134,8 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
 
         self.assertIn("cargo clippy --workspace --all-targets --all-features -- -D warnings", text)
         # Наборы гоняет шов; сами команды закреплены тестом `test_run_tests`.
-        self.assertIn("python3 scripts/ci/run-tests.py --profile all --ecosystem rust", text)
-        self.assertIn("python scripts/ci/run-tests.py --profile all --ecosystem python", text)
+        self.assertIn("python3 scripts/ci/run-tests.py --profile all --ecosystem rust --results", text)
+        self.assertIn("python scripts/ci/run-tests.py --profile all --ecosystem python --results", text)
         self.assertNotIn("cargo test --workspace", text)
         self.assertNotIn("unittest discover", text)
         self.assertIn("python -m py_compile scripts/dev/*.py tests/dev/*.py", text)
@@ -453,7 +453,7 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
     def test_registry_guards_run_in_the_source_contour(self) -> None:
         verify = job_block(self.release_text(), "verify-source")
 
-        self.assertIn("python scripts/ci/run-tests.py --profile all --ecosystem python", verify)
+        self.assertIn("python scripts/ci/run-tests.py --profile all --ecosystem python --results", verify)
         self.assertIn("python -m py_compile scripts/arch/*.py tests/arch/*.py", verify)
 
     def test_platform_build_uses_exact_cargo_cache_and_reports_outcome(self) -> None:


### PR DESCRIPTION
Шаг 3 порядка приведения из [замысла](docs/design/2026-09-04-test-pipeline-platform-design.md): эмиссия. Каждая тестовая джоба оставляет `allure-results`, план прогона и подпись — и всё это едет артефактом. Потребителя у артефактов пока нет, он появляется шагом 4.

## Что делает каждая джоба

- **План до тестов.** `run-tests.py --plan-only` пишет `plan.json` из `cargo nextest list` — все 4 555 тестов, включая 53 проигнорированных, — и он выгружается отдельным шагом **до** прогона. Упавший раннер не унесёт его с собой, и на шаге 4 недошедшие тесты попадут в отчёт как `skipped`, а не исчезнут.
- **Результаты при любом исходе.** Шаг выгрузки стоит под `if: always()`: результаты нужны ровно тогда, когда прогон красный.
- **Подпись `run.json`**: коммит, ссылка, номер прогона и попытки, раннер, ОС, профиль. Сайт читает её оттуда, не из события — у прогона по расписанию `head_branch` всегда `main`.

## Откуда берётся запись

| Экосистема | Как |
| --- | --- |
| Rust | JUnit от nextest даёт статус, время и трейс; `nextest list` — двоичный файл и путь; атрибут `#[ignore = "…"]` в исходнике — причину автора. Паника из assert → `failed`, любая другая → `broken`; nextest этого не различает, различаем по тексту. |
| Python | Свой класс результата у `unittest` — `run-unittest.py`. Тот же `discover`, тот же вывод, тот же код выхода; JUnit не нужен, зависимостей нет. |

`historyId` считается от имени теста **и раннера**: с одним идентификатором Allure счёл бы тест на ubuntu и на macOS повторами и показал бы только последний.

## Проверено локально

- Перевод настоящего JUnit последнего прогона: **4 555 записей — 4 502 `passed`, 53 `skipped`**, у всех 53 причина автора, не фраза nextest. `allure generate` собрал отчёт с теми же числами.
- План и результаты совпадают по составу один в один (4 555 полных имён).
- `tests/arch` через `run-unittest.py`: 122 записи, метки на месте, имя теста — первая строка докстринга.
- `tests/ci/test_allure_results.py` закрепляет статусы, причину из атрибута, трейс, метки, разделение `historyId` по раннерам и подпись из окружения. Всего стражей по этому шагу — 86, зелёные.

## Мелочи с последствиями

- Профиль ворот (`all`) и профиль nextest (`default`) — разные имена, отображение живёт в одном месте `run-tests.py`. Это всплыло тем, что `nextest list --profile all` отказал.
- Артефакты с `overwrite: true` — перезапуск джобы не упадёт на загрузке; `upload-artifact@v7`, как везде в workflow, — страж на мажоры это и поймал.
- Классификатор знает новые файлы конвейера как контракт CI: их правка едет полным контуром.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI test runs now generate structured reports compatible with Allure.
  * Test plans are published before execution for easier coverage review.
  * Test results and run metadata are uploaded as artifacts, including when runs fail.
  * Reports identify passed, failed, broken, skipped, and expected-failure tests with relevant details.

* **Bug Fixes**
  * Improved handling of test profiles and runner-specific results across supported platforms.

* **Tests**
  * Expanded validation for report generation, skipped-test reasons, failure details, and CI change detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->