### PR TITLE
feat(daemon): фронтенд протокола v5 — клиент, проекции и маршрутизатор без переключения

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -106,6 +106,7 @@ kind(test)
     | test(/^infrastructure::workspace_actor::(tests)::/)
     | test(/^infrastructure::workspace_index::(tests)::/)
     | test(/^infrastructure::workspace_services::(tests)::/)
+    | test(/^interfaces::daemon_router::(tests)::/)
     | test(/^interfaces::mcp::(tests)::/)
 )'''
 # <<< размер medium (ворота pr)
@@ -242,6 +243,7 @@ kind(test)
     | test(/^infrastructure::workspace_actor::(tests)::/)
     | test(/^infrastructure::workspace_index::(tests)::/)
     | test(/^infrastructure::workspace_services::(tests)::/)
+    | test(/^interfaces::daemon_router::(tests)::/)
     | test(/^interfaces::mcp::(tests)::/)
 '''
 slow-timeout = { period = "300s", terminate-after = 2 }

--- a/crates/unica-coder/src/infrastructure/daemon/client_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/client_v5.rs
@@ -1,16 +1,14 @@
 use super::identity::{CoreIdentity, DaemonStateDirectory};
-#[cfg(feature = "receipt-ledger-test-support")]
-use super::protocol_v5::V5DaemonErrorCode;
 use super::protocol_v5::{
     decode_v5_server_response, read_bounded_v5_probe_response_frame_before, V5ClientRequest,
-    V5EndpointRecord, V5HandshakeServerResponse, V5InvocationRequest, V5ProbeResponseKind,
-    V5ProbeServerResponse, V5ServerResponse,
+    V5DaemonErrorCode, V5DaemonTaskSnapshot, V5EndpointRecord, V5HandshakeServerResponse,
+    V5InvocationRequest, V5ProbeResponseKind, V5ProbeServerResponse, V5ServerResponse,
 };
 use crate::application::invocation::{RESPONSE_SERIALIZATION_MARGIN, TASK_RECONCILIATION_BUDGET};
 use crate::application::receipt_ledger::{ReceiptKey, TerminalDigest};
-#[cfg(any(test, feature = "receipt-ledger-test-support"))]
 use crate::domain::invocation::TaskId;
 use crate::infrastructure::platform::ManagedStartupChild;
+use std::fmt;
 use std::io::{self, BufReader, Write};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
@@ -24,17 +22,58 @@ const EXISTING_ENDPOINT_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
 const STARTUP_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
 const RETRY_INTERVAL: Duration = Duration::from_millis(20);
 
-/// Minimal side-by-side protocol-v5 process client.
+/// Protocol-v5 process client: one authenticated owner session over the
+/// loopback endpoint of the exact production-v5 daemon.
 ///
-/// This is intentionally narrower than the v3 production client while W0a is
-/// non-default: it proves the same-binary `--daemon` dispatch and one strict
-/// Hello/Ping exchange without introducing a second launch selector or routing
-/// ordinary frontend traffic to v5 before W0c.
+/// The frontend keeps one anchor session for its lifetime and opens a peer
+/// session per invocation or Task operation; every exchange carries one
+/// absolute deadline and a malformed or truncated response poisons the session
+/// it arrived on.
 pub(crate) struct V5DaemonProcessOwner {
     writer: TcpStream,
     reader: BufReader<TcpStream>,
     record: V5EndpointRecord,
     poisoned: bool,
+}
+
+/// Why an exchange produced no strict response, phrased by its consequence for
+/// the durable receipt: a request that was never written cannot have been
+/// reserved by the daemon, a lost response may hide a reserved receipt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum V5TransportError {
+    SessionPoisoned,
+    RequestNotSent(String),
+    ResponseLost(String),
+}
+
+impl fmt::Display for V5TransportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SessionPoisoned => formatter.write_str("protocol-v5 owner session is poisoned"),
+            Self::RequestNotSent(error) | Self::ResponseLost(error) => formatter.write_str(error),
+        }
+    }
+}
+
+/// Outcome classes of one Task operation, closed the same way as the v3
+/// exchange so the interface keeps one refusal mapping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum V5TaskExchangeError {
+    Protocol(V5DaemonErrorCode),
+    Transport,
+    SessionPoisoned,
+    UnexpectedResponse,
+}
+
+impl From<V5TransportError> for V5TaskExchangeError {
+    fn from(error: V5TransportError) -> Self {
+        match error {
+            V5TransportError::SessionPoisoned => Self::SessionPoisoned,
+            V5TransportError::RequestNotSent(_) | V5TransportError::ResponseLost(_) => {
+                Self::Transport
+            }
+        }
+    }
 }
 
 #[cfg(feature = "receipt-ledger-test-support")]
@@ -125,7 +164,9 @@ fn finish_ready_startup<C: V5StartupChildControl>(
 }
 
 impl V5DaemonProcessOwner {
-    pub(crate) fn connect_or_spawn_for_protocol_test(
+    /// Connect to the exact production-v5 daemon under `state_root`, spawning
+    /// the same binary in `--daemon` mode when no live endpoint answers.
+    pub(crate) fn connect_or_spawn(
         state_root: &Path,
         core_identity: CoreIdentity,
         executable: PathBuf,
@@ -225,7 +266,22 @@ impl V5DaemonProcessOwner {
         }
     }
 
-    fn connect_before(record: V5EndpointRecord, deadline: Instant) -> Result<Self, String> {
+    /// Open one more authenticated session on an already published endpoint.
+    /// Each session carries its own owner lease, so a slow direct response on
+    /// one peer never serializes another call behind it.
+    pub(crate) fn connect_peer_before(&self, deadline: Instant) -> Result<Self, V5TransportError> {
+        Self::connect_before(self.record.clone(), deadline)
+            .map_err(V5TransportError::RequestNotSent)
+    }
+
+    pub(crate) fn core_identity(&self) -> &CoreIdentity {
+        self.record.core_identity()
+    }
+
+    pub(crate) fn connect_before(
+        record: V5EndpointRecord,
+        deadline: Instant,
+    ) -> Result<Self, String> {
         let address = record.loopback_addr()?;
         let stream = TcpStream::connect_timeout(&address.into(), remaining(deadline, "connect")?)
             .map_err(|error| format!("connect protocol-v5 daemon: {error}"))?;
@@ -371,6 +427,96 @@ impl V5DaemonProcessOwner {
         )
     }
 
+    pub(crate) fn submit_invocation_before(
+        &mut self,
+        invocation: V5InvocationRequest,
+        deadline: Instant,
+    ) -> Result<V5ServerResponse, V5TransportError> {
+        self.exchange_typed_before(
+            V5ClientRequest::SubmitInvocation { invocation },
+            "submit invocation",
+            deadline,
+        )
+    }
+
+    pub(crate) fn recover_invocation_receipt_before(
+        &mut self,
+        receipt_key: ReceiptKey,
+        deadline: Instant,
+    ) -> Result<V5ServerResponse, V5TransportError> {
+        self.exchange_typed_before(
+            V5ClientRequest::RecoverInvocationReceipt { receipt_key },
+            "recover invocation receipt",
+            deadline,
+        )
+    }
+
+    pub(crate) fn acknowledge_invocation_receipt_before(
+        &mut self,
+        receipt_key: ReceiptKey,
+        terminal_digest: TerminalDigest,
+        deadline: Instant,
+    ) -> Result<V5ServerResponse, V5TransportError> {
+        self.exchange_typed_before(
+            V5ClientRequest::AcknowledgeInvocationReceipt {
+                receipt_key,
+                terminal_digest,
+            },
+            "acknowledge invocation receipt",
+            deadline,
+        )
+    }
+
+    pub(crate) fn get_task_before(
+        &mut self,
+        task_id: TaskId,
+        deadline: Instant,
+    ) -> Result<V5DaemonTaskSnapshot, V5TaskExchangeError> {
+        self.task_exchange_before(V5ClientRequest::GetTask { task_id }, "get task", deadline)
+    }
+
+    pub(crate) fn wait_task_before(
+        &mut self,
+        task_id: TaskId,
+        wait_ms: u64,
+        deadline: Instant,
+    ) -> Result<V5DaemonTaskSnapshot, V5TaskExchangeError> {
+        self.task_exchange_before(
+            V5ClientRequest::WaitTask { task_id, wait_ms },
+            "wait task",
+            deadline,
+        )
+    }
+
+    pub(crate) fn cancel_task_before(
+        &mut self,
+        task_id: TaskId,
+        deadline: Instant,
+    ) -> Result<V5DaemonTaskSnapshot, V5TaskExchangeError> {
+        self.task_exchange_before(
+            V5ClientRequest::CancelTask { task_id },
+            "cancel task",
+            deadline,
+        )
+    }
+
+    fn task_exchange_before(
+        &mut self,
+        request: V5ClientRequest,
+        stage: &'static str,
+        deadline: Instant,
+    ) -> Result<V5DaemonTaskSnapshot, V5TaskExchangeError> {
+        match self.exchange_typed_before(request, stage, deadline) {
+            Ok(V5ServerResponse::Task { snapshot }) => Ok(snapshot),
+            Ok(V5ServerResponse::Error { code }) => Err(V5TaskExchangeError::Protocol(code)),
+            Ok(_) => {
+                self.poison();
+                Err(V5TaskExchangeError::UnexpectedResponse)
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+
     #[cfg(feature = "receipt-ledger-test-support")]
     pub(crate) fn submit_invocation_with_timeout_for_test(
         &mut self,
@@ -465,25 +611,35 @@ impl V5DaemonProcessOwner {
         stage: &'static str,
         deadline: Instant,
     ) -> Result<V5ServerResponse, String> {
+        self.exchange_typed_before(request, stage, deadline)
+            .map_err(|error| error.to_string())
+    }
+
+    fn exchange_typed_before(
+        &mut self,
+        request: V5ClientRequest,
+        stage: &'static str,
+        deadline: Instant,
+    ) -> Result<V5ServerResponse, V5TransportError> {
         if self.poisoned {
-            return Err("protocol-v5 owner session is poisoned".to_string());
+            return Err(V5TransportError::SessionPoisoned);
         }
         if let Err(error) = self.write_before(&request, deadline, stage) {
             self.poison();
-            return Err(error);
+            return Err(V5TransportError::RequestNotSent(error));
         }
         let frame = match self.read_before(deadline, stage) {
             Ok(frame) => frame,
             Err(error) => {
                 self.poison();
-                return Err(error);
+                return Err(V5TransportError::ResponseLost(error));
             }
         };
         match decode_v5_server_response(&frame) {
             Ok(response) => Ok(response),
             Err(error) => {
                 self.poison();
-                Err(error)
+                Err(V5TransportError::ResponseLost(error))
             }
         }
     }

--- a/crates/unica-coder/src/infrastructure/daemon/protocol_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/protocol_v5.rs
@@ -9,7 +9,7 @@ use crate::application::receipt_ledger::{
     ReceiptKey, ReceiptKeyDigest, ReceiptTerminalOutcome, RequestIdentity, TerminalDigest,
     V5ToolIdentity,
 };
-use crate::domain::invocation::{DomainResult, InvocationId, TaskId};
+use crate::domain::invocation::{DomainResult, InvocationId, InvocationStatus, TaskId};
 #[cfg(feature = "receipt-ledger-test-support")]
 use crate::infrastructure::receipt_ledger_test_evidence::ProductionMissingTransitionEvidence;
 use serde::{Deserialize, Serialize};
@@ -691,6 +691,133 @@ pub(crate) enum V5DaemonTaskSnapshot {
         terminal_epoch_ms: u64,
         terminal_digest: TerminalDigest,
     },
+}
+
+impl V5DaemonTaskSnapshot {
+    pub(crate) fn task_id(&self) -> TaskId {
+        match self {
+            Self::Queued { task_id, .. }
+            | Self::Working { task_id, .. }
+            | Self::Completed { task_id, .. }
+            | Self::Failed { task_id, .. }
+            | Self::Cancelled { task_id, .. } => *task_id,
+        }
+    }
+
+    pub(crate) fn invocation_id(&self) -> InvocationId {
+        match self {
+            Self::Queued { invocation_id, .. }
+            | Self::Working { invocation_id, .. }
+            | Self::Completed { invocation_id, .. }
+            | Self::Failed { invocation_id, .. }
+            | Self::Cancelled { invocation_id, .. } => *invocation_id,
+        }
+    }
+
+    pub(crate) fn created_at_epoch_ms(&self) -> u64 {
+        match self {
+            Self::Queued {
+                created_at_epoch_ms,
+                ..
+            }
+            | Self::Working {
+                created_at_epoch_ms,
+                ..
+            }
+            | Self::Completed {
+                created_at_epoch_ms,
+                ..
+            }
+            | Self::Failed {
+                created_at_epoch_ms,
+                ..
+            }
+            | Self::Cancelled {
+                created_at_epoch_ms,
+                ..
+            } => *created_at_epoch_ms,
+        }
+    }
+
+    pub(crate) fn updated_at_epoch_ms(&self) -> u64 {
+        match self {
+            Self::Queued {
+                updated_at_epoch_ms,
+                ..
+            }
+            | Self::Working {
+                updated_at_epoch_ms,
+                ..
+            }
+            | Self::Completed {
+                updated_at_epoch_ms,
+                ..
+            }
+            | Self::Failed {
+                updated_at_epoch_ms,
+                ..
+            }
+            | Self::Cancelled {
+                updated_at_epoch_ms,
+                ..
+            } => *updated_at_epoch_ms,
+        }
+    }
+
+    pub(crate) fn ttl_ms(&self) -> u64 {
+        match self {
+            Self::Queued { ttl_ms, .. }
+            | Self::Working { ttl_ms, .. }
+            | Self::Completed { ttl_ms, .. }
+            | Self::Failed { ttl_ms, .. }
+            | Self::Cancelled { ttl_ms, .. } => *ttl_ms,
+        }
+    }
+
+    pub(crate) fn poll_interval_ms(&self) -> u64 {
+        match self {
+            Self::Queued {
+                poll_interval_ms, ..
+            }
+            | Self::Working {
+                poll_interval_ms, ..
+            }
+            | Self::Completed {
+                poll_interval_ms, ..
+            }
+            | Self::Failed {
+                poll_interval_ms, ..
+            }
+            | Self::Cancelled {
+                poll_interval_ms, ..
+            } => *poll_interval_ms,
+        }
+    }
+
+    /// Closed lifecycle status of the durable Task behind this snapshot.
+    pub(crate) fn status(&self) -> InvocationStatus {
+        match self {
+            Self::Queued { .. } => InvocationStatus::Queued,
+            Self::Working { .. } => InvocationStatus::Working,
+            Self::Completed { .. } => InvocationStatus::Completed,
+            Self::Failed { .. } => InvocationStatus::Failed,
+            Self::Cancelled { .. } => InvocationStatus::Cancelled,
+        }
+    }
+
+    pub(crate) fn completed_result(&self) -> Option<&DomainResult> {
+        match self {
+            Self::Completed { result, .. } => Some(result),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn failure_reason(&self) -> Option<V5SafeFailureReason> {
+        match self {
+            Self::Failed { reason, .. } => Some(*reason),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/unica-coder/src/infrastructure/daemon/runtime_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/runtime_v5.rs
@@ -7959,7 +7959,7 @@ mod tests {
             7_000,
         )
         .expect("valid known-long invocation");
-        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn(
             &state_root,
             identity,
             std::path::PathBuf::from("unused-existing-v5-endpoint"),
@@ -8233,7 +8233,7 @@ mod tests {
             7_000,
         )
         .expect("valid long-submit request");
-        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn(
             &state_root,
             identity,
             std::path::PathBuf::from("unused-existing-v5-endpoint"),
@@ -8286,7 +8286,7 @@ mod tests {
                 request_scope_hash("workspace-a").expect("request scope"),
             ),
         );
-        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn(
             &state_root,
             identity.clone(),
             std::path::PathBuf::from("unused-existing-v5-endpoint"),
@@ -8370,7 +8370,7 @@ mod tests {
             RESPONSE_SERIALIZATION_MARGIN,
             "response serialization gets exactly one non-renewable margin"
         );
-        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn(
             &state_root,
             identity.clone(),
             std::path::PathBuf::from("unused-existing-v5-endpoint"),
@@ -8493,7 +8493,7 @@ mod tests {
                 request_scope_hash("workspace-a").expect("request scope"),
             ),
         );
-        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn(
             &state_root,
             identity.clone(),
             std::path::PathBuf::from("unused-existing-v5-endpoint"),
@@ -8660,7 +8660,7 @@ mod tests {
             })
         });
         let _record = wait_for_v5_record(state_root, identity);
-        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn(
             state_root,
             identity.clone(),
             std::path::PathBuf::from("unused-existing-v5-endpoint"),
@@ -9952,7 +9952,7 @@ mod tests {
         .expect("strict invocation");
         let unused_executable = std::path::PathBuf::from("unused-existing-v5-endpoint");
 
-        let mut cancel_owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+        let mut cancel_owner = V5DaemonProcessOwner::connect_or_spawn(
             &state_root,
             identity.clone(),
             unused_executable.clone(),
@@ -9973,7 +9973,7 @@ mod tests {
             }
         ));
 
-        let mut submit_owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+        let mut submit_owner = V5DaemonProcessOwner::connect_or_spawn(
             &state_root,
             identity.clone(),
             unused_executable.clone(),
@@ -9991,7 +9991,7 @@ mod tests {
                 && receipt.receipt_key() == &key
         ));
 
-        let mut recover_owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+        let mut recover_owner = V5DaemonProcessOwner::connect_or_spawn(
             &state_root,
             identity,
             unused_executable,

--- a/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5.rs
@@ -4737,7 +4737,7 @@ fn recover_from_live_daemon(
     identity: &CoreIdentity,
     key: ReceiptKey,
 ) -> Result<V5ServerResponse, String> {
-    let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+    let mut owner = V5DaemonProcessOwner::connect_or_spawn(
         state_root,
         identity.clone(),
         std::path::PathBuf::from("unused-existing-v5-scenario-endpoint"),
@@ -4752,7 +4752,7 @@ fn read_task_from_live_daemon(
     task_id: TaskId,
     api: ScenarioTaskApi,
 ) -> Result<V5ServerResponse, String> {
-    let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+    let mut owner = V5DaemonProcessOwner::connect_or_spawn(
         state_root,
         identity.clone(),
         std::path::PathBuf::from("unused-existing-v5-scenario-endpoint"),
@@ -5679,7 +5679,7 @@ fn run_direct_load(
     });
     let operation = (|| {
         wait_for_endpoint(state_root, identity)?;
-        let _anchor = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+        let _anchor = V5DaemonProcessOwner::connect_or_spawn(
             state_root,
             identity.clone(),
             std::path::PathBuf::from("unused-existing-v5-load-anchor"),
@@ -7175,7 +7175,7 @@ fn exchange_once(
     });
     let response = (|| {
         wait_for_endpoint(state_root, identity)?;
-        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn(
             state_root,
             identity.clone(),
             std::path::PathBuf::from("unused-existing-v5-scenario-endpoint"),
@@ -7229,7 +7229,7 @@ fn exchange_once_retaining_actor(
         let actor = actor_receiver
             .recv_timeout(SCENARIO_ENDPOINT_STARTUP_TIMEOUT)
             .map_err(|_| "protocol-v5 retained receipt actor was not published".to_owned())?;
-        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn(
             state_root,
             identity.clone(),
             std::path::PathBuf::from("unused-existing-v5-scenario-endpoint"),
@@ -9167,7 +9167,7 @@ fn exchange_ack_and_expect_disconnect(
     });
     let result = (|| {
         wait_for_endpoint(state_root, identity)?;
-        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn(
             state_root,
             identity.clone(),
             std::path::PathBuf::from("unused-existing-v5-scenario-endpoint"),
@@ -9203,7 +9203,7 @@ fn exchange_submit_and_expect_disconnect(
     });
     let result = (|| {
         wait_for_endpoint(state_root, identity)?;
-        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn(
             state_root,
             identity.clone(),
             std::path::PathBuf::from("unused-existing-v5-scenario-endpoint"),
@@ -9461,7 +9461,7 @@ impl PendingSubmit {
         identity: &CoreIdentity,
         invocation: V5InvocationRequest,
     ) -> Result<V5ServerResponse, String> {
-        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn(
             state_root,
             identity.clone(),
             std::path::PathBuf::from("unused-existing-v5-scenario-endpoint"),
@@ -9530,7 +9530,7 @@ fn spawn_additional_submit_client(
     let client_state_root = state_root.to_path_buf();
     let client_identity = identity.clone();
     let client = thread::spawn(move || {
-        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn(
             &client_state_root,
             client_identity,
             std::path::PathBuf::from("unused-existing-v5-scenario-endpoint"),
@@ -9551,7 +9551,7 @@ fn cancel_on_live_daemon(
     identity: &CoreIdentity,
     key: ReceiptKey,
 ) -> Result<V5ServerResponse, String> {
-    let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+    let mut owner = V5DaemonProcessOwner::connect_or_spawn(
         state_root,
         identity.clone(),
         std::path::PathBuf::from("unused-existing-v5-scenario-endpoint"),
@@ -9608,7 +9608,7 @@ fn start_blocked_submit(
     let client_state_root = state_root.to_path_buf();
     let client_identity = identity.clone();
     let client = thread::spawn(move || {
-        let mut owner = V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+        let mut owner = V5DaemonProcessOwner::connect_or_spawn(
             &client_state_root,
             client_identity.clone(),
             std::path::PathBuf::from("unused-existing-v5-scenario-endpoint"),

--- a/crates/unica-coder/src/interfaces/daemon.rs
+++ b/crates/unica-coder/src/interfaces/daemon.rs
@@ -134,7 +134,7 @@ pub fn connect_owner_for_protocol_test(
         ))
         .connect_or_spawn()
         .map(DaemonOwnerLeaseInner::V3),
-        DaemonProtocolIdentity::V5 => V5DaemonProcessOwner::connect_or_spawn_for_protocol_test(
+        DaemonProtocolIdentity::V5 => V5DaemonProcessOwner::connect_or_spawn(
             state_root,
             identity,
             executable.to_path_buf(),

--- a/crates/unica-coder/src/interfaces/daemon_router.rs
+++ b/crates/unica-coder/src/interfaces/daemon_router.rs
@@ -566,10 +566,7 @@ mod tests {
         let hello = decode_v5_request_frame(hello).expect("strict hello");
         assert!(matches!(hello.request(), V5ClientRequest::Hello { .. }));
         write_frame(&mut writer, &V5HandshakeServerResponse::ready(&record));
-        loop {
-            let Ok(raw) = read_bounded_v5_request_frame(&mut reader) else {
-                break;
-            };
+        while let Ok(raw) = read_bounded_v5_request_frame(&mut reader) {
             let decoded = decode_v5_request_frame(raw.clone()).expect("strict client frame");
             let request = decoded.into_request();
             seen.lock().unwrap().push(request.clone());

--- a/crates/unica-coder/src/interfaces/daemon_router.rs
+++ b/crates/unica-coder/src/interfaces/daemon_router.rs
@@ -1,0 +1,1273 @@
+//! Canonical v0.13 router over the protocol-v5 user daemon.
+//!
+//! The stdio frontend keeps one anchor session for its lifetime and gives every
+//! invocation and every Task operation a peer session of its own. A Direct
+//! terminal is acknowledged only after its host-facing value exists; a lost
+//! submit response is recovered by the exact receipt key the frontend derives
+//! itself, never by a second submission.
+#![cfg_attr(not(test), allow(dead_code))] // wired into the stdio frontend by the v5 cutover
+
+use super::task_projection::{self, DirectProjection};
+use crate::application::invocation::{
+    handoff_budget, normalized_arguments_hash, INVOCATION_HANDOFF_WINDOW,
+    RESPONSE_SERIALIZATION_MARGIN, RESPONSE_SERIALIZATION_MARGIN_MS,
+};
+use crate::application::receipt_ledger::{
+    request_scope_hash, ReceiptKey, RequestIdentity, V5ToolIdentity,
+    MAX_ORIGINAL_RESPONSE_BUDGET_MS,
+};
+use crate::domain::cancellation::CancellationToken;
+use crate::domain::invocation::{InvocationId, TaskId};
+use crate::infrastructure::daemon::client_v5::{
+    V5DaemonProcessOwner, V5TaskExchangeError, V5TransportError,
+};
+use crate::infrastructure::daemon::protocol_v5::{
+    V5DaemonErrorCode, V5DaemonTaskSnapshot, V5InvocationRequest, V5InvocationResponse,
+    V5ServerResponse,
+};
+use rmcp::model::{CallToolResult, ErrorCode, ErrorData};
+use serde_json::{Map, Value};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+pub(super) const TOOL_EXECUTION_ERROR: i32 = -32000;
+/// The acknowledgement travels after the transport budget of the invocation
+/// may already be spent; it gets a short budget of its own instead of racing
+/// an exhausted cutoff.
+const ACKNOWLEDGEMENT_BUDGET: Duration = Duration::from_millis(500);
+/// Recovery of a still-reserved receipt polls the daemon no more often than this.
+const RECOVERY_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+/// One absolute frontend budget per request: captured at receipt and only
+/// narrowed afterwards, never re-derived from a later `now`.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct FrontendInvocationDeadline {
+    received_at: Instant,
+    host_remaining_at_receipt: Option<Duration>,
+}
+
+impl FrontendInvocationDeadline {
+    pub(super) fn new(received_at: Instant, host_remaining_at_receipt: Option<Duration>) -> Self {
+        Self {
+            received_at,
+            host_remaining_at_receipt,
+        }
+    }
+
+    pub(super) fn remaining_at(self, now: Instant) -> Duration {
+        remaining_invocation_budget(self.received_at, now, self.host_remaining_at_receipt)
+    }
+
+    pub(super) fn remaining_transport_at(self, now: Instant) -> Duration {
+        let elapsed = now.saturating_duration_since(self.received_at);
+        let own_remaining = INVOCATION_HANDOFF_WINDOW
+            .saturating_add(RESPONSE_SERIALIZATION_MARGIN)
+            .saturating_sub(elapsed);
+        let host_remaining = self
+            .host_remaining_at_receipt
+            .map(|remaining| remaining.saturating_sub(elapsed));
+        host_remaining.map_or(own_remaining, |remaining| own_remaining.min(remaining))
+    }
+
+    pub(super) fn transport_cutoff(self) -> Instant {
+        let own_cutoff = self
+            .received_at
+            .checked_add(INVOCATION_HANDOFF_WINDOW.saturating_add(RESPONSE_SERIALIZATION_MARGIN))
+            .expect("bounded frontend transport cutoff");
+        self.host_remaining_at_receipt
+            .and_then(|remaining| self.received_at.checked_add(remaining))
+            .map_or(own_cutoff, |host_cutoff| own_cutoff.min(host_cutoff))
+    }
+}
+
+pub(super) fn remaining_invocation_budget(
+    received_at: Instant,
+    now: Instant,
+    host_remaining_at_receipt: Option<Duration>,
+) -> Duration {
+    let elapsed = now.saturating_duration_since(received_at);
+    let own_remaining = INVOCATION_HANDOFF_WINDOW.saturating_sub(elapsed);
+    let host_remaining =
+        host_remaining_at_receipt.map(|remaining| remaining.saturating_sub(elapsed));
+    own_remaining.min(handoff_budget(host_remaining))
+}
+
+/// What one canonical call produced: the final `CallToolResult` of an
+/// acknowledged Direct terminal, or the durable Task the daemon handed off to.
+pub(super) enum CanonicalCallOutcome {
+    Direct(CallToolResult),
+    Task(V5DaemonTaskSnapshot),
+}
+
+pub(super) type CanonicalCallHandler = dyn Fn(
+        V5ToolIdentity,
+        &Map<String, Value>,
+        FrontendInvocationDeadline,
+        CancellationToken,
+    ) -> Result<CanonicalCallOutcome, ErrorData>
+    + Send
+    + Sync;
+
+pub(super) type CanonicalTaskHandler = dyn Fn(TaskId, FrontendInvocationDeadline) -> Result<V5DaemonTaskSnapshot, V5TaskExchangeError>
+    + Send
+    + Sync;
+
+pub(super) type CanonicalTaskWaitHandler = dyn Fn(TaskId, u64, FrontendInvocationDeadline) -> Result<V5DaemonTaskSnapshot, V5TaskExchangeError>
+    + Send
+    + Sync;
+
+#[derive(Clone)]
+pub(super) struct CanonicalDaemonRouter {
+    pub(super) call: Arc<CanonicalCallHandler>,
+    pub(super) get: Arc<CanonicalTaskHandler>,
+    pub(super) wait: Arc<CanonicalTaskWaitHandler>,
+    pub(super) cancel: Arc<CanonicalTaskHandler>,
+}
+
+type ReceiptObserver = Arc<dyn Fn(&ReceiptKey) + Send + Sync>;
+
+/// Build the router over one persistent protocol-v5 owner lease.
+pub(super) fn canonical_daemon_router(
+    owner: V5DaemonProcessOwner,
+    workspace_hint: String,
+) -> CanonicalDaemonRouter {
+    build_router(owner, workspace_hint, None)
+}
+
+#[cfg(test)]
+fn canonical_daemon_router_observed(
+    owner: V5DaemonProcessOwner,
+    workspace_hint: String,
+    observer: ReceiptObserver,
+) -> CanonicalDaemonRouter {
+    build_router(owner, workspace_hint, Some(observer))
+}
+
+fn build_router(
+    owner: V5DaemonProcessOwner,
+    workspace_hint: String,
+    observer: Option<ReceiptObserver>,
+) -> CanonicalDaemonRouter {
+    // The anchor holds the owner lease for the frontend lifetime; every
+    // invocation runs on its own peer session so a slow direct response cannot
+    // serialize another call behind it.
+    let anchor = Arc::new(owner);
+    let call_anchor = Arc::clone(&anchor);
+    let call: Arc<CanonicalCallHandler> =
+        Arc::new(move |tool, arguments, deadline, _cancellation| {
+            submit_and_settle(
+                &call_anchor,
+                &workspace_hint,
+                tool,
+                arguments,
+                deadline,
+                observer.as_ref(),
+            )
+        });
+    let get_anchor = Arc::clone(&anchor);
+    let get: Arc<CanonicalTaskHandler> = Arc::new(move |task_id, deadline| {
+        let cutoff = deadline.transport_cutoff();
+        let mut peer = task_peer(&get_anchor, cutoff)?;
+        peer.get_task_before(task_id, cutoff)
+    });
+    let wait_anchor = Arc::clone(&anchor);
+    let wait: Arc<CanonicalTaskWaitHandler> = Arc::new(move |task_id, wait_ms, deadline| {
+        let now = Instant::now();
+        let cutoff = wait_transport_cutoff(wait_ms, deadline, now);
+        let mut peer = task_peer(&wait_anchor, cutoff)?;
+        // The daemon wait shrinks by what connect and handshake already spent
+        // and by the response margin; the cutoff itself never moves.
+        let bounded_wait_ms = bounded_wait_ms(wait_ms, cutoff, Instant::now());
+        peer.wait_task_before(task_id, bounded_wait_ms, cutoff)
+    });
+    let cancel: Arc<CanonicalTaskHandler> = Arc::new(move |task_id, deadline| {
+        let cutoff = deadline.transport_cutoff();
+        let mut peer = task_peer(&anchor, cutoff)?;
+        peer.cancel_task_before(task_id, cutoff)
+    });
+    CanonicalDaemonRouter {
+        call,
+        get,
+        wait,
+        cancel,
+    }
+}
+
+fn task_peer(
+    anchor: &V5DaemonProcessOwner,
+    cutoff: Instant,
+) -> Result<V5DaemonProcessOwner, V5TaskExchangeError> {
+    if Instant::now() >= cutoff {
+        return Err(V5TaskExchangeError::Transport);
+    }
+    anchor
+        .connect_peer_before(cutoff)
+        .map_err(V5TaskExchangeError::from)
+}
+
+/// `unica.task.result` gets its own cutoff: the requested wait plus one
+/// response margin, never beyond the frontend transport cutoff.
+fn wait_transport_cutoff(
+    requested_wait_ms: u64,
+    deadline: FrontendInvocationDeadline,
+    now: Instant,
+) -> Instant {
+    let requested_cutoff = now
+        .checked_add(
+            Duration::from_millis(requested_wait_ms).saturating_add(RESPONSE_SERIALIZATION_MARGIN),
+        )
+        .expect("bounded task wait cutoff");
+    requested_cutoff.min(deadline.transport_cutoff())
+}
+
+fn bounded_wait_ms(requested_wait_ms: u64, cutoff: Instant, now: Instant) -> u64 {
+    let remaining = cutoff
+        .saturating_duration_since(now)
+        .saturating_sub(RESPONSE_SERIALIZATION_MARGIN);
+    requested_wait_ms.min(remaining.as_millis().min(u128::from(u64::MAX)) as u64)
+}
+
+fn submit_and_settle(
+    anchor: &V5DaemonProcessOwner,
+    workspace_hint: &str,
+    tool: V5ToolIdentity,
+    arguments: &Map<String, Value>,
+    deadline: FrontendInvocationDeadline,
+    observer: Option<&ReceiptObserver>,
+) -> Result<CanonicalCallOutcome, ErrorData> {
+    let cutoff = deadline.transport_cutoff();
+    let response_budget_ms = deadline
+        .remaining_at(Instant::now())
+        .as_millis()
+        .min(u128::from(MAX_ORIGINAL_RESPONSE_BUDGET_MS)) as u64;
+    // Fresh identities for every call: an exact identity is never reused, so a
+    // retry by the host is a new invocation with a new receipt.
+    let invocation = V5InvocationRequest::new(
+        InvocationId::new(),
+        TaskId::new(),
+        tool,
+        arguments.clone(),
+        workspace_hint.to_owned(),
+        response_budget_ms,
+    )
+    .map_err(|message| ErrorData::invalid_params(message, None))?;
+    let receipt_key = receipt_key_for(&invocation, anchor)?;
+    if let Some(observer) = observer {
+        observer(&receipt_key);
+    }
+    let mut peer = anchor
+        .connect_peer_before(cutoff)
+        .map_err(transport_refusal)?;
+    let (peer, response) = match peer.submit_invocation_before(invocation, cutoff) {
+        Ok(response) => (peer, response),
+        // The frame reached the daemon and the answer did not come back: the
+        // daemon may already hold a reserved or terminal receipt for it.
+        Err(V5TransportError::ResponseLost(_)) => recover_receipt(anchor, &receipt_key, cutoff)?,
+        Err(error) => return Err(transport_refusal(error)),
+    };
+    settle(peer, response, &receipt_key)
+}
+
+/// The exact key the daemon derives from the same submission
+/// (`receipt_key_is_canonicalized_identically_by_client_and_server`).
+fn receipt_key_for(
+    invocation: &V5InvocationRequest,
+    anchor: &V5DaemonProcessOwner,
+) -> Result<ReceiptKey, ErrorData> {
+    let scope = request_scope_hash(invocation.workspace_hint()).map_err(|_| {
+        ErrorData::invalid_params("workspace hint is not a valid request scope", None)
+    })?;
+    Ok(ReceiptKey::new(
+        invocation.invocation_id(),
+        invocation.reserved_task_id(),
+        RequestIdentity::new(
+            anchor.core_identity().digest().clone(),
+            invocation.tool(),
+            normalized_arguments_hash(invocation.arguments()),
+            scope,
+        ),
+    ))
+}
+
+/// Read the durable state of a submission whose response was lost. A receipt
+/// still inside its original budget is polled until that budget settles;
+/// nothing here opens a new budget or submits again.
+fn recover_receipt(
+    anchor: &V5DaemonProcessOwner,
+    receipt_key: &ReceiptKey,
+    cutoff: Instant,
+) -> Result<(V5DaemonProcessOwner, V5ServerResponse), ErrorData> {
+    loop {
+        let mut peer = anchor
+            .connect_peer_before(cutoff)
+            .map_err(transport_refusal)?;
+        let response = peer
+            .recover_invocation_receipt_before(receipt_key.clone(), cutoff)
+            .map_err(transport_refusal)?;
+        match response {
+            V5ServerResponse::Invocation {
+                outcome:
+                    V5InvocationResponse::ReceiptPending {
+                        accepted_epoch_ms,
+                        original_budget_ms,
+                        ..
+                    },
+            } => {
+                let settles_at_epoch_ms = accepted_epoch_ms
+                    .saturating_add(original_budget_ms)
+                    .saturating_add(RESPONSE_SERIALIZATION_MARGIN_MS);
+                let until_settled =
+                    Duration::from_millis(settles_at_epoch_ms.saturating_sub(epoch_ms_now()));
+                let remaining = cutoff.saturating_duration_since(Instant::now());
+                // A receipt that settles after the frontend cutoff cannot be
+                // delivered by this call; the daemon keeps it, nobody resubmits.
+                if until_settled >= remaining || remaining <= RECOVERY_POLL_INTERVAL {
+                    return Err(receipt_pending_refusal());
+                }
+                std::thread::sleep(until_settled.max(RECOVERY_POLL_INTERVAL));
+            }
+            V5ServerResponse::Error {
+                code: V5DaemonErrorCode::ReceiptNotFound,
+            } => {
+                return Err(transport_refusal(V5TransportError::ResponseLost(
+                    "daemon invocation submission was lost before a receipt was reserved"
+                        .to_string(),
+                )));
+            }
+            other => return Ok((peer, other)),
+        }
+    }
+}
+
+fn settle(
+    mut peer: V5DaemonProcessOwner,
+    response: V5ServerResponse,
+    receipt_key: &ReceiptKey,
+) -> Result<CanonicalCallOutcome, ErrorData> {
+    match response {
+        V5ServerResponse::Invocation {
+            outcome: V5InvocationResponse::Direct { receipt },
+        } => {
+            if receipt.receipt_key() != receipt_key {
+                return Err(protocol_refusal(
+                    "daemon answered with a receipt of a different invocation",
+                ));
+            }
+            // The final interface value is built first; a receipt whose value
+            // cannot be built stays unacknowledged and expires on its own.
+            let projection = task_projection::project_direct_terminal(receipt.terminal())
+                .map_err(task_projection::projection_error)?;
+            let acknowledgement_deadline = Instant::now() + ACKNOWLEDGEMENT_BUDGET;
+            // The acknowledgement proves the transfer daemon → frontend and
+            // nothing more: its own outcome cannot change what the host gets.
+            let _ = peer.acknowledge_invocation_receipt_before(
+                receipt_key.clone(),
+                receipt.terminal_digest().clone(),
+                acknowledgement_deadline,
+            );
+            match projection {
+                DirectProjection::Result(result) => Ok(CanonicalCallOutcome::Direct(result)),
+                DirectProjection::Error(error) => Err(error),
+            }
+        }
+        V5ServerResponse::Invocation {
+            outcome: V5InvocationResponse::Task { snapshot },
+        } => Ok(CanonicalCallOutcome::Task(snapshot)),
+        V5ServerResponse::Invocation {
+            outcome: V5InvocationResponse::ReceiptPending { .. },
+        } => Err(receipt_pending_refusal()),
+        V5ServerResponse::Invocation {
+            outcome: V5InvocationResponse::Acknowledged { .. },
+        } => Err(protocol_refusal(
+            "daemon reported an acknowledged receipt before its result was delivered",
+        )),
+        V5ServerResponse::Error { code } => Err(submission_rejected(code)),
+        V5ServerResponse::Ready { .. }
+        | V5ServerResponse::Pong
+        | V5ServerResponse::Released
+        | V5ServerResponse::Task { .. }
+        | V5ServerResponse::InvocationAcknowledged { .. } => Err(protocol_refusal(
+            "daemon returned an unexpected response to an invocation",
+        )),
+    }
+}
+
+fn epoch_ms_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or(0)
+}
+
+fn transport_refusal(error: V5TransportError) -> ErrorData {
+    ErrorData::new(ErrorCode(TOOL_EXECUTION_ERROR), error.to_string(), None)
+}
+
+fn submission_rejected(code: V5DaemonErrorCode) -> ErrorData {
+    ErrorData::new(
+        ErrorCode(TOOL_EXECUTION_ERROR),
+        format!("daemon invocation submission rejected: {code}"),
+        None,
+    )
+}
+
+fn protocol_refusal(message: &'static str) -> ErrorData {
+    ErrorData::new(
+        ErrorCode::INTERNAL_ERROR,
+        message,
+        Some(serde_json::json!({"code": "daemon_protocol_failed"})),
+    )
+}
+
+fn receipt_pending_refusal() -> ErrorData {
+    ErrorData::new(
+        ErrorCode::INTERNAL_ERROR,
+        "daemon invocation receipt is still pending at the frontend cutoff",
+        Some(serde_json::json!({"code": "receipt_pending"})),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application::receipt_ledger::{canonical_v5_terminal, ReceiptTerminalOutcome};
+    use crate::domain::invocation::DomainResult;
+    use crate::infrastructure::daemon::identity::{CoreIdentity, DaemonStateDirectory};
+    use crate::infrastructure::daemon::protocol_v5::{
+        decode_v5_request_frame, read_bounded_v5_request_frame, V5ClientRequest, V5EndpointRecord,
+        V5HandshakeServerResponse, V5PendingDirectReceipt,
+    };
+    use crate::infrastructure::daemon::server::DaemonServerConfig;
+    use serde_json::json;
+    use std::io::{BufReader, Write};
+    use std::net::{Ipv4Addr, TcpListener, TcpStream};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+    use std::thread;
+
+    const WORKSPACE_MANIFEST: &str =
+        "format: DESIGNER\nsource-set:\n  - name: main\n    type: CONFIGURATION\n    path: .\n";
+
+    fn arguments() -> Map<String, Value> {
+        json!({"at": "main:Catalog.Товары"})
+            .as_object()
+            .expect("argument object")
+            .clone()
+    }
+
+    fn deadline(host_remaining: Option<Duration>) -> FrontendInvocationDeadline {
+        FrontendInvocationDeadline::new(Instant::now(), host_remaining)
+    }
+
+    // --- scripted fake daemon -------------------------------------------------
+
+    /// One accepted session of the fake: what it saw and what it answered.
+    enum Step {
+        Reply(V5ServerResponse),
+        Close,
+    }
+
+    type Script = Box<dyn FnMut(&[u8], &V5ClientRequest) -> Step + Send>;
+
+    struct FakeDaemon {
+        record: V5EndpointRecord,
+        seen: Arc<Mutex<Vec<V5ClientRequest>>>,
+        sessions: Arc<AtomicUsize>,
+        thread: Option<thread::JoinHandle<()>>,
+    }
+
+    impl FakeDaemon {
+        fn start(script: Script) -> Self {
+            let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+            listener
+                .set_nonblocking(true)
+                .expect("nonblocking fake listener");
+            let record = V5EndpointRecord::new(
+                CoreIdentity::production_v5(),
+                listener.local_addr().unwrap().port(),
+            )
+            .unwrap();
+            let seen = Arc::new(Mutex::new(Vec::new()));
+            let sessions = Arc::new(AtomicUsize::new(0));
+            let script = Arc::new(Mutex::new(script));
+            let thread_record = record.clone();
+            let thread_seen = Arc::clone(&seen);
+            let thread_sessions = Arc::clone(&sessions);
+            let thread = thread::spawn(move || {
+                let started = Instant::now();
+                // Every session runs on its own thread: the anchor session stays
+                // silent for the whole test while peers come and go beside it.
+                while started.elapsed() < Duration::from_secs(20) {
+                    let (stream, _) = match listener.accept() {
+                        Ok(accepted) => accepted,
+                        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(2));
+                            continue;
+                        }
+                        Err(_) => return,
+                    };
+                    thread_sessions.fetch_add(1, Ordering::SeqCst);
+                    let record = thread_record.clone();
+                    let seen = Arc::clone(&thread_seen);
+                    let script = Arc::clone(&script);
+                    thread::spawn(move || serve_session(stream, record, seen, script));
+                }
+            });
+            Self {
+                record,
+                seen,
+                sessions,
+                thread: Some(thread),
+            }
+        }
+
+        fn owner(&self) -> V5DaemonProcessOwner {
+            V5DaemonProcessOwner::connect_before(
+                self.record.clone(),
+                Instant::now() + Duration::from_secs(5),
+            )
+            .expect("connect fake daemon anchor")
+        }
+
+        fn seen(&self) -> Vec<V5ClientRequest> {
+            self.seen.lock().unwrap().clone()
+        }
+
+        fn submissions(&self) -> usize {
+            self.seen()
+                .iter()
+                .filter(|request| matches!(request, V5ClientRequest::SubmitInvocation { .. }))
+                .count()
+        }
+    }
+
+    impl Drop for FakeDaemon {
+        fn drop(&mut self) {
+            // The accept loop ends by its own timeout; the router tests never wait for it.
+            if let Some(thread) = self.thread.take() {
+                drop(thread);
+            }
+        }
+    }
+
+    fn serve_session(
+        stream: TcpStream,
+        record: V5EndpointRecord,
+        seen: Arc<Mutex<Vec<V5ClientRequest>>>,
+        script: Arc<Mutex<Script>>,
+    ) {
+        stream.set_nonblocking(false).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(20)))
+            .unwrap();
+        let mut writer = stream.try_clone().unwrap();
+        let mut reader = BufReader::new(stream);
+        let hello = read_bounded_v5_request_frame(&mut reader).expect("hello frame");
+        let hello = decode_v5_request_frame(hello).expect("strict hello");
+        assert!(matches!(hello.request(), V5ClientRequest::Hello { .. }));
+        write_frame(&mut writer, &V5HandshakeServerResponse::ready(&record));
+        loop {
+            let Ok(raw) = read_bounded_v5_request_frame(&mut reader) else {
+                break;
+            };
+            let decoded = decode_v5_request_frame(raw.clone()).expect("strict client frame");
+            let request = decoded.into_request();
+            seen.lock().unwrap().push(request.clone());
+            let step = (script.lock().unwrap())(&raw, &request);
+            match step {
+                Step::Reply(response) => write_frame(&mut writer, &response),
+                Step::Close => break,
+            }
+        }
+    }
+
+    fn write_frame<T: serde::Serialize>(stream: &mut TcpStream, value: &T) {
+        let mut bytes = serde_json::to_vec(value).expect("serialize fake frame");
+        bytes.push(b'\n');
+        stream.write_all(&bytes).expect("write fake frame");
+        stream.flush().expect("flush fake frame");
+    }
+
+    /// The receipt key the daemon itself would derive from a strict submit frame.
+    fn daemon_side_key(raw: &[u8]) -> ReceiptKey {
+        decode_v5_request_frame(raw.to_vec())
+            .expect("strict submit frame")
+            .into_strict_submit(&CoreIdentity::production_v5())
+            .expect("strict submission")
+            .receipt_key()
+            .clone()
+    }
+
+    fn direct_receipt(key: ReceiptKey, terminal: ReceiptTerminalOutcome) -> V5ServerResponse {
+        let canonical = canonical_v5_terminal(&terminal).expect("canonical terminal");
+        V5ServerResponse::Invocation {
+            outcome: V5InvocationResponse::Direct {
+                receipt: V5PendingDirectReceipt::new(
+                    key,
+                    terminal,
+                    canonical.digest().clone(),
+                    epoch_ms_now(),
+                ),
+            },
+        }
+    }
+
+    fn completed(summary: &str) -> ReceiptTerminalOutcome {
+        ReceiptTerminalOutcome::Completed {
+            result: Box::new(DomainResult::success(summary)),
+        }
+    }
+
+    fn call(
+        router: &CanonicalDaemonRouter,
+        host_remaining: Option<Duration>,
+    ) -> Result<CanonicalCallOutcome, ErrorData> {
+        (router.call)(
+            V5ToolIdentity::View,
+            &arguments(),
+            deadline(host_remaining),
+            CancellationToken::new(),
+        )
+    }
+
+    fn direct_result(outcome: Result<CanonicalCallOutcome, ErrorData>) -> CallToolResult {
+        match outcome {
+            Ok(CanonicalCallOutcome::Direct(result)) => result,
+            Ok(CanonicalCallOutcome::Task(snapshot)) => {
+                panic!("unexpected Task handoff: {snapshot:?}")
+            }
+            Err(error) => panic!("unexpected refusal: {error}"),
+        }
+    }
+
+    #[test]
+    fn direct_terminal_is_projected_before_it_is_acknowledged_with_the_exact_digest() {
+        let fake = FakeDaemon::start(Box::new(|raw, request| match request {
+            V5ClientRequest::SubmitInvocation { .. } => {
+                Step::Reply(direct_receipt(daemon_side_key(raw), completed("viewed")))
+            }
+            V5ClientRequest::AcknowledgeInvocationReceipt { .. } => {
+                Step::Reply(V5ServerResponse::Error {
+                    code: V5DaemonErrorCode::TombstoneCapacity,
+                })
+            }
+            other => panic!("unexpected frame {other:?}"),
+        }));
+        let router = canonical_daemon_router(fake.owner(), "/workspace".to_string());
+
+        let result = direct_result(call(&router, None));
+
+        assert_eq!(result.is_error, Some(false));
+        assert!(result.content.is_empty());
+        assert_eq!(
+            result
+                .structured_content
+                .as_ref()
+                .and_then(|value| value["summary"].as_str()),
+            Some("viewed")
+        );
+        let seen = fake.seen();
+        assert_eq!(seen.len(), 2, "submit then acknowledgement: {seen:?}");
+        let V5ClientRequest::SubmitInvocation { invocation } = &seen[0] else {
+            panic!("first frame must be the submission");
+        };
+        let V5ClientRequest::AcknowledgeInvocationReceipt {
+            receipt_key,
+            terminal_digest,
+        } = &seen[1]
+        else {
+            panic!("second frame must be the acknowledgement");
+        };
+        assert_eq!(receipt_key.invocation_id(), invocation.invocation_id());
+        assert_eq!(
+            receipt_key.reserved_task_id(),
+            invocation.reserved_task_id()
+        );
+        assert_eq!(
+            terminal_digest,
+            canonical_v5_terminal(&completed("viewed"))
+                .unwrap()
+                .digest()
+        );
+        assert!(
+            (6_900..=7_000).contains(&invocation.response_budget_ms()),
+            "the daemon budget is the remaining handoff window: {}",
+            invocation.response_budget_ms()
+        );
+        assert_eq!(invocation.workspace_hint(), "/workspace");
+    }
+
+    #[test]
+    fn failed_and_cancelled_direct_terminals_answer_closed_errors_after_acknowledgement() {
+        use crate::application::invocation_store_v5::V5SafeFailureReason;
+
+        let terminals = Arc::new(Mutex::new(vec![
+            ReceiptTerminalOutcome::Cancelled,
+            ReceiptTerminalOutcome::Failed {
+                reason: V5SafeFailureReason::OutcomeUncertain,
+            },
+        ]));
+        let script_terminals = Arc::clone(&terminals);
+        let fake = FakeDaemon::start(Box::new(move |raw, request| match request {
+            V5ClientRequest::SubmitInvocation { .. } => {
+                let terminal = script_terminals.lock().unwrap().pop().unwrap();
+                Step::Reply(direct_receipt(daemon_side_key(raw), terminal))
+            }
+            V5ClientRequest::AcknowledgeInvocationReceipt { .. } => Step::Close,
+            other => panic!("unexpected frame {other:?}"),
+        }));
+        let router = canonical_daemon_router(fake.owner(), "/workspace".to_string());
+
+        let uncertain = call(&router, None)
+            .err()
+            .expect("failed terminal is an error");
+        let cancelled = call(&router, None)
+            .err()
+            .expect("cancelled terminal is an error");
+
+        assert_eq!(uncertain.code, ErrorCode::INTERNAL_ERROR);
+        assert_eq!(uncertain.message, "daemon invocation outcome is uncertain");
+        assert_eq!(uncertain.data, Some(json!({"code": "outcome_uncertain"})));
+        assert_eq!(cancelled.message, "daemon invocation was cancelled");
+        assert_eq!(
+            cancelled.data,
+            Some(json!({"code": "invocation_cancelled"}))
+        );
+        let acknowledgements = fake
+            .seen()
+            .iter()
+            .filter(|request| {
+                matches!(
+                    request,
+                    V5ClientRequest::AcknowledgeInvocationReceipt { .. }
+                )
+            })
+            .count();
+        assert_eq!(
+            acknowledgements, 2,
+            "every delivered terminal is acknowledged"
+        );
+    }
+
+    #[test]
+    fn malformed_direct_receipt_is_recovered_by_key_and_only_the_strict_one_is_acknowledged() {
+        let fake = FakeDaemon::start(Box::new(|raw, request| match request {
+            V5ClientRequest::SubmitInvocation { .. } => {
+                // A receipt whose digest does not match its terminal is not a
+                // strict frame: the client poisons the session and recovers.
+                let forged: crate::application::receipt_ledger::TerminalDigest =
+                    "0a".repeat(32).parse().unwrap();
+                Step::Reply(V5ServerResponse::Invocation {
+                    outcome: V5InvocationResponse::Direct {
+                        receipt: V5PendingDirectReceipt::new(
+                            daemon_side_key(raw),
+                            completed("forged"),
+                            forged,
+                            epoch_ms_now(),
+                        ),
+                    },
+                })
+            }
+            V5ClientRequest::RecoverInvocationReceipt { receipt_key } => {
+                Step::Reply(direct_receipt(receipt_key.clone(), completed("strict")))
+            }
+            V5ClientRequest::AcknowledgeInvocationReceipt { .. } => Step::Close,
+            other => panic!("unexpected frame {other:?}"),
+        }));
+        let router = canonical_daemon_router(fake.owner(), "/workspace".to_string());
+
+        let result = direct_result(call(&router, None));
+
+        assert_eq!(
+            result
+                .structured_content
+                .as_ref()
+                .and_then(|value| value["summary"].as_str()),
+            Some("strict")
+        );
+        let seen = fake.seen();
+        assert_eq!(fake.submissions(), 1);
+        let acknowledged = seen
+            .iter()
+            .filter_map(|request| match request {
+                V5ClientRequest::AcknowledgeInvocationReceipt {
+                    terminal_digest, ..
+                } => Some(terminal_digest.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            acknowledged,
+            vec![canonical_v5_terminal(&completed("strict"))
+                .unwrap()
+                .digest()
+                .clone()],
+            "only the strict receipt is acknowledged"
+        );
+    }
+
+    #[test]
+    fn lost_submit_response_is_recovered_by_the_exact_key_without_a_second_submission() {
+        let fake = FakeDaemon::start(Box::new(|raw, request| match request {
+            V5ClientRequest::SubmitInvocation { .. } => Step::Close,
+            V5ClientRequest::RecoverInvocationReceipt { receipt_key } => {
+                Step::Reply(direct_receipt(receipt_key.clone(), completed("recovered")))
+            }
+            V5ClientRequest::AcknowledgeInvocationReceipt { .. } => Step::Close,
+            other => panic!("unexpected frame {raw:?} {other:?}"),
+        }));
+        let router = canonical_daemon_router(fake.owner(), "/workspace".to_string());
+
+        let result = direct_result(call(&router, None));
+
+        assert_eq!(
+            result
+                .structured_content
+                .as_ref()
+                .and_then(|value| value["summary"].as_str()),
+            Some("recovered")
+        );
+        let seen = fake.seen();
+        assert_eq!(
+            fake.submissions(),
+            1,
+            "a lost response never resubmits: {seen:?}"
+        );
+        let V5ClientRequest::SubmitInvocation { invocation } = &seen[0] else {
+            panic!("first frame must be the submission");
+        };
+        let V5ClientRequest::RecoverInvocationReceipt { receipt_key } = &seen[1] else {
+            panic!("second frame must recover by key: {seen:?}");
+        };
+        assert_eq!(receipt_key.invocation_id(), invocation.invocation_id());
+        assert_eq!(
+            receipt_key.reserved_task_id(),
+            invocation.reserved_task_id()
+        );
+        assert_eq!(receipt_key.tool(), V5ToolIdentity::View);
+        assert!(matches!(
+            seen[2],
+            V5ClientRequest::AcknowledgeInvocationReceipt { .. }
+        ));
+        assert_eq!(
+            fake.sessions.load(Ordering::SeqCst),
+            3,
+            "anchor, submit peer, recovery peer"
+        );
+    }
+
+    #[test]
+    fn pending_receipt_is_polled_until_its_original_budget_settles() {
+        let recoveries = Arc::new(AtomicUsize::new(0));
+        let script_recoveries = Arc::clone(&recoveries);
+        let fake = FakeDaemon::start(Box::new(move |_, request| match request {
+            V5ClientRequest::SubmitInvocation { .. } => Step::Close,
+            V5ClientRequest::RecoverInvocationReceipt { receipt_key } => {
+                if script_recoveries.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Step::Reply(V5ServerResponse::Invocation {
+                        outcome: V5InvocationResponse::ReceiptPending {
+                            receipt_key: receipt_key.clone(),
+                            phase: crate::infrastructure::daemon::protocol_v5::V5InvocationPhase::ReservedBegun,
+                            accepted_epoch_ms: epoch_ms_now(),
+                            original_budget_ms: 100,
+                            cancel_requested: false,
+                        },
+                    })
+                } else {
+                    Step::Reply(direct_receipt(receipt_key.clone(), completed("settled")))
+                }
+            }
+            V5ClientRequest::AcknowledgeInvocationReceipt { .. } => Step::Close,
+            other => panic!("unexpected frame {other:?}"),
+        }));
+        let router = canonical_daemon_router(fake.owner(), "/workspace".to_string());
+
+        let started = Instant::now();
+        let result = direct_result(call(&router, None));
+
+        assert_eq!(
+            result
+                .structured_content
+                .as_ref()
+                .and_then(|value| value["summary"].as_str()),
+            Some("settled")
+        );
+        assert!(
+            started.elapsed() >= Duration::from_millis(100),
+            "recovery waited for the budget to settle"
+        );
+        assert_eq!(recoveries.load(Ordering::SeqCst), 2);
+        assert_eq!(fake.submissions(), 1);
+    }
+
+    #[test]
+    fn pending_receipt_beyond_the_frontend_cutoff_is_a_closed_refusal_not_a_retry() {
+        let fake = FakeDaemon::start(Box::new(move |_, request| {
+            match request {
+            V5ClientRequest::SubmitInvocation { .. } => Step::Close,
+            V5ClientRequest::RecoverInvocationReceipt { receipt_key } => {
+                Step::Reply(V5ServerResponse::Invocation {
+                    outcome: V5InvocationResponse::ReceiptPending {
+                        receipt_key: receipt_key.clone(),
+                        phase: crate::infrastructure::daemon::protocol_v5::V5InvocationPhase::ReservedActorBound,
+                        accepted_epoch_ms: epoch_ms_now(),
+                        original_budget_ms: 7_000,
+                        cancel_requested: false,
+                    },
+                })
+            }
+            other => panic!("unexpected frame {other:?}"),
+        }
+        }));
+        let router = canonical_daemon_router(fake.owner(), "/workspace".to_string());
+
+        let refusal = call(&router, Some(Duration::from_millis(400)))
+            .err()
+            .expect("a receipt pending past the cutoff is refused");
+
+        assert_eq!(refusal.data, Some(json!({"code": "receipt_pending"})));
+        assert_eq!(fake.submissions(), 1);
+    }
+
+    #[test]
+    fn recovery_without_a_receipt_is_a_transport_refusal_and_no_resubmission() {
+        let fake = FakeDaemon::start(Box::new(|_, request| match request {
+            V5ClientRequest::SubmitInvocation { .. } => Step::Close,
+            V5ClientRequest::RecoverInvocationReceipt { .. } => {
+                Step::Reply(V5ServerResponse::Error {
+                    code: V5DaemonErrorCode::ReceiptNotFound,
+                })
+            }
+            other => panic!("unexpected frame {other:?}"),
+        }));
+        let router = canonical_daemon_router(fake.owner(), "/workspace".to_string());
+
+        let refusal = call(&router, None)
+            .err()
+            .expect("lost submission is refused");
+
+        assert_eq!(refusal.code, ErrorCode(TOOL_EXECUTION_ERROR));
+        assert!(refusal
+            .message
+            .contains("lost before a receipt was reserved"));
+        assert_eq!(fake.submissions(), 1);
+    }
+
+    #[test]
+    fn daemon_rejection_and_foreign_receipt_are_distinct_closed_refusals() {
+        let fake = FakeDaemon::start(Box::new(|raw, request| match request {
+            V5ClientRequest::SubmitInvocation { invocation }
+                if invocation.arguments().contains_key("at") =>
+            {
+                Step::Reply(V5ServerResponse::Error {
+                    code: V5DaemonErrorCode::Overloaded,
+                })
+            }
+            V5ClientRequest::SubmitInvocation { .. } => {
+                let mut foreign = daemon_side_key(raw);
+                foreign = ReceiptKey::new(
+                    InvocationId::new(),
+                    foreign.reserved_task_id(),
+                    foreign.request_identity(),
+                );
+                Step::Reply(direct_receipt(foreign, completed("foreign")))
+            }
+            other => panic!("unexpected frame {other:?}"),
+        }));
+        let router = canonical_daemon_router(fake.owner(), "/workspace".to_string());
+
+        let rejected = call(&router, None)
+            .err()
+            .expect("overloaded daemon refuses");
+        let foreign = (router.call)(
+            V5ToolIdentity::Docs,
+            &Map::new(),
+            deadline(None),
+            CancellationToken::new(),
+        )
+        .err()
+        .expect("a foreign receipt is refused");
+
+        assert_eq!(rejected.code, ErrorCode(TOOL_EXECUTION_ERROR));
+        assert_eq!(
+            rejected.message,
+            "daemon invocation submission rejected: overloaded"
+        );
+        assert_eq!(
+            foreign.data,
+            Some(json!({"code": "daemon_protocol_failed"}))
+        );
+        thread::sleep(Duration::from_millis(50));
+        assert!(
+            !fake.seen().iter().any(|request| matches!(
+                request,
+                V5ClientRequest::AcknowledgeInvocationReceipt { .. }
+            )),
+            "neither refusal acknowledges anything"
+        );
+    }
+
+    #[test]
+    fn task_operations_use_peer_sessions_bounded_by_the_frontend_cutoff() {
+        let task_id = TaskId::new();
+        let fake = FakeDaemon::start(Box::new(move |_, request| match request {
+            V5ClientRequest::GetTask { task_id: asked } => {
+                assert_eq!(*asked, task_id);
+                Step::Reply(V5ServerResponse::Error {
+                    code: V5DaemonErrorCode::TaskExpired,
+                })
+            }
+            V5ClientRequest::WaitTask { wait_ms, .. } => {
+                assert!(
+                    *wait_ms <= 300,
+                    "wait shrank by the transport budget: {wait_ms}"
+                );
+                Step::Reply(V5ServerResponse::Pong)
+            }
+            V5ClientRequest::CancelTask { .. } => Step::Close,
+            other => panic!("unexpected frame {other:?}"),
+        }));
+        let router = canonical_daemon_router(fake.owner(), "/workspace".to_string());
+
+        let expired = (router.get)(task_id, deadline(None));
+        let unexpected = (router.wait)(task_id, 7_000, deadline(Some(Duration::from_millis(400))));
+        let closed = (router.cancel)(task_id, deadline(None));
+        let past = (router.get)(
+            task_id,
+            FrontendInvocationDeadline::new(Instant::now() - Duration::from_secs(8), None),
+        );
+
+        assert_eq!(
+            expired,
+            Err(V5TaskExchangeError::Protocol(
+                V5DaemonErrorCode::TaskExpired
+            ))
+        );
+        assert_eq!(unexpected, Err(V5TaskExchangeError::UnexpectedResponse));
+        assert_eq!(closed, Err(V5TaskExchangeError::Transport));
+        assert_eq!(past, Err(V5TaskExchangeError::Transport));
+    }
+
+    // --- the real protocol-v5 runtime in a thread -----------------------------
+
+    struct ScriptedService {
+        delay: Duration,
+        known_long: bool,
+        outcome: Mutex<Option<Result<DomainResult, crate::domain::invocation::InvocationFailure>>>,
+        executions: AtomicUsize,
+    }
+
+    impl crate::infrastructure::daemon::server::CanonicalInvocationService for ScriptedService {
+        fn prepare(
+            &self,
+            _invocation: &crate::infrastructure::daemon::server::ActorBoundInvocation,
+        ) -> Result<crate::application::operation_descriptors::ExecutionClass, Box<DomainResult>>
+        {
+            use crate::application::operation_descriptors::{ExecutionClass, KnownLongReason};
+            Ok(if self.known_long {
+                ExecutionClass::KnownLong(KnownLongReason::ExternalProcess)
+            } else {
+                ExecutionClass::InlineCandidate
+            })
+        }
+
+        fn execute(
+            &self,
+            _invocation: &crate::infrastructure::daemon::server::ActorBoundExecution,
+            _cancellation: CancellationToken,
+        ) -> Result<DomainResult, crate::domain::invocation::InvocationFailure> {
+            self.executions.fetch_add(1, Ordering::SeqCst);
+            thread::sleep(self.delay);
+            self.outcome
+                .lock()
+                .unwrap()
+                .clone()
+                .unwrap_or_else(|| Ok(DomainResult::success("executed")))
+        }
+    }
+
+    struct LiveDaemon {
+        _state: tempfile::TempDir,
+        _workspace: tempfile::TempDir,
+        workspace_hint: String,
+        state_root: std::path::PathBuf,
+        thread: Option<thread::JoinHandle<Result<(), String>>>,
+    }
+
+    impl LiveDaemon {
+        fn start(service: Arc<ScriptedService>) -> Self {
+            let state = tempfile::tempdir().unwrap();
+            let workspace = tempfile::tempdir().unwrap();
+            std::fs::write(workspace.path().join("v8project.yaml"), WORKSPACE_MANIFEST).unwrap();
+            let state_root = std::fs::canonicalize(state.path()).unwrap();
+            let workspace_hint = std::fs::canonicalize(workspace.path())
+                .unwrap()
+                .to_string_lossy()
+                .into_owned();
+            let config = DaemonServerConfig::new(
+                state_root.clone(),
+                CoreIdentity::production_v5(),
+                Duration::from_millis(400),
+            )
+            .with_invocation_service(service);
+            let thread = thread::spawn(move || {
+                crate::infrastructure::daemon::runtime_v5::run_daemon(config)
+            });
+            Self {
+                _state: state,
+                _workspace: workspace,
+                workspace_hint,
+                state_root,
+                thread: Some(thread),
+            }
+        }
+
+        fn owner(&self) -> V5DaemonProcessOwner {
+            let identity = CoreIdentity::production_v5();
+            let deadline = Instant::now() + Duration::from_secs(10);
+            loop {
+                let state = DaemonStateDirectory::open(&self.state_root, &identity).unwrap();
+                if let Some(record) = state.read_v5_endpoint_record().unwrap() {
+                    return V5DaemonProcessOwner::connect_before(record, deadline)
+                        .expect("connect live v5 daemon");
+                }
+                assert!(Instant::now() < deadline, "v5 endpoint was not published");
+                thread::sleep(Duration::from_millis(5));
+            }
+        }
+
+        fn finish(mut self) {
+            self.thread
+                .take()
+                .unwrap()
+                .join()
+                .expect("join v5 daemon thread")
+                .expect("v5 daemon exits cleanly after its idle grace");
+        }
+    }
+
+    #[test]
+    fn live_daemon_executes_once_and_compacts_the_acknowledged_receipt_to_a_tombstone() {
+        let service = Arc::new(ScriptedService {
+            delay: Duration::ZERO,
+            known_long: false,
+            outcome: Mutex::new(None),
+            executions: AtomicUsize::new(0),
+        });
+        let daemon = LiveDaemon::start(Arc::clone(&service));
+        let observed = Arc::new(Mutex::new(None));
+        let sink = Arc::clone(&observed);
+        let owner = daemon.owner();
+        let router = canonical_daemon_router_observed(
+            owner,
+            daemon.workspace_hint.clone(),
+            Arc::new(move |key: &ReceiptKey| *sink.lock().unwrap() = Some(key.clone())),
+        );
+
+        let result = direct_result(call(&router, None));
+        let key = observed
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("receipt key observed");
+        let mut peer = daemon.owner();
+        let recovered = peer
+            .recover_invocation_receipt_before(key, Instant::now() + Duration::from_secs(5))
+            .expect("recover after acknowledgement");
+
+        assert_eq!(
+            result
+                .structured_content
+                .as_ref()
+                .and_then(|value| value["summary"].as_str()),
+            Some("executed")
+        );
+        assert_eq!(service.executions.load(Ordering::SeqCst), 1);
+        assert!(
+            matches!(
+                recovered,
+                V5ServerResponse::Invocation {
+                    outcome: V5InvocationResponse::Acknowledged { .. }
+                }
+            ),
+            "acknowledged receipt must compact to a tombstone: {recovered:?}"
+        );
+        drop(peer);
+        drop(router);
+        daemon.finish();
+    }
+
+    #[test]
+    fn live_daemon_failure_is_delivered_as_the_closed_reason_without_its_text() {
+        let service = Arc::new(ScriptedService {
+            delay: Duration::ZERO,
+            known_long: false,
+            outcome: Mutex::new(Some(Err(
+                crate::domain::invocation::InvocationFailure::new(
+                    "provider_exploded",
+                    "/private/workspace bearer-secret",
+                ),
+            ))),
+            executions: AtomicUsize::new(0),
+        });
+        let daemon = LiveDaemon::start(service);
+        let router = canonical_daemon_router(daemon.owner(), daemon.workspace_hint.clone());
+
+        let refusal = call(&router, None)
+            .err()
+            .expect("failed execution is an error");
+
+        assert_eq!(refusal.code, ErrorCode::INTERNAL_ERROR);
+        assert_eq!(refusal.message, "daemon invocation failed");
+        assert_eq!(refusal.data, Some(json!({"code": "invocation_failed"})));
+        assert!(!format!("{refusal:?}").contains("bearer-secret"));
+        drop(router);
+        daemon.finish();
+    }
+
+    #[test]
+    fn live_daemon_hands_slow_work_off_to_a_task_that_get_wait_and_cancel_observe() {
+        // Known-long work is handed off before execution, so the Task path is
+        // exercised without racing the seven-second cutoff on a loaded runner.
+        let service = Arc::new(ScriptedService {
+            delay: Duration::from_millis(300),
+            known_long: true,
+            outcome: Mutex::new(None),
+            executions: AtomicUsize::new(0),
+        });
+        let daemon = LiveDaemon::start(Arc::clone(&service));
+        let router = canonical_daemon_router(daemon.owner(), daemon.workspace_hint.clone());
+
+        let handoff = match call(&router, None) {
+            Ok(CanonicalCallOutcome::Task(snapshot)) => snapshot,
+            Ok(CanonicalCallOutcome::Direct(result)) => {
+                panic!("slow work answered directly: {result:?}")
+            }
+            Err(error) => panic!("slow work refused: {error}"),
+        };
+        let task_id = handoff.task_id();
+        let observed = (router.get)(task_id, deadline(None)).expect("get the handed-off task");
+        let terminal =
+            (router.wait)(task_id, 5_000, deadline(None)).expect("wait for the terminal");
+        let cancelled = (router.cancel)(task_id, deadline(None)).expect("cancel after terminal");
+
+        assert!(!matches!(
+            handoff.status(),
+            crate::domain::invocation::InvocationStatus::Completed
+        ));
+        assert_eq!(observed.task_id(), task_id);
+        assert_eq!(
+            terminal
+                .completed_result()
+                .map(|result| result.summary.as_str()),
+            Some("executed")
+        );
+        assert_eq!(
+            cancelled.status(),
+            crate::domain::invocation::InvocationStatus::Completed
+        );
+        assert_eq!(service.executions.load(Ordering::SeqCst), 1);
+        drop(router);
+        daemon.finish();
+    }
+}

--- a/crates/unica-coder/src/interfaces/mcp.rs
+++ b/crates/unica-coder/src/interfaces/mcp.rs
@@ -6,9 +6,8 @@
 //! application layer (ADR-0002) and keeps the tool contract data-driven from
 //! operation descriptors (ADR-0001) instead of SDK macros.
 
-use crate::application::invocation::{
-    handoff_budget, INVOCATION_HANDOFF_WINDOW, RESPONSE_SERIALIZATION_MARGIN,
-};
+use super::daemon_router::FrontendInvocationDeadline;
+use crate::application::invocation::RESPONSE_SERIALIZATION_MARGIN;
 use crate::application::invocation_store::ToolIdentity;
 use crate::application::tool_contracts::{SurfaceRelease, V13TaskProfile};
 use crate::application::{
@@ -100,46 +99,6 @@ enum SurfaceToolOutcome {
     Legacy(Box<OperationResult>),
     Canonical(crate::domain::invocation::DomainResult),
     Task(crate::infrastructure::daemon::protocol::DaemonTaskSnapshot),
-}
-
-#[derive(Debug, Clone, Copy)]
-struct FrontendInvocationDeadline {
-    received_at: Instant,
-    host_remaining_at_receipt: Option<Duration>,
-}
-
-impl FrontendInvocationDeadline {
-    fn new(received_at: Instant, host_remaining_at_receipt: Option<Duration>) -> Self {
-        Self {
-            received_at,
-            host_remaining_at_receipt,
-        }
-    }
-
-    fn remaining_at(self, now: Instant) -> Duration {
-        remaining_invocation_budget(self.received_at, now, self.host_remaining_at_receipt)
-    }
-
-    fn remaining_transport_at(self, now: Instant) -> Duration {
-        let elapsed = now.saturating_duration_since(self.received_at);
-        let own_remaining = INVOCATION_HANDOFF_WINDOW
-            .saturating_add(RESPONSE_SERIALIZATION_MARGIN)
-            .saturating_sub(elapsed);
-        let host_remaining = self
-            .host_remaining_at_receipt
-            .map(|remaining| remaining.saturating_sub(elapsed));
-        host_remaining.map_or(own_remaining, |remaining| own_remaining.min(remaining))
-    }
-
-    fn transport_cutoff(self) -> Instant {
-        let own_cutoff = self
-            .received_at
-            .checked_add(INVOCATION_HANDOFF_WINDOW.saturating_add(RESPONSE_SERIALIZATION_MARGIN))
-            .expect("bounded frontend transport cutoff");
-        self.host_remaining_at_receipt
-            .and_then(|remaining| self.received_at.checked_add(remaining))
-            .map_or(own_cutoff, |host_cutoff| own_cutoff.min(host_cutoff))
-    }
 }
 
 pub fn run_stdio() {
@@ -346,18 +305,6 @@ impl UnicaServer {
     fn in_flight(&self) -> Arc<InFlightRegistry> {
         Arc::clone(&self.in_flight)
     }
-}
-
-fn remaining_invocation_budget(
-    received_at: Instant,
-    now: Instant,
-    host_remaining_at_receipt: Option<Duration>,
-) -> Duration {
-    let elapsed = now.saturating_duration_since(received_at);
-    let own_remaining = INVOCATION_HANDOFF_WINDOW.saturating_sub(elapsed);
-    let host_remaining =
-        host_remaining_at_receipt.map(|remaining| remaining.saturating_sub(elapsed));
-    own_remaining.min(handoff_budget(host_remaining))
 }
 
 fn execute_surface_tool(
@@ -1385,8 +1332,10 @@ impl Drop for InFlightGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::application::invocation::INVOCATION_HANDOFF_WINDOW;
     use crate::application::{ResultContract, ToolExecution};
     use crate::domain::cache::CacheReport;
+    use crate::interfaces::daemon_router::remaining_invocation_budget;
     use serde_json::json;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::mpsc;

--- a/crates/unica-coder/src/interfaces/mod.rs
+++ b/crates/unica-coder/src/interfaces/mod.rs
@@ -3,4 +3,5 @@ pub mod mcp;
 pub mod runtime_job_worker;
 pub mod workspace_service;
 
+mod daemon_router;
 mod task_projection;

--- a/crates/unica-coder/src/interfaces/task_projection.rs
+++ b/crates/unica-coder/src/interfaces/task_projection.rs
@@ -2,8 +2,11 @@ use crate::application::invocation_store::{
     canonical_result_size, CanonicalResultSizeError, MAX_CANONICAL_RESULT_BYTES,
     MAX_TASK_RECORD_ENVELOPE_BYTES,
 };
+use crate::application::invocation_store_v5::V5SafeFailureReason;
+use crate::application::receipt_ledger::ReceiptTerminalOutcome;
 use crate::domain::invocation::{DomainResult, InvocationStatus};
 use crate::infrastructure::daemon::protocol::DaemonTaskSnapshot;
+use crate::infrastructure::daemon::protocol_v5::V5DaemonTaskSnapshot;
 use chrono::{SecondsFormat, Utc};
 use rmcp::model::{
     CallToolResult, CreateTaskResult, DetailedTask, ErrorCode, ErrorData, JsonObject, Task,
@@ -200,6 +203,140 @@ pub(super) fn detailed_task(
     Ok(projected)
 }
 
+/// Native Task seed from a protocol-v5 snapshot: the durable identity, status
+/// and timing exactly as the daemon stored them.
+#[cfg_attr(not(test), allow(dead_code))] // selected by the v5 cutover
+pub(super) fn create_task_result_v5(
+    snapshot: &V5DaemonTaskSnapshot,
+) -> Result<CreateTaskResult, TaskProjectionError> {
+    let projected = CreateTaskResult::new(task_v5(snapshot)?);
+    ensure_projection_bounded(&projected)?;
+    Ok(projected)
+}
+
+/// `tasks/get` projection of a protocol-v5 snapshot. The v5 snapshot is a
+/// closed union, so the status/result/failure matrix cannot be violated on
+/// the wire; the only projection failures left are size, time and encoding.
+#[cfg_attr(not(test), allow(dead_code))] // selected by the v5 cutover
+pub(super) fn detailed_task_v5(
+    snapshot: &V5DaemonTaskSnapshot,
+) -> Result<DetailedTask, TaskProjectionError> {
+    let payload = match snapshot {
+        V5DaemonTaskSnapshot::Queued { .. } | V5DaemonTaskSnapshot::Working { .. } => {
+            TaskPayload::Working
+        }
+        V5DaemonTaskSnapshot::Completed { result, .. } => TaskPayload::Completed {
+            result: call_result_object(result)?,
+        },
+        V5DaemonTaskSnapshot::Failed { reason, .. } => TaskPayload::Failed {
+            error: closed_failure_object(*reason)?,
+        },
+        V5DaemonTaskSnapshot::Cancelled { .. } => TaskPayload::Cancelled,
+    };
+    let projected = DetailedTask::new(task_v5(snapshot)?, payload);
+    ensure_projection_bounded(&projected)?;
+    Ok(projected)
+}
+
+#[cfg_attr(not(test), allow(dead_code))] // selected by the v5 cutover
+fn task_v5(snapshot: &V5DaemonTaskSnapshot) -> Result<Task, TaskProjectionError> {
+    if snapshot.updated_at_epoch_ms() < snapshot.created_at_epoch_ms() {
+        return Err(TaskProjectionError::ReverseTimestampOrder);
+    }
+    let projected = Task::new(
+        snapshot.task_id().to_string(),
+        task_status(snapshot.status()),
+        iso8601(snapshot.created_at_epoch_ms())?,
+        iso8601(snapshot.updated_at_epoch_ms())?,
+    )
+    .with_ttl_ms(snapshot.ttl_ms())
+    .with_poll_interval_ms(snapshot.poll_interval_ms());
+    ensure_projection_bounded(&projected)?;
+    Ok(projected)
+}
+
+/// The closed failure vocabulary of the v5 daemon and its fixed host-facing
+/// text. The daemon never sends prose for a failure, so this table is the only
+/// place a failed invocation gets words.
+pub(super) fn closed_failure(reason: V5SafeFailureReason) -> (&'static str, &'static str) {
+    match reason {
+        V5SafeFailureReason::InvocationFailed => ("invocation_failed", "daemon invocation failed"),
+        V5SafeFailureReason::ResultTooLarge => (
+            "result_too_large",
+            "daemon invocation result exceeded the canonical byte limit",
+        ),
+        V5SafeFailureReason::Interrupted => ("interrupted", "daemon invocation was interrupted"),
+        V5SafeFailureReason::ResumeUnsupported => (
+            "resume_unsupported",
+            "daemon invocation cannot be resumed after restart",
+        ),
+        V5SafeFailureReason::PersistenceFailed => (
+            "persistence_failed",
+            "daemon invocation terminal state could not be persisted",
+        ),
+        V5SafeFailureReason::OutcomeUncertain => (
+            "outcome_uncertain",
+            "daemon invocation outcome is uncertain",
+        ),
+        V5SafeFailureReason::TaskCapacity => (
+            "task_capacity",
+            "daemon Task capacity was exhausted before execution",
+        ),
+        V5SafeFailureReason::WorkspaceCapacity => {
+            ("workspace_capacity", "workspace capacity was exhausted")
+        }
+        V5SafeFailureReason::WorkspaceRegistryFailed => (
+            "workspace_registry_failed",
+            "workspace registry is unavailable",
+        ),
+    }
+}
+
+fn closed_failure_error(reason: V5SafeFailureReason) -> ErrorData {
+    let (code, message) = closed_failure(reason);
+    ErrorData::new(
+        ErrorCode::INTERNAL_ERROR,
+        message,
+        Some(serde_json::json!({"code": code})),
+    )
+}
+
+#[cfg_attr(not(test), allow(dead_code))] // selected by the v5 cutover
+fn closed_failure_object(reason: V5SafeFailureReason) -> Result<JsonObject, TaskProjectionError> {
+    serde_json::to_value(closed_failure_error(reason))
+        .map_err(|_| TaskProjectionError::Serialization)?
+        .as_object()
+        .cloned()
+        .ok_or(TaskProjectionError::Serialization)
+}
+
+/// Final interface value of a Direct terminal: the same `CallToolResult` a
+/// completed Task later embeds, or the closed error a failed or cancelled
+/// terminal answers with. Built before the acknowledgement is sent, so a
+/// receipt is acknowledged only once its host-facing value exists.
+pub(super) enum DirectProjection {
+    Result(CallToolResult),
+    Error(ErrorData),
+}
+
+pub(super) fn project_direct_terminal(
+    terminal: &ReceiptTerminalOutcome,
+) -> Result<DirectProjection, TaskProjectionError> {
+    Ok(match terminal {
+        ReceiptTerminalOutcome::Completed { result } => {
+            DirectProjection::Result(call_tool_result(result)?)
+        }
+        ReceiptTerminalOutcome::Failed { reason } => {
+            DirectProjection::Error(closed_failure_error(*reason))
+        }
+        ReceiptTerminalOutcome::Cancelled => DirectProjection::Error(ErrorData::new(
+            ErrorCode::INTERNAL_ERROR,
+            "daemon invocation was cancelled",
+            Some(serde_json::json!({"code": "invocation_cancelled"})),
+        )),
+    })
+}
+
 pub(super) fn projection_error(error: TaskProjectionError) -> ErrorData {
     let code = match error {
         TaskProjectionError::ResultTooLarge => "result_too_large",
@@ -218,6 +355,7 @@ mod tests {
         DomainResult, InvocationFailure, InvocationId, InvocationStatus, TaskId,
     };
     use crate::infrastructure::daemon::protocol::DaemonTaskSnapshot;
+    use crate::infrastructure::daemon::protocol_v5::V5DaemonTaskSnapshot;
     use serde_json::{json, Value};
 
     fn snapshot(status: InvocationStatus) -> DaemonTaskSnapshot {
@@ -352,5 +490,235 @@ mod tests {
         let mut completed = snapshot(InvocationStatus::Completed);
         completed.result = Some(oversized);
         assert!(super::detailed_task(&completed).is_err());
+    }
+
+    fn v5_common() -> (
+        TaskId,
+        InvocationId,
+        crate::application::receipt_ledger::ReceiptKeyDigest,
+    ) {
+        (
+            "f741d562-9d42-4a4f-a626-fcd5c3fb9bc4".parse().unwrap(),
+            InvocationId::new(),
+            "07".repeat(32).parse().unwrap(),
+        )
+    }
+
+    fn v5_working() -> V5DaemonTaskSnapshot {
+        let (task_id, invocation_id, receipt_key_digest) = v5_common();
+        V5DaemonTaskSnapshot::Working {
+            task_id,
+            invocation_id,
+            receipt_key_digest,
+            created_at_epoch_ms: 1_777_012_345_678,
+            updated_at_epoch_ms: 1_777_012_346_789,
+            ttl_ms: 3_600_000,
+            poll_interval_ms: 250,
+            version: 2,
+            cancel_requested: false,
+        }
+    }
+
+    fn v5_terminal_digest() -> crate::application::receipt_ledger::TerminalDigest {
+        "09".repeat(32).parse().unwrap()
+    }
+
+    #[test]
+    fn v5_native_projection_keeps_durable_time_ttl_and_maps_queued_to_working() {
+        let (task_id, invocation_id, receipt_key_digest) = v5_common();
+        let queued = V5DaemonTaskSnapshot::Queued {
+            task_id,
+            invocation_id,
+            receipt_key_digest,
+            created_at_epoch_ms: 1_777_012_345_678,
+            updated_at_epoch_ms: 1_777_012_346_789,
+            ttl_ms: 3_600_000,
+            poll_interval_ms: 250,
+            version: 1,
+            cancel_requested: false,
+        };
+
+        let seed = super::create_task_result_v5(&queued).expect("project queued seed");
+        let detailed = super::detailed_task_v5(&queued).expect("project queued task");
+
+        assert_eq!(seed.task.task_id, task_id.to_string());
+        assert_eq!(seed.task.status, rmcp::model::TaskStatus::Working);
+        assert_eq!(seed.task.created_at, "2026-04-24T06:32:25.678Z");
+        assert_eq!(seed.task.last_updated_at, "2026-04-24T06:32:26.789Z");
+        assert_eq!(seed.task.ttl_ms, Some(3_600_000));
+        assert_eq!(seed.task.poll_interval_ms, Some(250));
+        assert!(matches!(
+            detailed.payload,
+            rmcp::model::TaskPayload::Working
+        ));
+        let raw = serde_json::to_value(&detailed).unwrap();
+        let mut keys = raw.as_object().unwrap().keys().collect::<Vec<_>>();
+        keys.sort();
+        assert_eq!(
+            keys,
+            [
+                "createdAt",
+                "lastUpdatedAt",
+                "pollIntervalMs",
+                "status",
+                "taskId",
+                "ttlMs"
+            ]
+        );
+    }
+
+    #[test]
+    fn v5_completed_task_embeds_the_exact_direct_call_result() {
+        let result = DomainResult {
+            ok: false,
+            at: Some("main:Catalog.Товары".into()),
+            summary: "checked".into(),
+            data: Some(json!({"nested": [1, 2, 3]})),
+            changed: vec![],
+            warnings: vec![],
+            diagnostics: vec![json!({"code": "bad_value"})],
+            artifacts: vec![],
+            next: vec![],
+            rev: None,
+            cursor: None,
+        };
+        let direct = match super::project_direct_terminal(
+            &crate::application::receipt_ledger::ReceiptTerminalOutcome::Completed {
+                result: Box::new(result.clone()),
+            },
+        )
+        .expect("project direct terminal")
+        {
+            super::DirectProjection::Result(projected) => projected,
+            super::DirectProjection::Error(error) => panic!("completed terminal errored: {error}"),
+        };
+        let (task_id, invocation_id, receipt_key_digest) = v5_common();
+        let completed = V5DaemonTaskSnapshot::Completed {
+            task_id,
+            invocation_id,
+            receipt_key_digest,
+            created_at_epoch_ms: 1_777_012_345_678,
+            updated_at_epoch_ms: 1_777_012_346_789,
+            ttl_ms: 3_600_000,
+            poll_interval_ms: 250,
+            version: 3,
+            cancel_requested: false,
+            terminal_epoch_ms: 1_777_012_346_789,
+            terminal_digest: v5_terminal_digest(),
+            result: Box::new(result),
+        };
+
+        let detailed = super::detailed_task_v5(&completed).expect("completed task");
+        let rmcp::model::TaskPayload::Completed { result: embedded } = detailed.payload else {
+            panic!("completed task must embed the original call result");
+        };
+
+        assert_eq!(
+            Value::Object(embedded),
+            serde_json::to_value(&direct).expect("serialize direct result")
+        );
+        assert_eq!(direct.is_error, Some(true));
+        assert!(direct.content.is_empty());
+    }
+
+    #[test]
+    fn v5_failed_and_cancelled_terminals_answer_only_the_closed_vocabulary() {
+        use crate::application::invocation_store_v5::V5SafeFailureReason;
+
+        for reason in V5SafeFailureReason::ALL {
+            let (code, message) = super::closed_failure(reason);
+            assert_eq!(code, reason.wire_name(), "code follows the wire name");
+            assert!(!message.is_empty());
+            let (task_id, invocation_id, receipt_key_digest) = v5_common();
+            let failed = V5DaemonTaskSnapshot::Failed {
+                task_id,
+                invocation_id,
+                receipt_key_digest,
+                created_at_epoch_ms: 1_777_012_345_678,
+                updated_at_epoch_ms: 1_777_012_346_789,
+                ttl_ms: 3_600_000,
+                poll_interval_ms: 250,
+                version: 3,
+                cancel_requested: false,
+                terminal_epoch_ms: 1_777_012_346_789,
+                terminal_digest: v5_terminal_digest(),
+                reason,
+            };
+            let detailed = super::detailed_task_v5(&failed).expect("failed task");
+            let rmcp::model::TaskPayload::Failed { error } = detailed.payload else {
+                panic!("failed task must embed a JSON-RPC error");
+            };
+            assert_eq!(error["code"], -32603);
+            assert_eq!(error["message"], message);
+            assert_eq!(error["data"], json!({"code": code}));
+            let direct = super::project_direct_terminal(
+                &crate::application::receipt_ledger::ReceiptTerminalOutcome::Failed { reason },
+            )
+            .expect("project failed direct terminal");
+            let super::DirectProjection::Error(direct) = direct else {
+                panic!("failed direct terminal must be an error");
+            };
+            assert_eq!(direct.message, message);
+            assert_eq!(direct.data, Some(json!({"code": code})));
+        }
+
+        let cancelled = super::project_direct_terminal(
+            &crate::application::receipt_ledger::ReceiptTerminalOutcome::Cancelled,
+        )
+        .expect("project cancelled direct terminal");
+        let super::DirectProjection::Error(cancelled) = cancelled else {
+            panic!("cancelled direct terminal must be an error");
+        };
+        assert_eq!(cancelled.code, rmcp::model::ErrorCode::INTERNAL_ERROR);
+        assert_eq!(cancelled.message, "daemon invocation was cancelled");
+        assert_eq!(
+            cancelled.data,
+            Some(json!({"code": "invocation_cancelled"}))
+        );
+        let (task_id, invocation_id, receipt_key_digest) = v5_common();
+        let cancelled_task = V5DaemonTaskSnapshot::Cancelled {
+            task_id,
+            invocation_id,
+            receipt_key_digest,
+            created_at_epoch_ms: 1_777_012_345_678,
+            updated_at_epoch_ms: 1_777_012_346_789,
+            ttl_ms: 3_600_000,
+            poll_interval_ms: 250,
+            version: 3,
+            cancel_requested: true,
+            terminal_epoch_ms: 1_777_012_346_789,
+            terminal_digest: v5_terminal_digest(),
+        };
+        assert!(matches!(
+            super::detailed_task_v5(&cancelled_task).unwrap().payload,
+            rmcp::model::TaskPayload::Cancelled
+        ));
+    }
+
+    #[test]
+    fn v5_projection_rejects_reverse_timestamps_and_oversized_results() {
+        use crate::application::invocation_store::MAX_CANONICAL_RESULT_BYTES;
+
+        let mut reversed = v5_working();
+        if let V5DaemonTaskSnapshot::Working {
+            updated_at_epoch_ms,
+            created_at_epoch_ms,
+            ..
+        } = &mut reversed
+        {
+            *updated_at_epoch_ms = *created_at_epoch_ms - 1;
+        }
+        assert!(super::create_task_result_v5(&reversed).is_err());
+        assert!(super::detailed_task_v5(&reversed).is_err());
+
+        let oversized = DomainResult::success("x".repeat(MAX_CANONICAL_RESULT_BYTES + 1));
+        assert!(matches!(
+            super::project_direct_terminal(
+                &crate::application::receipt_ledger::ReceiptTerminalOutcome::Completed {
+                    result: Box::new(oversized),
+                },
+            ),
+            Err(super::TaskProjectionError::ResultTooLarge)
+        ));
     }
 }

--- a/docs/design/2026-09-07-daemon-v5-production-cutover-design.md
+++ b/docs/design/2026-09-07-daemon-v5-production-cutover-design.md
@@ -227,6 +227,28 @@ receipt-ledger-test-support --test daemon_receipt_ledger`); признак не
 запускал тест по имени без `--include-ignored`; снятие атрибута чинит их
 без правки кода.
 
+**Шаг A на `main`, PR #773 влит 07.09.2026 через очередь.** Прогон push в
+`main`: план Rust 4614 тестов на ubuntu и 4621 на macOS (контракт ledger
+и process-тесты в плане), второй вызов nextest с признаком записал по 56
+результатов `medium` на каждом раннере; вторая компиляция и прогон — 1 мин
+48 с на ubuntu и 2 мин 4 с на macOS. Джоба Rust целиком: 7 мин 21 с и
+10 мин 51 с. Сайт пересобрался. Ночь запущена руками для яруса `large`.
+
+**Шаг B.** Клиент v5: `connect_or_spawn`, `connect_peer_before`,
+типизированные `V5TransportError` (не отправлено / ответ потерян) и
+`V5TaskExchangeError`, операции submit/recover/ACK/get/wait/cancel с
+абсолютным сроком. Проекции v5 в `task_projection.rs`: native Task,
+`DirectProjection` с таблицей девяти закрытых причин. Маршрутизатор
+`interfaces/daemon_router.rs`: ACK после проекции, recover по ключу,
+ожидание `ReceiptPending` до `accepted + budget + 125 мс` в пределах
+cutoff. Тесты: сценарный fake-daemon по кадрам (ACK с точным digest,
+потеря ответа без повторной отправки, pending за cutoff, чужая квитанция,
+подделанный digest) и настоящий рантайм v5 в потоке (tombstone после ACK,
+закрытая причина без текста, known-long handoff с get/wait/cancel).
+Находка: ответ с поддельным digest строгий декодер клиента отвергает, и
+клиент идёт в recover — «oversized Direct» до проекции не доходит, его
+отсекает сам daemon (`canonical_v5_terminal`).
+
 ## Открытые вопросы
 
 - Держит ли wall-clock ворота на раннерах ubuntu/macOS 32 квитанции в


### PR DESCRIPTION
## Что

Шаг B замысла перевода production daemon с v3 на v5
(`docs/design/2026-09-07-daemon-v5-production-cutover-design.md`).
Production по-прежнему поднимает v3: новый код подключён только тестами и
помечен `allow(dead_code)` до переключения (шаг C).

- **Клиент v5** (`client_v5.rs`): `connect_or_spawn` вместо тестового имени;
  `connect_peer_before` — сессия на вызов со своим owner lease;
  типизированные ошибки `V5TransportError` («не отправлено» / «ответ
  потерян» — по последствию для квитанции) и `V5TaskExchangeError`;
  submit/recover/ACK/get/wait/cancel с абсолютным сроком.
- **Снимок v5** (`protocol_v5.rs`): методы доступа к полям
  `V5DaemonTaskSnapshot`, статус как `InvocationStatus`.
- **Проекции v5** (`task_projection.rs`): native Task (`CreateTaskResult`,
  `DetailedTask`) по снимку v5; `DirectProjection` — тот же `CallToolResult`
  для Completed и закрытая `ErrorData` -32603 для Failed/Cancelled; таблица
  девяти закрытых причин с фиксированным текстом.
- **Маршрутизатор** (`interfaces/daemon_router.rs`): ACK только после
  построенной проекции, с собственным бюджетом; потеря ответа на submit →
  recover по ключу квитанции, вычисленному на клиенте (та же формула, что у
  daemon), без повторной отправки; `ReceiptPending` ждётся до
  `accepted + budget + 125 мс` в пределах cutoff, за cutoff — закрытый отказ
  `receipt_pending`; чужая квитанция и неожиданные ответы —
  `daemon_protocol_failed`. `FrontendInvocationDeadline` переехал сюда из
  `mcp.rs`.

## Тесты

- Сценарный fake-daemon по кадрам (сессия на поток): ACK с точным digest
  после submit; failed/cancelled → закрытые ошибки и ACK; поддельный digest →
  строгий декодер, recover, ACK только строгой квитанции; потеря ответа →
  recover по ключу, одна отправка; pending до конца бюджета; pending за
  cutoff → отказ; `receipt_not_found` → транспортный отказ; `overloaded` и
  чужая квитанция; операции Task с cutoff.
- Настоящий рантайм v5 в потоке с подставленным сервисом: Direct → результат,
  одно исполнение, квитанция сжата в tombstone (recover отвечает
  `acknowledged`); отказ исполнения → `invocation_failed` без текста;
  known-long → Task, get/wait/cancel.

## Проверено

`cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features
-D warnings`; `unica-coder` в профиле `queue` — 4410 зелёных; контракт ledger
локально — 64 из 65, красный только нагрузочный `wall_clock_writer…` под
параллельной нагрузкой (ярус `large`, в очередь не идёт).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable invocation handling with deadline-aware submission, recovery, and acknowledgement.
  * Added task operations for retrieving, waiting on, and cancelling work.
  * Added task status details, timestamps, results, and sanitized failure information.
  * Added support for projecting completed work directly into results or clear error responses.
  * Added safeguards for lost responses, expired requests, invalid results, and oversized outputs.

* **Documentation**
  * Updated daemon production cutover documentation with implementation progress, testing results, and runtime validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->