### PR TITLE
ci(windows): консоль в UTF-8 и сбой Windows не блокирует упаковку ночи

### DIFF
--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -194,6 +194,12 @@ jobs:
     needs: [classify-changes, guards]
     env:
       RUN_LINE: ${{ needs.classify-changes.outputs.line }}
+      # Консоль Windows — cp1252: без этого Python не выведет кириллицу
+      # скриптов площадки и упадёт на первом же `print`.
+      PYTHONUTF8: "1"
+    # Windows идёт только в ночном ярусе, и его сбой обязан быть виден, но
+    # не должен блокировать упаковку и пробу того же прогона.
+    continue-on-error: ${{ matrix.runner == 'windows-latest' }}
     # Любая правка Rust идёт на обеих платформах: `#[cfg]` решает, какие
     # элементы существуют, и один раннер этого класса не видит. Прежняя
     # экономия — один раннер для rust-only pull request — снята: под

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -517,6 +517,9 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         self.assertIn("runner: ${{ fromJSON(needs.classify-changes.outputs.runners) }}", platforms)
         self.assertIn("shell: bash", platforms)
         self.assertIn("uses: actions/setup-python@v7", platforms)
+        # Консоль Windows — cp1252; сбой Windows виден, но упаковку ночи не блокирует.
+        self.assertIn('PYTHONUTF8: "1"', platforms)
+        self.assertIn("continue-on-error: ${{ matrix.runner == 'windows-latest' }}", platforms)
         self.assertFalse((REPO_ROOT / ".github" / "workflows" / "unica-large.yml").exists())
 
     def test_pages_take_results_from_red_runs_and_from_the_nightly(self) -> None:


### PR DESCRIPTION
## Что сделано

Приёмка пункта 4 (ручная ночь после #746) показала две вещи:

- Windows упал не на тестах: `print("план Rust: …")` в консоль cp1252 — `UnicodeEncodeError` на первом же выводе скрипта площадки, хотя сборка и план были готовы. Лечение — `PYTHONUTF8=1` в окружении матрицы Rust.
- Красная Windows-джоба пропустила `build-tools`, и упаковка с пробой — половина смысла ночи — не пошли. Теперь `continue-on-error` только для `windows-latest`: сбой виден в джобе и в отчёте сайта, а контур доходит до конца. На теге и push Windows в матрице нет, так что там ничего не маскируется.

## Проверено

`tests.ci.test_unica_workflow`, `test_suite_hygiene` — зелёные.

## Что покажет только прод

Следующая ручная ночь: Windows гоняет весь набор (его красное — по делу и видно), упаковка, проба и оценка идут, сайт пишет память и добавляет Windows третьим раннером.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows release workflow reliability by ensuring platform scripts handle international text correctly.
  * Windows nightly platform-check failures are now reported without blocking packaging and probing.

* **Tests**
  * Added automated safeguards to verify Windows-specific release workflow behavior while keeping other platform checks blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->