### PR TITLE
fix(platform): stdio на Windows не наследуются потомками — демон держал трубы MCP-хоста

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ windows-sys = { version = "0.59", features = [
   "Win32_Security",
   "Win32_Security_Authorization",
   "Win32_Storage_FileSystem",
+  "Win32_System_Console",
   "Win32_System_Diagnostics_ToolHelp",
   "Win32_System_JobObjects",
   "Win32_System_Threading",

--- a/crates/unica-coder/src/infrastructure/platform/entrypoint.rs
+++ b/crates/unica-coder/src/infrastructure/platform/entrypoint.rs
@@ -3,6 +3,7 @@ const WINDOWS_MAIN_STACK_SIZE: usize = 8 * 1024 * 1024;
 
 #[cfg(windows)]
 pub fn run_platform_main(run: fn()) {
+    super::process::detach_std_handles_from_inheritance();
     let main_thread = std::thread::Builder::new()
         .name("unica-main".to_string())
         .stack_size(WINDOWS_MAIN_STACK_SIZE)
@@ -15,5 +16,6 @@ pub fn run_platform_main(run: fn()) {
 
 #[cfg(not(windows))]
 pub fn run_platform_main(run: fn()) {
+    super::process::detach_std_handles_from_inheritance();
     run();
 }

--- a/crates/unica-coder/src/infrastructure/platform/process.rs
+++ b/crates/unica-coder/src/infrastructure/platform/process.rs
@@ -1104,6 +1104,46 @@ impl Drop for ManagedChild {
     }
 }
 
+/// Снять флаг наследования со стандартных дескрипторов этого процесса.
+///
+/// Хост создаёт stdio для Unica наследуемыми — иначе он не смог бы передать
+/// их при запуске. На Windows `CreateProcessW` копирует ребёнку каждый
+/// наследуемый дескриптор родителя, а не только те три, что назначены ему
+/// как stdio. Так отсоединённый демон со `Stdio::null()` уносил с собой
+/// копии труб MCP-хоста и держал их до собственного выхода: после выхода
+/// сервера хост не видел EOF на stdout ещё четверть часа простоя демона.
+///
+/// `Stdio::inherit()` детей от этого не страдает: std дублирует дескриптор
+/// для ребёнка заново и уже с наследованием. На Unix дескрипторы и так
+/// закрываются при exec, поэтому там это пустая операция.
+#[cfg(windows)]
+pub(super) fn detach_std_handles_from_inheritance() {
+    use windows_sys::Win32::Foundation::{
+        SetHandleInformation, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE,
+    };
+    use windows_sys::Win32::System::Console::{
+        GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+    };
+
+    for id in [STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, STD_ERROR_HANDLE] {
+        // SAFETY: `GetStdHandle` takes a constant and returns a handle the
+        // process already owns, null, or `INVALID_HANDLE_VALUE`.
+        let handle = unsafe { GetStdHandle(id) };
+        if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+            continue;
+        }
+        // SAFETY: the handle stays live for the whole process; clearing the
+        // inherit flag changes no I/O. A failure keeps the old behaviour and
+        // is not worth refusing to start for.
+        unsafe {
+            SetHandleInformation(handle, HANDLE_FLAG_INHERIT, 0);
+        }
+    }
+}
+
+#[cfg(not(windows))]
+pub(super) fn detach_std_handles_from_inheritance() {}
+
 impl ManagedStartupChild {
     pub(crate) fn spawn_configured(mut process: Command) -> Result<Self, String> {
         let process_tree = ProcessTree::prepare_detachable(&mut process).map_err(process_error)?;
@@ -2510,6 +2550,25 @@ mod tests {
                 thread::sleep(Duration::from_secs(10));
             }
             "process_tree_child" => thread::sleep(Duration::from_secs(10)),
+            "exit_leaving_detached_grandchild" => {
+                super::detach_std_handles_from_inheritance();
+                let pid_file = std::env::var_os(HELPER_PID_FILE_ENV).unwrap();
+                let grandchild = Command::new(std::env::current_exe().unwrap())
+                    .args([
+                        "--exact",
+                        "infrastructure::platform::process::tests::managed_child_test_helper",
+                        "--nocapture",
+                    ])
+                    .env(HELPER_ENV, "process_tree_child")
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn()
+                    .unwrap();
+                std::fs::write(pid_file, format!("{}\n", grandchild.id())).unwrap();
+                print!("grandchild-detached");
+                std::io::Write::flush(&mut std::io::stdout()).unwrap();
+            }
             #[cfg(unix)]
             "graceful_runner_with_external_process_group" => {
                 use std::os::unix::process::CommandExt;
@@ -3301,6 +3360,55 @@ mod tests {
     fn runtime_process_tree_handle_waits_for_windows_job_object_descendants() {
         assert_windows_runtime_process_tree_semantics_for_test()
             .expect("retain and terminate Windows runtime Job Object");
+    }
+
+    #[test]
+    fn detached_null_stdio_grandchild_never_holds_the_parent_stdout_pipe() {
+        // Регрессия дыма упакованного MCP на Windows: отсоединённый демон со
+        // `Stdio::null()` уносил копии труб хоста, и хост не видел EOF на
+        // stdout после выхода сервера, пока демон не выйдет сам.
+        let pid_file = std::env::temp_dir().join(format!(
+            "unica-detached-grandchild-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _pid_file_cleanup = FileCleanupGuard(pid_file.clone());
+        let mut grandchild_cleanup = ProcessCleanupGuard(Vec::new());
+        let mut child = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "infrastructure::platform::process::tests::managed_child_test_helper",
+                "--nocapture",
+            ])
+            .env(HELPER_ENV, "exit_leaving_detached_grandchild")
+            .env(HELPER_PID_FILE_ENV, &pid_file)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let mut stdout = child.stdout.take().unwrap();
+        let started = Instant::now();
+        let mut output = String::new();
+        stdout.read_to_string(&mut output).unwrap();
+        let eof_after = started.elapsed();
+        let status = child.wait().unwrap();
+        if let Some(pid) = std::fs::read_to_string(&pid_file)
+            .ok()
+            .and_then(|text| text.trim().parse::<u32>().ok())
+        {
+            grandchild_cleanup.0.push(pid);
+        }
+
+        assert!(status.success(), "{status}");
+        assert!(output.contains("grandchild-detached"), "{output}");
+        assert!(
+            eof_after < Duration::from_secs(5),
+            "stdout EOF waited for the detached grandchild: {eof_after:?}"
+        );
     }
 
     #[test]

--- a/scripts/ci/probe-unica-wire.py
+++ b/scripts/ci/probe-unica-wire.py
@@ -399,6 +399,13 @@ class JsonRpcSession:
         timeout_seconds = getattr(self, "timeout_seconds", None)
         return min(remaining, timeout_seconds) if timeout_seconds is not None else remaining
 
+    def _pipe_eof_timeout(self) -> float:
+        remaining = max(0.0, self.deadline - time.monotonic())
+        timeout_seconds = getattr(self, "timeout_seconds", None)
+        if timeout_seconds is None:
+            return remaining
+        return min(remaining, timeout_seconds)
+
     def _request_timeout_message(self) -> str:
         timeout_seconds = getattr(self, "timeout_seconds", None)
         if timeout_seconds is not None:
@@ -466,14 +473,21 @@ class JsonRpcSession:
         except BaseException:
             self._terminate_owned()
             raise
-        remaining = max(0.0, self.deadline - time.monotonic())
-        self.reader.join(timeout=remaining)
-        self.error_reader.join(timeout=remaining)
+        # EOF on the pipes arrives only when every copy of their write handles
+        # is closed. A detached descendant that inherited them keeps the
+        # readers alive long after the leader exited, so this wait is capped
+        # like a request and reported as its own failure instead of silently
+        # consuming the aggregate deadline.
+        pipe_wait = self._pipe_eof_timeout()
+        pipe_deadline = time.monotonic() + pipe_wait
+        self.reader.join(timeout=max(0.0, pipe_deadline - time.monotonic()))
+        self.error_reader.join(timeout=max(0.0, pipe_deadline - time.monotonic()))
         if self.reader.is_alive() or self.error_reader.is_alive():
             self._terminate_owned()
             raise SystemExit(
-                f"{self.error_label} reader threads did not stop before the aggregate deadline: "
-                f"{self._detail()}"
+                f"{self.error_label} exited with {result} but its reader threads did not "
+                f"stop within {pipe_wait:g}s: a detached descendant still holds the "
+                f"stdout/stderr pipe handles: {self._detail()}"
             )
         detail = self._detail()
         self._close_streams()

--- a/scripts/ci/smoke-unica-mcp.py
+++ b/scripts/ci/smoke-unica-mcp.py
@@ -123,6 +123,53 @@ EXPECTED_META_OUTPUT_SCHEMA = {
 }
 
 
+_SMOKE_STARTED = time.monotonic()
+_PHASE_LOCK = threading.Lock()
+_LAST_PHASE: list[str] = ["starting"]
+
+
+def _trace(message: str) -> None:
+    """Progress line on stderr, stamped with seconds since the smoke started.
+
+    A hang is located by the last line written before the watchdog fires, so
+    every request and cleanup phase reports here. Bytes go straight to fd 2:
+    a cp1252 console on Windows must not turn a progress line into an
+    encoding error.
+    """
+    elapsed = time.monotonic() - _SMOKE_STARTED
+    with _PHASE_LOCK:
+        _LAST_PHASE[0] = f"{message} (at +{elapsed:.1f}s)"
+    try:
+        os.write(
+            2, f"[smoke +{elapsed:.1f}s] {message}\n".encode("utf-8", "replace")
+        )
+    except OSError:
+        pass
+
+
+def _last_phase() -> str:
+    with _PHASE_LOCK:
+        return _LAST_PHASE[0]
+
+
+def _request_label(message: dict) -> str:
+    method = str(message.get("method", "?"))
+    params = message.get("params")
+    if method == "tools/call" and isinstance(params, dict):
+        return f"{method} {params.get('name', '?')}"
+    return method
+
+
+def _describe_error(error: BaseException) -> str:
+    if isinstance(error, SystemExit):
+        return str(error.code) if error.code is not None else "SystemExit"
+    return f"{type(error).__name__}: {error}"
+
+
+def _tail(text: str, lines: int) -> str:
+    return "\n".join(text.rstrip("\n").splitlines()[-lines:])
+
+
 def _valid_unica_tool_name(value: object) -> bool:
     if not isinstance(value, str) or not 1 <= len(value) <= 128:
         return False
@@ -1155,12 +1202,23 @@ class McpSession(_WIRE_PROBE.JsonRpcSession):
         )
 
     def request(self, message: dict) -> dict:
+        label = _request_label(message)
+        started = time.monotonic()
+        _trace(f"-> {label}")
         try:
-            return super().request(message)
+            response = super().request(message)
+        except BaseException as error:
+            _trace(
+                f"!! {label} failed after {time.monotonic() - started:.1f}s: "
+                f"{_describe_error(error)}"
+            )
+            raise
         finally:
             cache_root = getattr(self, "_service_cache_root", None)
             if cache_root is not None:
                 self.observe_workspace_services(cache_root)
+        _trace(f"<- {label} in {time.monotonic() - started:.2f}s")
+        return response
 
     def observe_workspace_services(self, cache_root: Path) -> None:
         observed = getattr(self, "_service_identities", {})
@@ -1356,6 +1414,7 @@ def _exercise_bsl_search(
     deadline = time.monotonic() + max(10.0, timeout_seconds * 3)
     if smoke_deadline is not None:
         deadline = min(deadline, smoke_deadline)
+    attempt = 0
     while True:
         payload = _code_search_payload(
             session.request(
@@ -1375,17 +1434,25 @@ def _exercise_bsl_search(
             )
         )
         request_id += 1
+        attempt += 1
         if _bsl_search_is_ready(payload):
             if payload.get("ok") is not True:
                 raise SystemExit(
                     "Unica MCP code search has inconsistent success state: "
                     f"{payload}"
                 )
+            _trace(f"bsl-analyzer ready after {attempt} code.search attempt(s)")
             return request_id
+        section = payload["data"]["sections"][1]
+        _trace(
+            f"bsl-analyzer not ready (attempt {attempt}): "
+            + json.dumps(section, ensure_ascii=False)[:400]
+        )
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             raise SystemExit(
-                "Unica MCP bsl-analyzer stayed not_ready until the smoke deadline"
+                "Unica MCP bsl-analyzer stayed not_ready until the smoke deadline "
+                f"after {attempt} attempt(s); last section: {section}"
             )
         time.sleep(min(0.5, remaining))
 
@@ -1490,14 +1557,15 @@ def _wait_for_workspace_services(
     services_root = cache_root / "services"
     service_pids = service_pids or set()
     while True:
-        records_remain = any(services_root.glob("*/service.json"))
+        records = sorted(str(path) for path in services_root.glob("*/service.json"))
         running_pids = {pid for pid in service_pids if _process_is_running(pid)}
-        if not records_remain and not running_pids:
+        if not records and not running_pids:
             return
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             raise SystemExit(
-                "Unica MCP workspace service did not exit before smoke cleanup"
+                "Unica MCP workspace service did not exit before smoke cleanup "
+                f"(records left: {records}; running pids: {sorted(running_pids)})"
             )
         time.sleep(min(0.05, remaining))
 
@@ -1588,6 +1656,45 @@ def _shutdown_workspace_services(
     return service_pids
 
 
+def _dump_session_diagnostics(session: object, cache_root: Path) -> str:
+    """Copy the child's stderr and the workspace service logs to stderr.
+
+    The temp workspace disappears when the smoke ends, so the logs are copied
+    out on the failure path and by the watchdog, never on success. Returns the
+    rendered text so tests can check it without capturing fd 2.
+    """
+    # The failure path and the watchdog can both get here for one session;
+    # the second copy of the same logs only pushes the first off the screen.
+    with _PHASE_LOCK:
+        if getattr(session, "_smoke_diagnostics_dumped", False):
+            return ""
+        try:
+            session._smoke_diagnostics_dumped = True  # type: ignore[attr-defined]
+        except AttributeError:
+            pass
+    chunks = [f"---- smoke diagnostics (last phase: {_last_phase()}) ----"]
+    diagnostics = "".join(getattr(session, "diagnostics", None) or [])
+    chunks.append("MCP stderr tail:\n" + (_tail(diagnostics, 60) or "<empty>"))
+    services_root = cache_root / "services"
+    for service_dir in sorted(path for path in services_root.glob("*") if path.is_dir()):
+        chunks.append(f"workspace service directory {service_dir}:")
+        for name in ("service.json", "service.stderr.log", "service.stdout.log"):
+            try:
+                content = (service_dir / name).read_text(
+                    encoding="utf-8", errors="replace"
+                )
+            except OSError:
+                continue
+            chunks.append(f"{name} tail:\n" + (_tail(content, 40) or "<empty>"))
+    chunks.append("---- end of smoke diagnostics ----")
+    rendered = "\n".join(chunks) + "\n"
+    try:
+        os.write(2, rendered.encode("utf-8", "replace"))
+    except OSError:
+        pass
+    return rendered
+
+
 def _close_session_and_workspace_services(
     session: McpSession,
     cache_root: Path,
@@ -1609,6 +1716,9 @@ def _close_session_and_workspace_services(
             # waits for reader EOF while the service that owns those copies is
             # still alive, so cleanup never reaches its shutdown call.
             # Ask the authenticated services to stop before waiting for MCP EOF.
+            _trace(
+                f"cleanup: shutting down {len(service_pids)} recorded workspace service(s)"
+            )
             service_pids.update(
                 _shutdown_workspace_services(
                     cache_root,
@@ -1617,19 +1727,24 @@ def _close_session_and_workspace_services(
             )
         finally:
             try:
+                _trace("cleanup: closing MCP session (stdin EOF, exit, pipe EOF)")
                 session.close()
             finally:
+                _trace("cleanup: waiting for workspace services to exit")
                 _wait_for_workspace_services(
                     cache_root,
                     _remaining_smoke_timeout(deadline, timeout_seconds),
                     service_pids,
                 )
+                _trace("cleanup: quiescing owned processes")
                 _quiesce_owned_processes(
                     ownership,
                     owned_processes,
                     _remaining_smoke_timeout(deadline, timeout_seconds),
                 )
-    except BaseException:
+                _trace("cleanup: done")
+    except BaseException as error:
+        _trace(f"cleanup failed: {_describe_error(error)}")
         session.terminate_tree(cache_root, service_identities)
         raise
 
@@ -2012,6 +2127,7 @@ def smoke(
         if executable.exists():
             command = [str(executable.resolve()), *command[1:]]
         admission = admission_lock or contextlib.nullcontext()
+        _trace(f"spawning {command[0]} in {workspace}")
         with admission:
             session = McpSession(
                 command,
@@ -2023,6 +2139,8 @@ def smoke(
             )
             if session_started is not None:
                 session_started(session, cache_root)
+        _trace("session admitted")
+        body_error: BaseException | None = None
         try:
             initialize = session.request({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {
                 "protocolVersion": "2025-06-18", "capabilities": {},
@@ -2098,13 +2216,28 @@ def smoke(
                     raise SystemExit(
                         f"invalid Meta smoke returned unstable diagnostics: {invalid}"
                     )
+        except BaseException as error:
+            body_error = error
+            _trace(f"smoke failed: {_describe_error(error)}")
+            _dump_session_diagnostics(session, cache_root)
+            raise
         finally:
-            _close_session_and_workspace_services(
-                session,
-                cache_root,
-                max(5.0, timeout_seconds),
-                deadline,
-            )
+            try:
+                _close_session_and_workspace_services(
+                    session,
+                    cache_root,
+                    max(5.0, timeout_seconds),
+                    deadline,
+                )
+            except BaseException as cleanup_error:
+                if body_error is None:
+                    raise
+                # SystemExit prints only its own message, so a cleanup failure
+                # would otherwise replace the failure that caused it.
+                raise SystemExit(
+                    f"{_describe_error(body_error)}; cleanup after that failure "
+                    f"also failed: {_describe_error(cleanup_error)}"
+                ) from cleanup_error
         after = _source_snapshot(workspace)
         # The whole public source surface is read-only, so the packaged smoke
         # must end with the byte map it started from.
@@ -2146,7 +2279,7 @@ def main() -> None:
     def cleanup_expired_smoke() -> None:
         message = (
             "Unica MCP smoke exceeded its aggregate deadline of "
-            f"{args.total_timeout_seconds:g}s\n"
+            f"{args.total_timeout_seconds:g}s; last phase: {_last_phase()}\n"
         ).encode("utf-8", errors="replace")
         try:
             os.write(2, message)
@@ -2158,6 +2291,10 @@ def main() -> None:
                     active = active_session[0] if active_session else None
                 if active is not None:
                     session, cache_root = active
+                    try:
+                        _dump_session_diagnostics(session, cache_root)
+                    except BaseException:
+                        pass
                     session.terminate_tree(cache_root)
             finally:
                 cleanup_done.set()
@@ -2194,7 +2331,7 @@ def main() -> None:
                 # racing its slower tree cleanup must not commit exit code 0.
                 cleanup_done.wait(timeout=30)
                 os._exit(124)
-        except BaseException:
+        except BaseException as error:
             with outcome_lock:
                 if outcome[0] == "running" and time.monotonic() < deadline:
                     outcome[0] = "failed"
@@ -2206,6 +2343,19 @@ def main() -> None:
                     failure_action = "wait"
                 else:
                     failure_action = "raise"
+            if failure_action != "raise":
+                # The watchdog owns the exit code; the failure it pre-empted
+                # is still the most useful line of the log.
+                try:
+                    os.write(
+                        2,
+                        (
+                            "Unica MCP smoke failure pending at the deadline: "
+                            f"{_describe_error(error)}\n"
+                        ).encode("utf-8", errors="replace"),
+                    )
+                except OSError:
+                    pass
             if failure_action == "cleanup":
                 cleanup_expired_smoke()
             if failure_action == "wait":

--- a/tests/ci/test_smoke_unica_mcp.py
+++ b/tests/ci/test_smoke_unica_mcp.py
@@ -239,11 +239,102 @@ class SmokeUnicaMcpTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 124, result.stderr)
         self.assertIn("aggregate deadline", result.stderr)
+        # A silent 124 tells nothing; the watchdog names the phase it
+        # interrupted and copies out what the child had said so far.
+        self.assertIn("last phase:", result.stderr)
+        self.assertIn("initialize", result.stderr)
+        self.assertEqual(result.stderr.count("---- smoke diagnostics"), 1, result.stderr)
         self.assertLess(elapsed, 4.0)
         module = load_module()
         for child_pid in child_pids:
             with self.subTest(child_pid=child_pid):
                 self.assertFalse(module._process_is_running(child_pid))
+
+    def test_close_reports_pipes_held_by_a_detached_descendant_within_the_request_cap(
+        self,
+    ) -> None:
+        """A descendant that inherited the pipes must not eat the aggregate deadline.
+
+        This is the Windows shape of the packaged smoke hang: the MCP process
+        exits, a detached daemon keeps copies of its stdout/stderr handles, and
+        EOF never arrives. `close()` reports that within the request cap.
+        """
+        module = load_module()
+        grandchild_pid: int | None = None
+        try:
+            with tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                pid_path = root / "pipe-holder.pid"
+                server = root / "leave-pipe-holder.py"
+                server.write_text(
+                    textwrap.dedent(
+                        """
+                        import subprocess
+                        import sys
+                        from pathlib import Path
+
+                        # stdout is inherited on purpose: the descendant holds
+                        # the smoke's pipe the way a detached daemon does.
+                        child = subprocess.Popen(
+                            [sys.executable, "-c", "import time; time.sleep(60)"]
+                        )
+                        Path(sys.argv[1]).write_text(str(child.pid), encoding="utf-8")
+                        """
+                    ),
+                    encoding="utf-8",
+                )
+                session = module.McpSession(
+                    [sys.executable, str(server), str(pid_path)],
+                    os.environ.copy(),
+                    1.0,
+                    cwd=root,
+                    deadline=time.monotonic() + 30.0,
+                )
+                deadline = time.monotonic() + 5.0
+                while not pid_path.exists() and time.monotonic() < deadline:
+                    time.sleep(0.01)
+                grandchild_pid = int(pid_path.read_text(encoding="utf-8"))
+                started = time.monotonic()
+                with self.assertRaisesRegex(
+                    SystemExit, "reader threads did not stop within 1s"
+                ):
+                    session.close()
+                elapsed = time.monotonic() - started
+            self.assertLess(elapsed, 5.0)
+            module._wait_for_process_pids({grandchild_pid}, 2.0)
+            self.assertFalse(module._process_is_running(grandchild_pid))
+        finally:
+            if grandchild_pid is not None and module._process_is_running(grandchild_pid):
+                if os.name == "posix":
+                    os.kill(grandchild_pid, signal.SIGKILL)
+
+    def test_diagnostics_dump_copies_child_stderr_and_workspace_service_logs(
+        self,
+    ) -> None:
+        module = load_module()
+
+        class Session:
+            diagnostics = ["first line\n", "второй: кириллица\n"]
+
+        with tempfile.TemporaryDirectory() as directory:
+            cache_root = Path(directory) / "cache"
+            service_dir = cache_root / "services" / "svc-1"
+            service_dir.mkdir(parents=True)
+            (service_dir / "service.json").write_text(
+                '{"pid": 4242, "port": 1}', encoding="utf-8"
+            )
+            (service_dir / "service.stderr.log").write_text(
+                "\n".join(f"stderr {index}" for index in range(50)),
+                encoding="utf-8",
+            )
+            module._trace("phase under test")
+            rendered = module._dump_session_diagnostics(Session(), cache_root)
+
+        self.assertIn("last phase: phase under test", rendered)
+        self.assertIn("второй: кириллица", rendered)
+        self.assertIn('{"pid": 4242, "port": 1}', rendered)
+        self.assertNotIn("stderr 9\n", rendered)
+        self.assertIn("stderr 49", rendered)
 
     def test_expired_watchdog_cannot_race_a_success_exit(self) -> None:
         runner = textwrap.dedent(
@@ -1600,6 +1691,7 @@ class SmokeUnicaMcpTests(unittest.TestCase):
         code_search_ok: bool = True,
         code_search_status: str = "ok",
         code_search_root_field: str | None = None,
+        leave_pipe_holder: bool = False,
     ) -> subprocess.CompletedProcess[str]:
         expected_tools = self.expected_tools()
         module = load_module()
@@ -1621,6 +1713,11 @@ class SmokeUnicaMcpTests(unittest.TestCase):
 
             tools = json.loads(r'''__TOOLS__''')
             source_flows = json.loads(r'''__SOURCE_FLOWS__''')
+            if __LEAVE_PIPE_HOLDER__:
+                import subprocess
+                # Inherits stdout on purpose: a detached descendant keeps the
+                # smoke's pipes open after this server exits.
+                subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
             read_writes = __READ_WRITES__
             code_search_ok = __CODE_SEARCH_OK__
             code_search_status = __CODE_SEARCH_STATUS__
@@ -1808,6 +1905,7 @@ class SmokeUnicaMcpTests(unittest.TestCase):
                 json.dumps(source_flows, ensure_ascii=False, indent=2),
             )
             .replace("__READ_WRITES__", repr(read_writes))
+            .replace("__LEAVE_PIPE_HOLDER__", repr(leave_pipe_holder))
             .replace("__CODE_SEARCH_OK__", repr(code_search_ok))
             .replace("__CODE_SEARCH_STATUS__", repr(code_search_status))
             .replace("__CODE_SEARCH_ROOT_FIELD__", repr(code_search_root_field))
@@ -1907,6 +2005,17 @@ class SmokeUnicaMcpTests(unittest.TestCase):
                 set(module._source_snapshot(root)),
                 {".build/other/evidence.txt", "src/Configuration.xml"},
             )
+
+    def test_cleanup_failure_does_not_replace_the_failure_that_caused_it(self) -> None:
+        result = self.run_smoke(
+            self.tool_entries(), server_name="other", leave_pipe_holder=True
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertNotEqual(result.returncode, 124, result.stderr)
+        self.assertIn("serverInfo.name must be 'unica'", result.stderr)
+        self.assertIn("cleanup after that failure also failed", result.stderr)
+        self.assertIn("reader threads did not stop", result.stderr)
 
     def test_rejects_a_server_name_other_than_unica(self) -> None:
         # INV-MCP-SERVER-NAME fixes the published identity of the server. A


### PR DESCRIPTION
## Что сломалось

Ночной прогон 06.09.2026 «Build Unica Codex Plugin» с `profile=large` ([run 34042345593](https://github.com/IngvarConsulting/unica/actions/runs/34042345593)): джоба «Build tools (win-x64)» падает на шаге «Smoke packaged Unica MCP» кодом 124 — единственная строка в логе «Unica MCP smoke exceeded its aggregate deadline of 120s». darwin-arm64 и linux-x64 проходят тот же дым за 1,5 с. Последний зелёный прогон Windows был по тегу v0.12.3 (19.08.2026), с тех пор релизный контур на Windows не запускался.

## Причина

С v13 (31.08, `b6650bc1`) MCP-сервер при старте подключается к пользовательскому демону и при его отсутствии поднимает его отсоединённым процессом со `Stdio::null()` (`ManagedStartupChild::spawn_configured`).

На Windows `std::process::Command` вызывает `CreateProcessW` с `bInheritHandles = TRUE` и без списка дескрипторов, то есть ребёнок получает копии **всех** наследуемых дескрипторов родителя, а не только назначенных ему stdio. Дескрипторы stdin/stdout/stderr, которые хост (Python-дым, Codex, Claude) передал Unica, наследуемы по построению — иначе их нельзя было бы передать. Демон уносил их копии и держал весь свой простой (15 минут по умолчанию).

Для дыма это выглядело так: все проверки проходили, `close()` дожидался выхода `unica.exe`, а затем ждал EOF stdout/stderr до общего дедлайна — EOF не приходил, пока жив демон. Сторож срабатывал ровно на 120-й секунде и завершал процесс `os._exit(124)` раньше, чем печаталась ошибка. В коде очистки дыма уже был комментарий про этот класс для рабочего сервиса (его дым глушит явно через порт), а демона v3 дым не знает.

Это не только про CI: любой хост на Windows, который после закрытия stdin ждёт EOF stdout сервера, ждал бы демона.

## Что сделано

**Продукт.** `run_platform_main` до любого спавна снимает флаг наследования со своих stdio (`SetHandleInformation(HANDLE_FLAG_INHERIT, 0)`). Это касается всех ролей `unica.exe` (MCP, демон, рабочий сервис, воркер), потому что все они стартуют через ту же точку входа. `Stdio::inherit()` детей не страдает: std дублирует дескриптор для ребёнка заново и уже наследуемым. На Unix — пустая операция. В `windows-sys` добавлена фича `Win32_System_Console` ради `GetStdHandle`.

Регрессионный тест `detached_null_stdio_grandchild_never_holds_the_parent_stdout_pipe`: ребёнок оставляет отсоединённого внука со `Stdio::null()` и выходит; у родителя EOF stdout должен прийти сразу, а не через 10 секунд жизни внука. Тест кроссплатформенный; на Windows без правки падает.

**Дым (`scripts/ci/smoke-unica-mcp.py`, `scripts/ci/probe-unica-wire.py`).**
- Ожидание EOF труб после выхода процесса ограничено сроком запроса (20 с), а не общим дедлайном, и отчитывается типизированной ошибкой «reader threads did not stop … a detached descendant still holds the stdout/stderr pipe handles».
- Каждый запрос и каждая фаза очистки пишут строку `[smoke +N.Ns] …` в stderr; сторож называет последнюю фазу.
- При падении и по сторожу в лог уходят stderr MCP и `service.json`/логи рабочего сервиса — до удаления временного каталога.
- Ошибка тела дыма не подменяется ошибкой очистки: печатаются обе.
- Тесты: ограниченное ожидание EOF, дамп диагностики, совмещённая ошибка, фаза в сообщении сторожа.

## Проверка

- Локально: `tests/ci/test_smoke_unica_mcp.py` + `test_probe_unica_wire.py` (58 зелёных), `test_rust_platform_boundary.py`, новый Rust-тест на macOS, `cargo fmt --check`, `cargo clippy --all-features --all-targets`; Windows-код проверен `cargo check --target x86_64-pc-windows-msvc` в отдельном крейте с `windows-sys 0.59`.
- Ручной прогон workflow с `profile=large` на этой ветке: [run 34052206875](https://github.com/IngvarConsulting/unica/actions/runs/34052206875) — **success**.
  - «Build tools (win-x64)» зелёная. Шаг «Smoke packaged Unica MCP» — 5 с; по трассе: `initialize` 4,1 с, проверки поверхности 0,4 с, очистка от EOF stdin до EOF труб — 3 мс (там, где раньше висели 120 с). Пробы wire native/compatibility на Windows прошли.
  - Дальше контур дошёл до конца: упаковка тонкого плагина, пробы bootstrap на трёх платформах, P0 dry proof, оценка на BSP — всё зелёное. Публикация пропущена по правилу «только тег».
  - «Rust tests (windows-latest)» (large, `continue-on-error`) красная, как и на ночном main: `invocation_protocol_round_trips_all_four_strict_requests_and_closed_responses` («daemon deadline expired during invocation submit response», то же в run 34042345593) и `truncated_handshake_transport_closes_without_a_protocol_response` (таймаут сокета, os error 10060; внутрипроцессный TCP-тест без спавна процессов, на ночном main проходил за 0,45 с). Новый тест `detached_null_stdio_grandchild_never_holds_the_parent_stdout_pipe` на Windows прошёл (0,04 с).

  - Побочное подтверждение в той же Windows-джобе: интеграционные тесты `v13_workspace_bootstrap` на main шли 5,1 и 5,4 с (ждали, пока демон с `UNICA_DAEMON_IDLE_GRACE_MS=5000` выйдет и отпустит трубы MCP), на ветке — 0,4 и 0,6 с.

## Остаточный эффект

nextest помечает три интеграционных теста (`v13_search_integration`, `v13_workspace_bootstrap`) как `LEAK` — не падение. Тест-процесс получает свои stdio от nextest наследуемыми, и их копии едут транзитивно: тест → MCP → демон; правка снимает флаг только со своих stdio и не знает о чужих копиях. Для реальных хостов (Python со списком дескрипторов, Node/libuv) это не воспроизводится: Unica достаются только три stdio. Полное закрытие класса — спавн отсоединённых детей со списком `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`, чего std на stable не даёт; отдельная задача.

## Наблюдение вне объёма

На Windows `initialize` занял 4,1 с: это спавн демона при старте MCP, бюджет подключения `DEFAULT_CONNECT_TIMEOUT` — 5 с. На нагруженном раннере запас в секунду может не хватить, и тогда смоук упадёт уже с внятной ошибкой «failed to connect to unica user daemon» в дампе stderr.
