### PR TITLE
ci: репетиция двух полос — ошибка компиляции только под macOS (не вливать)

### DIFF
--- a/crates/unica-coder/src/lib.rs
+++ b/crates/unica-coder/src/lib.rs
@@ -12,3 +12,8 @@ pub mod receipt_ledger_test_support;
 pub(crate) mod test_support;
 
 pub use infrastructure::platform::run_platform_main;
+
+// Репетиция двух полос: ошибка только под macOS должна пройти PR-гейт на
+// ubuntu и покраснеть в очереди слияния, где идёт полная матрица.
+#[cfg(all(test, target_os = "macos"))]
+compile_error!("репетиция двух полос: macOS краснеет в очереди");

--- a/crates/unica-coder/src/lib.rs
+++ b/crates/unica-coder/src/lib.rs
@@ -13,7 +13,13 @@ pub(crate) mod test_support;
 
 pub use infrastructure::platform::run_platform_main;
 
-// Репетиция двух полос: ошибка только под macOS должна пройти PR-гейт на
-// ubuntu и покраснеть в очереди слияния, где идёт полная матрица.
-#[cfg(all(test, target_os = "macos"))]
-compile_error!("репетиция двух полос: macOS краснеет в очереди");
+// Репетиция двух полос: тест падает только на macOS и без `cfg` по ОС —
+// страж границы платформ не терпит таких условий вне фасада `platform/`.
+// Ожидание: PR-гейт на ubuntu зелёный, очередь с полной матрицей красная.
+#[cfg(test)]
+mod two_lane_rehearsal {
+    #[test]
+    fn fails_only_on_macos() {
+        assert_ne!(std::env::consts::OS, "macos", "репетиция двух полос: macOS краснеет в очереди");
+    }
+}

--- a/crates/unica-coder/src/lib.rs
+++ b/crates/unica-coder/src/lib.rs
@@ -20,6 +20,10 @@ pub use infrastructure::platform::run_platform_main;
 mod two_lane_rehearsal {
     #[test]
     fn fails_only_on_macos() {
-        assert_ne!(std::env::consts::OS, "macos", "репетиция двух полос: macOS краснеет в очереди");
+        assert_ne!(
+            std::env::consts::OS,
+            "macos",
+            "репетиция двух полос: macOS краснеет в очереди"
+        );
     }
 }


### PR DESCRIPTION
Репетиция шага 2 плана: `compile_error!` под `cfg(all(test, target_os = "macos"))`. Ожидание: PR-гейт на ubuntu зелёный, очередь слияния с полной матрицей красная на macOS, PR выкидывается из очереди. После проверки PR закрывается без вливания.