### PR TITLE
ci: очередь слияния — событие merge_group, профиль queue, контур гейта

### DIFF
--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+  # Очередь слияния: прогон на будущем состоянии main пачкой pull request.
+  # Здесь ловится то, что отбор по размеру на pull request пропускает.
+  merge_group:
+    types: [checks_requested]
   # Push в main и релизную линию — ворота линии: полный набор тестов без
   # отбора по файлам и без упаковки. Отсюда сайт собирает опубликованный
   # отчёт (`workflow_run` в unica-pages.yml). Упаковка, холодный старт и
@@ -16,12 +20,10 @@ on:
 permissions:
   contents: read
 
-# Ворота → профиль исполнителя: pull request — `pr`, push в ветку и ручной
-# запуск — `main`, тег — `release`; очередь слияния (`queue`) появится вместе
-# с ней. Сегодня каждый профиль гоняет всё, разница — только в подписи
-# результатов; отбор по размеру придёт вместе с расстановкой размеров.
+# Ворота → профиль исполнителя: pull request — `pr`, очередь слияния —
+# `queue`, push в ветку и ручной запуск — `main`, тег — `release`.
 env:
-  GATE_PROFILE: ${{ github.event_name == 'pull_request' && 'pr' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) && 'release' || 'main' }}
+  GATE_PROFILE: ${{ github.event_name == 'pull_request' && 'pr' || github.event_name == 'merge_group' && 'queue' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) && 'release' || 'main' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/scripts/ci/evaluate-ci-gate.py
+++ b/scripts/ci/evaluate-ci-gate.py
@@ -102,15 +102,18 @@ def expected_results(
     # Push в main или релизную линию — ворота линии: полный набор тестов без
     # упаковки. Отсюда сайт собирает опубликованный отчёт.
     is_branch = event_name == "push" and ref.startswith("refs/heads/")
+    # Очередь слияния — ворота будущего main: полный набор без отбора и без
+    # упаковки, как push в ветку.
+    is_queue = event_name == "merge_group"
     is_manual = event_name == "workflow_dispatch"
     is_pr = event_name == "pull_request"
-    if not (is_tag or is_branch or is_manual or is_pr):
-        invalid["event"] = (f"{event_name}:{ref}", "pull_request, branch push, tag push, or workflow_dispatch")
+    if not (is_tag or is_branch or is_queue or is_manual or is_pr):
+        invalid["event"] = (f"{event_name}:{ref}", "pull_request, merge_group, branch push, tag push, or workflow_dispatch")
 
-    if (is_tag or is_branch or is_manual) and not all(values.values()):
+    if (is_tag or is_branch or is_queue or is_manual) and not all(values.values()):
         invalid["classification"] = (
             ", ".join(name for name, enabled in values.items() if not enabled) or "invalid",
-            "all contours enabled for tag, branch push or workflow_dispatch",
+            "all contours enabled for tag, branch push, merge_group or workflow_dispatch",
         )
 
     full_matrix = values["platform_changed"] or values["toolchain_changed"] or values["ci_changed"]
@@ -144,6 +147,8 @@ def expected_results(
         contour = "full"
     elif is_branch:
         contour = "branch"
+    elif is_queue:
+        contour = "queue"
     elif not is_pr:
         contour = "invalid"
     elif all(values.values()) or values["ci_changed"]:

--- a/tests/ci/test_evaluate_ci_gate.py
+++ b/tests/ci/test_evaluate_ci_gate.py
@@ -339,6 +339,23 @@ class BranchPushGateTests(unittest.TestCase):
         for job in (*PACKAGE_SUCCESS, *ASSESSMENT_SUCCESS, *P0_SUCCESS, "probe-thin-bootstrap"):
             self.assertEqual("skipped", evaluation.expected[job], job)
 
+    def test_merge_group_is_the_queue_gate_full_tests_no_package_pipeline(self) -> None:
+        """Очередь слияния гоняет всё, как push в ветку; упаковка остаётся тегу."""
+        module = load_gate_module()
+        outputs = classification(**{name: True for name in OUTPUT_NAMES})
+        results = {
+            **source_results(),
+            "test-rust-platforms": "success",
+            "test-search-integration": "success",
+        }
+
+        evaluation = module.evaluate_gate("merge_group", "refs/heads/gh-readonly-queue/main/pr-738-abc", outputs, results)
+
+        self.assertTrue(evaluation.ok)
+        self.assertEqual("queue", evaluation.contour)
+        for job in (*PACKAGE_SUCCESS, *ASSESSMENT_SUCCESS, *P0_SUCCESS, "probe-thin-bootstrap"):
+            self.assertEqual("skipped", evaluation.expected[job], job)
+
     def test_branch_push_with_partial_classification_is_invalid(self) -> None:
         """На ветке отбора по файлам нет: неполная классификация — ошибка гейта."""
         module = load_gate_module()

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -500,10 +500,12 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         text = self.release_text()
 
         self.assertIn(
-            "GATE_PROFILE: ${{ github.event_name == 'pull_request' && 'pr' || "
+            "GATE_PROFILE: ${{ github.event_name == 'pull_request' && 'pr' || github.event_name == 'merge_group' && 'queue' || "
             "(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) && 'release' || 'main' }}",
             text,
         )
+        # Очередь слияния: конвейер отвечает на merge_group, иначе очередь ждёт вечно.
+        self.assertIn("  merge_group:\n    types: [checks_requested]", text)
         self.assertNotIn("run-tests.py --profile all", text)
 
     def test_line_rides_in_the_signature_and_tags_resolve_to_a_release_line(self) -> None:


### PR DESCRIPTION
## Что сделано

Конвейер учится очереди слияния до её включения — иначе очередь ждала бы проверку «Unica CI», которой прогон на `merge_group` ещё не даёт.

- `unica-plugin-release.yml`: триггер `merge_group` (`checks_requested`), профиль ворот `queue` для этого события.
- `evaluate-ci-gate.py`: событие `merge_group` допустимо, контур `queue` — как push в ветку: полная классификация, упаковка, оценка, проба и публикация `skipped`.
- Стражи workflow и гейта.

## Проверено

`tests.ci.test_unica_workflow`, `test_evaluate_ci_gate`, `test_gate_profiles`, `test_suite_hygiene` — зелёные.

## Что дальше

После вливания в ruleset «protected branches» (`main`, `release-*`) добавляется правило `merge_queue` (squash, до 5 в сборке, слияние по одному, ожидание 5 минут, срок проверки 60 минут); первым через очередь пойдёт PR с записью решения в замысле.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for running CI checks through the merge queue.
  - Merge queue runs now use a dedicated queue profile and apply the appropriate validation rules.
  - Merge queue checks run the applicable test suites while skipping jobs not required for queued changes.

- **Tests**
  - Added coverage confirming merge queue triggers, profile selection, and job execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->