### PR TITLE
feat(pages): переработка сайта по итогам ревью

### DIFF
--- a/docs/pages/architecture.html
+++ b/docs/pages/architecture.html
@@ -5,6 +5,15 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Архитектура Unica</title>
 <meta name="description" content="Как устроена Unica: кто приходит по MCP, две поверхности инструментов, процесс и демон, движки.">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Unica">
+<meta property="og:title" content="Архитектура Unica">
+<meta property="og:description" content="Кто приходит по MCP, демон и акторы, движки и лицензии, семантическая адресация, механика плана и записи, сеть и данные.">
+<meta property="og:url" content="https://ingvarconsulting.github.io/unica/architecture.html">
+<meta property="og:image" content="https://ingvarconsulting.github.io/unica/assets/unica-social-card.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="628">
+<meta name="twitter:card" content="summary_large_image">
 <meta name="theme-color" content="#F8FAFC">
 <link rel="icon" href="assets/unica-mark-blue.svg">
 <link rel="stylesheet" href="assets/site.css">
@@ -15,7 +24,7 @@
 <header>
   <div class="wrap bar">
     <a class="brand" href="index.html" aria-label="Unica">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192.096 53.36" aria-hidden="true">
+      <svg class="brand-full" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192.096 53.36" aria-hidden="true">
         <g transform="translate(0 0) scale(0.83375)">
           <rect x="0" y="0" width="64" height="64" rx="15.304" fill="#2563EB"/>
           <path d="M3.3 3.3v12.004278c0 3.542246 2.853476 6.395722 6.395722 6.395722h5.608556c3.542246 0 6.395722-2.853476 6.395722-6.395722V3.3" transform="translate(10.2608695652 10.2608695652) scale(1.73913043478)" fill="none" stroke="#FFFFFF" stroke-width="3.68" stroke-linecap="round" stroke-linejoin="round"/>
@@ -28,10 +37,15 @@
           <path d="M21.7 21.7V9.695722c0-3.542246-2.853476-6.395722-6.395722-6.395722H9.695722c-3.542246 0-6.395722 2.853476-6.395722 6.395722v5.608556c0 3.542246 2.853476 6.395722 6.395722 6.395722h5.608556c3.542246 0 6.395722-2.853476 6.395722-6.395722" transform="translate(95.68 0)"/>
         </g>
       </svg>
+      <svg class="brand-mark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" aria-hidden="true">
+        <rect x="0" y="0" width="64" height="64" rx="15.304" fill="#2563EB"/>
+        <path d="M3.3 3.3v12.004278c0 3.542246 2.853476 6.395722 6.395722 6.395722h5.608556c3.542246 0 6.395722-2.853476 6.395722-6.395722V3.3" transform="translate(10.2608695652 10.2608695652) scale(1.73913043478)" fill="none" stroke="#FFFFFF" stroke-width="3.68" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="32" cy="29.913" r="3.826" fill="#93C5FD"/>
+      </svg>
     </a>
     <nav>
       <a href="index.html#install">Установка</a>
-      <a href="scenarios.html">Сценарии</a>
+      <a href="scenarios.html">Что умеет</a>
       <a href="architecture.html">Архитектура</a>
       <a class="chip" href="https://github.com/IngvarConsulting/unica" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
         <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
@@ -39,16 +53,16 @@
       <a class="chip" href="https://t.me/unica_ai" target="_blank" rel="noopener noreferrer" aria-label="Telegram">
         <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/></svg>
         <span class="count">{{telegram_members}}</span></a>
-      <button class="theme" type="button" aria-label="Переключить тему">
-        <svg class="sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
-          <circle cx="12" cy="12" r="4"/>
-          <path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M19.1 4.9l-1.4 1.4M6.3 17.7l-1.4 1.4"/>
-        </svg>
-        <svg class="moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <path d="M20 14.5A8.5 8.5 0 1 1 9.5 4a6.6 6.6 0 0 0 10.5 10.5z"/>
-        </svg>
-      </button>
     </nav>
+    <button class="theme" type="button" aria-label="Переключить тему">
+      <svg class="sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+        <circle cx="12" cy="12" r="4"/>
+        <path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M19.1 4.9l-1.4 1.4M6.3 17.7l-1.4 1.4"/>
+      </svg>
+      <svg class="moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M20 14.5A8.5 8.5 0 1 1 9.5 4a6.6 6.6 0 0 0 10.5 10.5z"/>
+      </svg>
+    </button>
   </div>
 </header>
 
@@ -71,6 +85,7 @@
         Unica принимает три версии протокола и отвечает той, которую попросил агент.
       </p>
 
+      <div class="diagram-wrap">
       <svg class="diagram" viewBox="0 0 960 300" role="img" aria-label="Три клиента приходят к одному MCP-серверу Unica и договариваются о версии протокола MCP">
         <defs>
           <marker id="head" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
@@ -80,7 +95,7 @@
 
         <rect class="box" x="20" y="14" width="280" height="78" rx="12"/>
         <g class="glyph" transform="translate(44 40)"><rect x="0" y="0" width="22" height="18" rx="3"/><path d="M5 6l4 3-4 3M11 12h6"/></g>
-        <text class="t-title" x="80" y="46">Codex CLI</text>
+        <text class="t-title" x="80" y="46">Codex</text>
         <a href="https://modelcontextprotocol.io/specification/2025-06-18" target="_blank" rel="noopener noreferrer"><text class="t-mono t-link" x="80" y="68">MCP 2025-06-18</text></a>
 
         <rect class="box" x="340" y="14" width="280" height="78" rx="12"/>
@@ -103,6 +118,7 @@
         <text class="t-title" x="44" y="222">unica</text>
         <text class="t-muted" x="44" y="248">принимает версии MCP <a href="https://modelcontextprotocol.io/specification/2026-07-28" target="_blank" rel="noopener noreferrer"><tspan class="t-link">2026-07-28</tspan></a> · <a href="https://modelcontextprotocol.io/specification/2025-11-25" target="_blank" rel="noopener noreferrer"><tspan class="t-link">2025-11-25</tspan></a> · <a href="https://modelcontextprotocol.io/specification/2025-06-18" target="_blank" rel="noopener noreferrer"><tspan class="t-link">2025-06-18</tspan></a>; имя сервера и префикс инструментов не меняются</text>
       </svg>
+      </div>
     </div>
   </section>
 
@@ -127,12 +143,13 @@
         Выбирать не нужно: Unica смотрит, что объявил клиент, и сама решает, каким путём отвечать.
       </p>
 
+      <div class="diagram-wrap">
       <svg class="diagram" viewBox="0 0 960 400" role="img" aria-label="Соответствие задач протокола и трёх compatibility-инструментов">
         <rect class="box" x="20" y="14" width="440" height="350" rx="12"/>
         <text class="t-tag" x="44" y="44">NATIVE TASKS</text>
         <text class="t-title" x="44" y="72">Предметные инструменты</text>
         <text class="t-muted" x="44" y="96">Задача живёт в протоколе. Инструмент отвечает</text>
-        <text class="t-muted" x="44" y="116">квитанцией, дальше хост спрашивает сам протокол.</text>
+        <text class="t-muted" x="44" y="116">квитанцией, дальше агент спрашивает сам протокол.</text>
         <text class="t-mono" x="44" y="152">tasks/get</text>
         <text class="t-mono" x="44" y="176">tasks/result</text>
         <text class="t-mono" x="44" y="200">tasks/cancel</text>
@@ -160,6 +177,7 @@
         <path class="flow" marker-end="url(#head)" d="M470 176 L490 176"/>
         <path class="flow" marker-end="url(#head)" d="M470 200 L490 200"/>
       </svg>
+      </div>
     </div>
   </section>
 
@@ -171,10 +189,11 @@
         длительные операции и движки принадлежат демону, который переживает отдельный вызов.
       </p>
 
+      <div class="diagram-wrap">
       <svg class="diagram" viewBox="0 0 960 500" role="img" aria-label="Процесс MCP запускает демон, демон делит рабочие пространства и запускает движки, платформу 1С дёргает v8-runner">
         <rect class="box" x="20" y="14" width="330" height="76" rx="12"/>
         <text class="t-title" x="44" y="46">unica · процесс MCP</text>
-        <text class="t-muted" x="44" y="70">stdin/stdout, запускает хост</text>
+        <text class="t-muted" x="44" y="70">stdin/stdout, запускает агент</text>
 
         <path class="flow" marker-end="url(#head)" d="M185 90 L185 128"/>
         <text class="t-mono" x="196" y="114">protocol-v5</text>
@@ -218,6 +237,7 @@
         <text class="t-muted" x="44" y="430">Платформу 1С дёргает только v8-runner: собирает</text>
         <text class="t-muted" x="44" y="452">информационную базу через ibcmd, конфигурацию — конфигуратором.</text>
       </svg>
+      </div>
 
       <div class="table-wrap">
       <table>
@@ -264,7 +284,68 @@
         </div>
         <div class="card">
           <h4>Общий ли демон у Claude Code и Codex</h4>
-          <p>Нет. Каталог состояния демон берёт от хоста: у Codex он свой, у Claude Code свой — и процесс у каждого получается свой. Внутри одного хоста демон, наоборот, один на все worktree: их разделяют акторы.</p>
+          <p>Нет. Каталог состояния демон берёт от агента: у Codex он свой, у Claude Code свой — и процесс у каждого получается свой. Внутри одного агента демон, наоборот, один на все worktree: их разделяют акторы.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="network">
+    <div class="wrap">
+      <h2>Сеть и данные</h2>
+      <p class="caption">
+        Три вопроса службы безопасности перед тем, как пустить инструмент в контур.
+      </p>
+      <div class="qa">
+        <div class="qa-text">
+          <h3>Что уходит с машины</h3>
+          <ul class="qa-list">
+            <li>Исходники остаются на диске. Unica читает, проверяет и пишет файлы локально и никуда их не отправляет.</li>
+            <li>С моделью говорит агент, Codex или Claude Code. Что он отправляет, задаёт его политика, а не Unica.</li>
+            <li>В сеть ходит только поиск по документации: стандарты разработки и база знаний 1С получают текст запроса. Оба поставщика выключаются в <code>unica.toml</code>.</li>
+          </ul>
+        </div>
+        <div class="qa-aside">
+<pre><code><span class="p"># unica.toml в корне проекта</span>
+<span class="k">[network]</span>
+<span class="k">default</span> <span class="p">=</span> <span class="v">"deny"</span>
+
+<span class="k">[providers.v8std]</span>
+<span class="k">network</span> <span class="p">=</span> <span class="v">"allow"</span></code></pre>
+        </div>
+      </div>
+
+      <div class="qa">
+        <div class="qa-text">
+          <h3>Что качается при установке</h3>
+          <ul class="qa-list">
+            <li>Ядро и движки приходят из релизов на GitHub, движки при первом вызове, которому они нужны. Других адресов у загрузчика нет.</li>
+            <li>Каждый архив и каждый файл сверяются по SHA-256. Неполная загрузка не считается готовой и повторяется.</li>
+            <li>Кеш лежит в каталоге данных агента и переживает обновление плагина.</li>
+            <li>Движок v8-runner умеет докачивать YAxUnit, Vanessa Automation и client MCP из их релизов на GitHub. Unica в версии 0.13 такую операцию не публикует, но агент может позвать v8-runner напрямую, в обход Unica: тогда загрузка идёт по правилам самого раннера.</li>
+          </ul>
+        </div>
+        <div class="qa-aside">
+          <dl class="kv">
+            <dt>Ядро</dt><dd><code>IngvarConsulting/unica</code></dd>
+            <dt>Движки</dt><dd class="stack"><code>unica-toolchain</code><code>v8-runner-rust</code></dd>
+            <dt>Откуда</dt><dd>github.com, страницы релизов</dd>
+            <dt>Проверка</dt><dd>SHA-256 на архив и каждый файл</dd>
+            <dt>По запросу</dt><dd>YAxUnit, Vanessa Automation, client MCP, через v8-runner</dd>
+          </dl>
+        </div>
+      </div>
+
+      <div class="qa">
+        <div class="qa-text">
+          <h3>Без сети и за прокси</h3>
+          <ul class="qa-list">
+            <li>Для образа без сети ядро и движки скачиваются заранее на машине с доступом, каталог кеша переносится вместе с образом.</li>
+            <li>Прокси с подменой сертификатов загрузчик пока не проходит: он доверяет только вшитым корням. Это открытая задача <a href="https://github.com/IngvarConsulting/unica/issues/592" target="_blank" rel="noopener noreferrer">#592</a>, до её закрытия используйте предзагрузку.</li>
+          </ul>
+        </div>
+        <div class="qa-aside">
+<pre><code>unica-bootstrap prefetch --plugin-root &lt;каталог плагина&gt;</code></pre>
         </div>
       </div>
     </div>
@@ -273,18 +354,27 @@
   <section>
     <div class="wrap">
       <h2>Набор исходников</h2>
-      <p class="caption">
-        Набор исходников — именованный каталог с выгрузкой конфигурации или расширения.
-        Наборов в проекте может быть несколько: рядом с основной конфигурацией лежат
-        расширения и другие её версии.
-      </p>
-      <p class="caption">
-        Список наборов Unica не придумывает и не хранит у себя: она читает <code>v8project.yaml</code>
-        — файл проекта v8-runner, который лежит в корне и уже описывает проект для запуска 1С.
-        Одно описание работает и на запуск, и на адресацию.
-      </p>
-
-<pre><code><span class="k">format</span><span class="p">:</span> <span class="v">DESIGNER</span>
+      <div class="split">
+        <div>
+          <p class="caption">
+            Набор исходников — именованный каталог с выгрузкой конфигурации или расширения.
+            Наборов в проекте может быть несколько: рядом с основной конфигурацией лежат
+            расширения и другие её версии.
+          </p>
+          <p class="caption">
+            Список наборов Unica не придумывает и не хранит у себя: она читает
+            <code>v8project.yaml</code>, файл проекта v8-runner в корне, который уже описывает
+            проект для запуска 1С. Одно описание работает и на запуск, и на адресацию.
+          </p>
+          <p class="caption">
+            Отсюда связь между адресом и диском: <code>main:Catalog.Валюты</code> читается
+            в каталоге <code>src</code>, тот же справочник из другого набора — в каталоге этого
+            набора. Инструменты работают с именем набора и никогда не получают путь.
+          </p>
+        </div>
+        <div>
+<pre><code><span class="p"># v8project.yaml</span>
+<span class="k">format</span><span class="p">:</span> <span class="v">DESIGNER</span>
 <span class="k">source-set</span><span class="p">:</span>
   <span class="p">-</span> <span class="k">name</span><span class="p">:</span> <span class="v">main</span>
     <span class="k">type</span><span class="p">:</span> <span class="v">CONFIGURATION</span>
@@ -292,24 +382,24 @@
   <span class="p">-</span> <span class="k">name</span><span class="p">:</span> <span class="v">ext</span>
     <span class="k">type</span><span class="p">:</span> <span class="v">EXTENSION</span>
     <span class="k">path</span><span class="p">:</span> <span class="v">src-ext</span></code></pre>
+        </div>
+      </div>
 
       <div class="table-wrap">
-      <table>
+      <table class="fields">
         <thead><tr><th class="field-col">Поле</th><th>Что задаёт</th></tr></thead>
         <tbody>
-          <tr><td class="addr-cell field-col">format</td><td>Как выгружены исходники: <code>DESIGNER</code> или <code>EDT</code>. Поле можно не писать — тогда действует умолчание v8-runner.</td></tr>
-          <tr><td class="addr-cell field-col">basePath</td><td>От чего считаются пути наборов. По умолчанию — каталог самого файла.</td></tr>
-          <tr><td class="addr-cell field-col">name</td><td>Имя набора. Оно же стоит слева от двоеточия в адресе. По умолчанию <code>main</code>.</td></tr>
-          <tr><td class="addr-cell field-col">type</td><td><code>CONFIGURATION</code> или <code>EXTENSION</code>. Синоним поля — <code>purpose</code>.</td></tr>
+          <tr><td class="addr-cell field-col">format</td><td>Как выгружены исходники: <code>DESIGNER</code> или <code>EDT</code>. Можно не писать, тогда действует умолчание v8-runner.</td></tr>
+          <tr><td class="addr-cell field-col">basePath</td><td>От чего считаются пути наборов. По умолчанию каталог самого файла.</td></tr>
+          <tr><td class="addr-cell field-col">name</td><td>Имя набора, оно же стоит слева от двоеточия в адресе. По умолчанию <code>main</code>.</td></tr>
+          <tr><td class="addr-cell field-col">type</td><td><code>CONFIGURATION</code> или <code>EXTENSION</code>. Синоним поля <code>purpose</code>.</td></tr>
           <tr><td class="addr-cell field-col">path</td><td>Каталог, в котором лежит выгрузка этого набора.</td></tr>
         </tbody>
       </table>
       </div>
-
-      <p class="caption">
-        Отсюда и берётся связь между адресом и диском: <code>main:Catalog.Валюты</code> читается
-        в каталоге <code>src</code>, а тот же справочник из другого набора — в каталоге этого
-        набора. Инструменты работают с именем набора и никогда не получают путь.
+      <p class="caption note-line">
+        В версии 0.13 инструменты читают, проверяют и записывают только выгрузку конфигуратора.
+        Набор в формате EDT распознаётся при подключении проекта, но не читается и не изменяется.
       </p>
     </div>
   </section>
@@ -345,7 +435,7 @@
       </p>
 
       <div class="table-wrap">
-      <table>
+      <table class="addr-table">
         <thead><tr><th>Адрес</th><th>Что это</th></tr></thead>
         <tbody>
           <tr><td class="addr-cell">main:Configuration</td><td>Корень конфигурации. <code>Configuration</code> стоит только здесь и больше нигде.</td></tr>
@@ -378,12 +468,12 @@
         <thead><tr><th>Инструмент</th><th>Что делает</th><th>Почему так удобнее агенту</th></tr></thead>
         <tbody>
           <tr><td><span class="tool">unica.view</span></td><td>Показывает, что есть в проекте, и открывает объект по адресу: реквизиты, формы, макеты, код.</td><td>Агент смотрит на объект, а не на файлы: не нужно знать, где что лежит на диске.</td></tr>
-          <tr><td><span class="tool">unica.find</span></td><td>По имени объекта находит адрес, по адресу — файл, и в обратную сторону тоже.</td><td>Имя из задачи превращается в адрес, с которым работают остальные инструменты. Гадать путь больше не нужно.</td></tr>
+          <tr><td><span class="tool">unica.resolve</span></td><td>Переводит адрес в файл и файл в адрес. Поиска по имени здесь нет, только конвертация в обе стороны.</td><td>Путь агент получает лишь тогда, когда без него не обойтись, а остальные инструменты работают с адресом.</td></tr>
           <tr><td><span class="tool">unica.search</span></td><td>Ищет по коду: текст или объявления процедур и функций. Можно искать внутри одного объекта.</td><td>Ищет по коду, а не по строкам файла, и область поиска сужается до нужной ветки.</td></tr>
           <tr><td><span class="tool">unica.diff</span></td><td>Показывает, чем отличаются два объекта одного вида.</td><td>Сравнение без выгрузок во временные файлы, и ничего при этом не меняется.</td></tr>
           <tr><td><span class="tool">unica.check</span></td><td>Без адреса проверяет, что проект принят в работу. С адресом гоняет по объекту все проверки его вида: модуль, форму, роль, СКД.</td><td>Ошибки приходят списком, поэтому агент чинит их по одной и видит, что осталось.</td></tr>
           <tr><td><span class="tool">unica.apply</span></td><td>Вносит правку: добавить реквизит, изменить свойство, дописать код. Сначала можно посмотреть план и ничего не записывать.</td><td>План до записи совпадает с самой записью, поэтому правку видно раньше, чем она попадёт в файлы.</td></tr>
-          <tr><td><span class="tool">unica.run</span></td><td>Запускает 1С: собрать конфигурацию, перенести её в базу, выгрузить или загрузить информационную базу. Без аргументов показывает, что умеет.</td><td>Список операций приходит из кода, поэтому агент не выдумывает команду, которой нет.</td></tr>
+          <tr><td><span class="tool">unica.run</span></td><td>Без аргументов отдаёт словарь из двенадцати операций запуска: подготовить рабочее пространство, создать и собрать информационную базу, выгрузить и загрузить конфигурацию или расширение, снять и восстановить полный снимок базы, собрать поставку, запустить клиент. Каждая операция, которая меняет файлы или базу, проходит через план и запись, как <span class="tool">apply</span>.</td><td>Словарь приходит из кода вместе с отметкой, какие операции уже реализованы, поэтому агент не выдумывает команду, которой нет, и не зовёт ту, которой ещё нет.</td></tr>
           <tr><td><span class="tool">unica.docs</span></td><td>Ищет сразу по четырём источникам: справка проекта в рабочем пространстве, синтакс-помощник установленной платформы и два сетевых — база знаний 1С и стандарты разработки.</td><td>Локальные источники отвечают без сети, сетевые включаются политикой проекта. Результат разложен по источникам, поэтому видно, откуда взят ответ.</td></tr>
           <tr class="planned"><td><span class="tool">unica.test</span></td><td colspan="2">Планируется в версии 0.14, пока недоступен.</td></tr>
           <tr class="planned"><td><span class="tool">unica.feature</span></td><td colspan="2">Планируется в версии 0.14, пока недоступен.</td></tr>
@@ -430,6 +520,18 @@
         проверки перед записью не нужно — план и запись идут одним кодом, поэтому показанное
         планом и запишется.
       </p>
+    </div>
+  </section>
+
+  <section id="proof">
+    <div class="wrap">
+      <h2>На чём проверено</h2>
+      <p class="caption">Раздел заполняется после приёмки версии 0.13.</p>
+      <div class="stub">
+        <b>Здесь появятся:</b> размер тестовой конфигурации приёмочного корпуса, самая крупная
+        конфигурация, на которой Unica работала в реальном проекте, время первого и повторного
+        вызова на ней, и пределы, если они есть.
+      </div>
     </div>
   </section>
 </main>

--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -5,6 +5,15 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Unica — плагин Codex и Claude Code для 1С</title>
 <meta name="description" content="Unica помогает агенту находить нужный код, изменять объекты 1С и проверять результат.">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Unica">
+<meta property="og:title" content="Unica — разработка на 1С с AI-агентом">
+<meta property="og:description" content="Плагин для Codex и Claude Code: агент находит нужный код, изменяет объекты 1С и проверяет результат. Сначала план, потом запись.">
+<meta property="og:url" content="https://ingvarconsulting.github.io/unica/">
+<meta property="og:image" content="https://ingvarconsulting.github.io/unica/assets/unica-social-card.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="628">
+<meta name="twitter:card" content="summary_large_image">
 <meta name="theme-color" content="#F8FAFC">
 <link rel="icon" href="assets/unica-mark-blue.svg">
 <link rel="stylesheet" href="assets/site.css">
@@ -15,7 +24,7 @@
 <header>
   <div class="wrap bar">
     <a class="brand" href="#top" aria-label="Unica">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192.096 53.36" aria-hidden="true">
+      <svg class="brand-full" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192.096 53.36" aria-hidden="true">
         <g transform="translate(0 0) scale(0.83375)">
           <rect x="0" y="0" width="64" height="64" rx="15.304" fill="#2563EB"/>
           <path d="M3.3 3.3v12.004278c0 3.542246 2.853476 6.395722 6.395722 6.395722h5.608556c3.542246 0 6.395722-2.853476 6.395722-6.395722V3.3" transform="translate(10.2608695652 10.2608695652) scale(1.73913043478)" fill="none" stroke="#FFFFFF" stroke-width="3.68" stroke-linecap="round" stroke-linejoin="round"/>
@@ -28,10 +37,15 @@
           <path d="M21.7 21.7V9.695722c0-3.542246-2.853476-6.395722-6.395722-6.395722H9.695722c-3.542246 0-6.395722 2.853476-6.395722 6.395722v5.608556c0 3.542246 2.853476 6.395722 6.395722 6.395722h5.608556c3.542246 0 6.395722-2.853476 6.395722-6.395722" transform="translate(95.68 0)"/>
         </g>
       </svg>
+      <svg class="brand-mark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" aria-hidden="true">
+        <rect x="0" y="0" width="64" height="64" rx="15.304" fill="#2563EB"/>
+        <path d="M3.3 3.3v12.004278c0 3.542246 2.853476 6.395722 6.395722 6.395722h5.608556c3.542246 0 6.395722-2.853476 6.395722-6.395722V3.3" transform="translate(10.2608695652 10.2608695652) scale(1.73913043478)" fill="none" stroke="#FFFFFF" stroke-width="3.68" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="32" cy="29.913" r="3.826" fill="#93C5FD"/>
+      </svg>
     </a>
     <nav>
       <a href="#install">Установка</a>
-      <a href="scenarios.html">Сценарии</a>
+      <a href="scenarios.html">Что умеет</a>
       <a href="architecture.html">Архитектура</a>
       <a class="chip" href="https://github.com/IngvarConsulting/unica" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
         <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
@@ -39,46 +53,63 @@
       <a class="chip" href="https://t.me/unica_ai" target="_blank" rel="noopener noreferrer" aria-label="Telegram">
         <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/></svg>
         <span class="count">{{telegram_members}}</span></a>
-      <button class="theme" type="button" aria-label="Переключить тему">
-        <svg class="sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
-          <circle cx="12" cy="12" r="4"/>
-          <path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M19.1 4.9l-1.4 1.4M6.3 17.7l-1.4 1.4"/>
-        </svg>
-        <svg class="moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <path d="M20 14.5A8.5 8.5 0 1 1 9.5 4a6.6 6.6 0 0 0 10.5 10.5z"/>
-        </svg>
-      </button>
     </nav>
+    <button class="theme" type="button" aria-label="Переключить тему">
+      <svg class="sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+        <circle cx="12" cy="12" r="4"/>
+        <path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M19.1 4.9l-1.4 1.4M6.3 17.7l-1.4 1.4"/>
+      </svg>
+      <svg class="moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M20 14.5A8.5 8.5 0 1 1 9.5 4a6.6 6.6 0 0 0 10.5 10.5z"/>
+      </svg>
+    </button>
   </div>
 </header>
 
 <main id="top">
   <div class="wrap hero">
     <p class="eyebrow">Unica · плагин для Codex и Claude Code</p>
-    <h1>Разработка на <span>1С</span> с AI-агентом</h1>
+    <h1>Разработка на <span>1С</span> с AI‑агентом</h1>
     <p class="lede">
       Unica помогает агенту находить нужный код, изменять объекты 1С и проверять
       результат.
     </p>
     <div class="cta">
       <a class="btn btn-primary" href="#install">Установить Unica</a>
-      <a class="btn btn-ghost" href="https://ingvar.pro/products/unica" target="_blank" rel="noopener noreferrer">Страница продукта</a>
+      <a class="btn btn-ghost" href="scenarios.html">Что умеет</a>
       <a class="btn btn-ghost" href="https://t.me/unica_ai" target="_blank" rel="noopener noreferrer">Telegram</a>
+      <p class="platforms" aria-label="Работает на Windows, macOS и Linux">
+        <span class="os"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 5.5 11 4.4v7.2H3zM12 4.2 21 3v8.6h-9zM3 12.4h8v7.2L3 18.5zM12 12.4h9V21l-9-1.3z"/></svg>Windows</span>
+        <span class="os"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701"/></svg>macOS</span>
+        <span class="os"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12.504 0c-.155 0-.315.008-.48.021-4.226.333-3.105 4.807-3.17 6.298-.076 1.092-.3 1.953-1.05 3.02-.885 1.051-2.127 2.75-2.716 4.521-.278.832-.41 1.684-.287 2.489a.424.424 0 00-.11.135c-.26.268-.45.6-.663.839-.199.199-.485.267-.797.4-.313.136-.658.269-.864.68-.09.189-.136.394-.132.602 0 .199.027.4.055.536.058.399.116.728.04.97-.249.68-.28 1.145-.106 1.484.174.334.535.47.94.601.81.2 1.91.135 2.774.6.926.466 1.866.67 2.616.47.526-.116.97-.464 1.208-.946.587-.003 1.23-.269 2.26-.334.699-.058 1.574.267 2.577.2.025.134.063.198.114.333l.003.003c.391.778 1.113 1.132 1.884 1.071.771-.06 1.592-.536 2.257-1.306.631-.765 1.683-1.084 2.378-1.503.348-.199.629-.469.649-.853.023-.4-.2-.811-.714-1.376v-.097l-.003-.003c-.17-.2-.25-.535-.338-.926-.085-.401-.182-.786-.492-1.046h-.003c-.059-.054-.123-.067-.188-.135a.357.357 0 00-.19-.064c.431-1.278.264-2.55-.173-3.694-.533-1.41-1.465-2.638-2.175-3.483-.796-1.005-1.576-1.957-1.56-3.368.026-2.152.236-6.133-3.544-6.139zm.529 3.405h.013c.213 0 .396.062.584.198.19.135.33.332.438.533.105.259.158.459.166.724 0-.02.006-.04.006-.06v.105a.086.086 0 01-.004-.021l-.004-.024a1.807 1.807 0 01-.15.706.953.953 0 01-.213.335.71.71 0 00-.088-.042c-.104-.045-.198-.064-.284-.133a1.312 1.312 0 00-.22-.066c.05-.06.146-.133.183-.198.053-.128.082-.264.088-.402v-.02a1.21 1.21 0 00-.061-.4c-.045-.134-.101-.2-.183-.333-.084-.066-.167-.132-.267-.132h-.016c-.093 0-.176.03-.262.132a.8.8 0 00-.205.334 1.18 1.18 0 00-.09.4v.019c.002.089.008.179.02.267-.193-.067-.438-.135-.607-.202a1.635 1.635 0 01-.018-.2v-.02a1.772 1.772 0 01.15-.768c.082-.22.232-.406.43-.533a.985.985 0 01.594-.2zm-2.962.059h.036c.142 0 .27.048.399.135.146.129.264.288.344.465.09.199.14.4.153.667v.004c.007.134.006.2-.002.266v.08c-.03.007-.056.018-.083.024-.152.055-.274.135-.393.2.012-.09.013-.18.003-.267v-.015c-.012-.133-.04-.2-.082-.333a.613.613 0 00-.166-.267.248.248 0 00-.183-.064h-.021c-.071.006-.13.04-.186.132a.552.552 0 00-.12.27.944.944 0 00-.023.33v.015c.012.135.037.2.08.334.046.134.098.2.166.268.01.009.02.018.034.024-.07.057-.117.07-.176.136a.304.304 0 01-.131.068 2.62 2.62 0 01-.275-.402 1.772 1.772 0 01-.155-.667 1.759 1.759 0 01.08-.668 1.43 1.43 0 01.283-.535c.128-.133.26-.2.418-.2zm1.37 1.706c.332 0 .733.065 1.216.399.293.2.523.269 1.052.468h.003c.255.136.405.266.478.399v-.131a.571.571 0 01.016.47c-.123.31-.516.643-1.063.842v.002c-.268.135-.501.333-.775.465-.276.135-.588.292-1.012.267a1.139 1.139 0 01-.448-.067 3.566 3.566 0 01-.322-.198c-.195-.135-.363-.332-.612-.465v-.005h-.005c-.4-.246-.616-.512-.686-.71-.07-.268-.005-.47.193-.6.224-.135.38-.271.483-.336.104-.074.143-.102.176-.131h.002v-.003c.169-.202.436-.47.839-.601.139-.036.294-.065.466-.065zm2.8 2.142c.358 1.417 1.196 3.475 1.735 4.473.286.534.855 1.659 1.102 3.024.156-.005.33.018.513.064.646-1.671-.546-3.467-1.089-3.966-.22-.2-.232-.335-.123-.335.59.534 1.365 1.572 1.646 2.757.13.535.16 1.104.021 1.67.067.028.135.06.205.067 1.032.534 1.413.938 1.23 1.537v-.043c-.06-.003-.12 0-.18 0h-.016c.151-.467-.182-.825-1.065-1.224-.915-.4-1.646-.336-1.77.465-.008.043-.013.066-.018.135-.068.023-.139.053-.209.064-.43.268-.662.669-.793 1.187-.13.533-.17 1.156-.205 1.869v.003c-.02.334-.17.838-.319 1.35-1.5 1.072-3.58 1.538-5.348.334a2.645 2.645 0 00-.402-.533 1.45 1.45 0 00-.275-.333c.182 0 .338-.03.465-.067a.615.615 0 00.314-.334c.108-.267 0-.697-.345-1.163-.345-.467-.931-.995-1.788-1.521-.63-.4-.986-.87-1.15-1.396-.165-.534-.143-1.085-.015-1.645.245-1.07.873-2.11 1.274-2.763.107-.065.037.135-.408.974-.396.751-1.14 2.497-.122 3.854a8.123 8.123 0 01.647-2.876c.564-1.278 1.743-3.504 1.836-5.268.048.036.217.135.289.202.218.133.38.333.59.465.21.201.477.335.876.335.039.003.075.006.11.006.412 0 .73-.134.997-.268.29-.134.52-.334.74-.4h.005c.467-.135.835-.402 1.044-.7zm2.185 8.958c.037.6.343 1.245.882 1.377.588.134 1.434-.333 1.791-.765l.211-.01c.315-.007.577.01.847.268l.003.003c.208.199.305.53.391.876.085.4.154.78.409 1.066.486.527.645.906.636 1.14l.003-.007v.018l-.003-.012c-.015.262-.185.396-.498.595-.63.401-1.746.712-2.457 1.57-.618.737-1.37 1.14-2.036 1.191-.664.053-1.237-.2-1.574-.898l-.005-.003c-.21-.4-.12-1.025.056-1.69.176-.668.428-1.344.463-1.897.037-.714.076-1.335.195-1.814.12-.465.308-.797.641-.984l.045-.022zm-10.814.049h.01c.053 0 .105.005.157.014.376.055.706.333 1.023.752l.91 1.664.003.003c.243.533.754 1.064 1.189 1.637.434.598.77 1.131.729 1.57v.006c-.057.744-.48 1.148-1.125 1.294-.645.135-1.52.002-2.395-.464-.968-.536-2.118-.469-2.857-.602-.369-.066-.61-.2-.723-.4-.11-.2-.113-.602.123-1.23v-.004l.002-.003c.117-.334.03-.752-.027-1.118-.055-.401-.083-.71.043-.94.16-.334.396-.4.69-.533.294-.135.64-.202.915-.47h.002v-.002c.256-.268.445-.601.668-.838.19-.201.38-.336.663-.336zm7.159-9.074c-.435.201-.945.535-1.488.535-.542 0-.97-.267-1.28-.466-.154-.134-.28-.268-.373-.335-.164-.134-.144-.333-.074-.333.109.016.129.134.199.2.096.066.215.2.36.333.292.2.68.467 1.167.467.485 0 1.053-.267 1.398-.466.195-.135.445-.334.648-.467.156-.136.149-.267.279-.267.128.016.034.134-.147.332a8.097 8.097 0 01-.69.468zm-1.082-1.583V5.64c-.006-.02.013-.042.029-.05.074-.043.18-.027.26.004.063 0 .16.067.15.135-.006.049-.085.066-.135.066-.055 0-.092-.043-.141-.068-.052-.018-.146-.008-.163-.065zm-.551 0c-.02.058-.113.049-.166.066-.047.025-.086.068-.14.068-.05 0-.13-.02-.136-.068-.01-.066.088-.133.15-.133.08-.031.184-.047.259-.005.019.009.036.03.03.05v.02h.003z"/></svg>Linux</span>
+      </p>
     </div>
 
+    <!-- Версия и пререлиз — карточки в одной сетке с плитками прогонов.
+         Пререлиз появляется только пока он впереди публичной версии, плитки
+         прогонов — только у линий с отчётом: пустая плитка «нет прогонов» на
+         первом экране читалась как «проект не живёт». -->
     <div class="cards" id="state">
-      <div class="card">
+      <div class="card card-version">
         <h3>Публичная версия</h3>
-        <a class="metric" href="{{version_url}}" target="_blank" rel="noopener noreferrer">{{version}}</a>
+        <div class="metric-row">
+          <a class="metric" href="{{version_url}}" target="_blank" rel="noopener noreferrer">{{version}}</a>
+          <span class="card-action"><a href="{{version_url}}" target="_blank" rel="noopener noreferrer">Заметки о выпуске →</a></span>
+        </div>
         <div class="sub">опубликована {{version_date}}</div>
       </div>
-      <div class="card">
+      <!-- repeat: prereleases -->
+      <div class="card card-version">
         <h3>Пререлиз</h3>
-        <span class="metric metric-idle">{{prerelease}}</span>
-        <div class="sub">{{prerelease_note}}</div>
+        <div class="metric-row">
+          <a class="metric" href="{{prerelease_url}}" target="_blank" rel="noopener noreferrer">{{prerelease}}</a>
+          <span class="card-action"><a href="{{prerelease_url}}" target="_blank" rel="noopener noreferrer">Заметки о выпуске →</a></span>
+        </div>
+        <div class="sub">опубликован {{prerelease_date}}</div>
       </div>
+      <!-- /repeat -->
       <!-- repeat: tested_lines -->
-      <div class="card">
+      <div class="card card-line">
         <h3 class="ident line-head"><svg class="branch-icon" viewBox="0 0 14 14" aria-hidden="true"><circle cx="4" cy="3" r="1.7"/><circle cx="4" cy="11" r="1.7"/><circle cx="10.5" cy="3" r="1.7"/><path d="M4 4.7v4.6M10.5 4.7v1.2c0 1.7-1.4 3.1-3.1 3.1H4"/></svg>{{line}}<span class="line-run"><a href="{{build_url}}" target="_blank" rel="noopener noreferrer">{{build_sha}}</a> от {{build_date}}</span></h3>
         <div class="metric-row">
           <a class="metric" href="{{report_url}}" target="_blank" rel="noopener noreferrer">{{tests_total}} <small>теста</small></a>
@@ -91,20 +122,26 @@
         </div>
       </div>
       <!-- /repeat -->
-      <!-- repeat: plain_lines -->
-      <div class="card">
-        <h3 class="ident line-head"><svg class="branch-icon" viewBox="0 0 14 14" aria-hidden="true"><circle cx="4" cy="3" r="1.7"/><circle cx="4" cy="11" r="1.7"/><circle cx="10.5" cy="3" r="1.7"/><path d="M4 4.7v4.6M10.5 4.7v1.2c0 1.7-1.4 3.1-3.1 3.1H4"/></svg>{{line}}</h3>
-        <span class="metric metric-idle">{{build_state}}</span>
-        <div class="sub">{{build_note}}</div>
-      </div>
-      <!-- /repeat -->
     </div>
   </div>
 
   <section id="install">
     <div class="wrap">
       <h2>Установка</h2>
-      <p>Codex и Claude Code ставятся из одного маркетплейса. Нужен Git.</p>
+      <ol class="setup">
+        <li>
+          <h3>Что понадобится</h3>
+          <ul class="needs">
+            <li><b>Агент.</b> <span><a href="https://openai.com/codex/" target="_blank" rel="noopener noreferrer">Codex</a> или <a href="https://code.claude.com/docs/en/overview" target="_blank" rel="noopener noreferrer">Claude Code</a> с действующей подпиской. Unica подключается к нему как плагин.</span></li>
+            <li><b>Git.</b> <span>Через него ставится плагин. На Windows подойдёт Git for Windows.</span></li>
+            <li><b>Выгрузка конфигурации в файлы.</b> <span>Unica работает с каталогом, в который конфигуратор 8.3.27 выгрузил конфигурацию или расширение, а не с базой напрямую. Если выгрузки ещё нет, Unica сделает её сама из вашей базы: для этого нужна установленная платформа.</span></li>
+            <li><b>Платформа 1С только для запуска.</b> <span>Читать, проверять и править выгрузку можно без установленной платформы. Она нужна операциям, которые собирают базу или запускают конфигуратор.</span></li>
+          </ul>
+          <p style="margin-top:14px">Работает на Windows, macOS и Linux. Ядро и движки докачиваются при первом запуске; что именно и откуда, описано в разделе <a href="architecture.html#network">«Сеть и данные»</a>.</p>
+        </li>
+        <li>
+          <h3>Поставить плагин</h3>
+          <p>Codex и Claude Code ставятся из одного маркетплейса.</p>
       <div class="tabs">
         <input type="radio" id="host-codex" name="host" checked>
         <input type="radio" id="host-claude" name="host">
@@ -123,19 +160,60 @@ claude plugin install unica@unica</code></pre>
           <button class="copy" type="button" data-target="cmd-claude" aria-label="Скопировать" title="Скопировать"><svg class="i-copy" viewBox="0 0 24 24" aria-hidden="true"><rect x="9" y="9" width="12" height="12" rx="2.5"/><path d="M15 5.5V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h.5"/></svg><svg class="i-done" viewBox="0 0 24 24" aria-hidden="true"><path d="M4.5 12.5 9.5 17.5 19.5 6.5"/></svg></button>
         </div>
       </div>
+          <p style="margin-top:14px">После установки начните новую сессию агента или выполните в нём <code>/reload-plugins</code>.</p>
+        </li>
+        <li>
+          <h3>Первый запрос</h3>
+          <p>Откройте агента в каталоге проекта и попросите подключить его. Дальше разговор идёт словами разработчика, а Unica отвечает планом до каждой записи.</p>
+          <div class="dialogue" aria-label="Пример диалога">
+            <div class="msg msg-user">Подключи проект и покажи, что в нём есть</div>
+            <div class="msg msg-agent">
+              <span class="who">Агент с Unica</span>
+              <p>Нашёл выгрузку конфигуратора в каталоге <code>src</code>. Файла проекта ещё нет, план такой:</p>
+              <ul class="plan-list"><li>создать <code>v8project.yaml</code> с набором <code>main</code>, тип CONFIGURATION, путь <code>src</code></li></ul>
+              <p>Создать?</p>
+            </div>
+            <div class="msg msg-user">Да</div>
+            <div class="msg msg-agent">
+              <span class="who">Агент с Unica</span>
+              <p>Готово. Конфигурация прочитана: справочники, документы, регистры, общие модули, роли. Готовность проверена, можно работать.</p>
+            </div>
+            <div class="msg msg-user">Добавь справочнику Контрагенты реквизит ИНН, строка 12</div>
+            <div class="msg msg-agent">
+              <span class="who">Агент с Unica</span>
+              <p>План правки <code>main:Catalog.Контрагенты</code>:</p>
+              <ul class="plan-list">
+                <li>реквизит <b>ИНН</b>, Строка (12), переменная длина</li>
+                <li class="same">остальные реквизиты, формы и модули без изменений</li>
+              </ul>
+              <p>Записать в файлы?</p>
+            </div>
+            <div class="msg msg-user">Записывай</div>
+            <div class="msg msg-agent">
+              <span class="who">Агент с Unica</span>
+              <p>Записано в <code>src/Catalogs/Контрагенты.xml</code>. Проверка справочника прошла без ошибок.</p>
+            </div>
+          </div>
+        </li>
+      </ol>
     </div>
   </section>
 
   <section>
     <div class="wrap">
       <h2>Поддерживаемые версии платформы</h2>
+      <p>
+        Версия платформы задаёт формат выгрузки, а Unica читает и пишет ровно один формат.
+        Каждая лишняя ветка это ещё один формат, который нужно держать в тестах, поэтому старые
+        версии не поддерживаем намеренно: актуальные типовые конфигурации уже вышли на 8.3.27 и выше.
+      </p>
       <div class="table-wrap">
-      <table>
-        <thead><tr><th>Версия</th><th>Статус</th><th>Что это означает</th></tr></thead>
+      <table class="versions">
+        <thead><tr><th>Платформа</th><th>Формат выгрузки</th><th>Статус</th></tr></thead>
         <tbody>
-          <tr><td><code>8.5.1.x</code>, <code>8.5.4.x</code></td><td>Планируется</td><td>Хотим добавить в ближайшее время.</td></tr>
-          <tr><td><code>8.3.27.x</code></td><td>Поддерживается</td><td>Поддержаны все актуальные релизы ветки.</td></tr>
-          <tr><td><code>8.3.26.x</code> и ниже</td><td>Не планируется</td><td>Помогаем мигрировать на 8.3.27.</td></tr>
+          <tr><td><code>8.5.1.x</code>, <code>8.5.4.x</code></td><td><code>2.21</code> и выше</td><td><span class="status status-plan">Планируем</span></td></tr>
+          <tr><td><code>8.3.27.x</code></td><td><code>2.20</code></td><td><span class="status status-ok">Поддержали</span></td></tr>
+          <tr><td><code>8.3.26.x</code> и ниже</td><td><code>2.19</code> и ниже</td><td><span class="status status-no">Не планируем</span></td></tr>
         </tbody>
       </table>
       </div>
@@ -149,8 +227,8 @@ claude plugin install unica@unica</code></pre>
       <ol class="steps">
         <li>
           <a href="scenarios.html">
-            <b>Сценарии и операции</b>
-            <p>Задачи разработчика, которые Unica проходит на канонической поверхности: области, операции и шаги приёмочного корпуса.</p>
+            <b>Что умеет</b>
+            <p>Каталог задач разработчика, которые Unica проходит цепочкой вызовов. Тот же список гоняет приёмочный тест, поэтому в нём нет ничего, что не работает.</p>
           </a>
         </li>
         <li>
@@ -161,19 +239,19 @@ claude plugin install unica@unica</code></pre>
         </li>
         <li>
           <a href="https://github.com/IngvarConsulting/unica/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">
-            <b><span class="repo">github.com/IngvarConsulting/unica/</span>CONTRIBUTING.md</b>
+            <b><span class="repo">github.com/<wbr>IngvarConsulting/<wbr>unica/<wbr></span>CONTRIBUTING.md</b>
             <p>Окружение: Python 3.12, Rust, <code>rust-analyzer</code> для кодового агента и навыки для Codex и Claude Code.</p>
           </a>
         </li>
         <li>
           <a href="https://github.com/IngvarConsulting/unica/blob/main/AGENTS.md" target="_blank" rel="noopener noreferrer">
-            <b><span class="repo">github.com/IngvarConsulting/unica/</span>AGENTS.md</b>
+            <b><span class="repo">github.com/<wbr>IngvarConsulting/<wbr>unica/<wbr></span>AGENTS.md</b>
             <p>Порядок источников истины, куда смотреть и где менять, правила разработки и топология pull request.</p>
           </a>
         </li>
         <li>
           <a href="https://github.com/IngvarConsulting/unica/tree/main/arch" target="_blank" rel="noopener noreferrer">
-            <b><span class="repo">github.com/IngvarConsulting/unica/</span>arch<span class="repo">/</span></b>
+            <b><span class="repo">github.com/<wbr>IngvarConsulting/<wbr>unica/<wbr></span>arch<span class="repo">/</span></b>
             <p>Нормативный слой: решения, инварианты и контракты, одна запись — один файл. На них ссылаются тесты, поэтому спор о правиле решается здесь.</p>
           </a>
         </li>

--- a/docs/pages/scenarios.html
+++ b/docs/pages/scenarios.html
@@ -3,8 +3,17 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Сценарии Unica</title>
-<meta name="description" content="Каталог задач разработчика, которые Unica проходит на канонической поверхности: области, операции, сценарии.">
+<title>Что умеет Unica</title>
+<meta name="description" content="Каталог задач разработчика 1С, которые Unica проходит цепочкой вызовов: формы, роли, СКД, макеты, код, поддержка поставщика.">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Unica">
+<meta property="og:title" content="Что умеет Unica">
+<meta property="og:description" content="Каталог задач разработчика 1С, которые Unica проходит цепочкой вызовов: формы, роли, СКД, макеты, код, поддержка поставщика.">
+<meta property="og:url" content="https://ingvarconsulting.github.io/unica/scenarios.html">
+<meta property="og:image" content="https://ingvarconsulting.github.io/unica/assets/unica-social-card.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="628">
+<meta name="twitter:card" content="summary_large_image">
 <meta name="theme-color" content="#F8FAFC">
 <link rel="icon" href="assets/unica-mark-blue.svg">
 <link rel="stylesheet" href="assets/site.css">
@@ -15,7 +24,7 @@
 <header>
   <div class="wrap bar">
     <a class="brand" href="index.html" aria-label="Unica">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192.096 53.36" aria-hidden="true">
+      <svg class="brand-full" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192.096 53.36" aria-hidden="true">
         <g transform="translate(0 0) scale(0.83375)">
           <rect x="0" y="0" width="64" height="64" rx="15.304" fill="#2563EB"/>
           <path d="M3.3 3.3v12.004278c0 3.542246 2.853476 6.395722 6.395722 6.395722h5.608556c3.542246 0 6.395722-2.853476 6.395722-6.395722V3.3" transform="translate(10.2608695652 10.2608695652) scale(1.73913043478)" fill="none" stroke="#FFFFFF" stroke-width="3.68" stroke-linecap="round" stroke-linejoin="round"/>
@@ -28,10 +37,15 @@
           <path d="M21.7 21.7V9.695722c0-3.542246-2.853476-6.395722-6.395722-6.395722H9.695722c-3.542246 0-6.395722 2.853476-6.395722 6.395722v5.608556c0 3.542246 2.853476 6.395722 6.395722 6.395722h5.608556c3.542246 0 6.395722-2.853476 6.395722-6.395722" transform="translate(95.68 0)"/>
         </g>
       </svg>
+      <svg class="brand-mark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" aria-hidden="true">
+        <rect x="0" y="0" width="64" height="64" rx="15.304" fill="#2563EB"/>
+        <path d="M3.3 3.3v12.004278c0 3.542246 2.853476 6.395722 6.395722 6.395722h5.608556c3.542246 0 6.395722-2.853476 6.395722-6.395722V3.3" transform="translate(10.2608695652 10.2608695652) scale(1.73913043478)" fill="none" stroke="#FFFFFF" stroke-width="3.68" stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="32" cy="29.913" r="3.826" fill="#93C5FD"/>
+      </svg>
     </a>
     <nav>
       <a href="index.html#install">Установка</a>
-      <a href="scenarios.html">Сценарии</a>
+      <a href="scenarios.html">Что умеет</a>
       <a href="architecture.html">Архитектура</a>
       <a class="chip" href="https://github.com/IngvarConsulting/unica" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
         <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
@@ -39,79 +53,115 @@
       <a class="chip" href="https://t.me/unica_ai" target="_blank" rel="noopener noreferrer" aria-label="Telegram">
         <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/></svg>
         <span class="count">{{telegram_members}}</span></a>
-      <button class="theme" type="button" aria-label="Переключить тему">
-        <svg class="sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
-          <circle cx="12" cy="12" r="4"/>
-          <path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M19.1 4.9l-1.4 1.4M6.3 17.7l-1.4 1.4"/>
-        </svg>
-        <svg class="moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <path d="M20 14.5A8.5 8.5 0 1 1 9.5 4a6.6 6.6 0 0 0 10.5 10.5z"/>
-        </svg>
-      </button>
     </nav>
+    <button class="theme" type="button" aria-label="Переключить тему">
+      <svg class="sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+        <circle cx="12" cy="12" r="4"/>
+        <path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M19.1 4.9l-1.4 1.4M6.3 17.7l-1.4 1.4"/>
+      </svg>
+      <svg class="moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M20 14.5A8.5 8.5 0 1 1 9.5 4a6.6 6.6 0 0 0 10.5 10.5z"/>
+      </svg>
+    </button>
   </div>
 </header>
 
 <main>
   <div class="wrap hero">
-    <p class="eyebrow">Для контрибьютора</p>
+    <p class="eyebrow">Каталог задач</p>
     <h1>Что Unica уже <span>умеет</span></h1>
     <p class="page-lede">
-      Каждый сценарий — настоящая задача разработчика, разложенная в цепочку вызовов
-      <code>unica.*</code>. Приёмочный тест гоняет их все и сверяет с замороженным классом ответа,
-      поэтому список ниже — не обещание, а то, что проходит на каждом прогоне.
+      Каждая строка — задача разработчика 1С, которую Unica проходит цепочкой вызовов
+      <code>unica.*</code>. Тот же список гоняет приёмочный тест на каждом прогоне,
+      поэтому здесь нет ничего, что не работает сегодня.
     </p>
     <div class="cta">
-      <a class="btn btn-primary" href="https://github.com/IngvarConsulting/unica/issues/new?template=new_operation.yml" target="_blank" rel="noopener noreferrer">Добавить сценарий</a>
+      <a class="btn btn-primary" href="index.html#install">Установить Unica</a>
       <a class="btn btn-ghost" href="architecture.html">Как это устроено</a>
-    </div>
-
-    <div class="badges">
-      <span class="badge"><b>{{scenarios_total}}</b> сценариев</span>
-      <span class="badge"><b>{{ops_total}}</b> операций</span>
+      <p class="cta-note"><b>{{scenarios_total}}</b> сценариев</p>
     </div>
   </div>
 
   <section>
     <div class="wrap">
-      <h2>Каталог сценариев</h2>
-      <p class="caption">
-        Не нашли своей задачи — заведите сценарий: опишите её и цепочку вызовов, которой
-        она должна проходить.
-      </p>
+      <h2>Каталог</h2>
+
+      <div class="catalog-controls">
+        <label class="search">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/></svg>
+          <input type="search" id="search" placeholder="Например: реквизит, роль, СКД, форма" aria-label="Поиск по задачам" autocomplete="off">
+        </label>
+      </div>
 
       <!-- На телефоне шапка таблицы скрыта, а сортировка и отбор живут в ней.
            Эти кнопки — те же самые: класс `col-sort` подхватывается тем же
            обработчиком, поэтому состояние у них общее с шапкой. -->
       <div class="toolbar">
         <button class="col-sort" type="button" data-sort="id">ID<span class="sort-mark" aria-hidden="true"></span></button>
-        <button class="col-sort" type="button" data-sort="area">Область<span class="sort-mark" aria-hidden="true"></span></button>
-        <button class="col-sort col-filter tool-filter" type="button">Инструменты<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M1.5 2.5h13l-5 5.6v4.4l-3 1.5V8.1z"/></svg></button>
+        <button class="col-sort col-filter area-filter" type="button">Область<svg class="filter-icon" viewBox="0 0 24 24" aria-hidden="true"><path class="off" d="M4 4h16v2.172a2 2 0 0 1-.586 1.414l-4.414 4.414v7l-6 2v-8.5l-4.48-4.928a2 2 0 0 1-.52-1.345v-2.227"/><g class="on"><path d="M11.18 20.274l-2.18.726v-8.5l-4.48-4.928a2 2 0 0 1-.52-1.345v-2.227h16v2.172a2 2 0 0 1-.586 1.414l-4.414 4.414v3"/><path d="M15 19l2 2l4-4"/></g></svg></button>
+        <button class="col-sort col-filter tool-filter" type="button">Инструменты<svg class="filter-icon" viewBox="0 0 24 24" aria-hidden="true"><path class="off" d="M4 4h16v2.172a2 2 0 0 1-.586 1.414l-4.414 4.414v7l-6 2v-8.5l-4.48-4.928a2 2 0 0 1-.52-1.345v-2.227"/><g class="on"><path d="M11.18 20.274l-2.18.726v-8.5l-4.48-4.928a2 2 0 0 1-.52-1.345v-2.227h16v2.172a2 2 0 0 1-.586 1.414l-4.414 4.414v3"/><path d="M15 19l2 2l4-4"/></g></svg></button>
       </div>
 
-      <p class="catalog-count" id="shown"></p>
-
       <div class="table-wrap">
-      <table>
+      <table class="catalog-table">
+        <!-- Ширины заданы явно: иначе таблица пересчитывает их по строкам,
+             и колонки прыгают при каждом отборе. -->
+        <colgroup>
+          <col class="c-id"><col class="c-area"><col class="c-task"><col class="c-mode"><col class="c-tools"><col class="c-open">
+        </colgroup>
         <thead><tr>
           <th class="id-col"><button class="col-sort" type="button" data-sort="id">ID<span class="sort-mark" aria-hidden="true"></span></button></th>
-          <th><button class="col-sort" type="button" data-sort="area">Область<span class="sort-mark" aria-hidden="true"></span></button></th>
+          <th><button class="col-sort col-filter area-filter" type="button">Область<svg class="filter-icon" viewBox="0 0 24 24" aria-hidden="true"><path class="off" d="M4 4h16v2.172a2 2 0 0 1-.586 1.414l-4.414 4.414v7l-6 2v-8.5l-4.48-4.928a2 2 0 0 1-.52-1.345v-2.227"/><g class="on"><path d="M11.18 20.274l-2.18.726v-8.5l-4.48-4.928a2 2 0 0 1-.52-1.345v-2.227h16v2.172a2 2 0 0 1-.586 1.414l-4.414 4.414v3"/><path d="M15 19l2 2l4-4"/></g></svg></button></th>
           <th>Задача</th>
-          <th><button class="col-sort col-filter tool-filter" type="button">Инструменты<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M1.5 2.5h13l-5 5.6v4.4l-3 1.5V8.1z"/></svg></button></th>
+          <th class="mode-col">Режим</th>
+          <th><button class="col-sort col-filter tool-filter" type="button">Инструменты<svg class="filter-icon" viewBox="0 0 24 24" aria-hidden="true"><path class="off" d="M4 4h16v2.172a2 2 0 0 1-.586 1.414l-4.414 4.414v7l-6 2v-8.5l-4.48-4.928a2 2 0 0 1-.52-1.345v-2.227"/><g class="on"><path d="M11.18 20.274l-2.18.726v-8.5l-4.48-4.928a2 2 0 0 1-.52-1.345v-2.227h16v2.172a2 2 0 0 1-.586 1.414l-4.414 4.414v3"/><path d="M15 19l2 2l4-4"/></g></svg></button></th>
           <th></th>
         </tr></thead>
+        <!-- Итог отбора стоит между шапкой и первой строкой: там его ищут,
+             когда таблица вдруг стала короче. Без отбора строки нет. -->
+        <tbody id="shown-row" hidden><tr><td class="catalog-count" id="shown" colspan="6"></td></tr></tbody>
         <tbody id="catalog">
           <!-- repeat: scenarios -->
-          <tr><td class="addr-cell id-col">{{id}}</td><td>{{area}}</td><td>{{task}}</td><td class="addr-cell">{{tools}}</td><td></td></tr>
+          <tr><td class="addr-cell id-col">{{id}}</td><td>{{area}}</td><td>{{task}}</td><td class="mode-col"><span class="mode mode-{{mode_key}}">{{mode}}</span></td><td class="addr-cell">{{tools}}</td><td></td></tr>
           <!-- /repeat -->
         </tbody>
       </table>
       </div>
+
+      <div class="legend">
+        <h3>Классы ответа в цепочках</h3>
+        <ul>
+          <!-- repeat: classes -->
+          <li><span class="cls"><span class="step-expect is-{{cls}}">{{cls}}</span> <small>{{cls_count}}</small></span><span>{{cls_note}}</span></li>
+          <!-- /repeat -->
+        </ul>
+      </div>
+
+      <div class="contrib">
+        <h3>Для контрибьютора</h3>
+        <p>
+          Каталог порождается из приёмочного корпуса: каждый сценарий — цепочка вызовов с
+          замороженным классом ответа на каждом шаге. Не нашли своей задачи — заведите сценарий:
+          опишите её и цепочку, которой она должна проходить.
+        </p>
+        <a class="btn btn-ghost" href="https://github.com/IngvarConsulting/unica/issues/new?template=new_operation.yml" target="_blank" rel="noopener noreferrer">Добавить сценарий</a>
+      </div>
     </div>
   </section>
 
+  <dialog id="area-dialog">
+    <div class="dialog-head" tabindex="-1">
+      <div>
+        <h3>Область</h3>
+        <p class="dialog-area">Показать сценарии одной области</p>
+      </div>
+      <button class="dialog-close" id="area-close" type="button" aria-label="Закрыть">✕</button>
+    </div>
+    <div class="tool-list" id="area-list"></div>
+  </dialog>
+
   <dialog id="tool-dialog">
-    <div class="dialog-head">
+    <div class="dialog-head" tabindex="-1">
       <div>
         <h3>Инструмент</h3>
         <p class="dialog-area">Показать сценарии, где он встречается в цепочке</p>
@@ -122,7 +172,7 @@
   </dialog>
 
   <dialog id="details">
-    <div class="dialog-head">
+    <div class="dialog-head" tabindex="-1">
       <div>
         <p class="dialog-id" id="details-id"></p>
         <h3 id="details-task"></h3>
@@ -131,6 +181,7 @@
       <button class="dialog-close" id="details-close" type="button" aria-label="Закрыть">✕</button>
     </div>
     <div id="details-wire"></div>
+    <dl class="dialog-legend" id="details-legend"></dl>
   </dialog>
 </main>
 
@@ -159,13 +210,16 @@
   const scenarios = JSON.parse(document.getElementById('scenario-data').textContent);
   const body = document.getElementById('catalog');
   const shown = document.getElementById('shown');
+  const shownRow = document.getElementById('shown-row');
   const dialog = document.getElementById('details');
   const toolDialog = document.getElementById('tool-dialog');
+  const areaDialog = document.getElementById('area-dialog');
 
   // Очень короткие подписи: в окне выбора нужно узнать инструмент, а не изучить его.
   const ABOUT = {
     'unica.view': 'смотрит проект и объекты',
     'unica.find': 'имя, адрес и файл — в обе стороны',
+    'unica.resolve': 'адрес в файл и файл в адрес',
     'unica.search': 'ищет по коду',
     'unica.diff': 'сравнивает два объекта',
     'unica.check': 'гоняет проверки объекта',
@@ -174,9 +228,48 @@
     'unica.docs': 'ищет в документации',
   };
 
+  const MODE = { write: 'запись', plan: 'план', read: 'чтение' };
+  const CLASS_NOTE = {
+    ok: 'инструмент ответил результатом',
+    task: 'работа ушла в фоновую задачу, вернулась квитанция',
+    provider: 'ответ зависит от внешнего поставщика: сети или платформы',
+    refused: 'намеренный отказ по правилу, с кодом и причиной',
+    unsupported: 'в этой версии не поддержано, отказ типизирован',
+    gap: 'известный пробел, причина записана в корпусе',
+    cancelled: 'задача отменена по запросу',
+    failed: 'задача завершилась отказом',
+  };
+
   let sortKey = 'id';
   let sortDown = false;
   let toolFilter = '';
+  let areaFilter = '';
+  let query = '';
+
+  // Состояние отбора живёт в адресе: ссылку «все сценарии про роли» можно
+  // переслать, а обновление страницы не сбрасывает поиск.
+  function readHash() {
+    const params = new URLSearchParams(location.hash.slice(1));
+    query = params.get('q') || '';
+    areaFilter = params.get('area') || '';
+    toolFilter = params.get('tool') || '';
+    // Сортировка осталась только по номеру: областей восемнадцать, и отбор
+    // по одной полезнее, чем порядок по всем.
+    sortDown = params.get('sort') === '-id';
+    sortKey = 'id';
+  }
+
+  function writeHash() {
+    const params = new URLSearchParams();
+    if (query) params.set('q', query);
+    if (areaFilter) params.set('area', areaFilter);
+    if (toolFilter) params.set('tool', toolFilter);
+    if (sortKey !== 'id' || sortDown) params.set('sort', (sortDown ? '-' : '') + sortKey);
+    const next = params.toString();
+    history.replaceState(null, '', next ? '#' + next : location.pathname + location.search);
+  }
+
+  const fold = (text) => text.toLowerCase().replace(/ё/g, 'е');
 
   // Лесенка вместо стрелки: растущие столбики — по возрастанию, убывающие —
   // по убыванию, вразнобой — «сейчас сортируем не по этой колонке».
@@ -209,12 +302,23 @@
     return td;
   }
 
+  function modeCell(scenario) {
+    const td = document.createElement('td');
+    td.className = 'mode-col';
+    const mark = document.createElement('span');
+    mark.className = 'mode mode-' + scenario.mode;
+    mark.textContent = MODE[scenario.mode] || scenario.mode;
+    td.append(mark);
+    return td;
+  }
+
   function row(scenario) {
     const tr = document.createElement('tr');
     tr.append(
       cell(scenario.id, 'addr-cell id-col'),
       cell(scenario.area),
       cell(scenario.task),
+      modeCell(scenario),
       cell(toolsOf(scenario).join(' · '), 'addr-cell'),
     );
     const action = document.createElement('td');
@@ -291,6 +395,7 @@
         const mark = document.createElement('span');
         mark.className = 'step-expect is-' + expected;
         mark.textContent = expected;
+        if (CLASS_NOTE[expected]) mark.title = CLASS_NOTE[expected];
         facts.append(mark);
       }
       // Проверяемая часть ответа показывается так же, как запрос: тем же
@@ -307,7 +412,22 @@
       if (payload) block.append(payload);
       return block;
     }));
+    // Легенда только для классов этой цепочки: обычно одна-две строки,
+    // а не шесть подряд.
+    const legend = document.getElementById('details-legend');
+    const seenClasses = [...new Set(scenario.wire.flatMap((step) => step.expect))];
+    legend.replaceChildren(...seenClasses.flatMap((expected) => {
+      const dt = document.createElement('dt');
+      const mark = document.createElement('span');
+      mark.className = 'step-expect is-' + expected;
+      mark.textContent = expected;
+      dt.append(mark);
+      const dd = document.createElement('dd');
+      dd.textContent = CLASS_NOTE[expected] || '';
+      return [dt, dd];
+    }));
     dialog.showModal();
+    dialog.querySelector('.dialog-head').focus();
   }
 
   function toolRow(tool) {
@@ -331,9 +451,42 @@
     button.addEventListener('click', () => {
       toolFilter = tool;
       toolDialog.close();
+      writeHash();
       render();
     });
     return button;
+  }
+
+  // Области идут по убыванию числа сценариев: крупные разделы сверху, как в
+  // окне инструментов. Пустая строка — «любая», то есть без отбора.
+  const areaCounts = new Map();
+  for (const scenario of scenarios) areaCounts.set(scenario.area, (areaCounts.get(scenario.area) || 0) + 1);
+  const allAreas = [...areaCounts.keys()].sort((a, b) => areaCounts.get(b) - areaCounts.get(a) || a.localeCompare(b, 'ru'));
+
+  function areaRow(area) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'tool-row area-row' + (areaFilter === area ? ' is-active' : '');
+    const name = document.createElement('span');
+    name.className = 'area-name';
+    name.textContent = area || 'Любая';
+    const count = document.createElement('span');
+    count.className = 'tool-count';
+    count.textContent = area ? areaCounts.get(area) : scenarios.length;
+    button.append(name, count);
+    button.addEventListener('click', () => {
+      areaFilter = area;
+      areaDialog.close();
+      writeHash();
+      render();
+    });
+    return button;
+  }
+
+  function openAreas() {
+    document.getElementById('area-list').replaceChildren(areaRow(''), ...allAreas.map(areaRow));
+    areaDialog.showModal();
+    areaDialog.querySelector('.dialog-head').focus();
   }
 
   function openTools() {
@@ -341,14 +494,21 @@
       toolRow(''), ...allTools.map(toolRow),
     );
     toolDialog.showModal();
+    toolDialog.querySelector('.dialog-head').focus();
+  }
+
+  function matches(scenario) {
+    if (toolFilter && !toolsOf(scenario).includes(toolFilter)) return false;
+    if (areaFilter && scenario.area !== areaFilter) return false;
+    if (!query) return true;
+    const haystack = fold(scenario.id + ' ' + scenario.area + ' ' + scenario.task + ' ' + toolsOf(scenario).join(' '));
+    return fold(query).split(/\s+/).filter(Boolean).every((word) => haystack.includes(word));
   }
 
   function render() {
-    const rows = scenarios.filter((scenario) => !toolFilter || toolsOf(scenario).includes(toolFilter));
+    const rows = scenarios.filter(matches);
     const direction = sortDown ? -1 : 1;
-    rows.sort(sortKey === 'area'
-      ? (a, b) => direction * (a.area.localeCompare(b.area, 'ru') || number(a.id) - number(b.id))
-      : (a, b) => direction * (number(a.id) - number(b.id)));
+    rows.sort((a, b) => direction * (number(a.id) - number(b.id)));
     body.replaceChildren(...rows.map(row));
 
     for (const header of document.querySelectorAll('.col-sort[data-sort]')) {
@@ -357,21 +517,43 @@
       header.querySelector('.sort-mark')
         .replaceChildren(ladder(active ? (sortDown ? 'desc' : 'asc') : 'none'));
     }
+    // Заголовок колонки с отбором подсвечивается, имя колонки не меняется:
+    // что именно выбрано, говорит строка счётчика над таблицей.
     for (const button of document.querySelectorAll('.tool-filter')) {
       button.classList.toggle('is-active', Boolean(toolFilter));
     }
+    for (const button of document.querySelectorAll('.area-filter')) {
+      button.classList.toggle('is-active', Boolean(areaFilter));
+    }
 
-    // Строка нужна, только когда фильтр сузил каталог: без фильтра она
+    // Строка нужна, только когда отбор сузил каталог: без него она
     // повторила бы число, уже названное в шапке страницы.
-    shown.textContent = toolFilter ? `${rows.length} из ${scenarios.length} · ${toolFilter}` : '';
-    shown.hidden = !toolFilter;
+    const narrowed = Boolean(toolFilter || areaFilter || query);
+    const parts = [areaFilter, toolFilter, query && `«${query}»`].filter(Boolean);
+    shown.textContent = narrowed
+      ? (rows.length ? `${rows.length} из ${scenarios.length}` : 'Ничего не нашлось') + ' · ' + parts.join(' · ')
+      : '';
+    shownRow.hidden = !narrowed;
   }
+
+  const searchBox = document.getElementById('search');
+  searchBox.addEventListener('input', () => {
+    query = searchBox.value.trim();
+    writeHash();
+    render();
+  });
+  for (const button of document.querySelectorAll('.area-filter')) {
+    button.addEventListener('click', openAreas);
+  }
+  document.getElementById('area-close').addEventListener('click', () => areaDialog.close());
+  areaDialog.addEventListener('click', (event) => { if (event.target === areaDialog) areaDialog.close(); });
 
   for (const header of document.querySelectorAll('.col-sort[data-sort]')) {
     header.addEventListener('click', () => {
       const key = header.dataset.sort;
       if (key === sortKey) sortDown = !sortDown;
       else { sortKey = key; sortDown = false; }
+      writeHash();
       render();
     });
   }
@@ -383,6 +565,9 @@
   toolDialog.addEventListener('click', (event) => { if (event.target === toolDialog) toolDialog.close(); });
   document.getElementById('details-close').addEventListener('click', () => dialog.close());
   dialog.addEventListener('click', (event) => { if (event.target === dialog) dialog.close(); });
+  readHash();
+  searchBox.value = query;
+  window.addEventListener('hashchange', () => { readHash(); searchBox.value = query; render(); });
   render();
 </script>
 

--- a/docs/pages/site.css
+++ b/docs/pages/site.css
@@ -76,9 +76,15 @@
   .brand { display: flex; align-items: center; color: var(--blue); }
   .brand:hover { text-decoration: none; }
   .brand svg { height: 27px; width: auto; display: block; }
+  /* На узком экране от логотипа остаётся марка: слово не помещается рядом с
+     тремя пунктами меню, а марка узнаётся и одна. */
+  .brand .brand-mark { display: none; }
   @media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) .brand { color: var(--ink); } }
   :root[data-theme="dark"] .brand { color: var(--ink); }
   nav { margin-left: auto; display: flex; align-items: center; gap: 20px; flex-wrap: wrap; }
+  /* Кнопка темы стоит вне навигации: на телефоне ссылки уезжают в прокрутку,
+     а кнопка остаётся на месте. */
+  .bar > .theme { margin-left: 0; }
   nav a { color: var(--muted); font-size: 14px; }
   nav a:hover { color: var(--ink); text-decoration: none; }
   /* Ссылка с числом: сколько звёзд у репозитория, сколько людей в группе.
@@ -117,7 +123,19 @@
      порог контраста 3, а не 4,5 — приглушать его незачем. */
   .hero h1 span { color: var(--blue-fill); }
   .lede { font-size: clamp(17px, 2.2vw, 20px); color: var(--muted); max-width: 62ch; margin: 0 0 28px; }
-  .cta { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 34px; }
+  .cta { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; margin-bottom: 34px; }
+  /* Три системы одной тихой строкой: значок и слово, без рамок. Многие
+     инструменты для 1С живут только на Windows, поэтому это стоит сказать
+     сразу, но не громче кнопок. На десктопе строка стоит в ряду с кнопками
+     и закрывает пустоту справа, на телефоне уходит под кнопки по центру. */
+  .platforms { display: flex; flex-wrap: wrap; gap: 6px 22px; margin: 0 0 0 10px; font-size: 13px; color: var(--muted); }
+  /* Число сценариев живёт по тем же правилам: справа от кнопок, на телефоне
+     под ними по центру. Текстом, не баблом: бабл рядом с кнопками читается
+     как ещё одна кнопка. */
+  .cta-note { margin: 0 0 0 10px; font-size: 14px; color: var(--muted); }
+  .cta-note b { font-size: 17px; font-weight: 680; color: var(--ink); margin-right: 2px; }
+  .os { display: inline-flex; align-items: center; gap: 7px; }
+  .os svg { width: 15px; height: 15px; fill: currentColor; opacity: 0.85; }
   .btn {
     display: inline-flex; align-items: center; gap: 8px;
     padding: 11px 20px; border-radius: 10px; font-weight: 600; font-size: 15px;
@@ -128,11 +146,34 @@
   .btn-ghost { border-color: var(--line); color: var(--ink); background: var(--card); }
   .btn-ghost:hover { border-color: var(--blue); text-decoration: none; }
 
-  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(238px, 1fr)); gap: 16px; }
-  /* Между «все в строку» и «по одной» карточки идут парами: раскладка 3 + 1
-     выглядит обрывком, а не сеткой. */
+  /* auto-fill, а не auto-fit: одна карточка занимает своё место, а не всю
+     ширину, поэтому сетка выглядит одинаково при одной плитке и при четырёх. */
+  .cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px; }
+  /* Четыре и больше карточек идут парами: в три колонки они дают раскладку
+     3 + 1, а в четыре — плитка линии ужимается и переносит каждую строку. */
+  @media (min-width: 1101px) {
+    .cards:has(> :nth-child(4)) { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  }
   @media (max-width: 1100px) { .cards { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
-  @media (max-width: 560px) { .cards { grid-template-columns: 1fr; } }
+  /* На телефоне версия и пререлиз короткие и встают парой, плитка линии
+     занимает всю ширину: так четыре карточки не уводят установку на два
+     экрана вниз. */
+  @media (max-width: 560px) {
+    .cards { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+    .card-line { grid-column: 1 / -1; }
+    .card-version { padding: 16px; }
+    .card-version .metric { font-size: 22px; }
+    .card-version .sub { font-size: 12.5px; }
+    /* В узкой карточке ссылке на заметки не хватает места; номер версии
+       и так ведёт на выпуск. */
+    .card-version .card-action { display: none; }
+  }
+  /* Совсем узкий экран: пара карточек версий переносит и подпись, и номер,
+     поэтому они снова идут столбиком. */
+  @media (max-width: 400px) {
+    .cards { grid-template-columns: 1fr; }
+    .card-version .metric { font-size: 26px; }
+  }
   .card {
     background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
     padding: 20px 22px;
@@ -161,7 +202,7 @@
   }
   .note { font-size: 14px; color: var(--muted); }
 
-  /* Переключатель хостов держится на радиокнопках: без скрипта он работает
+  /* Переключатель агентов держится на радиокнопках: без скрипта он работает
      так же, как со скриптом. Скрипт нужен только кнопке «Скопировать». */
   .tabs { margin-top: 24px; }
   .tabs > input { position: absolute; opacity: 0; pointer-events: none; }
@@ -210,16 +251,24 @@
      не съедают высоту второй строкой. */
   @media (max-width: 760px) {
     .wrap { padding: 0 18px; }
-    .bar { height: 56px; gap: 12px; }
+    .bar { height: 56px; gap: 14px; }
     .brand { flex: none; }
     .brand svg { height: 24px; }
     nav {
-      margin-left: auto; gap: 18px; flex-wrap: nowrap; min-width: 0;
+      margin-left: auto; gap: 14px; flex-wrap: nowrap; min-width: 0;
       overflow-x: auto; -webkit-overflow-scrolling: touch;
       scrollbar-width: none; -ms-overflow-style: none;
     }
     nav::-webkit-scrollbar { display: none; }
     nav a { white-space: nowrap; }
+    /* Правый край тает только когда меню действительно не поместилось:
+       класс ставит скрипт по замеру. Иначе затухание съедало бы хвост
+       последнего пункта там, где всё влезло. */
+    nav.is-scrollable {
+      -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 28px), transparent);
+      mask-image: linear-gradient(to right, #000 calc(100% - 28px), transparent);
+      padding-right: 28px;
+    }
 
     .hero { padding-top: 44px; padding-bottom: 32px; }
     .eyebrow {
@@ -231,6 +280,7 @@
     .cta { gap: 10px; }
     .btn { flex: 1 1 calc(50% - 5px); justify-content: center; padding: 12px 14px; }
     .btn-primary { flex-basis: 100%; }
+    .platforms, .cta-note { flex-basis: 100%; justify-content: center; text-align: center; margin: 14px 0 0; }
 
     section { padding: 40px 0; }
     .card { padding: 18px; }
@@ -243,6 +293,18 @@
     .foot { gap: 18px; }
   }
 
+  /* Числа у значков пропадают там, где перестают помещаться, а не раньше. */
+  @media (max-width: 600px) { nav .chip .count { display: none; } }
+  /* Совсем узко: значки GitHub и Telegram уходят из шапки, они есть в
+     футере, а от логотипа остаётся марка. Кегль меню чуть меньше, чтобы три
+     пункта были видны целиком на 360 px. */
+  @media (max-width: 560px) {
+    nav .chip { display: none; }
+    .brand .brand-full { display: none; }
+    .brand .brand-mark { display: block; height: 26px; }
+    nav a { font-size: 13px; }
+  }
+
   /* Таблица из трёх колонок на телефоне превращается в столбик блоков:
      версия, статус, пояснение. Заголовки колонок при этом не нужны — роль
      ячейки видна по её месту и начертанию. */
@@ -253,8 +315,19 @@
     tr { border-bottom: 1px solid var(--line); padding: 14px 0; }
     td { border: 0; padding: 0; }
     td:nth-child(1) { margin-bottom: 7px; }
-    td:nth-child(2) { font-weight: 620; }
+    /* Полужирным только статус версии и область в каталоге: там вторая
+       ячейка — заголовок блока. В остальных таблицах она — пояснение. */
+    td:nth-child(2) { color: var(--muted); font-size: 14px; }
+    .catalog-table td:nth-child(2) { font-weight: 620; color: var(--ink); font-size: 15px; }
     td:nth-child(3) { color: var(--muted); font-size: 14px; margin-top: 3px; }
+    /* Версии платформы: строка становится карточкой. Слева номер платформы,
+       справа статус, под ними подпись с форматом выгрузки, чтобы без шапки
+       таблицы было понятно, что это за число. */
+    .versions tr { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 4px 12px; padding: 14px 0; }
+    .versions td:nth-child(1) { margin: 0; }
+    .versions td:nth-child(3) { grid-column: 2; grid-row: 1; margin: 0; }
+    .versions td:nth-child(2) { grid-column: 1 / -1; font-size: 13.5px; }
+    .versions td:nth-child(2)::before { content: "Формат выгрузки "; }
   }
 
   @media (max-width: 400px) {
@@ -282,19 +355,33 @@
 .caption { color: var(--muted); font-size: 14px; margin: 0 0 8px; }
 .pair { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; margin-top: 22px; }
 @media (max-width: 760px) { .pair { grid-template-columns: 1fr; } }
+/* Пояснения «почему так» — абзацы с полужирным вопросом, а не карточки:
+   рамка и подложка остаются плиткам и таблицам, где они разделяют объекты. */
+.pair .card { background: none; border: 0; border-top: 2px solid var(--line); border-radius: 0; padding: 14px 0 0; }
 .pair .card h4 { margin: 0 0 8px; font-size: 15px; }
 .pair .card p { margin: 0; color: var(--muted); font-size: 14px; }
 /* Имя файла или инструмента внутри фразы — тот же бабл, что и в таблицах:
    в приглушённом тексте одно моноширинное начертание его не выделяет. */
 .pair .card h4 code,
 .pair .card p code,
+.page-lede code,
 .caption code {
   background: color-mix(in srgb, var(--blue) 13%, transparent);
   color: var(--blue); padding: 2px 6px; border-radius: 5px;
 }
 td .tool { font-family: var(--mono); font-size: 13px; color: var(--blue); white-space: nowrap; }
+/* На телефоне диаграмма не ужимается до нечитаемого: она остаётся в своём
+   размере и прокручивается вбок, как разбор адреса. */
+.diagram-wrap { margin: 26px 0 10px; }
+.diagram-wrap .diagram { margin: 0; }
 @media (max-width: 760px) {
-  .diagram { margin: 18px -18px 10px; width: calc(100% + 36px); }
+  .diagram-wrap {
+    margin: 18px -18px 10px; padding: 0 18px;
+    overflow-x: auto; -webkit-overflow-scrolling: touch;
+    scrollbar-width: none; -ms-overflow-style: none;
+  }
+  .diagram-wrap::-webkit-scrollbar { display: none; }
+  .diagram-wrap .diagram { min-width: 720px; }
 }
 .diagram a .t-link { fill: var(--blue); }
 .diagram a:hover .t-link { text-decoration: underline; }
@@ -328,9 +415,53 @@ pre .k { color: var(--code-key); }
 pre .v { color: var(--code-val); }
 pre .p { color: var(--muted); }
 tr.planned td, tr.planned .tool { color: var(--muted); }
+/* Статус версии платформы: бабл в цвете смысла. Синий — впереди, зелёный —
+   есть, жёлтый — нет и не будет. Жёлтый берётся из раскраски значений в
+   коде: он уже подобран под обе темы. */
+.status {
+  display: inline-block; font-size: 13px; font-weight: 600; letter-spacing: 0.02em;
+  padding: 3px 10px; border-radius: 999px; white-space: nowrap; border: 1px solid;
+}
+.status-plan { color: var(--blue); border-color: color-mix(in srgb, var(--blue) 50%, transparent); background: color-mix(in srgb, var(--blue) 10%, transparent); }
+.status-ok { color: var(--ok); border-color: color-mix(in srgb, var(--ok) 50%, transparent); background: color-mix(in srgb, var(--ok) 10%, transparent); }
+.status-no { color: var(--code-val); border-color: color-mix(in srgb, var(--code-val) 50%, transparent); background: color-mix(in srgb, var(--code-val) 10%, transparent); }
+
 /* Идентификатор не переносится и держит ширину под пятизначный номер:
    при двух тысячах сценариев колонка не должна прыгать. */
 .id-col { width: 10ch; white-space: nowrap; }
+/* Фиксированная раскладка: ширины колонок заданы здесь и не зависят от
+   того, какие строки прошли отбор. На телефоне таблица становится блоками,
+   и раскладка не действует. */
+.catalog-table { table-layout: fixed; }
+.catalog-table .c-id { width: 8%; }
+.catalog-table .c-area { width: 17%; }
+.catalog-table .c-mode { width: 10%; }
+.catalog-table .c-tools { width: 20%; }
+/* Колонка с кнопкой в пикселях: доля от ширины в узкой панели меньше
+   самой кнопки, и её подрезало. */
+.catalog-table .c-open { width: 112px; }
+.catalog-table td { overflow-wrap: anywhere; }
+@media (max-width: 560px) {
+  .catalog-table { table-layout: auto; }
+  .catalog-table colgroup { display: none; }
+  /* Строка каталога — карточка, как у таблицы версий: номер и режим в
+     верхней строке, задача крупно, под ней область и инструменты мелко,
+     кнопка справа. Шесть строк подряд одним кеглем не читались. */
+  .catalog-table tbody#catalog tr {
+    display: grid; grid-template-columns: minmax(0, 1fr) auto; grid-template-rows: auto auto auto auto;
+    gap: 4px 12px; align-items: center; padding: 14px 0;
+  }
+  .catalog-table tbody#catalog td { margin: 0; }
+  .catalog-table td:nth-child(1) { grid-column: 1; grid-row: 1; font-size: 12.5px; color: var(--muted); }
+  /* Ячейка режима на десктопе держит ширину колонки; в карточке ей нужна
+     ширина по содержимому, иначе бабл висит слева от своего края. */
+  .catalog-table td:nth-child(4) { grid-column: 2; grid-row: 1; justify-self: end; width: auto; text-align: right; }
+  .catalog-table td:nth-child(3) { grid-column: 1 / -1; grid-row: 2; color: var(--ink); font-size: 15px; line-height: 1.45; margin-bottom: 4px; }
+  .catalog-table td:nth-child(2) { grid-column: 1; grid-row: 3; font-size: 13px; color: var(--muted); font-weight: 400; }
+  .catalog-table td:nth-child(5) { grid-column: 1; grid-row: 4; font-size: 12.5px; color: var(--muted); }
+  .catalog-table td:nth-child(6) { grid-column: 2; grid-row: 3 / 5; justify-self: end; }
+  #shown-row tr { display: block; padding: 10px 0 0; border: 0; }
+}
 
 /* Баджи сводки: две цифры рядом с призывом, а не отдельный блок карточек. */
 .badges { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 2px; }
@@ -351,10 +482,14 @@ tr.planned td, tr.planned .tool { color: var(--muted); }
     display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
     margin: 18px 0 0; font-size: 14px; color: var(--muted);
   }
+  /* Три кнопки должны встать в один ряд и на 320 px: кегль и отступы меньше,
+     чем в шапке таблицы. */
+  .toolbar { gap: 5px; }
   .toolbar .col-sort, .toolbar .col-filter {
-    border: 1px solid var(--line); border-radius: 999px; padding: 7px 13px;
-    background: var(--card);
+    border: 1px solid var(--line); border-radius: 999px; padding: 4px 7px;
+    background: var(--card); font-size: 11px; letter-spacing: 0.03em; gap: 4px;
   }
+  .toolbar .filter-icon { width: 13px; height: 13px; }
   .toolbar .col-sort.is-sorted, .toolbar .col-filter.is-active { border-color: var(--blue); }
 }
 .row-button {
@@ -375,6 +510,9 @@ dialog::backdrop { background: rgba(15, 23, 42, 0.42); }
   padding: 22px 24px 16px; border-bottom: 1px solid var(--line);
   position: sticky; top: 0; background: var(--card);
 }
+/* Фокус при открытии окна уходит на шапку, а не на кнопку закрытия: иначе
+   кнопка получает кольцо фокуса и выглядит иначе, чем в соседнем окне. */
+.dialog-head:focus { outline: none; }
 .dialog-head h3 { margin: 6px 0; font-size: 19px; letter-spacing: -0.01em; }
 .dialog-id { margin: 0; font-family: var(--mono); font-size: 12px; color: var(--blue); }
 .dialog-area { margin: 0; font-size: 13px; color: var(--muted); }
@@ -392,10 +530,6 @@ dialog::backdrop { background: rgba(15, 23, 42, 0.42); }
   background: color-mix(in srgb, var(--blue) 13%, transparent); color: var(--blue);
 }
 .step-tool { font-family: var(--mono); font-size: 13px; font-weight: 600; }
-.step-expect {
-  font-family: var(--mono); font-size: 11.5px; color: var(--muted);
-  border: 1px solid var(--line); border-radius: 999px; padding: 2px 9px;
-}
 .step pre { margin: 0; font-size: 12.5px; }
 @media (max-width: 760px) {
   .dialog-head { padding: 18px 16px 14px; }
@@ -403,7 +537,8 @@ dialog::backdrop { background: rgba(15, 23, 42, 0.42); }
 }
 
 /* Сортировка и отбор живут в шапке таблицы */
-.catalog-count { margin: 18px 0 0; font-size: 14px; color: var(--muted); font-variant-numeric: tabular-nums; }
+td.catalog-count { padding: 9px 12px; font-size: 13.5px; color: var(--muted); font-variant-numeric: tabular-nums; }
+@media (max-width: 560px) { td.catalog-count { padding: 6px 0 2px; } }
 .col-sort {
   display: inline-flex; align-items: center; gap: 6px; padding: 0;
   font: inherit; font-size: 13px; text-transform: uppercase; letter-spacing: 0.05em;
@@ -415,7 +550,15 @@ dialog::backdrop { background: rgba(15, 23, 42, 0.42); }
 .sort-mark svg { width: 12px; height: 12px; display: block; }
 .sort-mark rect { fill: currentColor; }
 .col-sort:not(.is-sorted) .sort-mark { opacity: 0.45; }
-.col-filter svg { width: 13px; height: 13px; fill: currentColor; }
+/* Два состояния воронки из Tabler Icons (MIT): filter, пока отбора нет, и
+   filter-check, когда отбор поставлен. Разница видна по значку, без чтения. */
+.col-filter .filter-icon {
+  width: 15px; height: 15px; fill: none; stroke: currentColor;
+  stroke-width: 2; stroke-linecap: round; stroke-linejoin: round;
+}
+.col-filter .filter-icon .on { display: none; }
+.col-filter.is-active .filter-icon .off { display: none; }
+.col-filter.is-active .filter-icon .on { display: block; }
 .tool-list { padding: 10px; display: grid; gap: 2px; }
 .tool-row {
   display: grid; grid-template-columns: max-content 1fr max-content; align-items: baseline; gap: 12px;
@@ -435,7 +578,14 @@ dialog::backdrop { background: rgba(15, 23, 42, 0.42); }
 /* Шаг цепочки: сверху запрос, снизу то, что проверяется в ответе */
 .step-label { margin: 12px 0 6px; font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); font-weight: 600; }
 .step-answer { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
-.step-expect { font-family: var(--mono); font-size: 12px; border-radius: 999px; padding: 3px 10px; border: 1px solid var(--line); color: var(--muted); }
+/* Чип класса ответа один и тот же в шаге, в легенде окна и в легенде под
+   каталогом: собственная высота строки, чтобы форма не зависела от того,
+   лежит он во flex-ряду или в обычной строке текста. */
+.step-expect {
+  display: inline-flex; align-items: center; line-height: 1.3;
+  font-family: var(--mono); font-size: 12px; border-radius: 999px; padding: 3px 10px;
+  border: 1px solid var(--line); color: var(--muted); vertical-align: middle;
+}
 .step-expect.is-ok { color: var(--ok); border-color: color-mix(in srgb, var(--ok) 45%, transparent); }
 .step-expect.is-refused, .step-expect.is-unsupported { color: var(--bad); border-color: color-mix(in srgb, var(--bad) 45%, transparent); }
 .step-expect.is-task, .step-expect.is-provider { color: var(--blue); border-color: color-mix(in srgb, var(--blue) 45%, transparent); }
@@ -449,13 +599,14 @@ dialog::backdrop { background: rgba(15, 23, 42, 0.42); }
    идти и что там лежит. Номер рисует счётчик, чтобы разметка осталась списком,
    а не списком с вписанными цифрами. */
 .steps { list-style: none; counter-reset: step; margin: 0; padding: 0; display: grid; gap: 12px; }
+.steps { gap: 0; }
 .steps li {
   counter-increment: step;
   /* minmax(0, 1fr), а не 1fr: иначе колонка не сжимается ниже своего
      min-content, и длинный путь распирает всю страницу на телефоне. */
   display: grid; grid-template-columns: 26px minmax(0, 1fr); gap: 14px; align-items: start;
-  background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
-  padding: 16px 20px;
+  border-bottom: 1px solid var(--line);
+  padding: 16px 4px;
 }
 .steps li::before {
   content: counter(step);
@@ -467,13 +618,14 @@ dialog::backdrop { background: rgba(15, 23, 42, 0.42); }
 /* Кликает вся карточка, а не только заголовок: цель у шага одна. */
 .steps li > a { display: block; color: var(--ink); }
 .steps li > a:hover { text-decoration: none; }
-.steps li:hover { border-color: var(--muted); }
 .steps li:hover b { color: var(--blue); }
-.steps b { display: block; font-weight: 620; font-size: 15px; overflow-wrap: anywhere; }
+/* Путь переносится только после слэша: разрыв внутри имени файла читается
+   как опечатка. Точки переноса стоят в разметке. */
+.steps b { display: block; font-weight: 620; font-size: 15px; overflow-wrap: normal; word-break: keep-all; }
 /* Путь до репозитория — опора для глаза, а имя файла — то, куда идти. */
 .steps .repo { color: var(--muted); font-weight: 500; }
 .steps p { margin: 4px 0 0; color: var(--muted); font-size: 14px; }
-@media (max-width: 560px) { .steps li { padding: 14px 16px; gap: 11px; } }
+@media (max-width: 560px) { .steps li { padding: 14px 0; gap: 11px; } }
 
 .card-action { white-space: nowrap; font-size: 13px; }
 /* Точка, число и слово — одна величина: переносится группа целиком. */
@@ -483,3 +635,153 @@ dialog::backdrop { background: rgba(15, 23, 42, 0.42); }
 .line-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .branch-icon { width: 13px; height: 13px; flex: none; fill: none; stroke: currentColor; stroke-width: 1.5; stroke-linecap: round; }
 .line-run { font-weight: 400; white-space: nowrap; }
+
+
+/* Установка в три шага: что понадобится, команды, первый запрос. */
+.setup { counter-reset: setup; display: grid; gap: 34px; margin-top: 22px; }
+/* На телефоне шаги без отступа списка: сорок пикселей слева отнимали
+   десятую часть экрана у текста. */
+@media (max-width: 760px) { .setup { padding-left: 0; gap: 28px; } }
+.setup > li { list-style: none; counter-increment: setup; }
+.setup h3 {
+  display: flex; align-items: center; gap: 12px; margin: 0 0 10px; font-size: 18px;
+}
+.setup h3::before {
+  content: counter(setup);
+  display: inline-flex; align-items: center; justify-content: center; flex: none;
+  width: 28px; height: 28px; border-radius: 8px; font-size: 14px; font-weight: 700;
+  background: color-mix(in srgb, var(--blue) 13%, transparent); color: var(--blue);
+}
+.setup p { color: var(--muted); max-width: 68ch; margin: 0 0 12px; }
+.setup .tabs { margin-top: 12px; }
+.needs { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; max-width: 68ch; }
+.needs li { position: relative; padding-left: 22px; }
+.needs li::before {
+  content: ""; position: absolute; left: 4px; top: 9px;
+  width: 8px; height: 8px; border-radius: 50%; background: var(--accent);
+}
+.needs b { font-weight: 620; }
+.needs span { color: var(--muted); }
+
+/* Пример диалога: реплика человека справа, ответ Unica слева, план — как
+   таблица изменений. Это разметка примера, а не живой чат. */
+.dialogue { display: grid; gap: 12px; max-width: 720px; margin-top: 14px; }
+.msg { padding: 12px 16px; border-radius: 14px; font-size: 15px; line-height: 1.5; }
+.msg-user {
+  justify-self: end; max-width: 80%;
+  background: var(--blue-fill); color: #fff; border-bottom-right-radius: 4px;
+}
+.msg-agent {
+  justify-self: start; max-width: 92%;
+  background: var(--card); border: 1px solid var(--line); border-bottom-left-radius: 4px;
+}
+.msg-agent p { margin: 0 0 8px; }
+.msg-agent p:last-child { margin: 0; }
+.msg-agent .who { display: block; font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); font-weight: 600; margin-bottom: 6px; }
+.plan-list { margin: 6px 0 0; padding: 0; list-style: none; display: grid; gap: 4px; font-size: 14px; }
+.plan-list li { position: relative; padding-left: 18px; }
+.plan-list li::before { content: "+"; position: absolute; left: 0; top: 0; color: var(--ok); font-family: var(--mono); font-weight: 700; }
+.plan-list li.same::before { content: "="; color: var(--muted); }
+
+/* Каталог: поиск, отбор по области, метка режима. */
+.catalog-controls { margin-top: 18px; }
+.search {
+  display: flex; align-items: center; gap: 10px;
+  border: 1px solid var(--line); border-radius: 10px; background: var(--card);
+  padding: 0 12px; flex: 1 1 320px; max-width: 520px;
+}
+.search svg { width: 16px; height: 16px; flex: none; fill: none; stroke: var(--muted); stroke-width: 2; stroke-linecap: round; }
+.search input {
+  flex: 1; min-width: 0; font: inherit; font-size: 15px; padding: 10px 0;
+  border: 0; background: none; color: var(--ink); outline: none;
+}
+.search input::placeholder { color: var(--muted); }
+.search:focus-within { border-color: var(--blue); }
+.area-name { font-size: 14px; }
+.tool-row.area-row { grid-template-columns: 1fr max-content; }
+.mode {
+  display: inline-block; font-size: 11.5px; font-weight: 600; letter-spacing: 0.03em;
+  padding: 2px 8px; border-radius: 999px; white-space: nowrap;
+  border: 1px solid var(--line); color: var(--muted);
+}
+.mode-write { color: var(--ok); border-color: color-mix(in srgb, var(--ok) 50%, transparent); }
+.mode-plan { color: var(--blue); border-color: color-mix(in srgb, var(--blue) 50%, transparent); }
+.mode-col { width: 9ch; white-space: nowrap; }
+.legend { margin-top: 26px; display: grid; gap: 6px; font-size: 14px; color: var(--muted); }
+.legend li { display: grid; grid-template-columns: 15ch 1fr; gap: 10px; align-items: baseline; list-style: none; }
+.legend ul { margin: 0; padding: 0; display: grid; gap: 6px; }
+.legend h3 { margin: 0 0 4px; font-size: 13px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); font-weight: 600; }
+/* Чип класса тот же, что в окне цепочки: одна раскраска в двух местах. */
+.legend .cls { display: inline-flex; align-items: baseline; gap: 8px; }
+.legend .cls small { font-size: 12.5px; color: var(--muted); font-variant-numeric: tabular-nums; }
+/* Легенда классов ответа: чип слева, значение справа, по строке на класс. */
+.dialog-legend {
+  display: grid; grid-template-columns: max-content 1fr; gap: 8px 12px; align-items: baseline;
+  margin: 0; padding: 14px 24px 20px; border-top: 1px solid var(--line);
+  font-size: 13px; color: var(--muted);
+}
+.dialog-legend dt, .dialog-legend dd { margin: 0; }
+.dialog-legend:empty { display: none; }
+/* Подпись отделяет легенду от последнего ответа: без неё тот же чип строкой
+   ниже читался как повтор. */
+.dialog-legend::before {
+  content: "Классы ответа"; grid-column: 1 / -1; margin-bottom: 2px;
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; font-weight: 600; color: var(--muted);
+}
+@media (max-width: 760px) { .dialog-legend { padding: 0 16px 16px; } }
+.contrib { margin-top: 40px; padding-top: 24px; border-top: 1px solid var(--line); }
+.contrib h3 { margin: 0 0 8px; font-size: 17px; }
+.contrib p { color: var(--muted); font-size: 14px; max-width: 68ch; margin: 0 0 14px; }
+
+/* Заглушка раздела, который пополнится после приёмки версии. */
+.stub {
+  border: 1px dashed var(--line); border-radius: var(--radius); padding: 18px 20px;
+  color: var(--muted); font-size: 15px; max-width: 68ch; margin-top: 22px;
+}
+.stub b { color: var(--ink); font-weight: 620; }
+
+/* Текст слева, короткий пример справа: восемь строк YAML на всю ширину
+   оставляли пустой ящик, а рядом с абзацами читаются как иллюстрация. */
+.split { display: grid; grid-template-columns: minmax(0, 3fr) minmax(0, 2fr); gap: 16px 40px; align-items: start; margin-top: 4px; }
+.split pre { margin: 0; font-size: 13px; }
+.split .caption { font-size: 15px; margin: 0 0 12px; }
+.split .caption code { background: color-mix(in srgb, var(--blue) 13%, transparent); color: var(--blue); padding: 2px 6px; border-radius: 5px; }
+@media (max-width: 760px) { .split { grid-template-columns: 1fr; gap: 14px; } }
+/* Таблица полей: имя поля не тянет на себя ширину, пояснение читается строкой. */
+.fields { margin-top: 26px; }
+.fields td { font-size: 14.5px; }
+/* Пояснение во второй колонке приглушено и на десктопе: имя поля и адрес
+   слева — то, что ищут глазами, справа — подпись к ним. */
+.fields td:nth-child(2), .addr-table td:nth-child(2) { color: var(--muted); }
+.note-line { margin-top: 14px; max-width: 68ch; }
+@media (max-width: 560px) {
+  .fields tr { padding: 12px 0; }
+  .fields td:nth-child(1) { margin-bottom: 4px; }
+}
+
+/* Сеть и данные: вопрос за вопросом, стопкой. Слева короткие факты, справа
+   то, что копируют: конфиг, команда, адреса. Три узкие колонки прозы не
+   читались и рвались на длинных путях. */
+.qa {
+  display: grid; grid-template-columns: minmax(0, 3fr) minmax(0, 2fr); gap: 16px 40px;
+  align-items: start; padding: 24px 0; border-top: 1px solid var(--line);
+}
+.qa:first-of-type { border-top: 0; margin-top: 10px; }
+.qa h3 { margin: 0 0 10px; font-size: 17px; }
+.qa-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 9px; font-size: 15px; color: var(--muted); }
+.qa-list li { position: relative; padding-left: 18px; }
+.qa-list li::before { content: ""; position: absolute; left: 2px; top: 10px; width: 7px; height: 7px; border-radius: 50%; background: var(--accent); }
+.qa-list code, .stub code, .setup p code, .needs code, .kv code {
+  background: color-mix(in srgb, var(--blue) 13%, transparent);
+  color: var(--blue); padding: 2px 6px; border-radius: 5px; overflow-wrap: anywhere;
+}
+.qa-aside pre { margin: 0; font-size: 12.5px; }
+.kv { display: grid; grid-template-columns: max-content minmax(0, 1fr); gap: 8px 14px; margin: 4px 0 0; font-size: 14px; }
+.kv dt { color: var(--muted); }
+.kv dd { margin: 0; overflow-wrap: anywhere; }
+/* Несколько имён в одной ячейке идут столбиком, каждое целиком. */
+.kv dd.stack { display: flex; flex-direction: column; align-items: flex-start; gap: 6px; }
+.kv dd.stack code { white-space: nowrap; }
+@media (max-width: 760px) {
+  .qa { grid-template-columns: 1fr; gap: 14px; padding: 20px 0; }
+}

--- a/docs/pages/site.js
+++ b/docs/pages/site.js
@@ -74,6 +74,18 @@
   ready(function () {
     apply(current());
 
+    // Навигация на телефоне прокручивается вбок. Тающий край показываем
+    // только когда пункты действительно не поместились: класс ставится по
+    // замеру и снимается при повороте экрана.
+    var nav = document.querySelector("header nav");
+    if (nav) {
+      var hint = function () {
+        nav.classList.toggle("is-scrollable", nav.scrollWidth > nav.clientWidth + 1);
+      };
+      hint();
+      window.addEventListener("resize", hint);
+    }
+
     var button = document.querySelector(".theme");
     if (button) {
       button.addEventListener("click", function () {
@@ -89,7 +101,7 @@
     // подсказка без единого слова. Тем, кто просил меньше движения, её не
     // показываем.
     var still = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)");
-    var scrollable = document.querySelectorAll(".table-wrap, .addr");
+    var scrollable = document.querySelectorAll(".table-wrap, .addr, .diagram-wrap");
     if (scrollable.length && window.IntersectionObserver && !(still && still.matches)) {
       // Кадры считаем сами: `scrollTo({behavior:"smooth"})` молча ничего не
       // делает там, где сглаживание отключено, и подсказка бы не показалась.

--- a/docs/visual-kit/README.md
+++ b/docs/visual-kit/README.md
@@ -9,3 +9,17 @@
 
 Open `index.html` directly. No network connection is required.
 The production plugin icon is not changed by this package.
+
+## Palette
+
+| Token | Value | Use |
+| --- | --- | --- |
+| Blue | `#2563EB` | Mark fill, primary buttons, links on light surfaces |
+| Blue on ink | `#7FA8E0` | Links and accents on dark surfaces: the site in dark theme, dark IDE panels. Fills keep plain Blue |
+| Signal | `#93C5FD` | The mark's dot, small accents, highlights on Blue |
+| Ink | `#0F172A` | Text on light surfaces, dark backgrounds |
+| Paper | `#F8FAFC` | Page background |
+| Neutral 200 | `#D8DEE8` | Rules and borders |
+| Neutral 500 | `#64748B` | Secondary text |
+
+`Blue on ink` exists because plain Blue on Ink reads as a fill, not as a link: white text on it is legible, blue text next to it is not. Keep fills on Blue and move text accents to Blue on ink.

--- a/scripts/ci/build-site.py
+++ b/scripts/ci/build-site.py
@@ -46,7 +46,7 @@ def render_pages(status: Path, out: Path) -> list[str]:
         raise SystemExit("status carries generated corpus values: " + ", ".join(overlap))
     status_document.update(generated)
 
-    (out / "assets").mkdir(parents=True, exist_ok=True)
+    module.copy_assets(out)
     written = []
     for template in sorted(module.PAGES.glob("*.html")):
         page = module.render(template.read_text(encoding="utf-8"), status_document)
@@ -56,8 +56,6 @@ def render_pages(status: Path, out: Path) -> list[str]:
     (out / "status.json").write_text(
         json.dumps(status_document, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
     )
-    for asset in (module.MARK, module.VISUAL_KIT):
-        shutil.copy2(asset, out / "assets" / asset.name)
     return written
 
 

--- a/scripts/ci/render-pages.py
+++ b/scripts/ci/render-pages.py
@@ -23,6 +23,20 @@ MARK = REPO_ROOT / "docs" / "visual-kit" / "logos" / "unica-mark-blue.svg"
 # Визуальный набор кладётся рядом с сайтом, а не ссылкой на репозиторий:
 # ссылка на файл в гите ведёт на просмотрщик, а не на сам PDF.
 VISUAL_KIT = REPO_ROOT / "docs" / "visual-kit" / "unica-visual-kit.pdf"
+# Карточка для мессенджеров и соцсетей: без неё ссылка на сайт уходит в
+# Telegram голой строкой. Баннер 1200×628 из кита подходит по пропорции.
+SOCIAL_CARD = REPO_ROOT / "docs" / "visual-kit" / "ads" / "unica-ad-1200x628.png"
+ASSETS = (
+    (MARK, MARK.name),
+    (VISUAL_KIT, VISUAL_KIT.name),
+    (SOCIAL_CARD, "unica-social-card.png"),
+)
+
+
+def copy_assets(out: Path) -> None:
+    (out / "assets").mkdir(parents=True, exist_ok=True)
+    for source, name in ASSETS:
+        shutil.copy2(source, out / "assets" / name)
 STYLESHEET = PAGES / "site.css"
 SCRIPT = PAGES / "site.js"
 # Стили и скрипт лежат отдельными файлами, чтобы их правили в одном месте, но
@@ -134,7 +148,7 @@ def main() -> int:
         )
     status.update(generated)
     out = args.out
-    (out / "assets").mkdir(parents=True, exist_ok=True)
+    copy_assets(out)
 
     written = []
     for template in sorted(args.pages.glob("*.html")):
@@ -144,8 +158,6 @@ def main() -> int:
         written.append(template.name)
 
     (out / "status.json").write_text(json.dumps(status, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-    for asset in (MARK, VISUAL_KIT):
-        shutil.copy2(asset, out / "assets" / asset.name)
     print("written: " + ", ".join(written))
     return 0
 

--- a/scripts/ci/scenario-status.py
+++ b/scripts/ci/scenario-status.py
@@ -17,6 +17,31 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CORPUS = REPO_ROOT / "tests" / "fixtures" / "acceptance" / "scenario-corpus.json"
 
+# Режим сценария по его цепочке: пишет ли он файлы, только строит план или
+# ничего не меняет. Каталог называется «что умеет», и без этой метки
+# сценарий с превью читается как сценарий с записью.
+MODE_LABEL = {"write": "запись", "plan": "план", "read": "чтение"}
+
+# Классы ответа, которые замораживает приёмочный корпус, и их смысл словами.
+# Порядок — от обычного к редкому; класс без сценариев в легенду не попадает.
+CLASS_NOTES = (
+    ("ok", "инструмент ответил результатом"),
+    ("task", "работа ушла в фоновую задачу, вернулась квитанция"),
+    ("provider", "ответ зависит от внешнего поставщика: сети или платформы"),
+    ("refused", "намеренный отказ по правилу, с кодом и причиной"),
+    ("unsupported", "в этой версии не поддержано, отказ типизирован"),
+    ("gap", "известный пробел, причина записана в корпусе"),
+    ("cancelled", "задача отменена по запросу"),
+    ("failed", "задача завершилась отказом"),
+)
+
+
+def scenario_mode(scenario: dict) -> str:
+    applies = [step for step in scenario["wire"] if step["tool"] in ("unica.apply", "unica.run")]
+    if any(not (step.get("args") or {}).get("dryRun", False) for step in applies):
+        return "write"
+    return "plan" if applies else "read"
+
 
 def build(corpus: dict) -> dict[str, object]:
     scenarios = corpus["scenarios"]
@@ -24,6 +49,9 @@ def build(corpus: dict) -> dict[str, object]:
     ops = collections.Counter()
     steps = 0
     rows = []
+
+    classes = collections.Counter()
+    modes = collections.Counter()
 
     for scenario in scenarios:
         areas[scenario["area"]] += 1
@@ -36,12 +64,18 @@ def build(corpus: dict) -> dict[str, object]:
             for operation in (step.get("args") or {}).get("ops") or []:
                 if isinstance(operation, dict) and "op" in operation:
                     ops[operation["op"]] += 1
+            for expected in step.get("expect") or []:
+                classes[expected] += 1
+        mode = scenario_mode(scenario)
+        modes[mode] += 1
         rows.append(
             {
                 "id": scenario["id"],
                 "area": scenario["area"],
                 "task": scenario["task"],
                 "tools": " · ".join(tools),
+                "mode": MODE_LABEL[mode],
+                "mode_key": mode,
             }
         )
 
@@ -55,6 +89,7 @@ def build(corpus: dict) -> dict[str, object]:
             "area": scenario["area"],
             "task": scenario["task"],
             "workspace": scenario.get("workspace", ""),
+            "mode": scenario_mode(scenario),
             "wire": [
                 {
                     "tool": step["tool"],
@@ -86,6 +121,20 @@ def build(corpus: dict) -> dict[str, object]:
         "ops": [
             {"op": op, "op_count": f"{count}"}
             for op, count in sorted(ops.items(), key=lambda item: (-item[1], item[0]))
+        ],
+        # Сколько сценариев действительно записывают файлы: заголовок «что умеет»
+        # без этой цифры выдаёт план за запись.
+        "writes_total": f"{modes['write']}",
+        "plans_total": f"{modes['plan']}",
+        "reads_total": f"{modes['read']}",
+        "classes": [
+            {
+                "cls": name,
+                "cls_count": f"{classes.get(name, 0)}",
+                "cls_note": note,
+            }
+            for name, note in CLASS_NOTES
+            if classes.get(name, 0)
         ],
         "scenarios": rows,
         "scenarios_json": blob,

--- a/scripts/ci/site-status.py
+++ b/scripts/ci/site-status.py
@@ -199,14 +199,18 @@ def main() -> int:
     }
 
     # Пререлиз показывается только пока он впереди опубликованной версии:
-    # прошлогодний rc уже ничего не готовит.
+    # прошлогодний rc уже ничего не готовит. Список из нуля или одного
+    # элемента: страница не показывает «планируется» вместо пустого места.
     newest = max(prereleases, key=lambda r: moment(r["published_at"]), default=None)
+    status["prereleases"] = []
     if newest and moment(newest["published_at"]) > moment(latest["published_at"]):
-        status["prerelease"] = newest["tag_name"]
-        status["prerelease_note"] = "опубликован " + human(moment(newest["published_at"]))
-    else:
-        status["prerelease"] = "Планируется"
-        status["prerelease_note"] = "сборка перед публикацией"
+        status["prereleases"].append(
+            {
+                "prerelease": newest["tag_name"],
+                "prerelease_date": human(moment(newest["published_at"])),
+                "prerelease_url": newest["html_url"],
+            }
+        )
 
     tested, plain = [], []
     for line in site_lines(args.branch, args.repo, now):


### PR DESCRIPTION
## Что сделано

Сайт переработан по итогам ревью от пяти ролей (UI, UX, три уровня специалиста 1С) и последующих правок в предпросмотре.

### Главная
- Установка в три шага: «Что понадобится» со ссылками на Codex и Claude Code, команды, «Первый запрос» с примером диалога.
- Версия и пререлиз карточками в одной сетке с плитками прогонов; заглушки «Планируется» и «Нет прогонов» убраны, плитки появляются только у линий с отчётом.
- Таблица версий платформы: платформа, формат выгрузки, статус баблом (планируем, поддержали, не планируем) и причина, почему старые ветки не поддерживаем.
- Строка Windows · macOS · Linux рядом с кнопками; og-разметка с карточкой из кита.

### Что умеет (бывшие «Сценарии»)
- Поиск по задаче, отбор по области и инструменту в заголовках колонок, иконки Tabler filter / filter-check для состояний.
- Метка режима (чтение, план, запись) у каждой строки, фиксированные ширины колонок, строка счётчика между шапкой и первой строкой, легенда классов ответа.
- Окно цепочки: легенда только по классам этой цепочки, фокус не на кнопке закрытия.
- На телефоне строки каталога карточками.

### Архитектура
- Раздел «Сеть и данные»: что уходит с машины, что качается, офлайн и прокси, v8-runner и его загрузки.
- Заглушка «На чём проверено» до приёмки 0.13.
- unica.run описан словарём операций 0.13, unica.resolve вместо unica.find, граница EDT.
- «Набор исходников» скомпонован заново: текст и пример рядом, таблица полей короче.

### Везде
- Кнопка темы вне прокручиваемой навигации, на телефоне марка вместо логотипа и меню без обрезки.
- Диаграммы на телефоне прокручиваются, а не ужимаются.
- Термин «хост» заменён на «агент».
- Тёмный акцент закреплён в README visual kit.

### Сборка
- `scenario-status.py`: режим сценария, счётчики записи/плана/чтения и классов ответа.
- `site-status.py`: пререлиз списком из нуля или одного элемента.
- `render-pages.py` / `build-site.py`: копирование социальной карточки в ассеты.

## Проверка
- Сборка проходит на настоящем статусе из GitHub API и на четырёх смоделированных состояниях (версия, пререлиз, линии с тестами).
- Все страницы отрендерены на 1440, 1280, 1024, 800, 640, 560, 500, 430, 390, 360 и 320 px в обеих темах.
- Встроенные скрипты проверены на синтаксис.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added searchable, filterable scenario catalog with modes, response classifications, URL-shareable filters, and contributor information.
  - Added platform support details, installation guidance, first-request examples, and release/build information to the landing page.
  - Added network and data behavior guidance and expanded architecture documentation.
  - Added social sharing previews and responsive diagram presentation across documentation pages.

- **Documentation**
  - Updated terminology and navigation labels for clearer guidance.
  - Added brand color usage guidance to the Visual Kit.
  - Improved mobile layouts, tables, navigation, setup steps, and visual status indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->