### PR TITLE
ci: контракт ReceiptLedger и process-тесты daemon в конвейере, ярус large

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -110,19 +110,69 @@ kind(test)
 )'''
 # <<< размер medium (ворота pr)
 
+# Очередь и `main` — `small` и `medium`: всё, кроме `large`. Выражение `large`
+# ниже — одно на четыре места (очередь, `main`, ночь и срок); страж состава
+# держит их равными.
 [profile.queue]
-default-filter = 'all()'
+# >>> размер large (ворота queue)
+default-filter = '''not (
+binary(daemon_receipt_ledger) & (
+    test(/^deterministic_horizon_load_does_not_saturate$/)
+    | test(/^link_capacity_before_begun_terminalizes_receipt_backed_without_callback$/)
+    | test(/^link_capacity_preserves_staged_terminal_winner$/)
+    | test(/^receipt_pools_and_task_store_limits_are_independent_after_restart$/)
+    | test(/^retained_receipt_backed_terminals_do_not_starve_target_direct_load$/)
+    | test(/^task_store_4097_boundary_preserves_existing_tasks_and_listener_availability$/)
+    | test(/^task_store_capacity_after_reservation_is_invariant_violation_and_fail_stops$/)
+    | test(/^thirty_two_lazy_cancel_actor_batch_finishes_within_125ms$/)
+    | test(/^wall_clock_writer_sustains_32_receipts_per_second_on_posix$/)
+)
+)'''
+# <<< размер large (ворота queue)
 
 [profile.main]
-default-filter = 'all()'
+# >>> размер large (ворота main)
+default-filter = '''not (
+binary(daemon_receipt_ledger) & (
+    test(/^deterministic_horizon_load_does_not_saturate$/)
+    | test(/^link_capacity_before_begun_terminalizes_receipt_backed_without_callback$/)
+    | test(/^link_capacity_preserves_staged_terminal_winner$/)
+    | test(/^receipt_pools_and_task_store_limits_are_independent_after_restart$/)
+    | test(/^retained_receipt_backed_terminals_do_not_starve_target_direct_load$/)
+    | test(/^task_store_4097_boundary_preserves_existing_tasks_and_listener_availability$/)
+    | test(/^task_store_capacity_after_reservation_is_invariant_violation_and_fail_stops$/)
+    | test(/^thirty_two_lazy_cancel_actor_batch_finishes_within_125ms$/)
+    | test(/^wall_clock_writer_sustains_32_receipts_per_second_on_posix$/)
+)
+)'''
+# <<< размер large (ворота main)
 
+# Релиз гоняет всё, включая `large`: тег — те же ворота, что ночь, плюс всё
+# остальное.
 [profile.release]
 default-filter = 'all()'
 
-# Ночной ярус. Пуст до расстановки размеров: выражение придёт вместе с ней,
-# а до тех пор ночь честно гоняет ноль и пишет память о проверенной вершине.
+# Ночной ярус: тесты ёмкости и нагрузки контракта ReceiptLedger
+# (`tests/daemon_receipt_ledger.rs`). Ярус объявлен именами, а не структурой:
+# двоичный файл контракта целиком `medium` по `kind(test)`, а эти тесты внутри
+# него идут по 200–520 с каждый и меряют настенное время, поэтому ночью и по
+# одному на машину (`threads-required` ниже). Замер 07.09.2026, локально.
 [profile.large]
-default-filter = 'none()'
+# >>> размер large (ворота large)
+default-filter = '''
+binary(daemon_receipt_ledger) & (
+    test(/^deterministic_horizon_load_does_not_saturate$/)
+    | test(/^link_capacity_before_begun_terminalizes_receipt_backed_without_callback$/)
+    | test(/^link_capacity_preserves_staged_terminal_winner$/)
+    | test(/^receipt_pools_and_task_store_limits_are_independent_after_restart$/)
+    | test(/^retained_receipt_backed_terminals_do_not_starve_target_direct_load$/)
+    | test(/^task_store_4097_boundary_preserves_existing_tasks_and_listener_availability$/)
+    | test(/^task_store_capacity_after_reservation_is_invariant_violation_and_fail_stops$/)
+    | test(/^thirty_two_lazy_cancel_actor_batch_finishes_within_125ms$/)
+    | test(/^wall_clock_writer_sustains_32_receipts_per_second_on_posix$/)
+)
+'''
+# <<< размер large (ворота large)
 
 # Ночью Windows гоняет весь набор: с матрицы pull request и main он снят за
 # нестабильность раннера, а в ночном ярусе сбой виден и никого не блокирует.
@@ -196,3 +246,25 @@ kind(test)
 '''
 slow-timeout = { period = "300s", terminate-after = 2 }
 # <<< размер medium (срок)
+
+# Срок `large` — 900 с, остановка после второго периода, и вся машина одному
+# тесту: нагрузочные ворота меряют p99 задержки записи, и соседний тест на
+# том же ядре красит их без вины кода.
+# >>> размер large (срок)
+[[profile.default.overrides]]
+filter = '''
+binary(daemon_receipt_ledger) & (
+    test(/^deterministic_horizon_load_does_not_saturate$/)
+    | test(/^link_capacity_before_begun_terminalizes_receipt_backed_without_callback$/)
+    | test(/^link_capacity_preserves_staged_terminal_winner$/)
+    | test(/^receipt_pools_and_task_store_limits_are_independent_after_restart$/)
+    | test(/^retained_receipt_backed_terminals_do_not_starve_target_direct_load$/)
+    | test(/^task_store_4097_boundary_preserves_existing_tasks_and_listener_availability$/)
+    | test(/^task_store_capacity_after_reservation_is_invariant_violation_and_fail_stops$/)
+    | test(/^thirty_two_lazy_cancel_actor_batch_finishes_within_125ms$/)
+    | test(/^wall_clock_writer_sustains_32_receipts_per_second_on_posix$/)
+)
+'''
+slow-timeout = { period = "900s", terminate-after = 2 }
+threads-required = "num-cpus"
+# <<< размер large (срок)

--- a/crates/unica-coder/tests/daemon_process.rs
+++ b/crates/unica-coder/tests/daemon_process.rs
@@ -16,7 +16,6 @@ const PROCESS_FIXTURE_IDLE_GRACE_MS: u64 = 2_000;
 const STALE_ENDPOINT_INITIAL_IDLE_GRACE_MS: u64 = 500;
 
 #[test]
-#[ignore = "daemon tier: raises a daemon process; disabled on purpose until the tier is routed"]
 fn daemon_frontend_process_fixture() {
     if std::env::var_os(PROCESS_FIXTURE_ENV).is_none() {
         return;
@@ -53,7 +52,6 @@ fn daemon_frontend_process_fixture() {
 }
 
 #[test]
-#[ignore = "daemon tier: raises a daemon process; disabled on purpose until the tier is routed"]
 fn two_frontend_processes_race_to_one_daemon_pid_record_and_endpoint() {
     let root = tempfile::tempdir().unwrap();
     let state_root = std::fs::canonicalize(root.path()).unwrap();
@@ -108,7 +106,6 @@ fn two_frontend_processes_race_to_one_daemon_pid_record_and_endpoint() {
 }
 
 #[test]
-#[ignore = "daemon tier: raises a daemon process; disabled on purpose until the tier is routed"]
 fn incompatible_core_identities_spawn_separate_process_endpoints() {
     let root = tempfile::tempdir().unwrap();
     let state_root = std::fs::canonicalize(root.path()).unwrap();
@@ -159,7 +156,6 @@ fn incompatible_core_identities_spawn_separate_process_endpoints() {
 }
 
 #[test]
-#[ignore = "daemon tier: raises a daemon process; disabled on purpose until the tier is routed"]
 fn v5_frontend_process_spawns_the_same_binary_and_pings_the_v5_runtime() {
     let root = tempfile::tempdir().unwrap();
     let state_root = std::fs::canonicalize(root.path()).unwrap();
@@ -187,7 +183,6 @@ fn v5_frontend_process_spawns_the_same_binary_and_pings_the_v5_runtime() {
 }
 
 #[test]
-#[ignore = "daemon tier: raises a daemon process; disabled on purpose until the tier is routed"]
 fn stale_v5_endpoint_probe_preserves_budget_to_spawn_a_replacement() {
     let root = tempfile::tempdir().unwrap();
     let state_root = std::fs::canonicalize(root.path()).unwrap();

--- a/docs/design/2026-09-07-daemon-v5-production-cutover-design.md
+++ b/docs/design/2026-09-07-daemon-v5-production-cutover-design.md
@@ -1,0 +1,236 @@
+- Date: `2026-09-07`
+- Status: `draft`
+- Decision: `none` — записка ведёт к решению о переключении production daemon на протокол v5; само решение заводится вместе с переключением (шаг C ниже), до него реестр остаётся на v3
+
+# Перевод production daemon с протокола v3 на v5 и снятие v3
+
+## Задача
+
+Production frontend (`unica` в режиме stdio) поднимает пользовательский
+daemon протокола v3. Протокол v5 с durable ReceiptLedger реализован
+полностью, доказан 65 именованными чёрноящичными тестами на трёх ОС
+(D0, #647) и стоит рядом, но в продукт не подключён: его выбирает только
+тестовый вход. Задача — перевести production на v5, довести до
+подтверждения на конвейере и после этого удалить v3 из системы, не оставив
+двух wire identity ни в коде, ни в реестре.
+
+Источники требований: план W0a → W0b → W0c в
+[`docs/plans/2026-08-28-v0-13-completion.md`](../plans/2026-08-28-v0-13-completion.md),
+семантика фронтенда в
+[2026-08-28-daemon-receipt-ledger-design.md](2026-08-28-daemon-receipt-ledger-design.md),
+порядок волн в
+[2026-08-28-v0-13-completion-wavefront-design.md](2026-08-28-v0-13-completion-wavefront-design.md),
+пункты J0-1 и J0-2 зонтичной задачи #581.
+
+## Что есть сейчас
+
+**Выбор протокола — только identity.** `CoreIdentity::production()`
+даёт digest v3, `production_v5()` — digest v5. Режим `--daemon` выбирает
+рантайм по identity (`interfaces/daemon.rs`): ровно v5-digest поднимает
+`runtime_v5::run_daemon`, любой другой — `server::run_daemon`. Каталоги
+состояния разведены: `daemon-p3-<digest>` и `daemon-p5-<digest>`, поэтому
+v3-процесс и v5-процесс никогда не делят endpoint, receipts и TaskStore.
+Производственный вход `connect_default_user_daemon` строит клиент v3 с
+`production()`; больше ничего в продукте v3 не выбирает.
+
+**Серверная сторона v5 готова.** `runtime_v5.rs` держит полный цикл:
+handshake, reserve до валидации, Direct/Task, recover, ACK, cancel,
+startup reconciliation, fail-stop, capacity. Предметный сервис v13 у него
+тот же, что у v3 (`DaemonServerConfig::invocation_service`), поэтому
+переключение не меняет исполнение инструментов, только durable-контур
+вокруг них.
+
+**Клиентской стороны v5 нет.** `client_v5.rs` умеет connect-or-spawn
+(имя `_for_protocol_test`), Hello/Ping, submit/cancel/recover/ACK
+(без вызывающих, `dead_code`), а `get/wait/cancel_task` закрыты под
+`cfg(test | feature)`. Маршрутизатор MCP (`canonical_daemon_router`),
+типы обработчиков, проекции native Task (`interfaces/task_projection.rs`)
+и compatibility-инструментов (`application/v13/task_tools.rs`) написаны
+на типах v3: `DaemonOwner`, `InvocationResponse`, `DaemonTaskSnapshot`,
+`DaemonErrorCode`. Модулей `task_projection_v5.rs` и `task_tools_v5.rs`,
+которые план называл, в дереве нет.
+
+**Свидетельства v5 не идут в конвейере.** Контракт
+`tests/daemon_receipt_ledger.rs` собирается только с признаком
+`receipt-ledger-test-support` (`required-features`), а команды nextest в
+`run-tests.py` и `allure_results.nextest_list` признаков не передают:
+65 тестов не попадают ни в план, ни в отчёт. Пять тестов
+`tests/daemon_process.rs` стоят под `#[ignore]` «до маршрутизации яруса»;
+из-за `#[ignore]` сломан и их собственный дочерний fixture: `spawn_frontend`
+запускает тест по имени без `--include-ignored`, ребёнок ничего не
+исполняет, и два v3-теста падают по таймауту готовности.
+
+**Реестр закреплён на v3.** `CTR.WIRE.DAEMON-INVOCATION-PROTOCOL`
+(версия 3, producer `protocol.rs`, четыре запроса), восемь
+`INV.APP.DAEMON-*` с проверками в `daemon/mod.rs`, `task_store.rs`,
+`invocation_store_actor.rs`, `application/invocation.rs`,
+`CTR.APP.DAEMON-LONG-WORK-CAPABILITIES` с producer `server.rs`; владельцы —
+`DEC.2026-08-24.DAEMON-INVOCATION-ROUTING-SLICE` и
+`DEC.2026-08-24.NATIVE-TASK-PROJECTION-SLICE`. Wavefront-замысел прямо
+требует, чтобы после W0c в реестре осталась ровно одна текущая wire
+identity.
+
+**Замер 07.09.2026, локально (Apple Silicon, профиль `default`, все ядра).**
+Контракт ledger и пять process-тестов: 70 тестов, 559 с стены, 67 зелёных
+(три нестабильных прошли повтором), три красных: нагрузочный
+`wall_clock_writer_sustains_32_receipts_per_second_on_posix` (p99 428 мс
+при бюджете 250 мс под параллельной нагрузкой) и два v3 process-теста
+(сломанный fixture, см. выше). Самые долгие — тесты ёмкости и нагрузки,
+200–520 с каждый.
+
+## Развилки и выбор
+
+**Фронтенд строится на wire v5 напрямую, а не через адаптер к типам v3.**
+Адаптер «v5 → DaemonTaskSnapshot v3» сохранил бы v3-типы в интерфейсе и
+сделал бы удаление v3 второй переделкой того же кода. Вместо этого
+интерфейс переводится на `V5DaemonTaskSnapshot` и коды `V5DaemonErrorCode`
+теми же функциями и с теми же именами проверок реестра; v3-ветки этих
+функций уходят вместе с v3.
+
+**Дисциплина квитанций — как в замысле ledger.** Direct-ответ приходит
+как `V5PendingDirectReceipt`; фронтенд сначала строит окончательную
+проекцию (`CallToolResult` для Completed, `ErrorData` -32603 с закрытым
+кодом для Failed/Cancelled), и только после этого шлёт ACK с exact
+`receiptKey` и `terminalDigest`. Ошибка проекции (размер, сериализация)
+ACK не шлёт: терминал остаётся unacked и истекает через час без replay.
+ACK идёт на той же сессии с собственным коротким бюджетом, а не на
+остатке транспортного, который к этому моменту может быть исчерпан.
+Ответ на ACK (tombstone, `tombstone_capacity`, `receipt_expired`,
+транспортная ошибка) на результат для хоста не влияет: ACK доказывает
+передачу daemon → frontend, не доставку хосту.
+
+**Потеря ответа на submit — восстановление, не повтор.** Если запись
+frame прошла, а ответ не пришёл, фронтенд открывает новую сессию и шлёт
+`RecoverInvocationReceipt` с ключом, который умеет вычислить сам
+(`invocationId`, `reservedTaskId`, digest core identity, инструмент,
+нормализованный hash аргументов, hash workspace hint —
+`receipt_key_is_canonicalized_identically_by_client_and_server`). Direct
+terminal → проекция и ACK, Task → снимок, `receipt_not_found` → submit не
+дошёл, честная транспортная ошибка; `ReceiptPending` → ждать до
+`acceptedEpochMs + originalBudgetMs + 125 мс` в пределах своего cutoff и
+спросить снова. UUID никогда не генерируются повторно, за горизонт
+cutoff восстановление не продолжается. Двух исполнений одного вызова не
+бывает ни в одной ветке.
+
+**Compatibility-инструменты держат действующий контракт v2, а не форму
+сценарного бегунка.** `CTR.WIRE.COMPATIBILITY-TASK-TOOLS` (версия 2,
+`DEC.2026-09-01.V0-13-REFUSAL-DISCIPLINE`) кладёт код отказа в
+`diagnostics[]` и оставляет `data.task` чистым снимком. Проекции в
+сценарном бегунке `receipt_scenario_v5.rs` написаны раньше этого решения и
+несут `data.code`; они — свидетельство ledger, а не продукта, и остаются
+как есть. Native-проекция совпадает с замыслом побайтово: `status`
+queued/working → `working`, `completed.result` — тот же `CallToolResult`,
+`failed.error` — таблица девяти закрытых причин, включая
+`outcome_uncertain`, `task_capacity`, `workspace_capacity`,
+`workspace_registry_failed`.
+
+**Отмена со стороны хоста в этом переходе не расширяется.** v3 не
+передаёт `notifications/cancelled` в daemon; v5 умеет `CancelInvocation`
+по exact ключу. Ленивая отмена — отдельный шаг после переключения: она
+меняет наблюдаемое поведение хоста и требует своего свидетельства.
+
+**Свидетельства v5 идут своими ярусами.** Контракт ledger — второй
+вызов nextest с признаком (`-p unica-coder --features
+receipt-ledger-test-support --test daemon_receipt_ledger`); признак не
+включается на весь workspace, потому что под ним рантайм ведёт себя иначе
+на пути fail-stop (`cfg(all(feature, not(test)))`), а тестировать надо
+поставляемый код. Размер `medium` (очередь, `main`, релиз) для всего
+контракта, кроме тестов ёмкости и нагрузки; те — `large` (ночь, все три
+ОС, `threads-required = "num-cpus"`, срок 900 с). На Windows ночью
+контракт идёт целиком, как весь набор. Ярус process-тестов
+маршрутизируется снятием `#[ignore]`: они `kind(test)` и уже `medium`.
+
+**Одна wire identity в реестре — одним решением.** Новое решение
+заводится вместе с переключением по умолчанию: оно заменяет
+`DEC.2026-08-24.DAEMON-INVOCATION-ROUTING-SLICE` и
+`DEC.2026-08-24.NATIVE-TASK-PROJECTION-SLICE`, принимает во владение
+каждое правило, чья проверка или producer переезжают на v5, переводит
+`CTR.WIRE.DAEMON-INVOCATION-PROTOCOL` в версию 5 и переносит проверки
+`INV.APP.DAEMON-*` на именованные тесты v5. Решения, чьи свидетельства
+достаточно переадресовать (`realized` — записываемое поле), не
+заменяются: `DEC.2026-08-23.USER-CORE-DAEMON-SLICE` получает v5-версию
+того же process-теста под тем же именем. `DEC.2026-08-28.DAEMON-RECEIPT-LEDGER`
+уже `active`, описывает сам ledger и остаётся в силе.
+
+**v3 снимается после подтверждения, а не вместе с переключением.**
+Переключение и снятие — разные риски: первое доказывается прогоном
+продукта, второе — тем, что после удаления ни одна проверка реестра не
+осиротела. Между ними — очередь, push в `main`, ночь с Windows и полный
+контур с дымом упакованного MCP.
+
+## Шаги
+
+| Шаг | PR | Содержание | Готово, когда |
+| --- | --- | --- | --- |
+| A | свидетельства v5 в конвейере | эта записка; второй вызов nextest для контракта ledger; план и результаты из двух вызовов; ярусы `medium`/`large` в `.config/nextest.toml`; снятие `#[ignore]` с process-тестов; стражи состава | `daemon_receipt_ledger` и `daemon_process` видны в отчёте очереди; large-подмножество — в ночном прогоне |
+| B | фронтенд v5 | клиент: `connect_or_spawn`, `connect_peer`, типизированные ошибки, операции Task без cfg; ключ квитанции на клиенте; проекции native и compatibility на `V5DaemonTaskSnapshot`; маршрутизатор v5 с ACK и recover; тесты на fake-сервере v5 и на настоящем рантайме в потоке | маршрутизатор v5 доказан тестами, production всё ещё v3 |
+| C | переключение и реестр | `connect_default_user_daemon` → v5; тест identity переписан под новый default (J0-2); решение-преемник, контракт протокола версии 5, проверки `INV.APP.DAEMON-*` на v5; process-тесты на v5 identity | реестр зелёный с одной wire identity; PR влит через очередь |
+| D | доказательство | push в `main`, ночь (Windows), ручной запуск полного контура с дымом упакованного MCP на трёх ОС; запись в «Ход» | все линии зелёные на вершине с v5 или каждый красный разобран |
+| E | снятие v3 | клиент, протокол и роутер v3, v3-ветки проекций, цикл сервера v3 в `server.rs` (общий предметный сервис остаётся), `FileInvocationStore`/`invocation_store_actor`, `production()` = v5, каталог `daemon-p3-*` больше не создаётся; тесты и документы v3 | `grep` не находит `unica-daemon-jsonl-3`, `DaemonOwner`, `protocol::DaemonTaskSnapshot`; реестр и стражи зелёные |
+
+Шаг E может идти несколькими PR по слоям (фронтенд → сервер → хранилища),
+каждый через очередь.
+
+## Критерии готовности
+
+| Критерий | Как измеряется |
+| --- | --- |
+| Production поднимает v5 | дым упакованного MCP на трёх ОС; в каталоге состояния появляется `daemon-p5-*`, `daemon-p3-*` — нет |
+| Ни одного двойного исполнения | тесты recover: потеря ответа на submit, крах фронтенда до ACK, повтор ACK |
+| Проекции побайтово | `completed.result` == direct `CallToolResult`; `failed.error` — девять причин; compatibility по контракту v2 |
+| Контракт ledger в отчёте | сайт показывает `unica-coder::daemon_receipt_ledger` в линии `main`; large-подмножество — в ночи |
+| Реестр | `registry.py --check`, `immutability.py --base origin/main`, `tests/arch` зелёные; ровно одна wire identity |
+| Стоимость | шаг тестов Rust в очереди растёт не больше чем на длительность второй компиляции с признаком; замер в «Ход» |
+
+## Реестр: что переустанавливается на шаге C
+
+| Запись | Сейчас | После |
+| --- | --- | --- |
+| `CTR.WIRE.DAEMON-INVOCATION-PROTOCOL` | версия 3, producer `protocol.rs`, check `mod.rs::invocation_protocol_round_trips_all_four_strict_requests_and_closed_responses` | версия 5, producer `protocol_v5.rs`, check `protocol_v5.rs::strict_v5_client_decoder_round_trips_every_closed_request_kind`; текст: identity `unica-daemon-jsonl-5`, десять запросов, receipt/ACK/recover, коды v5 |
+| `CTR.APP.DAEMON-LONG-WORK-CAPABILITIES` | producer/check `server.rs::daemon_exact_long_work_ownership_contract` | producer `runtime_v5.rs`, check `tests/daemon_receipt_ledger.rs::production_known_long_task_executes_after_the_initial_working_projection`; версия 1 — форма capability не меняется |
+| `INV.APP.DAEMON-INVOCATION-OWNERSHIP` | `mod.rs::daemon_executes_one_canonical_invocation_and_poll_cancel_never_relaunches_it` | `daemon_receipt_ledger.rs::exact_duplicate_preserves_cutoff_without_second_domain_callback` |
+| `INV.APP.DAEMON-INVOCATION-HANDOFF` | `mod.rs::daemon_invocation_receipt_deadline_is_single_and_never_replenished` | `runtime_v5.rs::complete_v5_frame_near_cutoff_cannot_receive_a_fresh_response_budget`, `daemon_receipt_ledger.rs::cutoff_during_admission_projects_exact_unbound_task` |
+| `INV.APP.DAEMON-TASK-PERSISTENCE` | `mod.rs::durable_handoff_persists_only_closed_hashes_not_arguments_paths_or_failure_text` | `invocation_store_v5.rs::all_five_task_statuses_round_trip_with_the_exact_selected_fields`, `record_rejects_wrong_schema_unknown_duplicate_and_every_missing_root_field` |
+| `INV.APP.DAEMON-TASK-RECOVERY` | восемь проверок миграции v1→v2 в `task_store.rs` | `task_store_v5.rs::recovery_terminalizes_queued_without_starting_domain_work`, `runtime_v5.rs::startup_terminalizes_pre_task_receipts_without_replaying_domain_work`, `daemon_receipt_ledger.rs::restart_begun_without_committed_handoff_is_direct_outcome_uncertain` |
+| `INV.APP.DAEMON-TERMINAL-RECONCILIATION` | `application/invocation.rs::terminal_publication_faults_reconcile_without_reexecution_or_false_idle` | `task_store_v5.rs::completed_terminal_cas_reconciles_commit_uncertain_by_exact_readback`, `daemon_receipt_ledger.rs::every_cross_store_crash_point_reconciles_without_split_brain` |
+| `INV.APP.DAEMON-STORE-FAIL-STOP` | семнадцать проверок в `invocation_store_actor.rs`, `task_store.rs`, `server.rs`, `mod.rs` | `receipt_ledger_actor.rs::*_fail_stops_actor`, `runtime_v5.rs::commit_uncertain_is_returned_before_process_owned_fail_stop_retains_endpoint`, `displaced_receipt_authority_fail_stops_until_process_death`, `task_store_v5.rs::capacity_never_lazily_expires_terminal_records_and_not_found_is_typed`, `daemon_receipt_ledger.rs::noncooperative_prepare_forces_fail_stop_after_two_second_grace` |
+| `INV.APP.DAEMON-ACTOR-AUTHORITY` | `mod.rs::canonical_invocation_authority_is_actor_bound_and_revision_fenced` | `daemon_receipt_ledger.rs::bound_task_start_rejects_missing_foreign_stale_actor_proof_without_mutation` |
+| `INV.APP.DAEMON-ACTOR-CAPACITY` | `server.rs::daemon_workspace_actor_admission_is_concurrent_bounded_and_fail_closed` | без изменений: реестр actor общий для v3 и v5 и остаётся в `server.rs` |
+| `INV.WIRE.NATIVE-TASK-CAPABILITY`, `CTR.WIRE.NATIVE-TASK-PROJECTION`, `INV.WIRE.V13-TASK-PROFILES`, `CTR.WIRE.COMPATIBILITY-TASK-TOOLS` | проверки в `mcp.rs` | те же имена проверок, тесты переписаны на v5; владелец native-проекции — решение-преемник |
+| `DEC.2026-08-23.USER-CORE-DAEMON-SLICE` | `realized: tests/daemon_process.rs::two_frontend_processes_race_to_one_daemon_pid_record_and_endpoint` (v3) | тот же тест на identity v5 |
+
+Точные имена сверяются с деревом при заведении решения; таблица — карта,
+а не текст записей.
+
+## Чего в плане нет
+
+- Ленивая отмена по `notifications/cancelled` через `CancelInvocation`.
+- Публичный idempotency/resume API, `unica.receipt.*`, второй MCP-сервер —
+  их запрещает замысел ledger.
+- Перенос общего предметного сервиса из `server.rs` в отдельный модуль:
+  пути проверок реестра остались бы теми же только при сохранении файла.
+- Переключение публичной версии (`0.13.0-rc.1`, G6) — отдельные ворота
+  зонтичной задачи.
+
+## Ход
+
+**Шаг A, 07.09.2026.** Контракт ledger в одиночном локальном прогоне
+(профиль `default`, все ядра): 65 тестов, все зелёные, 572 с стены, 2547 с
+суммарно; четыре прошли повтором (`wall_clock_writer…`, два
+`link_capacity_…`, `deterministic_horizon_load…`). Девять тестов по
+200–530 с плюс два настенных ворот (`wall_clock_writer…` 60 с,
+`thirty_two_lazy_cancel…` 125 мс) объявлены `large`; остальные 56 — 340 с
+суммарно, самый долгий 80 с — идут `medium`. Регулярное выражение nextest
+читается буквально, перенос строки внутри `test(/…/)` — символ имени,
+поэтому ярус объявлен по одному `test(/^имя$/)` на строку. Причина двух
+красных v3 process-тестов — `#[ignore]` на fixture: дочерний процесс
+запускал тест по имени без `--include-ignored`; снятие атрибута чинит их
+без правки кода.
+
+## Открытые вопросы
+
+- Держит ли wall-clock ворота на раннерах ubuntu/macOS 32 квитанции в
+  секунду в одиночном прогоне (`threads-required = "num-cpus"`)? Локально
+  под параллельной нагрузкой — нет. Ответ даст первая ночь после шага A.
+- Сколько стоит вторая компиляция с признаком в очереди: если больше
+  трёх минут, контракт ledger переезжает в отдельную джобу матрицы.

--- a/scripts/ci/allure_results.py
+++ b/scripts/ci/allure_results.py
@@ -138,17 +138,14 @@ def ignore_reasons(root: Path) -> dict[str, str]:
     return found
 
 
-def nextest_list(root: Path, profile: str) -> list[dict]:
+def nextest_list(root: Path, command: list[str]) -> list[dict]:
     """Состав прогона по nextest: двоичный файл, имя, признак `ignored`.
 
     Это и план прогона, и источник дерева для отчёта. Проигнорированные
-    перечисляются тоже: план обязан знать всё, что дерево знает.
+    перечисляются тоже: план обязан знать всё, что дерево знает. Команду
+    строит шов прогона — тот же отбор, что и у `nextest run`.
     """
-    completed = subprocess.run(
-        ["cargo", "nextest", "list", "--workspace", "--profile", profile,
-         "--run-ignored", "all", "--message-format", "json"],
-        cwd=root, capture_output=True, text=True, check=True,
-    )
+    completed = subprocess.run(command, cwd=root, capture_output=True, text=True, check=True)
     listed = json.loads(completed.stdout)
     entries = []
     for suite in listed["rust-suites"].values():
@@ -168,29 +165,35 @@ def write_plan(out: Path, entries: list[dict]) -> Path:
     return path
 
 
-class MediumMatcher:
-    """Размер теста по выражению `medium` из `.config/nextest.toml`.
+class SizeMatcher:
+    """Размер теста по выражениям `medium` и `large` из `.config/nextest.toml`.
 
     Выражение объявляет размер вне теста: `kind(test)` — интеграционные
-    цели, `test(/…/)` — модули по пути. Здесь оно читается, чтобы отчёт нёс
+    цели, `test(/…/)` — модули по пути, `binary(…)` в `large` — цель, чьи
+    тесты по именам ушли в ночной ярус. Здесь они читаются, чтобы отчёт нёс
     метку `size` тем же правилом, каким ворота отбирают тесты.
     """
 
-    def __init__(self, expression: str):
-        self.integration = "kind(test)" in expression
-        self.patterns = [re.compile(found) for found in re.findall(r"test\(/(.*?)/\)", expression)]
+    def __init__(self, medium: str, large: str = ""):
+        self.integration = "kind(test)" in medium
+        self.patterns = [re.compile(found) for found in re.findall(r"test\(/(.*?)/\)", medium)]
+        self.large_binaries = set(re.findall(r"binary\(([A-Za-z0-9_-]+)\)", large))
+        self.large_patterns = [re.compile(found) for found in re.findall(r"test\(/(.*?)/\)", large)]
 
     @classmethod
-    def from_toml(cls, path: Path = NEXTEST_TOML) -> "MediumMatcher":
+    def from_toml(cls, path: Path = NEXTEST_TOML) -> "SizeMatcher":
         try:
             config = tomllib.loads(path.read_text(encoding="utf-8"))
             overrides = config["profile"]["default"].get("overrides", [])
-            expression = next(o["filter"] for o in overrides if "slow-timeout" in o)
+            medium = next(o["filter"] for o in overrides if "slow-timeout" in o)
+            large = config["profile"].get("large", {}).get("default-filter", "")
         except (OSError, KeyError, StopIteration):
-            expression = ""
-        return cls(expression)
+            medium, large = "", ""
+        return cls(medium, large)
 
     def size(self, binary: str, name: str) -> str:
+        if binary.rsplit("::", 1)[-1] in self.large_binaries and any(p.search(name) for p in self.large_patterns):
+            return "large"
         if self.integration and "::" in binary and "bin/" not in binary:
             return "medium"
         if any(pattern.search(name) for pattern in self.patterns):
@@ -198,14 +201,14 @@ class MediumMatcher:
         return "small"
 
 
-_MEDIUM: MediumMatcher | None = None
+_SIZES: SizeMatcher | None = None
 
 
 def size_of(binary: str, name: str) -> str:
-    global _MEDIUM
-    if _MEDIUM is None:
-        _MEDIUM = MediumMatcher.from_toml()
-    return _MEDIUM.size(binary, name)
+    global _SIZES
+    if _SIZES is None:
+        _SIZES = SizeMatcher.from_toml()
+    return _SIZES.size(binary, name)
 
 
 def rust_labels(binary: str, name: str, profile: str) -> dict[str, str]:

--- a/scripts/ci/run-tests.py
+++ b/scripts/ci/run-tests.py
@@ -75,17 +75,52 @@ def nextest_junit(profile: str) -> Path:
     return REPO_ROOT / "target" / "nextest" / nextest_profile(profile) / "junit.xml"
 
 
-def rust_commands(profile: str) -> list[list[str]]:
-    """Команды Rust для профиля. Сегодня — весь набор, одним потоком."""
+# Контракт ReceiptLedger (`tests/daemon_receipt_ledger.rs`) собирается только с
+# признаком тестовой поддержки: у цели стоит `required-features`. Признак не
+# включается на весь workspace — под ним рантайм ведёт себя иначе на пути
+# fail-stop, а тестировать надо поставляемый код, — поэтому контракт идёт
+# вторым вызовом nextest ровно на одну цель. Он целиком `medium` и `large`:
+# ворота, принимающие только `small`, второго вызова не получают, потому что
+# пустой отбор у nextest — отказ, а не зелёный ноль.
+LEDGER_CONTRACT = (
+    "-p", "unica-coder", "--features", "receipt-ledger-test-support", "--test", "daemon_receipt_ledger",
+)
+
+
+def rust_selections(profile: str) -> list[tuple[str, ...]]:
+    """Что отбирает каждый вызов nextest: весь workspace и, если ворота
+    принимают `medium` или `large`, контракт ReceiptLedger."""
+    selections = [("--workspace",)]
+    if set(ADMITTED[profile]) & {"medium", "large"}:
+        selections.append(LEDGER_CONTRACT)
+    return selections
+
+
+def rust_command(profile: str, selection: tuple[str, ...]) -> list[str]:
     # nextest: процесс на тест и JUnit из коробки. Число потоков, повторы
     # и отчёт описаны в `.config/nextest.toml`, а не здесь: конвейер и
     # локальный прогон обязаны идти одной настройкой.
-    command = ["cargo", "nextest", "run", "--workspace", "--profile", nextest_profile(profile)]
+    command = ["cargo", "nextest", "run", *selection, "--profile", nextest_profile(profile)]
     if profile == "large":
-        # Ярус пуст до расстановки размеров: ноль тестов — честный результат,
-        # а не ошибка выбора. У остальных ворот пустой набор — ошибка.
+        # Ночной ярус на ubuntu и macOS — только large-подмножество контракта:
+        # для workspace-вызова ноль тестов — честный результат, а не ошибка
+        # выбора. У остальных ворот пустой набор — ошибка.
         command.append("--no-tests=pass")
-    return [command]
+    return command
+
+
+def rust_commands(profile: str) -> list[list[str]]:
+    """Команды Rust для профиля, по одной на отбор."""
+    return [rust_command(profile, selection) for selection in rust_selections(profile)]
+
+
+def rust_list_commands(profile: str) -> list[list[str]]:
+    """Состав тех же отборов: план обязан перечислять то, что прогон гоняет."""
+    return [
+        ["cargo", "nextest", "list", *selection, "--profile", nextest_profile(profile),
+         "--run-ignored", "all", "--message-format", "json"]
+        for selection in rust_selections(profile)
+    ]
 
 
 # Наборы, которые в CI делятся на полосы по размеру: одна джоба на размер.
@@ -199,7 +234,9 @@ def commands(
 
 def write_rust_plan(results: Path, profile: str) -> int:
     """План прогона — до тестов, чтобы упавший раннер не унёс его с собой."""
-    entries = allure_results.nextest_list(REPO_ROOT, nextest_profile(profile))
+    entries = []
+    for command in rust_list_commands(profile):
+        entries.extend(allure_results.nextest_list(REPO_ROOT, command))
     allure_results.write_plan(results, entries)
     return len(entries)
 
@@ -310,13 +347,19 @@ def execute(
         allure_results.write_run(results, profile=profile, runner=runner, ecosystem=ecosystem, line=line, sha=sha)
     code = 0
     if ecosystem in ("rust", "all"):
-        # Старый JUnit от прошлого прогона — не результат этого. Если nextest
-        # упадёт до отчёта, файл на месте выдал бы чужие записи за свежие.
-        if junit.is_file():
-            junit.unlink()
-        code = run_commands(rust_commands(profile))
-        if results is not None and junit.is_file():
-            print(f"результаты Rust: {emit_rust(results, profile, runner, junit)} записей")
+        # Оба вызова nextest пишут JUnit в один каталог профиля, поэтому
+        # результаты снимаются после каждого. Старый JUnit от прошлого
+        # прогона — не результат этого: если nextest упадёт до отчёта, файл на
+        # месте выдал бы чужие записи за свежие. Красный первый вызов второго
+        # не отменяет — упавший тест не прячет остальных, — но Python после
+        # красного Rust не идёт, как не шёл следующий шаг workflow.
+        for command in rust_commands(profile):
+            if junit.is_file():
+                junit.unlink()
+            rust_code = run_commands([command])
+            if results is not None and junit.is_file():
+                print(f"результаты Rust: {emit_rust(results, profile, runner, junit)} записей")
+            code = code or rust_code
         if code != 0:
             return code
     if ecosystem in ("python", "all"):

--- a/tests/ci/test_allure_results.py
+++ b/tests/ci/test_allure_results.py
@@ -138,13 +138,19 @@ class JunitTranslationTests(unittest.TestCase):
             ["index out of bounds: первая попытка", "index out of bounds: вторая попытка"],
         )
 
-    def test_size_label_follows_the_medium_expression_of_nextest(self) -> None:
-        """Интеграционная цель и модуль с процессом — medium; остальное — small."""
-        matcher = self.module.MediumMatcher("kind(test)\n    | test(/^infrastructure::daemon::(tests)::/)")
+    def test_size_label_follows_the_size_expressions_of_nextest(self) -> None:
+        """Интеграционная цель и модуль с процессом — medium; названный ночной тест — large; остальное — small."""
+        matcher = self.module.SizeMatcher(
+            "kind(test)\n    | test(/^infrastructure::daemon::(tests)::/)",
+            "binary(daemon_receipt_ledger) & (\n    test(/^load_a$/)\n    | test(/^load_b$/)\n)",
+        )
 
         self.assertEqual(matcher.size("unica-coder::v13_search_integration", "canonical_search"), "medium")
         self.assertEqual(matcher.size("unica-coder", "infrastructure::daemon::tests::spawns"), "medium")
         self.assertEqual(matcher.size("unica-coder", "domain::address::tests::resolves"), "small")
+        self.assertEqual(matcher.size("unica-coder::daemon_receipt_ledger", "load_b"), "large")
+        self.assertEqual(matcher.size("unica-coder::daemon_receipt_ledger", "reserve_first"), "medium")
+        self.assertEqual(matcher.size("unica-coder::other_target", "load_b"), "medium")
         labels = {l["name"]: l["value"] for l in self.entries()["address::resolves_catalog"]["labels"]}
         self.assertIn(labels["size"], ("small", "medium"))
 

--- a/tests/ci/test_gate_profiles.py
+++ b/tests/ci/test_gate_profiles.py
@@ -1,8 +1,9 @@
 """Страж состава: ворота, профили nextest и размеры наборов согласованы.
 
-Отбор объявлен профилями: `pr` пропускает только `small`, очередь, `main` и
-релиз гоняют всё, `large` пуст везде, кроме Windows. Меняется этот страж
-осознанно, вместе с выражениями профилей.
+Отбор объявлен профилями: `pr` пропускает только `small`, очередь и `main` —
+всё, кроме `large`, релиз гоняет всё, `large` — названные тесты ёмкости и
+нагрузки контракта ReceiptLedger, а на Windows — весь набор. Меняется этот
+страж осознанно, вместе с выражениями профилей.
 """
 
 from __future__ import annotations
@@ -32,6 +33,7 @@ class GateProfileCompositionTests(unittest.TestCase):
     def test_every_gate_has_a_nextest_profile_that_admits_its_sizes(self) -> None:
         profiles = self.config["profile"]
 
+        large = profiles["large"]["default-filter"].strip()
         for gate in GATES:
             with self.subTest(gate=gate):
                 self.assertIn(gate, profiles)
@@ -39,14 +41,41 @@ class GateProfileCompositionTests(unittest.TestCase):
                 if gate == "pr":
                     # Pull request — только small: всё, что не объявлено medium.
                     self.assertTrue(profiles[gate]["default-filter"].startswith("not ("))
-                else:
+                elif gate == "release":
                     self.assertEqual(profiles[gate].get("default-filter"), "all()")
+                else:
+                    # Очередь и `main` — всё, кроме ночного яруса, тем же выражением.
+                    self.assertEqual(profiles[gate]["default-filter"].strip(), f"not (\n{large}\n)")
         self.assertEqual(set(self.run_tests.PROFILES), {"all", "large", *GATES})
-        # Ночной ярус пуст на ubuntu и macOS: их набор целиком идёт в `main`.
-        self.assertEqual(profiles["large"].get("default-filter"), "none()")
+        # Ночной ярус на ubuntu и macOS — только названные тесты одной цели;
+        # тот же список стоит и у срока `large`.
+        self.assertTrue(large.startswith("binary(daemon_receipt_ledger) & (\n    test(/^"))
+        deadline = next(o for o in profiles["default"]["overrides"] if o.get("threads-required"))
+        self.assertEqual(deadline["filter"].strip(), large)
+        self.assertEqual(deadline["slow-timeout"], {"period": "900s", "terminate-after": 2})
+        self.assertEqual(deadline["threads-required"], "num-cpus")
         # Ночью Windows гоняет всё: переопределение по платформе в профиле large.
         self.assertEqual(profiles["large"]["overrides"], [{"platform": "cfg(windows)", "default-filter": "all()"}])
-        self.assertIn("--no-tests=pass", self.run_tests.rust_commands("large")[0])
+        for command in self.run_tests.rust_commands("large"):
+            self.assertIn("--no-tests=pass", command)
+
+    def test_large_tier_names_only_tests_that_exist_in_the_ledger_contract(self) -> None:
+        """Ярус объявлен именами: переименованный тест выпал бы из ночи молча."""
+        import re
+
+        large = self.config["profile"]["large"]["default-filter"]
+        # Регулярное выражение nextest читается буквально, перенос строки в
+        # нём — символ имени; поэтому ярус — по одному `test(/^имя$/)` на строку.
+        names = re.findall(r"test\(/\^(\w+)\$/\)", large)
+        self.assertEqual(len(names), large.count("test("))
+        source = (REPO_ROOT / "crates" / "unica-coder" / "tests" / "daemon_receipt_ledger.rs").read_text(encoding="utf-8")
+
+        self.assertEqual(names, sorted(names))
+        for name in names:
+            with self.subTest(test=name.strip()):
+                self.assertIsNotNone(
+                    re.search(rf"^fn {name.strip()}\(\)", source, re.M), "тест яруса large не найден в контракте"
+                )
 
     def test_python_matrix_names_every_suite_of_the_seam_and_lanes_only_admitted_sizes(self) -> None:
         """Матрица ворот: каждый набор шва, полосатый — по допущенным размерам, не больше."""

--- a/tests/ci/test_run_tests.py
+++ b/tests/ci/test_run_tests.py
@@ -34,7 +34,15 @@ class RunTestsSeamTests(unittest.TestCase):
         python = module.commands("all", "python", interpreter="python")
 
         self.assertEqual(
-            rust, [["cargo", "nextest", "run", "--workspace", "--profile", "default"]]
+            rust,
+            [
+                ["cargo", "nextest", "run", "--workspace", "--profile", "default"],
+                [
+                    "cargo", "nextest", "run", "-p", "unica-coder",
+                    "--features", "receipt-ledger-test-support", "--test", "daemon_receipt_ledger",
+                    "--profile", "default",
+                ],
+            ],
         )
         runner_script = str(MODULE_PATH.with_name("run-unittest.py"))
         self.assertEqual(
@@ -63,10 +71,11 @@ class RunTestsSeamTests(unittest.TestCase):
 
         planned = module.commands("all", "all", interpreter="python")
 
-        self.assertEqual(planned[0][0], "cargo")
-        self.assertTrue(all(command[0] == "python" for command in planned[1:]))
-        self.assertTrue(all(command[1].endswith("run-unittest.py") for command in planned[1:]))
-        self.assertEqual(len(planned), 4)
+        # Два вызова nextest — workspace и контракт ReceiptLedger, — потом Python.
+        self.assertEqual([command[0] for command in planned[:2]], ["cargo", "cargo"])
+        self.assertTrue(all(command[0] == "python" for command in planned[2:]))
+        self.assertTrue(all(command[1].endswith("run-unittest.py") for command in planned[2:]))
+        self.assertEqual(len(planned), 5)
 
     def test_results_directory_turns_emission_on_for_python_suites(self) -> None:
         """Без `--results` набор идёт как раньше; с ним пишет результаты и знает раннер."""
@@ -114,7 +123,10 @@ class RunTestsSeamTests(unittest.TestCase):
                               junit=out / "no-such-junit.xml")
 
         self.assertEqual(code, 0)
-        self.assertEqual(len(calls), 2)
+        # Два вызова nextest — по одному, чтобы снять JUnit после каждого, — и
+        # один список Python.
+        self.assertEqual(len(calls), 3)
+        self.assertEqual([len(planned) for planned in calls[:2]], [1, 1])
         signature = json.loads((out / "run.json").read_text(encoding="utf-8"))
         self.assertEqual(signature["ecosystem"], "all")
         self.assertEqual(signature["runner"], "ubuntu-latest")
@@ -177,7 +189,12 @@ class RunTestsSeamTests(unittest.TestCase):
 
         self.assertEqual(code, 0)
         self.assertEqual(
-            captured.getvalue().strip(), "cargo nextest run --workspace --profile default"
+            captured.getvalue().strip().splitlines(),
+            [
+                "cargo nextest run --workspace --profile default",
+                "cargo nextest run -p unica-coder --features receipt-ledger-test-support"
+                " --test daemon_receipt_ledger --profile default",
+            ],
         )
 
 
@@ -187,14 +204,63 @@ class GateProfileTests(unittest.TestCase):
     def test_each_gate_maps_to_its_own_nextest_profile_and_junit_directory(self) -> None:
         module = load_module()
 
+        ledger = [
+            "-p", "unica-coder", "--features", "receipt-ledger-test-support", "--test", "daemon_receipt_ledger",
+        ]
         for gate in ("pr", "queue", "main", "release"):
             with self.subTest(gate=gate):
-                self.assertEqual(
-                    module.rust_commands(gate),
-                    [["cargo", "nextest", "run", "--workspace", "--profile", gate]],
-                )
+                commands = module.rust_commands(gate)
+                self.assertEqual(commands[0], ["cargo", "nextest", "run", "--workspace", "--profile", gate])
+                if gate == "pr":
+                    # Контракт ReceiptLedger — `medium` и `large` целиком; ворота
+                    # `small` его не гоняют и не вызывают nextest впустую.
+                    self.assertEqual(len(commands), 1)
+                else:
+                    self.assertEqual(commands[1], ["cargo", "nextest", "run", *ledger, "--profile", gate])
                 self.assertEqual(module.nextest_junit(gate).parts[-3:], ("nextest", gate, "junit.xml"))
         self.assertEqual(module.nextest_junit("all").parts[-3:], ("nextest", "default", "junit.xml"))
+
+    def test_plan_lists_exactly_the_selections_the_run_executes(self) -> None:
+        """Состав и прогон — один отбор: `list` повторяет `run` флаг в флаг."""
+        module = load_module()
+
+        for gate in module.PROFILES:
+            with self.subTest(gate=gate):
+                runs = module.rust_commands(gate)
+                lists = module.rust_list_commands(gate)
+                self.assertEqual(len(runs), len(lists))
+                for run, listing in zip(runs, lists):
+                    selection = run[3:run.index("--profile")]
+                    self.assertEqual(listing[:3], ["cargo", "nextest", "list"])
+                    self.assertEqual(listing[3:3 + len(selection)], selection)
+                    self.assertEqual(listing[-4:], ["--run-ignored", "all", "--message-format", "json"])
+
+    def test_second_rust_invocation_gets_its_own_junit_snapshot(self) -> None:
+        """JUnit одного каталога снимается после каждого вызова, а не раз в конце."""
+        import tempfile
+        from pathlib import Path as P
+
+        module = load_module()
+        out = P(tempfile.mkdtemp(prefix="run-tests-"))
+        junit = out / "junit.xml"
+        seen = []
+
+        def run_commands(planned):
+            seen.append(planned[0][3])
+            junit.write_text(
+                '<testsuites name="unica"><testsuite name="unica-coder' + ("::daemon_receipt_ledger" if planned[0][3] == "-p" else "") + '">'
+                '<testcase name="case" classname="unica-coder" time="0.1"/>'
+                "</testsuite></testsuites>",
+                encoding="utf-8",
+            )
+            return 0
+
+        code = module.execute("queue", "rust", out, "ubuntu-latest", run_commands=run_commands, junit=junit)
+
+        self.assertEqual(code, 0)
+        self.assertEqual(seen, ["--workspace", "-p"])
+        names = sorted(json.loads(path.read_text(encoding="utf-8"))["fullName"] for path in out.glob("*-result.json"))
+        self.assertEqual(names, ["unica-coder::case", "unica-coder::daemon_receipt_ledger::case"])
 
     def test_every_gate_runs_every_python_suite_while_all_suites_are_small(self) -> None:
         """Отбора пока нет: все наборы `small`, и любые ворота гоняют все три."""


### PR DESCRIPTION
## Что

Шаг A замысла перевода production daemon с протокола v3 на v5
(`docs/design/2026-09-07-daemon-v5-production-cutover-design.md`, записка
добавлена этим PR): свидетельства v5 начинают идти в конвейере.

- **Второй вызов nextest** в `run-tests.py`: `-p unica-coder --features
  receipt-ledger-test-support --test daemon_receipt_ledger` для ворот,
  принимающих `medium` или `large` (очередь, `main`, релиз, ночь, локальный
  `all`). PR-ворота его не получают: контракт целиком `medium`/`large`, а
  пустой отбор у nextest — отказ. Признак не включается на весь workspace:
  под ним рантайм ведёт себя иначе на пути fail-stop, а тестировать надо
  поставляемый код.
- **План и результаты** из двух отборов: `nextest list` повторяет `nextest
  run` флаг в флаг; JUnit одного каталога профиля снимается после каждого
  вызова.
- **Ярус `large`** в `.config/nextest.toml`: девять тестов ёмкости и
  нагрузки контракта (200–530 с каждый и два настенных ворот) — ночью, с
  сроком 900 с и `threads-required = "num-cpus"`; очередь и `main` гоняют
  всё, кроме них; релиз — всё; Windows ночью — всё, как раньше. Метка
  `size` в отчёте знает `large`.
- **Ярус process-тестов** маршрутизирован снятием `#[ignore]` с пяти
  тестов `tests/daemon_process.rs`. Атрибут же и ломал их дочерний
  fixture: `spawn_frontend` запускал тест по имени без `--include-ignored`,
  ребёнок ничего не исполнял, и два v3-теста падали по таймауту. Без
  атрибута все пять зелёные.

## Замер, локально 07.09.2026

Контракт ledger в одиночном прогоне: 65 тестов, все зелёные, 572 с стены,
2547 с суммарно, четыре прошли повтором. `medium`-подмножество — 56 тестов,
340 с суммарно, самый долгий 80 с.

## Проверено

- `tests/ci` (852) и `tests/arch` (127) — зелёные из venv по
  `tests/ci/requirements.txt`.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features
  -D warnings` — чисто; `daemon_process` под профилем `queue` — 5 из 5.

## Открытый вопрос

Держит ли `wall_clock_writer_sustains_32_receipts_per_second_on_posix`
раннеры ubuntu/macOS в одиночном прогоне — ответ даст первая ночь.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated execution for Receipt Ledger contract tests in applicable CI profiles.
  * Large test profiles now select and run designated Receipt Ledger tests with extended timeouts and optimized scheduling.
  * Previously skipped daemon process integration tests now run as part of the test suite.

* **Documentation**
  * Added a design document outlining the planned daemon protocol v5 production transition.

* **CI Improvements**
  * Test planning, execution, result reporting, and size classification now support multiple test selections and large-test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->