### PR TITLE
test: обходы дерева идут через git ls-files — .DS_Store не роняет три теста

### DIFF
--- a/tests/arch/test_registry.py
+++ b/tests/arch/test_registry.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import ast
 import importlib.util
 import hashlib
+import os
 import re
 import subprocess
 import sys
@@ -206,6 +207,39 @@ def evidence_reference_error(
         qualifier = " an executable test" if require_executable else ""
         return f"{owner}: {path_text} does not declare{qualifier} {name}"
     return None
+
+
+def repository_files(repo_root: Path, *pathspecs: str) -> list[Path]:
+    """Files git tracks or would track under `pathspecs`; ignored files never enter.
+
+    `Path.rglob` also returns what the desktop drops into a checkout: `.DS_Store`,
+    editor swap files, a locally built binary. One such file breaks a text scan on
+    a developer machine while CI, whose checkout carries none of them, stays
+    green. A file git ignores is not part of the repository, so it is not part
+    of a scan; an untracked file git would accept still is, exactly as with
+    `rglob`. A tracked file deleted from the working tree is still listed, so
+    callers keep their `is_file()` guard.
+    """
+    listed = subprocess.run(
+        ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard", "--", *pathspecs],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+    ).stdout.split(b"\0")
+    return sorted(repo_root / os.fsdecode(raw_path) for raw_path in listed if raw_path)
+
+
+def archive_digests(repo_root: Path, archive: Path) -> dict[str, str]:
+    """SHA-256 of every archive file, keyed by its archive-relative path.
+
+    The manifest itself is the expectation, not a member of the archive.
+    """
+    manifest = archive / "MANIFEST.sha256"
+    return {
+        path.relative_to(archive).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in repository_files(repo_root, archive.relative_to(repo_root).as_posix())
+        if path.is_file() and path != manifest
+    }
 
 
 def contract_record(props: dict) -> REGISTRY.Record:
@@ -945,13 +979,37 @@ class LayerBoundaryTests(unittest.TestCase):
             self.assertEqual(separator, "  ", f"malformed archive manifest line: {line!r}")
             expected[relative] = digest
 
-        actual = {
-            path.relative_to(ARCHIVE).as_posix(): hashlib.sha256(path.read_bytes()).hexdigest()
-            for path in ARCHIVE.rglob("*")
-            if path.is_file() and path != manifest
-        }
+        actual = archive_digests(REPO_ROOT, ARCHIVE)
         self.assertEqual(set(actual), set(expected), "archive file set differs from its manifest")
         self.assertEqual(actual, expected, "archive bytes differ from their frozen digests")
+
+    def test_archive_digests_skip_what_git_ignores(self) -> None:
+        """Finder's `.DS_Store` in the archive is not drift; an unstaged file still is.
+
+        The freeze covers what git tracks or would track. An ignored file
+        cannot reach a commit, so it cannot change the archive anyone
+        receives, while a file dropped into the archive without `git add`
+        is still reported before it is staged.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            archive = root / "docs" / "arch-v1"
+            archive.mkdir(parents=True)
+            (root / ".gitignore").write_text(".DS_Store\n", encoding="utf-8")
+            (archive / "MANIFEST.sha256").write_text("", encoding="utf-8")
+            (archive / "frozen.md").write_bytes(b"frozen\n")
+            subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            (archive / ".DS_Store").write_bytes(b"\x00\x00\x00\x01Bud1\xa8\xff")
+            (archive / "unstaged.md").write_bytes(b"drift\n")
+
+            self.assertEqual(
+                archive_digests(root, archive),
+                {
+                    "frozen.md": hashlib.sha256(b"frozen\n").hexdigest(),
+                    "unstaged.md": hashlib.sha256(b"drift\n").hexdigest(),
+                },
+            )
 
     def test_v2_process_policy_changes_are_explicit_and_compatible(self) -> None:
         agents = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")

--- a/tests/ci/test_dcs_naming_contract.py
+++ b/tests/ci/test_dcs_naming_contract.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+import os
 import re
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -71,26 +74,30 @@ class DcsNamingContractTests(unittest.TestCase):
             self.assertIn(f"unica.dcs.{skill.removeprefix('dcs-')}", header)
 
     def test_active_english_identifiers_use_dcs_and_never_dsc(self) -> None:
-        violations: list[str] = []
-        for path in self.active_text_paths():
-            relative = path.relative_to(REPO_ROOT).as_posix()
-            if SKD_IDENTIFIER.search(relative):
-                violations.append(f"{relative}: path contains SKD identifier")
-            if DSC_IDENTIFIER.search(relative):
-                violations.append(f"{relative}: path contains DSC identifier")
+        self.assertEqual(naming_violations(REPO_ROOT), [])
 
-            text = self.text_for_naming_scan(path)
-            for line_number, line in enumerate(text.splitlines(), start=1):
-                if (
-                    SKD_IDENTIFIER.search(line)
-                    and line.strip()
-                    not in ALLOWED_DONOR_SKD_LINES.get(relative, set())
-                ):
-                    violations.append(f"{relative}:{line_number}: {line.strip()}")
-                if DSC_IDENTIFIER.search(line):
-                    violations.append(f"{relative}:{line_number}: {line.strip()}")
+    def test_naming_scan_skips_what_git_ignores(self) -> None:
+        """`.DS_Store` has no suffix, so the suffix filter alone admits the binary.
 
-        self.assertEqual(violations, [])
+        Finder drops it into any directory; git ignores it, so the scan must
+        too, while an extensionless tracked file and an unstaged text file
+        are still read.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "arch").mkdir()
+            (root / ".gitignore").write_text(".DS_Store\n", encoding="utf-8")
+            (root / "README.md").write_text("DCS only\n", encoding="utf-8")
+            (root / "arch" / "LICENSE").write_text("SKD in a licence\n", encoding="utf-8")
+            subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            (root / "arch" / ".DS_Store").write_bytes(b"\x00\x00\x00\x01Bud1\xa8\xff")
+            (root / "arch" / "unstaged.md").write_text("DSC typo\n", encoding="utf-8")
+
+            self.assertEqual(
+                naming_violations(root),
+                ["arch/LICENSE:1: SKD in a licence", "arch/unstaged.md:1: DSC typo"],
+            )
 
     def test_provenance_names_local_dcs_contract_but_preserves_donor_paths(self) -> None:
         path = REPO_ROOT / "docs" / "provenance" / "skill-upstreams.json"
@@ -134,47 +141,89 @@ class DcsNamingContractTests(unittest.TestCase):
         self.assertNotIn('"SetMainDCS"', contracts)
         self.assertNotIn('"setMainDCS"', contracts)
 
-    def active_text_paths(self) -> list[Path]:
-        roots = [
-            REPO_ROOT / "README.md",
-            REPO_ROOT / ".github",
-            REPO_ROOT / "crates" / "unica-coder" / "src",
-            REPO_ROOT / "plugins" / "unica",
-            REPO_ROOT / "scripts",
-            REPO_ROOT / "arch",
-            REPO_ROOT / "tests" / "ci",
-        ]
-        excluded = {
-            "docs/provenance/skill-upstreams.json",
-            "tests/ci/test_dcs_naming_contract.py",
-        }
-        paths: list[Path] = []
-        for root in roots:
-            candidates = [root] if root.is_file() else root.rglob("*")
-            for path in candidates:
-                if not path.is_file() or path.suffix not in TEXT_SUFFIXES:
-                    continue
-                relative = path.relative_to(REPO_ROOT).as_posix()
-                if relative in excluded:
-                    continue
-                if relative.startswith("docs/provenance/reviews/"):
-                    continue
-                if relative.startswith("docs/plans/"):
-                    continue
-                paths.append(path)
-        return sorted(set(paths))
 
-    def text_for_naming_scan(self, path: Path) -> str:
-        text = path.read_text(encoding="utf-8")
-        relative = path.relative_to(REPO_ROOT).as_posix()
-        if relative == "plugins/unica/README.md":
-            text = re.sub(
-                r"\n## DCS naming migration\n.*?(?=\n## )",
-                "",
-                text,
-                flags=re.DOTALL,
-            )
-        return text
+
+def repository_files(repo_root: Path, *pathspecs: str) -> list[Path]:
+    """Files git tracks or would track under `pathspecs`; ignored files never enter.
+
+    `Path.rglob` also returns what the desktop drops into a checkout: `.DS_Store`,
+    editor swap files, a locally built binary. One such file breaks a text scan on
+    a developer machine while CI, whose checkout carries none of them, stays
+    green. A file git ignores is not part of the repository, so it is not part
+    of a scan; an untracked file git would accept still is, exactly as with
+    `rglob`. A tracked file deleted from the working tree is still listed, so
+    callers keep their `is_file()` guard.
+    """
+    listed = subprocess.run(
+        ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard", "--", *pathspecs],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+    ).stdout.split(b"\0")
+    return sorted(repo_root / os.fsdecode(raw_path) for raw_path in listed if raw_path)
+
+
+def active_text_paths(repo_root: Path) -> list[Path]:
+    roots = [
+        "README.md",
+        ".github",
+        "crates/unica-coder/src",
+        "plugins/unica",
+        "scripts",
+        "arch",
+        "tests/ci",
+    ]
+    excluded = {
+        "docs/provenance/skill-upstreams.json",
+        "tests/ci/test_dcs_naming_contract.py",
+    }
+    paths: list[Path] = []
+    for path in repository_files(repo_root, *roots):
+        if not path.is_file() or path.suffix not in TEXT_SUFFIXES:
+            continue
+        relative = path.relative_to(repo_root).as_posix()
+        if relative in excluded:
+            continue
+        if relative.startswith("docs/provenance/reviews/"):
+            continue
+        if relative.startswith("docs/plans/"):
+            continue
+        paths.append(path)
+    return sorted(set(paths))
+
+
+def text_for_naming_scan(repo_root: Path, path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    relative = path.relative_to(repo_root).as_posix()
+    if relative == "plugins/unica/README.md":
+        text = re.sub(
+            r"\n## DCS naming migration\n.*?(?=\n## )",
+            "",
+            text,
+            flags=re.DOTALL,
+        )
+    return text
+
+
+def naming_violations(repo_root: Path) -> list[str]:
+    violations: list[str] = []
+    for path in active_text_paths(repo_root):
+        relative = path.relative_to(repo_root).as_posix()
+        if SKD_IDENTIFIER.search(relative):
+            violations.append(f"{relative}: path contains SKD identifier")
+        if DSC_IDENTIFIER.search(relative):
+            violations.append(f"{relative}: path contains DSC identifier")
+
+        text = text_for_naming_scan(repo_root, path)
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if (
+                SKD_IDENTIFIER.search(line)
+                and line.strip() not in ALLOWED_DONOR_SKD_LINES.get(relative, set())
+            ):
+                violations.append(f"{relative}:{line_number}: {line.strip()}")
+            if DSC_IDENTIFIER.search(line):
+                violations.append(f"{relative}:{line_number}: {line.strip()}")
+    return violations
 
 
 if __name__ == "__main__":

--- a/tests/ci/test_product_contracts.py
+++ b/tests/ci/test_product_contracts.py
@@ -167,6 +167,38 @@ def tracked_workspace_production_rust_sources(repo_root: Path) -> dict[str, byte
     return sources
 
 
+def repository_files(repo_root: Path, *pathspecs: str) -> list[Path]:
+    """Files git tracks or would track under `pathspecs`; ignored files never enter.
+
+    `Path.rglob` also returns what the desktop drops into a checkout: `.DS_Store`,
+    editor swap files, a locally built binary. One such file breaks a text scan on
+    a developer machine while CI, whose checkout carries none of them, stays
+    green. A file git ignores is not part of the repository, so it is not part
+    of a scan; an untracked file git would accept still is, exactly as with
+    `rglob`. A tracked file deleted from the working tree is still listed, so
+    callers keep their `is_file()` guard.
+    """
+    listed = subprocess.run(
+        ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard", "--", *pathspecs],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+    ).stdout.split(b"\0")
+    return sorted(repo_root / os.fsdecode(raw_path) for raw_path in listed if raw_path)
+
+
+def retired_corpus_references(repo_root: Path) -> list[str]:
+    """Active `arch/` files that still send the reader to the retired local corpus.
+
+    The frozen `docs/arch-v1/` is deliberately outside this scan.
+    """
+    return [
+        path.relative_to(repo_root).as_posix()
+        for path in repository_files(repo_root, "arch")
+        if path.is_file() and "docs-local/1ci" in path.read_text(encoding="utf-8")
+    ]
+
+
 def rmcp_reference_confinement_errors(
     sources: dict[str, bytes], owner: str
 ) -> list[str]:
@@ -1276,15 +1308,35 @@ class ProductContractTests(unittest.TestCase):
         self.assertNotIn("kb.1ci.com/bin/download", agents)
         # Действующий нормативный слой не отправляет читателя к снятому корпусу.
         # Замороженный `docs/arch-v1/` сюда намеренно не входит.
-        for arch_path in sorted((REPO_ROOT / "arch").rglob("*")):
-            if not arch_path.is_file():
-                continue
-            with self.subTest(path=arch_path.relative_to(REPO_ROOT).as_posix()):
-                self.assertNotIn(
-                    "docs-local/1ci",
-                    arch_path.read_text(encoding="utf-8"),
-                    "активный слой arch не должен ссылаться на снятый корпус",
-                )
+        self.assertEqual(
+            retired_corpus_references(REPO_ROOT),
+            [],
+            "активный слой arch не должен ссылаться на снятый корпус",
+        )
+
+    def test_retired_corpus_scan_skips_what_git_ignores(self) -> None:
+        """Finder кладёт `.DS_Store` в `arch/`; git его игнорирует, скан тоже.
+
+        Бинарный файл ронял обход `UnicodeDecodeError` локально, а CI, где
+        такого файла нет, оставался зелёным. Неотслеживаемый, но не
+        игнорируемый файл по-прежнему читается: нарушение в нём ловится
+        до `git add`.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "arch").mkdir()
+            (root / ".gitignore").write_text(".DS_Store\n", encoding="utf-8")
+            (root / "arch" / "clean.md").write_text("справка из установки\n", encoding="utf-8")
+            (root / "arch" / "stale.md").write_text("см. docs-local/1ci\n", encoding="utf-8")
+            subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+            subprocess.run(["git", "add", "."], cwd=root, check=True)
+            (root / "arch" / ".DS_Store").write_bytes(b"\x00\x00\x00\x01Bud1\xa8\xff")
+            (root / "arch" / "unstaged.md").write_text("docs-local/1ci\n", encoding="utf-8")
+
+            self.assertEqual(
+                retired_corpus_references(root),
+                ["arch/stale.md", "arch/unstaged.md"],
+            )
 
     def test_local_corpus_directory_stays_ignored(self) -> None:
         """Каталог остаётся игнорируемым: снят контракт корпуса, а не каталог."""


### PR DESCRIPTION
## Что меняется

Три теста обходили каталоги через `Path.rglob("*")` и на macOS падали от игнорируемого `.DS_Store`, который Finder кладёт в `arch/`, `docs/arch-v1/` и соседние каталоги; на CI-раннерах таких файлов нет, и там те же тесты зелёные. Теперь обходы вынесены в функции от `repo_root`, а файлы перечисляются через `git ls-files -z --cached --others --exclude-standard -- <pathspec>`: отслеживаемые плюс неотслеживаемые, которые git принял бы. Игнорируемое не попадает в скан по построению, файл без `git add` сканируется как прежде.

- `tests/ci/test_product_contracts.py::test_downloader_and_local_corpus_contract_are_retired` читал `arch/.DS_Store` как UTF-8 и падал с `UnicodeDecodeError`. Фильтр `*.md` здесь не годится: в `arch/` лежат ещё три JSON.
- `tests/ci/test_dcs_naming_contract.py::test_active_english_identifiers_use_dcs_and_never_dsc` пропускал `.DS_Store` через фильтр расширений: у имени с ведущей точкой суффикс пустой, а пустой суффикс нужен ради LICENSE и NOTICE. Той же дорогой в скан попал бы локальный бинарь из игнорируемого `plugins/unica/bin/<os>/`. Фильтр расширений остаётся: он отвечает за тип файла, git за принадлежность репозиторию.
- `tests/arch/test_registry.py::test_archive_matches_frozen_manifest` находил в `docs/arch-v1/` лишний файл: «archive file set differs from its manifest».

**Почему заморозка `docs/arch-v1/` не ослаблена.** На CI checkout состоит только из отслеживаемых файлов, поэтому прежний `rglob` и новое перечисление дают там одно и то же множество: сила гейта не изменилась. Локально из множества выпадают только файлы под `.gitignore`, а такой файл не может попасть в коммит без `git add -f`, который AGENTS.md запрещает; правило игнорирования не скрывает уже отслеживаемый файл, `--cached` перечисляет его независимо от исключений (проверено на модельном репозитории). Манифест по-прежнему покрывает все 95 отслеживаемых файлов архива. Добавление отслеживаемого файла ловится через `--cached`, файла без `git add` через `--others`, удаление через запись индекса без файла на диске, изменение байтов через дайджест, переписывание манифеста под новое содержимое тестом `test_archive_manifest_cannot_change_after_acceptance` против `origin/main`.

Соседние обходы `rglob("*")` в `tests/ci/test_skill_provenance.py` читают с `errors="ignore"` и на бинарь не падают, поэтому граница правки осталась на трёх тестах.

## Архитектурный слой

- Затронутые записи реестра: нет. `DEC.2026-08-18.ARCHITECTURE-RESET` и `INV.DOC.ARCHIVE-FROZEN` называют `tests/arch/test_registry.py::test_archive_matches_frozen_manifest` своим свидетельством; имя теста и проверяемое множество на CI не изменились, записи не тронуты.
- Решение (`DEC.*`), если публичный или архитектурный контракт меняется: нет, это тестовая гигиена, контракт не меняется.

- [x] Прочитаны относящиеся к изменению записи из `arch/index.md`.

## Проверка

Порядок по AGENTS.md: сначала падающий тест. Посаженные в worktree игнорируемые `.DS_Store` (корень, `arch/`, `docs/`, `docs/arch-v1/`, `tests/`, `scripts/`, `crates/`) дали ровно три отчётных падения, чистое дерево было зелёным. Затем в каждый модуль добавлен тест на временном git-репозитории с игнорируемым бинарным `.DS_Store`, отслеживаемым нарушителем и нарушителем без `git add`: до правки они падали ровно по причине дефекта (два `UnicodeDecodeError`, одно расхождение множеств), после правки проходят.

Прогон из venv по `tests/ci/requirements.txt` (`/opt/homebrew/bin/python3.12`), наборы последовательно, при посаженных `.DS_Store`:

| Команда | Результат |
| --- | --- |
| `python scripts/ci/run-unittest.py -s tests/ci` | 820 тестов, OK (skipped=11), 261 с |
| `python scripts/ci/run-unittest.py -s tests/arch` | 123 теста, OK, 30 с |
| `python -m py_compile` трёх файлов | ок |
| `git diff --check origin/main...HEAD` | чисто |

Rust-часть гейта (`cargo fmt`, `clippy`, `cargo test`) не запускалась: Rust-файлы не затронуты.

- [x] Новое поведение покрыто тестом, который можно назвать по имени: `test_retired_corpus_scan_skips_what_git_ignores`, `test_naming_scan_skips_what_git_ignores`, `test_archive_digests_skip_what_git_ignores`.
- [x] Документация, описывающая изменённое поведение, обновлена в этом же PR: отдельной документации у этих тестов нет, поведение описано в докстрингах помощника `repository_files` и новых тестов.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved repository scans to respect Git tracking and ignore rules.
  - Added coverage confirming ignored files are excluded while relevant untracked files remain included.
  - Strengthened archive integrity checks by validating archive contents against frozen digests.
  - Improved naming and product contract validation across repository files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->