### PR TITLE
fix(nightly): адрес запущенного прогона — в stderr, stdout только для GITHUB_OUTPUT

### DIFF
--- a/scripts/ci/nightly-lines.py
+++ b/scripts/ci/nightly-lines.py
@@ -61,7 +61,12 @@ def has_platform(repo: str, line: str, gh) -> bool:
 
 
 def dispatch_large(line: str) -> None:
-    subprocess.run(["gh", "workflow", "run", LARGE_WORKFLOW, "--ref", line], check=True)
+    # `gh` печатает адрес прогона в stdout, а stdout этого скрипта — строки
+    # для GITHUB_OUTPUT: чужая строка там — отказ раннера. Адрес — в stderr.
+    completed = subprocess.run(
+        ["gh", "workflow", "run", LARGE_WORKFLOW, "--ref", line], check=True, capture_output=True, text=True
+    )
+    print(f"{line}: {completed.stdout.strip() or 'запущен'}", file=sys.stderr)
 
 
 def enumerate_lines(repo: str, site: str, now: datetime, *, gh, fetch, open_lines, platform=None) -> list[dict]:

--- a/tests/ci/test_nightly_lines.py
+++ b/tests/ci/test_nightly_lines.py
@@ -76,5 +76,29 @@ class NightlyLinesTests(unittest.TestCase):
         self.assertEqual(self.module.dispatch(self.decisions(memory=memory), run_workflow=lambda line: None), [])
 
 
+    def test_dispatch_prints_the_run_address_to_stderr_not_stdout(self) -> None:
+        """stdout скрипта — строки для GITHUB_OUTPUT; адрес прогона от `gh` идёт в stderr."""
+        import contextlib
+        import io
+
+        module = self.module
+        calls = []
+
+        class Completed:
+            stdout = "https://github.com/x/actions/runs/1\n"
+
+        original = module.subprocess.run
+        module.subprocess.run = lambda command, **kwargs: (calls.append(command), Completed())[1]
+        out, err = io.StringIO(), io.StringIO()
+        try:
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                module.dispatch_large("main")
+        finally:
+            module.subprocess.run = original
+
+        self.assertEqual(out.getvalue(), "")
+        self.assertIn("runs/1", err.getvalue())
+        self.assertEqual(calls[0][:6], ["gh", "workflow", "run", "unica-large.yml", "--ref", "main"])
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Что сделано

Первый ручной запуск ночи (33960628026) перечислил линии верно и запустил `Unica Large` на `main`, но сам покраснел: `gh workflow run` печатает адрес прогона в stdout, а stdout скрипта уходит в `GITHUB_OUTPUT` — раннер отверг строку без `имя=значение`. Вывод `gh` теперь перехватывается и идёт в stderr; тест держит контракт stdout.

## Проверено

`tests.ci.test_nightly_lines` (новый тест на перехват `subprocess.run`), `test_suite_hygiene` — зелёные.

## Что покажет только прод

Следующий ручной запуск ночи: `main` сдвинулся этим же вливанием — «вершина сдвинулась — запущен», прогон зелёный; запуск после него — «вершина на месте», ничего не запущено.