### PR TITLE
ci(site): метрика «вливание → отчёт» считает только пересборку по результатам прогона

### DIFF
--- a/scripts/ci/pipeline_metrics.py
+++ b/scripts/ci/pipeline_metrics.py
@@ -72,7 +72,12 @@ def load_runs(gh, repo: str, since: datetime) -> dict[str, list[dict]]:
     by_event: dict[str, list[dict]] = defaultdict(list)
     for run in recent:
         by_event[run["event"]].append(run)
-    by_event["pages"] = [run for run in pages if run["status"] == "completed" and moment(run["createdAt"]) >= since]
+    # Отчёт на сайт приносит только пересборка по завершении прогона-источника:
+    # прямой push-прогон сайта, снятый 07.09.2026, шёл без свежих результатов.
+    by_event["pages"] = [
+        run for run in pages
+        if run["status"] == "completed" and run["event"] == "workflow_run" and moment(run["createdAt"]) >= since
+    ]
     return by_event
 
 
@@ -136,7 +141,7 @@ def compute(by_event: dict[str, list[dict]], merged: list[dict], retry_trend, su
         "metric": "Вливание → отчёт на сайте, медиана",
         "value": fmt_minutes(statistics.median(to_site)) if to_site else "—",
         "target": "15 мин",
-        "source": f"{len(to_site)} push в main с пересборкой сайта",
+        "source": f"{len(to_site)} push в main с пересборкой сайта по результатам прогона",
     })
 
     green = sum(1 for r in mains if r["conclusion"] == "success")

--- a/tests/ci/test_pipeline_metrics.py
+++ b/tests/ci/test_pipeline_metrics.py
@@ -47,7 +47,11 @@ class PipelineMetricsTests(unittest.TestCase):
             run("merge_group", "gh-readonly-queue/main/pr-3-x", "m3", "success", "2026-09-07T12:00:00+00:00", 9, 8),
             run("push", "main", "old", "success", "2026-08-01T10:20:00+00:00", 10, 9),
         ]
-        self.pages = [run("workflow_run", "main", "m1", "success", "2026-09-07T10:31:00+00:00", 3, 10)]
+        self.pages = [
+            run("workflow_run", "main", "m1", "success", "2026-09-07T10:31:00+00:00", 3, 10),
+            # Прямой push-прогон сайта без результатов — не пересборка по прогону.
+            run("push", "main", "m1", "success", "2026-09-07T10:20:00+00:00", 1, 11),
+        ]
         self.merged = [
             {"number": 1, "createdAt": "2026-09-07T08:00:00Z", "mergedAt": "2026-09-07T10:20:00Z", "headRefName": "feature/a", "mergeCommit": {"oid": "m1"}},
             {"number": 3, "createdAt": "2026-09-07T08:00:00Z", "mergedAt": "2026-09-07T12:19:00Z", "headRefName": "feature/c", "mergeCommit": {"oid": "m3"}},


### PR DESCRIPTION
Уточнение шага 6: на живой странице «Конвейер» путь «вливание → отчёт» показал 0,9 мин, потому что метрика ловила прямые push-прогоны сайта, снятые в #757: они шли без свежих результатов. Теперь считаются только пересборки по `workflow_run`. Тест на выдуманных прогонах различает оба вида.