### PR TITLE
ci: джоба guards ставит зависимости наборов перед стражем неизменности

### DIFF
--- a/.github/workflows/unica-plugin-release.yml
+++ b/.github/workflows/unica-plugin-release.yml
@@ -139,6 +139,10 @@ jobs:
       - run: python -m py_compile scripts/arch/*.py tests/arch/*.py
       - run: python -m py_compile scripts/dev/*.py tests/dev/*.py
       - run: python scripts/ci/check-version-contract.py
+      # Страж неизменности разбирает Rust-свидетельства через tree-sitter и без
+      # него честно отказывает: правка продуктового правила без парсера не
+      # проходит. Зависимости — те же, что у наборов Python.
+      - run: python -m pip install -r tests/ci/requirements.txt
       - name: Check accepted architecture records
         if: github.event_name == 'pull_request'
         env:


### PR DESCRIPTION
## Что

Страж `scripts/arch/immutability.py` разбирает Rust-свидетельства через
tree-sitter и без парсера честно отказывает («tree-sitter Rust parser
unavailable; install tests/ci/requirements.txt»). Джоба `guards` ставила
только Python и не ставила зависимости, поэтому первая правка продуктового
правила с Rust-основанием — #776, переключение daemon на v5 — красила
ворота, хотя локально из venv стражи зелёные.

Перед шагом «Check accepted architecture records» джоба ставит
`tests/ci/requirements.txt` — те же четыре зависимости, что у наборов Python
в `test-python`.

## Проверено

`tests/ci/test_unica_workflow.py`, `test_action_pins.py` — 48 зелёных.
