### PR TITLE
ci: ночному ярусу large — три часа на джобу Rust

### DIFF
--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -225,7 +225,10 @@ jobs:
   test-rust-platforms:
     name: Rust tests (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
+    # Ночной ярус `large` на Windows гоняет весь набор вместе с контрактом
+    # ReceiptLedger и в час не укладывается (прогон 34141437672 отменён на
+    # 60-й минуте); остальным воротам часа хватает с запасом.
+    timeout-minutes: ${{ github.event_name == 'workflow_dispatch' && inputs.profile == 'large' && 180 || 60 }}
     permissions:
       contents: read
       security-events: write

--- a/tests/ci/test_unica_workflow.py
+++ b/tests/ci/test_unica_workflow.py
@@ -458,7 +458,9 @@ class UnicaWorkflowGuardrailTests(unittest.TestCase):
             "classify-changes": 10,
             "guards": 15,
             "test-python": 90,
-            "test-rust-platforms": 60,
+            # Час всем воротам, три — ночному `large`: там Windows гоняет весь
+            # набор вместе с контрактом ReceiptLedger.
+            "test-rust-platforms": "${{ github.event_name == 'workflow_dispatch' && inputs.profile == 'large' && 180 || 60 }}",
             "build-tools": 90,
             "package-thin": 30,
             "probe-thin-bootstrap": 30,


### PR DESCRIPTION
## Что

Шаг D замысла перевода daemon на v5: ночной прогон яруса `large`
(run 34141437672, запущен руками 07.09.2026 после #773) на ubuntu и macOS
зелёный — девять тестов ёмкости и нагрузки контракта ReceiptLedger прошли, —
а на Windows отменён ровно на 60-й минуте: там ночью идёт весь набор вместе
с полным контрактом, и в `timeout-minutes: 60` джобы Rust он не укладывается.

Срок джобы `test-rust-platforms` становится выражением: 180 минут при ручном
запуске с `profile: large`, остальным воротам — прежний час. Страж
`test_heavy_and_external_jobs_have_timeouts` ждёт ровно это выражение.

## Проверено

`tests/ci/test_unica_workflow.py` и `test_action_pins.py` — 48 зелёных.
