### PR TITLE
ci: шаг 3 плана, полосы — tests/ci идёт в очереди двумя джобами по размеру

### DIFF
--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -58,6 +58,7 @@ jobs:
       assessment_required: ${{ steps.scope.outputs.assessment_required }}
       line: ${{ steps.line.outputs.line }}
       runners: ${{ steps.runners.outputs.runners }}
+      python_matrix: ${{ steps.python-matrix.outputs.python_matrix }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -82,6 +83,10 @@ jobs:
           else
             echo 'runners=["ubuntu-latest"]' >> "$GITHUB_OUTPUT"
           fi
+      # Матрица джоб Python: набор на джобу, `tests/ci` — по полосам размера.
+      # Список считает шов: наборы и допуски ворот живут в нём, а не здесь.
+      - id: python-matrix
+        run: echo "python_matrix=$(python scripts/ci/run-tests.py --profile "$GATE_PROFILE" --python-matrix)" >> "$GITHUB_OUTPUT"
       # Линия прогона едет в подписи результатов: для ветки — она сама, для
       # тега — релизная линия с его коммитом; тег вне релизной линии — отказ.
       - id: line
@@ -169,26 +174,23 @@ jobs:
           category: zizmor
 
   test-python:
-    name: Python tests (${{ matrix.suite }})
+    name: Python tests (${{ matrix.slug }})
     runs-on: ubuntu-latest
     timeout-minutes: 90
     needs: [classify-changes, guards]
-    # Наборы идут параллельными джобами, по одной на набор: одним процессом
-    # очередь и `main` ждали восемь минут, из них две — корпус приёмки.
-    # Каждая джоба зовёт тот же шов с `--suite`; гейт видит одну джобу.
+    # Наборы идут параллельными джобами, по одной на набор, а `tests/ci` —
+    # по полосам размера: одним процессом он шёл в очереди шесть с половиной
+    # минут, из них четыре — несколько `medium`-тестов. Матрицу считает шов
+    # по воротам; каждая джоба зовёт тот же шов с `--suite` и `--only-size`,
+    # гейт видит одну джобу.
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - suite: tests/ci
-            slug: ci
-          - suite: tests/arch
-            slug: arch
-          - suite: tests/dev
-            slug: dev
+        include: ${{ fromJSON(needs.classify-changes.outputs.python_matrix) }}
     env:
       RUN_LINE: ${{ needs.classify-changes.outputs.line }}
       SUITE: ${{ matrix.suite }}
+      LANE: ${{ matrix.lane }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -201,7 +203,7 @@ jobs:
       - run: python -m pip install -r tests/ci/requirements.txt
       # План выгружается до тестов, как у Rust: джоба, умершая на середине
       # набора, оставляет состав, и недошедшие тесты попадут в отчёт `skipped`.
-      - run: python scripts/ci/run-tests.py --profile "$GATE_PROFILE" --ecosystem python --suite "$SUITE" --plan-only --results .build/results --runner ubuntu-latest --line "$RUN_LINE"
+      - run: python scripts/ci/run-tests.py --profile "$GATE_PROFILE" --ecosystem python --suite "$SUITE" --only-size "$LANE" --plan-only --results .build/results --runner ubuntu-latest --line "$RUN_LINE"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: plan-python-${{ matrix.slug }}
@@ -210,7 +212,7 @@ jobs:
           overwrite: true
       # Наборы гоняет одна точка входа: профиль ворот меняется в ней, а не
       # здесь; `--suite` сужает вызов до набора этой джобы.
-      - run: python scripts/ci/run-tests.py --profile "$GATE_PROFILE" --ecosystem python --suite "$SUITE" --results .build/results --runner ubuntu-latest --line "$RUN_LINE"
+      - run: python scripts/ci/run-tests.py --profile "$GATE_PROFILE" --ecosystem python --suite "$SUITE" --only-size "$LANE" --results .build/results --runner ubuntu-latest --line "$RUN_LINE"
       # Результаты едут артефактом и при красном прогоне: ради них он и шёл.
       - if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/scripts/ci/collect-results.py
+++ b/scripts/ci/collect-results.py
@@ -35,7 +35,13 @@ from site_fetch import fetch  # noqa: E402
 # Имя Rust-джобы в workflow и шаблоны имён артефактов: сайт читает их отсюда,
 # а страж сверяет с workflow — переименование в одном месте красит тест.
 RUST_JOB = "Rust tests ({runner})"
-PYTHON_JOB = "Python tests ({suite})"
+PYTHON_JOB = "Python tests ({slug})"
+
+
+def python_slug(suite: str, lane: str) -> str:
+    """То же правило, что у шва `run-tests.py`: основание набора и полоса."""
+    base = suite.rstrip("/").split("/")[-1]
+    return f"{base}-{lane}" if lane else base
 RESULTS_PREFIX = "results-"
 PLAN_PREFIX = "plan-"
 
@@ -120,6 +126,9 @@ def fill_gaps(plan_dir: Path, run: dict, seen: set[str], out: Path, conclusions:
     job = RUST_JOB.format(runner=runner)
     conclusion = conclusions.get(job) or "unknown"
     filled = 0
+    # Полоса, которую ворота не принимают, оставляет подпись без плана: пусто.
+    if not (plan_dir / "plan.json").is_file():
+        return 0
     for case in load_json(plan_dir / "plan.json"):
         if "binary" not in case:
             continue
@@ -150,10 +159,12 @@ def fill_python_gaps(plan_dir: Path, run: dict, seen: set[str], out: Path, concl
     runner = run.get("runner", "")
     profile = run.get("profile", "all")
     filled = 0
+    if not (plan_dir / "plan.json").is_file():
+        return 0
     for case in load_json(plan_dir / "plan.json"):
         if case.get("ecosystem") != "python" or case["id"] in seen:
             continue
-        job = PYTHON_JOB.format(suite=case["suite"])
+        job = PYTHON_JOB.format(slug=python_slug(case["suite"], case.get("lane", "")))
         conclusion = conclusions.get(job) or "unknown"
         message = f"раннер не дошёл: {job} · {conclusion}"
         if run.get("run_url"):

--- a/scripts/ci/run-tests.py
+++ b/scripts/ci/run-tests.py
@@ -88,8 +88,40 @@ def rust_commands(profile: str) -> list[list[str]]:
     return [command]
 
 
+# Наборы, которые в CI делятся на полосы по размеру: одна джоба на размер.
+# `tests/ci` одним процессом шёл в очереди шесть с половиной минут, из них
+# четыре — несколько `medium`-тестов; полоса `medium` идёт своей джобой.
+LANED_SUITES = ("tests/ci",)
+
+
 def python_suite_names() -> tuple[str, ...]:
     return tuple(suite for suite, _, _ in PYTHON_SUITES)
+
+
+def python_slug(suite: str, lane: str) -> str:
+    """Имя джобы и артефакта: основание набора и полоса, если она есть."""
+    base = suite.rstrip("/").split("/")[-1]
+    return f"{base}-{lane}" if lane else base
+
+
+def python_matrix(profile: str) -> list[dict]:
+    """Матрица джоб Python для ворот: набор на джобу, полосатый набор — по размеру.
+
+    Считается швом, а не пишется в workflow: список наборов и допуски ворот
+    живут здесь, и workflow берёт матрицу готовой.
+    """
+    try:
+        admitted = ADMITTED[profile]
+    except KeyError:
+        raise ValueError(f"профиль {profile!r} для Python не описан") from None
+    entries: list[dict] = []
+    for suite, size, _ in PYTHON_SUITES:
+        if size not in admitted:
+            continue
+        lanes = [lane for lane in SIZES if lane in admitted] if suite in LANED_SUITES else [""]
+        for lane in lanes:
+            entries.append({"suite": suite, "lane": lane, "slug": python_slug(suite, lane)})
+    return entries
 
 
 def python_commands(
@@ -98,6 +130,7 @@ def python_commands(
     results: Path | None = None,
     runner: str = "local",
     suite: str | None = None,
+    only_size: str | None = None,
 ) -> list[list[str]]:
     """Команды Python для профиля: наборы тех размеров, что ворота принимают.
 
@@ -113,13 +146,25 @@ def python_commands(
         raise ValueError(f"профиль {profile!r} для Python не описан") from None
     if suite is not None and suite not in python_suite_names():
         raise ValueError(f"набор {suite!r} не описан; известны: {', '.join(python_suite_names())}")
+    # Полоса размера: джоба гоняет один размер из допущенных воротами внутри
+    # набора. Размер, которого ворота не принимают, даёт пустой список —
+    # команд нет, а не «все». Сам набор допускается по его объявленному размеру.
+    lane_sizes = list(admitted)
+    if only_size:
+        if only_size not in SIZES:
+            raise ValueError(f"размер {only_size!r} не описан; известны: {', '.join(SIZES)}")
+        lane_sizes = [size for size in admitted if size == only_size]
+        if not lane_sizes:
+            return []
     # Размер набора — умолчание; манифест поднимает отдельные классы и тесты
     # до `medium`. Ворота, допускающие не все размеры, получают `--admit`;
     # `all` без записи результатов повторяет прежнюю команду один в один.
     def tail(size: str) -> list[str]:
         sizing: list[str] = []
-        if set(admitted) != set(SIZES):
-            sizing = ["--sizes", str(PYTHON_SIZES), "--admit", ",".join(admitted)]
+        if set(lane_sizes) != set(SIZES):
+            sizing = ["--sizes", str(PYTHON_SIZES), "--admit", ",".join(lane_sizes)]
+        if only_size:
+            sizing += ["--lane", only_size]
         if results is None:
             return sizing
         return ["--results", str(results), "--runner", runner, "--profile", profile, "--size", size, "--sizes", str(PYTHON_SIZES), *sizing]
@@ -138,6 +183,7 @@ def commands(
     results: Path | None = None,
     runner: str = "local",
     suite: str | None = None,
+    only_size: str | None = None,
 ) -> list[list[str]]:
     if profile not in PROFILES:
         raise ValueError(f"неизвестный профиль {profile!r}; известны: {', '.join(PROFILES)}")
@@ -147,7 +193,7 @@ def commands(
     if ecosystem in ("rust", "all"):
         planned.extend(rust_commands(profile))
     if ecosystem in ("python", "all"):
-        planned.extend(python_commands(profile, interpreter, results, runner, suite))
+        planned.extend(python_commands(profile, interpreter, results, runner, suite, only_size))
     return planned
 
 
@@ -158,9 +204,9 @@ def write_rust_plan(results: Path, profile: str) -> int:
     return len(entries)
 
 
-def write_python_plan(profile: str, results: Path, runner: str, suite: str | None = None) -> int:
+def write_python_plan(profile: str, results: Path, runner: str, suite: str | None = None, only_size: str | None = None) -> int:
     """План Python — тем же швом и теми же командами, что и прогон, только состав."""
-    for command in python_commands(profile, results=results, runner=runner, suite=suite):
+    for command in python_commands(profile, results=results, runner=runner, suite=suite, only_size=only_size):
         completed = subprocess.run([*command, "--plan-only"], cwd=REPO_ROOT, stdout=subprocess.DEVNULL)
         if completed.returncode != 0:
             raise SystemExit(f"план Python не записан: {' '.join(command)}")
@@ -208,9 +254,16 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--sha", default=None, help="вершина линии для подписи; по умолчанию — из окружения")
     parser.add_argument("--suite", default=None, choices=python_suite_names(),
                         help="один набор Python вместо всех: в CI наборы идут джобами, по одной на набор")
+    parser.add_argument("--only-size", default="", help="полоса размера набора Python; пусто — все допущенные")
+    parser.add_argument("--python-matrix", action="store_true", help="напечатать матрицу джоб Python для ворот и выйти")
     args = parser.parse_args(argv)
+    only_size = args.only_size or None
 
-    planned = commands(args.profile, args.ecosystem, results=args.results, runner=args.runner, suite=args.suite)
+    if args.python_matrix:
+        print(json.dumps(python_matrix(args.profile), ensure_ascii=False, separators=(",", ":")))
+        return 0
+
+    planned = commands(args.profile, args.ecosystem, results=args.results, runner=args.runner, suite=args.suite, only_size=only_size)
     if args.dry_run:
         for command in planned:
             print(" ".join(command))
@@ -227,10 +280,10 @@ def main(argv: list[str] | None = None) -> int:
         if args.ecosystem in ("rust", "all"):
             print(f"план Rust: {write_rust_plan(args.results, args.profile)} тестов")
         if args.ecosystem in ("python", "all"):
-            print(f"план Python: {write_python_plan(args.profile, args.results, args.runner, args.suite)} тестов")
+            print(f"план Python: {write_python_plan(args.profile, args.results, args.runner, args.suite, only_size)} тестов")
         return 0
 
-    return execute(args.profile, args.ecosystem, args.results, args.runner, line=args.line, sha=args.sha, suite=args.suite)
+    return execute(args.profile, args.ecosystem, args.results, args.runner, line=args.line, sha=args.sha, suite=args.suite, only_size=only_size)
 
 
 def execute(
@@ -243,6 +296,7 @@ def execute(
     line: str | None = None,
     sha: str | None = None,
     suite: str | None = None,
+    only_size: str | None = None,
 ) -> int:
     """Прогнать экосистемы и оставить результаты.
 
@@ -266,7 +320,7 @@ def execute(
         if code != 0:
             return code
     if ecosystem in ("python", "all"):
-        code = run_commands(python_commands(profile, results=results, runner=runner, suite=suite))
+        code = run_commands(python_commands(profile, results=results, runner=runner, suite=suite, only_size=only_size))
     return code
 
 

--- a/scripts/ci/run-unittest.py
+++ b/scripts/ci/run-unittest.py
@@ -133,6 +133,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--sizes", type=Path, default=None, help="манифест размеров .config/python-sizes.toml")
     parser.add_argument("--admit", default="", help="какие размеры гонять, через запятую; пусто — все")
     parser.add_argument("--plan-only", action="store_true", help="перечислить тесты и выйти")
+    parser.add_argument("--lane", default="", help="полоса размера этой джобы: идёт в план, чтобы сайт нашёл её джобу")
     args = parser.parse_args(argv)
 
     sizes = Sizes.load(args.sizes, args.size)
@@ -147,7 +148,7 @@ def main(argv: list[str] | None = None) -> int:
         for case in planned:
             print(case.id())
         if args.results is not None:
-            write_python_plan(args.results, planned, args.start_directory, sizes)
+            write_python_plan(args.results, planned, args.start_directory, sizes, args.lane)
         return 0
 
     AllureResult.out = args.results
@@ -162,7 +163,7 @@ def main(argv: list[str] | None = None) -> int:
     return 0 if result.wasSuccessful() else 1
 
 
-def write_python_plan(out: Path, cases, suite_name: str, sizes: Sizes) -> Path:
+def write_python_plan(out: Path, cases, suite_name: str, sizes: Sizes, lane: str = "") -> Path:
     """Состав набора до запуска: джоба, умершая на середине, оставляет список.
 
     Записи идут с той же подписью, что и результаты; сайт дописывает
@@ -172,7 +173,10 @@ def write_python_plan(out: Path, cases, suite_name: str, sizes: Sizes) -> Path:
     out.mkdir(parents=True, exist_ok=True)
     path = out / "plan.json"
     entries = json.loads(path.read_text(encoding="utf-8")) if path.is_file() else []
-    entries = [entry for entry in entries if not (entry.get("ecosystem") == "python" and entry.get("suite") == suite_name)]
+    entries = [
+        entry for entry in entries
+        if not (entry.get("ecosystem") == "python" and entry.get("suite") == suite_name and entry.get("lane", "") == lane)
+    ]
     for case in cases:
         doc = (getattr(case, "_testMethodDoc", None) or "").strip().splitlines()
         entries.append(
@@ -181,6 +185,7 @@ def write_python_plan(out: Path, cases, suite_name: str, sizes: Sizes) -> Path:
                 "id": case.id(),
                 "name": doc[0] if doc else getattr(case, "_testMethodName", case.id()),
                 "suite": suite_name,
+                "lane": lane,
                 "subSuite": case.__class__.__qualname__,
                 "size": sizes.size_of(case.id()),
             }

--- a/tests/ci/test_collect_results.py
+++ b/tests/ci/test_collect_results.py
@@ -100,10 +100,10 @@ class CollectResultsTests(unittest.TestCase):
         plan = self.signed("plan-python-ci", "ubuntu-latest", "python", [])
         (plan / "plan.json").write_text(json.dumps([
             {"ecosystem": "python", "id": "test_x.Guard.test_it", "name": "страж", "suite": "tests/ci", "subSuite": "Guard", "size": "small"},
-            {"ecosystem": "python", "id": "test_x.Guard.test_never_reached", "name": "не дошёл", "suite": "tests/ci", "subSuite": "Guard", "size": "medium"},
+            {"ecosystem": "python", "id": "test_x.Guard.test_never_reached", "name": "не дошёл", "suite": "tests/ci", "lane": "medium", "subSuite": "Guard", "size": "medium"},
         ]), encoding="utf-8")
         jobs = self.root / "jobs.json"
-        jobs.write_text(json.dumps({"jobs": [{"name": "Python tests (tests/ci)", "conclusion": "cancelled"}]}), encoding="utf-8")
+        jobs.write_text(json.dumps({"jobs": [{"name": "Python tests (ci-medium)", "conclusion": "cancelled"}]}), encoding="utf-8")
         out = self.root / "fresh"
 
         lines = self.collect.collect(self.artifacts, out, jobs, "", "https://example.invalid")
@@ -113,7 +113,7 @@ class CollectResultsTests(unittest.TestCase):
         gaps = [json.loads(r.read_text(encoding="utf-8")) for r in (out / "release-v0.12").glob("*-result.json")]
         gap = next(g for g in gaps if g["fullName"] == "test_x.Guard.test_never_reached")
         self.assertEqual(gap["status"], "skipped")
-        self.assertIn("раннер не дошёл: Python tests (tests/ci) · cancelled", gap["statusDetails"]["message"])
+        self.assertIn("раннер не дошёл: Python tests (ci-medium) · cancelled", gap["statusDetails"]["message"])
         labels = {l["name"]: l["value"] for l in gap["labels"]}
         self.assertEqual((labels["language"], labels["suite"], labels["size"]), ("python", "tests/ci", "medium"))
         self.assertEqual(gap["historyId"], self.allure.history_id("test_x.Guard.test_never_reached", "ubuntu-latest"))
@@ -230,7 +230,12 @@ class CollectResultsTests(unittest.TestCase):
         rust_job = release["jobs"]["test-rust-platforms"]["name"]
         self.assertEqual(rust_job.replace("${{ matrix.runner }}", "{runner}"), self.collect.RUST_JOB)
         python_job = release["jobs"]["test-python"]["name"]
-        self.assertEqual(python_job.replace("${{ matrix.suite }}", "{suite}"), self.collect.PYTHON_JOB)
+        self.assertEqual(python_job.replace("${{ matrix.slug }}", "{slug}"), self.collect.PYTHON_JOB)
+        # Правило имени полосы одно у шва и у сборщика: матрица ворот совпадает с ним.
+        run_tests = load("run-tests")
+        for profile in ("pr", "queue", "main"):
+            for entry in run_tests.python_matrix(profile):
+                self.assertEqual(entry["slug"], self.collect.python_slug(entry["suite"], entry["lane"]))
 
         prefixes = (self.collect.RESULTS_PREFIX, self.collect.PLAN_PREFIX)
         uploads = []

--- a/tests/ci/test_gate_profiles.py
+++ b/tests/ci/test_gate_profiles.py
@@ -48,15 +48,15 @@ class GateProfileCompositionTests(unittest.TestCase):
         self.assertEqual(profiles["large"]["overrides"], [{"platform": "cfg(windows)", "default-filter": "all()"}])
         self.assertIn("--no-tests=pass", self.run_tests.rust_commands("large")[0])
 
-    def test_python_matrix_in_the_workflow_names_every_suite_of_the_seam(self) -> None:
-        """Джоба на набор: матрица workflow и `PYTHON_SUITES` шва — один список."""
-        import yaml
-
-        release = yaml.safe_load((REPO_ROOT / ".github" / "workflows" / "unica-plugin-release.yml").read_text(encoding="utf-8"))
-        matrix = release["jobs"]["test-python"]["strategy"]["matrix"]["include"]
-
-        self.assertEqual([entry["suite"] for entry in matrix], [suite for suite, _, _ in self.run_tests.PYTHON_SUITES])
-        self.assertEqual([entry["slug"] for entry in matrix], [suite.split("/")[-1] for suite, _, _ in self.run_tests.PYTHON_SUITES])
+    def test_python_matrix_names_every_suite_of_the_seam_and_lanes_only_admitted_sizes(self) -> None:
+        """Матрица ворот: каждый набор шва, полосатый — по допущенным размерам, не больше."""
+        for gate in ("pr", "queue", "main", "release"):
+            with self.subTest(gate=gate):
+                matrix = self.run_tests.python_matrix(gate)
+                self.assertEqual(sorted({entry["suite"] for entry in matrix}), sorted(suite for suite, _, _ in self.run_tests.PYTHON_SUITES))
+                lanes = {entry["lane"] for entry in matrix if entry["suite"] in self.run_tests.LANED_SUITES}
+                self.assertEqual(lanes, set(self.run_tests.ADMITTED[gate]))
+                self.assertTrue(all(not entry["lane"] for entry in matrix if entry["suite"] not in self.run_tests.LANED_SUITES))
 
     def test_nextest_version_in_config_matches_the_workflow_install(self) -> None:
         """Одна версия исполнителя для CI и локального прогона."""

--- a/tests/ci/test_run_tests.py
+++ b/tests/ci/test_run_tests.py
@@ -223,6 +223,29 @@ class GateProfileTests(unittest.TestCase):
         self.assertTrue(all(entry["suite"] == "tests/arch" for entry in planned))
         self.assertTrue(all(entry["id"].count(".") >= 2 and entry["subSuite"] and entry["size"] for entry in planned))
 
+    def test_size_lanes_split_a_suite_by_the_sizes_the_gate_admits(self) -> None:
+        """Полоса гоняет один размер внутри набора; недопущенный воротами размер — пустой список."""
+        module = load_module()
+
+        medium = module.python_commands("queue", "python3", suite="tests/ci", only_size="medium")
+        small = module.python_commands("queue", "python3", suite="tests/ci", only_size="small")
+        self.assertEqual(len(medium), 1)
+        self.assertEqual(medium[0][medium[0].index("--admit") + 1], "medium")
+        self.assertEqual(medium[0][medium[0].index("--lane") + 1], "medium")
+        self.assertEqual(small[0][small[0].index("--admit") + 1], "small")
+        # Ворота pr не принимают medium: полоса пуста, а не «все».
+        self.assertEqual(module.python_commands("pr", "python3", suite="tests/ci", only_size="medium"), [])
+        with self.assertRaises(ValueError):
+            module.python_commands("queue", "python3", suite="tests/ci", only_size="huge")
+        # Матрица ворот: полосатый набор — по размерам, остальные — одной джобой.
+        self.assertEqual(
+            [entry["slug"] for entry in module.python_matrix("queue")],
+            ["ci-small", "ci-medium", "arch", "dev"],
+        )
+        self.assertEqual([entry["slug"] for entry in module.python_matrix("pr")], ["ci-small", "arch", "dev"])
+        for entry in module.python_matrix("main"):
+            self.assertEqual(entry["slug"], module.python_slug(entry["suite"], entry["lane"]))
+
     def test_one_suite_per_job_narrows_the_seam_without_changing_the_command(self) -> None:
         """В CI наборы идут параллельными джобами: `--suite` даёт ровно одну команду, ту же самую."""
         module = load_module()

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -179,7 +179,7 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
         self.assertIn("cargo clippy --workspace --all-targets --all-features --message-format=json -- -D warnings", text)
         # Наборы гоняет шов; сами команды закреплены тестом `test_run_tests`.
         self.assertIn('python3 scripts/ci/run-tests.py --profile "$GATE_PROFILE" --ecosystem rust --results', text)
-        self.assertIn('python scripts/ci/run-tests.py --profile "$GATE_PROFILE" --ecosystem python --suite "$SUITE" --results', text)
+        self.assertIn('python scripts/ci/run-tests.py --profile "$GATE_PROFILE" --ecosystem python --suite "$SUITE" --only-size "$LANE" --results', text)
         self.assertNotIn("cargo test --workspace", text)
         self.assertNotIn("unittest discover", text)
         self.assertIn("python -m py_compile scripts/dev/*.py tests/dev/*.py", text)
@@ -490,11 +490,18 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
 
         self.assertIn("python -m py_compile scripts/arch/*.py tests/arch/*.py", script(guards))
         self.assertIn("python scripts/arch/registry.py --check", script(guards))
-        self.assertIn('python scripts/ci/run-tests.py --profile "$GATE_PROFILE" --ecosystem python --suite "$SUITE" --results', script(python))
+        self.assertIn('python scripts/ci/run-tests.py --profile "$GATE_PROFILE" --ecosystem python --suite "$SUITE" --only-size "$LANE" --results', script(python))
         self.assertEqual(needs(python), ["classify-changes", "guards"])
-        # Наборы идут параллельными джобами, по одной на набор из шва `run-tests.py`.
-        self.assertEqual([entry["suite"] for entry in matrix_include(python)], ["tests/ci", "tests/arch", "tests/dev"])
+        # Матрицу джоб Python считает шов по воротам; джоба знает набор и полосу.
+        self.assertEqual(python["strategy"]["matrix"]["include"], "${{ fromJSON(needs.classify-changes.outputs.python_matrix) }}")
         self.assertEqual(python["env"]["SUITE"], "${{ matrix.suite }}")
+        self.assertEqual(python["env"]["LANE"], "${{ matrix.lane }}")
+        self.assertEqual(python["name"], "Python tests (${{ matrix.slug }})")
+        classify = job(self.release, "classify-changes")
+        self.assertEqual(classify["outputs"]["python_matrix"], "${{ steps.python-matrix.outputs.python_matrix }}")
+        self.assertIn('run-tests.py --profile "$GATE_PROFILE" --python-matrix', step_by_id(classify, "python-matrix")["run"])
+        for run_line in [step["run"] for step in steps(python) if "run-tests.py" in step.get("run", "")]:
+            self.assertIn('--suite "$SUITE" --only-size "$LANE"', run_line)
         self.assertEqual([upload["name"] for upload in uploads(python)], ["plan-python-${{ matrix.slug }}", "results-python-${{ matrix.slug }}"])
         # План выгружается до тестов, как у Rust.
         plan_index = next(index for index, step in enumerate(steps(python)) if "--plan-only" in step.get("run", ""))


### PR DESCRIPTION
Продолжение шага 3 плана [2026-09-07-pipeline-parallel-sessions-plan-design.md](https://github.com/IngvarConsulting/unica/blob/main/docs/design/2026-09-07-pipeline-parallel-sessions-plan-design.md): в очереди `tests/ci` одной джобой шёл 390 с, из них около 230 с — несколько `medium`-тестов, и цель в 4 минуты не взята. Теперь набор делится по размеру: `ci-small` и `ci-medium` параллельно, `arch` и `dev` как прежде. Матрицу считает шов (`run-tests.py --python-matrix`), на PR полосы `medium` нет. Полоса идёт в план, сборщик находит её джобу по тому же правилу имени; недопущенный воротами размер даёт пустой список команд. Стражи: полосы шва, матрица по воротам, правило имени у шва и сборщика, джоба и её шаги. Проверка на проде: джобы Python в очереди — самая долгая не дольше 4,5 минут.