### PR TITLE
fix(pages): окружение отчёта в ASCII — Allure читает properties как ISO-8859-1

### DIFF
--- a/scripts/ci/collect-results.py
+++ b/scripts/ci/collect-results.py
@@ -112,6 +112,19 @@ def fill_gaps(plans: list[Path], seen: dict[str, set[str]], out: Path, run: dict
     return filled
 
 
+def properties_line(key: str, value: str) -> str:
+    """Строка Java Properties: файл читается как ISO-8859-1, всё вне ASCII — `\\uXXXX`.
+
+    Иначе кириллица в виджете окружения превращается в кракозябры — так и
+    вышло на первом отчёте.
+    """
+
+    def escape(text: str) -> str:
+        return "".join(c if ord(c) < 128 else f"\\u{ord(c):04x}" for c in text)
+
+    return f"{escape(key)}={escape(value)}\n"
+
+
 def write_metadata(out: Path, run: dict, line: str, runners: list[str], site: str) -> None:
     (out / "categories.json").write_text(json.dumps(CATEGORIES, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     environment = {
@@ -123,7 +136,7 @@ def write_metadata(out: Path, run: dict, line: str, runners: list[str], site: st
         "Раннеры": ", ".join(runners),
     }
     (out / "environment.properties").write_text(
-        "".join(f"{key}={value}\n" for key, value in environment.items() if value), encoding="utf-8"
+        "".join(properties_line(key, value) for key, value in environment.items() if value), encoding="ascii"
     )
     executor = {
         "name": "GitHub Actions",

--- a/tests/ci/test_collect_results.py
+++ b/tests/ci/test_collect_results.py
@@ -90,9 +90,11 @@ class CollectResultsTests(unittest.TestCase):
 
         categories = json.loads((out / "categories.json").read_text(encoding="utf-8"))
         self.assertIn("Инфраструктура: раннер не дошёл", [c["name"] for c in categories])
-        environment = (out / "environment.properties").read_text(encoding="utf-8")
-        self.assertIn("Ветка=release-v0.12", environment)
-        self.assertIn("Попытка=2", environment)
+        # Java Properties читается как ISO-8859-1: кириллица едет `\\uXXXX`.
+        environment = (out / "environment.properties").read_text(encoding="ascii")
+        decoded = environment.encode("ascii").decode("unicode_escape")
+        self.assertIn("Ветка=release-v0.12", decoded)
+        self.assertIn("Попытка=2", decoded)
         executor = json.loads((out / "executor.json").read_text(encoding="utf-8"))
         self.assertEqual(executor["buildOrder"], 42)
         self.assertEqual(executor["reportUrl"], "https://example.invalid/allure/release-v0.12/")


### PR DESCRIPTION
## Что сделано

На первом настоящем отчёте `main` (прогон 33935877515) виджет «Окружение» показал кракозябры вместо кириллицы: `environment.properties` для Allure — Java Properties, кодировка ISO-8859-1. Всё вне ASCII теперь пишется как `\uXXXX` (родной способ формата), файл — чистый ASCII.

## Проверено

- Опыт на Allure 2.46.1: и `\uXXXX` в properties, и `environment.xml` дают правильную кириллицу; выбран первый — формат файла не меняется.
- `tests.ci.test_collect_results` — зелёный; сквозная сборка на настоящих артефактах: виджет читаем.

## Что покажет только прод

Вливание — второй push в `main`: второй отчёт обязан принести историю первого (в логе сборки сайта «файлов истории» больше нуля, в тренде два запуска).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed metadata export to safely preserve non-ASCII characters in environment properties.
  - Environment property files now use consistent ASCII-compatible escaping while retaining the original values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->