### PR TITLE
fix(pages): пересборка линии из сохранённых результатов не удваивает историю

### DIFF
--- a/scripts/ci/build-site.py
+++ b/scripts/ci/build-site.py
@@ -88,6 +88,44 @@ def carry_history(results: Path, site: str | None, line: str) -> int:
     return carried
 
 
+TREND_FILES = tuple(name for name in HISTORY_FILES if name != "history.json")
+
+
+def unwind_history(history: Path) -> int:
+    """Снять вершину перенесённой истории перед пересборкой из сохранённых результатов.
+
+    Вершина — тот самый прогон, что сейчас пересобирается: Allure положит его
+    в историю заново, и без этого каждая пересборка сайта удваивала бы запуск
+    в тренде и в истории каждого теста. Тест с единственным запуском убирается
+    целиком — Allure заведёт его заново тем же запуском.
+    """
+    unwound = 0
+    for name in TREND_FILES:
+        path = history / name
+        if not path.is_file():
+            continue
+        entries = json.loads(path.read_text(encoding="utf-8"))
+        if entries:
+            path.write_text(json.dumps(entries[1:], ensure_ascii=False), encoding="utf-8")
+            unwound += 1
+    path = history / "history.json"
+    if path.is_file():
+        kept = {}
+        for key, entry in json.loads(path.read_text(encoding="utf-8")).items():
+            items = list(entry.get("items", []))
+            if len(items) < 2:
+                continue
+            top, rest = items[0], items[1:]
+            statistic = dict(entry.get("statistic", {}))
+            for field in (str(top.get("status", "")).lower(), "total"):
+                if statistic.get(field, 0) > 0:
+                    statistic[field] -= 1
+            kept[key] = {**entry, "statistic": statistic, "items": rest}
+        path.write_text(json.dumps(kept, ensure_ascii=False), encoding="utf-8")
+        unwound += 1
+    return unwound
+
+
 def previous_results(site: str | None, line: str, work: Path) -> Path | None:
     """Взять результаты последнего опубликованного прогона линии с сайта.
 
@@ -132,6 +170,8 @@ def record_run(data: Path, line: str, fresh: bool, args: argparse.Namespace) -> 
 def publish_line(out: Path, line: str, results: Path, fresh: bool, args: argparse.Namespace) -> str:
     """Собрать отчёт линии и положить рядом сырые данные для следующего раза."""
     carried = carry_history(results, args.site, line)
+    if not fresh and carried:
+        unwind_history(results / "history")
     if shutil.which(args.allure_command) is None:
         raise SystemExit(
             f"{args.allure_command} не найден: поставьте Allure CLI или уберите линию из сборки"
@@ -152,7 +192,7 @@ def publish_line(out: Path, line: str, results: Path, fresh: bool, args: argpars
         shutil.copy2(summary, data / "summary.json")
     record_run(data, line, fresh, args)
     return f"{line}: отчёт собран, файлов истории {carried}, результаты " + (
-        "свежие" if fresh else "с сайта"
+        "свежие" if fresh else "с сайта, вершина истории снята"
     )
 
 

--- a/scripts/ci/collect-results.py
+++ b/scripts/ci/collect-results.py
@@ -145,7 +145,8 @@ def write_metadata(out: Path, run: dict, line: str, runners: list[str], site: st
         "buildOrder": int(run["run_id"]) if str(run.get("run_id", "")).isdigit() else 0,
         "buildName": f"{line} · {run.get('sha', '')[:7]}",
         "buildUrl": run.get("run_url", ""),
-        "reportUrl": f"{site}/allure/{line}/" if site else "",
+        # Без завершающей косой черты: Allure сам дописывает `/#testresult/…`.
+        "reportUrl": f"{site}/allure/{line}" if site else "",
     }
     (out / "executor.json").write_text(json.dumps(executor, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 

--- a/tests/ci/test_build_site.py
+++ b/tests/ci/test_build_site.py
@@ -1,0 +1,46 @@
+"""Пересборка линии из сохранённых результатов не удваивает историю."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "ci" / "build-site.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("build_site", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class UnwindHistoryTests(unittest.TestCase):
+    def test_unwind_drops_the_rebuilt_launch_from_trends_and_test_history(self) -> None:
+        """Вершина истории — пересобираемый прогон; Allure положит его заново."""
+        module = load_module()
+        history = Path(tempfile.mkdtemp(prefix="history-"))
+        (history / "history-trend.json").write_text(json.dumps([{"buildOrder": 2}, {"buildOrder": 1}]), encoding="utf-8")
+        (history / "duration-trend.json").write_text(json.dumps([{"buildOrder": 2}]), encoding="utf-8")
+        (history / "history.json").write_text(json.dumps({
+            "old": {"statistic": {"failed": 1, "passed": 1, "total": 2}, "items": [{"status": "failed"}, {"status": "passed"}]},
+            "new": {"statistic": {"passed": 1, "total": 1}, "items": [{"status": "passed"}]},
+        }), encoding="utf-8")
+
+        unwound = module.unwind_history(history)
+
+        self.assertEqual(3, unwound)
+        self.assertEqual([{"buildOrder": 1}], json.loads((history / "history-trend.json").read_text(encoding="utf-8")))
+        self.assertEqual([], json.loads((history / "duration-trend.json").read_text(encoding="utf-8")))
+        tests = json.loads((history / "history.json").read_text(encoding="utf-8"))
+        self.assertEqual({"old"}, set(tests))
+        self.assertEqual({"failed": 0, "passed": 1, "total": 1}, tests["old"]["statistic"])
+        self.assertEqual([{"status": "passed"}], tests["old"]["items"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ci/test_collect_results.py
+++ b/tests/ci/test_collect_results.py
@@ -97,7 +97,7 @@ class CollectResultsTests(unittest.TestCase):
         self.assertIn("Попытка=2", decoded)
         executor = json.loads((out / "executor.json").read_text(encoding="utf-8"))
         self.assertEqual(executor["buildOrder"], 42)
-        self.assertEqual(executor["reportUrl"], "https://example.invalid/allure/release-v0.12/")
+        self.assertEqual(executor["reportUrl"], "https://example.invalid/allure/release-v0.12")
 
     def test_no_result_artifacts_is_a_refusal(self) -> None:
         self.artifacts.mkdir(parents=True)


### PR DESCRIPTION
## Что сделано

Push в `main` пересобирает отчёт линии из результатов, лежащих на сайте, и Allure кладёт тот же прогон в историю заново. После двух push-ов на сайте в тренде `main` лежало три запуска, два из них — один и тот же прогон 33935877515.

- `build-site.py`: перед пересборкой из сохранённых результатов снимается вершина перенесённой истории (`unwind_history`): из четырёх трендов — первая запись, из истории каждого теста — первый запуск с поправкой статистики; тест с единственным запуском убирается целиком, Allure заведёт его заново тем же запуском. Свежие результаты идут как раньше.
- `collect-results.py`: `reportUrl` без завершающей косой черты — в ссылках истории выходило `allure/main//#testresult/…`.

## Проверено

- Сквозная проверка на живых данных `main` (10 264 записи, история с сайта) той же версией Allure, что на сайте, — 2.35.1: после снятия вершины и генерации история совпадает с исходной один в один — 10 264 ключа, по 3 запуска на тест, та же статистика, тренд `[33937383259, 33935877515, 33935877515]`.
- Локальный Allure 2.46.1 для этой проверки не годится: он ведёт ключи истории в составном формате и мигрирует старые — на нём картина расходится по версии, а не по коду.
- `tests.ci.test_build_site` (новый), `test_collect_results`, `test_suite_hygiene` — зелёные.

## Что покажет только прод

Следующая push-пересборка `main` без свежих результатов: сохранённая история не должна вырасти. Дубль, уже лежащий на сайте, уйдёт сам, когда окно истории сдвинется.