### PR TITLE
feat(source): командный интерфейс конфигурации — её свойство, а не узел

### DIFF
--- a/crates/unica-coder/src/infrastructure/native_operations/cf.rs
+++ b/crates/unica-coder/src/infrastructure/native_operations/cf.rs
@@ -886,6 +886,7 @@ pub(crate) struct CfInfoData {
     pub(crate) child_objects: Vec<CfChildObjectCount>,
     pub(crate) total_objects: usize,
     pub(crate) home_page: Option<CfHomePageData>,
+    pub(crate) interface: Option<CfInterfaceData>,
 }
 
 #[derive(serde::Serialize)]
@@ -913,6 +914,20 @@ pub(crate) struct CfInfoProperties {
 pub(crate) struct CfChildObjectCount {
     pub(crate) kind: String,
     pub(crate) count: usize,
+}
+
+/// Командный интерфейс конфигурации.
+///
+/// В корневом `Ext/CommandInterface.xml` лежит только порядок подсистем
+/// верхнего уровня — команд там нет, они у подсистем. Поэтому интерфейс
+/// конфигурации это свойство корня, рядом с `homePage`, а не отдельный узел:
+/// листать и адресовать поштучно тут нечего.
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CfInterfaceData {
+    /// Ссылки на подсистемы в объявленном порядке, как их пишет платформа:
+    /// `Subsystem.Планирование`. Набором исходников их дополняет проекция.
+    pub(crate) subsystem_order: Vec<String>,
 }
 
 #[derive(serde::Serialize)]
@@ -974,10 +989,42 @@ pub(crate) fn cf_home_page_item_data(items: &[CfHomePageItem]) -> Vec<CfHomePage
         .collect()
 }
 
+/// Разбирает корневой `Ext/CommandInterface.xml`.
+///
+/// Документ несёт единственную секцию — `SubsystemsOrder`, список ссылок вида
+/// `Subsystem.Планирование` в порядке, заданном разработчиком. Порядок —
+/// содержательный факт: он задаёт, как разделы встают в интерфейсе.
+pub(crate) fn parse_cf_command_interface_xml(text: &str) -> Result<CfInterfaceData, String> {
+    const CI_NS: &str = "http://v8.1c.ru/8.3/xcf/extrnprops";
+
+    let doc = Document::parse(text.trim_start_matches('\u{feff}'))
+        .map_err(|err| format!("CommandInterface XML parse error: {err}"))?;
+    let root = doc.root_element();
+    if root.tag_name().name() != "CommandInterface" {
+        return Err(
+            "[ERROR] Not a command-interface XML file (no CommandInterface root)".to_string(),
+        );
+    }
+    let subsystem_order = root
+        .children()
+        .filter(|node| node.tag_name().name() == "SubsystemsOrder")
+        .flat_map(|section| section.children())
+        .filter(|node| {
+            node.tag_name().name() == "Subsystem"
+                && node.tag_name().namespace().is_none_or(|ns| ns == CI_NS)
+        })
+        .filter_map(|node| node.text())
+        .map(|text| text.trim().to_string())
+        .filter(|reference| !reference.is_empty())
+        .collect();
+    Ok(CfInterfaceData { subsystem_order })
+}
+
 pub(crate) fn parse_cf_info_xml(
     text: &str,
     support: ConfigurationSupportData,
     home_page: Option<CfHomePageData>,
+    interface: Option<CfInterfaceData>,
 ) -> Result<ParsedCfInfo, String> {
     const MD_NS: &str = "http://v8.1c.ru/8.3/MDClasses";
 
@@ -1065,6 +1112,7 @@ pub(crate) fn parse_cf_info_xml(
             .collect(),
         total_objects,
         home_page,
+        interface,
     };
     Ok(ParsedCfInfo {
         data,
@@ -1091,7 +1139,13 @@ pub(crate) fn analyze_cf_info(
             left: cf_home_page_item_data(&layout.left),
             right: cf_home_page_item_data(&layout.right),
         });
-        let parsed = parse_cf_info_xml(&text, support, home_page)?;
+        // Тот же документ, что читает канонический корень: интерфейс
+        // конфигурации — её свойство, и здесь он не должен расходиться.
+        let interface = fs::read_to_string(config_dir.join("Ext/CommandInterface.xml"))
+            .ok()
+            .map(|text| parse_cf_command_interface_xml(&text))
+            .transpose()?;
+        let parsed = parse_cf_info_xml(&text, support, home_page, interface)?;
         Ok((parsed.data, config_path))
     })();
 
@@ -5437,5 +5491,54 @@ pub(super) mod cf_read_selector_bridge_tests {
         assert_eq!(logical.ok, physical.ok, "{logical:?} vs {physical:?}");
         assert_eq!(logical.errors, physical.errors);
         let _ = fs::remove_dir_all(&context.workspace_root);
+    }
+}
+
+#[cfg(test)]
+mod configuration_interface_tests {
+    use super::*;
+
+    /// Форма взята из настоящего корневого `Ext/CommandInterface.xml`
+    /// конфигурации класса УТ: единственная секция `SubsystemsOrder` и ссылки
+    /// на подсистемы верхнего уровня. Команд в корневом документе не бывает —
+    /// они у подсистем, и потому интерфейс конфигурации это свойство, а не
+    /// узел с ветвью.
+    const ROOT_DOCUMENT: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<CommandInterface xmlns="http://v8.1c.ru/8.3/xcf/extrnprops" version="2.20">
+	<SubsystemsOrder>
+		<Subsystem>Subsystem.Планирование</Subsystem>
+		<Subsystem>Subsystem.Продажи</Subsystem>
+	</SubsystemsOrder>
+</CommandInterface>"#;
+
+    #[test]
+    fn the_root_interface_is_the_declared_order_of_top_level_subsystems() {
+        let parsed = parse_cf_command_interface_xml(ROOT_DOCUMENT).expect("документ разбирается");
+        assert_eq!(
+            parsed.subsystem_order,
+            vec!["Subsystem.Планирование", "Subsystem.Продажи"],
+            "порядок содержателен: он задаёт, как разделы встают в интерфейсе"
+        );
+    }
+
+    #[test]
+    fn a_document_that_is_not_a_command_interface_is_refused_by_name() {
+        let error = parse_cf_command_interface_xml(
+            r#"<?xml version="1.0"?><MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses"/>"#,
+        )
+        .expect_err("чужой корень не принимается");
+        assert!(
+            error.contains("no CommandInterface root"),
+            "отказ обязан назвать, чего не хватило: {error}"
+        );
+    }
+
+    #[test]
+    fn an_interface_without_an_order_section_is_empty_not_a_failure() {
+        let parsed = parse_cf_command_interface_xml(
+            r#"<CommandInterface xmlns="http://v8.1c.ru/8.3/xcf/extrnprops"/>"#,
+        )
+        .expect("пустой интерфейс — законное состояние");
+        assert!(parsed.subsystem_order.is_empty());
     }
 }

--- a/crates/unica-coder/src/infrastructure/v13_read_port.rs
+++ b/crates/unica-coder/src/infrastructure/v13_read_port.rs
@@ -19,7 +19,8 @@ use crate::infrastructure::logical_event_source::{
     module_relative as shared_module_relative,
 };
 use crate::infrastructure::native_operations::cf::{
-    cf_home_page_item_data, parse_cf_home_page_xml_strict, parse_cf_info_xml, CfHomePageData,
+    cf_home_page_item_data, parse_cf_command_interface_xml, parse_cf_home_page_xml_strict,
+    parse_cf_info_xml, CfHomePageData, CfInterfaceData,
 };
 use crate::infrastructure::native_operations::common::{
     parse_subsystem_info_xml, parse_support_state_strict_bytes, support_root_uuid_from_bytes,
@@ -265,8 +266,13 @@ impl ProviderReadAuthority {
                 "Configuration.xml is not UTF-8",
             )
         })?;
-        let parsed = parse_cf_info_xml(text, self.configuration_support()?, self.home_page()?)
-            .map_err(|error| ViewError::new(RefusalCode::ProviderUnavailable, error))?;
+        let parsed = parse_cf_info_xml(
+            text,
+            self.configuration_support()?,
+            self.home_page()?,
+            self.command_interface()?,
+        )
+        .map_err(|error| ViewError::new(RefusalCode::ProviderUnavailable, error))?;
         let owner = prove_already_read_source_set_owner(
             Path::new("Configuration.xml"),
             &bytes,
@@ -860,6 +866,28 @@ impl ProviderReadAuthority {
             .map(Arc::new);
         *memo = Some(state.clone());
         Ok(state)
+    }
+
+    /// Командный интерфейс конфигурации читается так же, как домашняя
+    /// страница: отдельным документом рядом с `Configuration.xml`, и ложится
+    /// свойством корня. Отсутствие документа — законное состояние, а не отказ.
+    fn command_interface(&self) -> Result<Option<CfInterfaceData>, ViewError> {
+        let Some(bytes) = self.read_optional_relative(
+            Path::new("Ext/CommandInterface.xml"),
+            MAX_CONFIGURATION_BYTES,
+        )?
+        else {
+            return Ok(None);
+        };
+        let text = std::str::from_utf8(&bytes).map_err(|_| {
+            ViewError::detailed(
+                RefusalDetail::SourceUnreadable,
+                "CommandInterface.xml is not UTF-8",
+            )
+        })?;
+        parse_cf_command_interface_xml(text)
+            .map(Some)
+            .map_err(|error| ViewError::new(RefusalCode::ProviderUnavailable, error))
     }
 
     fn home_page(&self) -> Result<Option<CfHomePageData>, ViewError> {

--- a/crates/unica-coder/src/infrastructure/v13_read_projection.rs
+++ b/crates/unica-coder/src/infrastructure/v13_read_projection.rs
@@ -576,6 +576,24 @@ fn project_configuration(
             "totalObjects",
         ],
     );
+    // `interface` идёт рядом с `homePage` не по сходству имён: оба живут
+    // отдельным документом рядом с `Configuration.xml` и оба описывают корень
+    // целиком. Командного интерфейса как узла у конфигурации нет — внутри
+    // корневого документа только порядок подсистем, листать там нечего.
+    if let Some(Value::Object(interface)) = payload.get("interface") {
+        let mut interface = interface.clone();
+        // Ссылка `Subsystem.Планирование` дополняется до адреса: читателю
+        // нужен адрес, по которому можно спуститься, а не строка платформы.
+        if let Some(Value::Array(order)) = interface.get("subsystemOrder") {
+            let qualified: Vec<Value> = order
+                .iter()
+                .filter_map(Value::as_str)
+                .map(|reference| Value::String(format!("{}:{reference}", address.source_set())))
+                .collect();
+            interface.insert("subsystemOrder".to_string(), Value::Array(qualified));
+        }
+        props.insert("interface".to_string(), Value::Object(interface));
+    }
     for key in ["support", "properties", "homePage"] {
         match payload.get(key) {
             Some(Value::Object(object)) => {
@@ -677,6 +695,7 @@ fn validate_reader_payload(reader: LogicalReader, payload: &Value) -> Result<(),
             "registeredObjects",
             "totalObjects",
             "homePage",
+            "interface",
         ],
         LogicalReader::Metadata => &[
             "name",


### PR DESCRIPTION
Пункт 1.2… точнее 1.3 из #717 — но сделанный не так, как был записан. План говорил «проложить маршрут `main:Interface` в профиле». Проверка на настоящих данных показала, что маршрут не нужен.

## Почему свойство

Корневой `Ext/CommandInterface.xml` несёт **единственную секцию `SubsystemsOrder`** — порядок подсистем верхнего уровня, шестнадцать записей в конфигурации класса УТ. Команд там нет: они у подсистем, в `CommandsVisibility`. Листать и адресовать поштучно нечего, значит узла с ветвью предмет не требует — он описывает корень целиком.

Прецедент в продукте буквальный: **`homePage`** живёт отдельным документом рядом с `Configuration.xml` и уже проецируется свойством корня. Интерфейс читается тем же приёмом и ложится рядом.

Отсюда снимается и вопрос о маршруте: адреса `main:Interface` заводить не надо. Иначе у одного предмета два способа адресации в зависимости от владельца — свойство у конфигурации и узел у подсистемы.

Различие с подсистемой при этом настоящее и сохраняется: у `main:Subsystem.X.Interface` внутри сто восемнадцать команд, там узел с ветвью нужен.

## Что сделано

- Разборщик корневого документа: `SubsystemsOrder` → список ссылок в объявленном порядке. Порядок содержателен — он задаёт, как разделы встают в интерфейсе.
- Читатель корня получает интерфейс тем же приёмом, что и домашнюю страницу; отсутствие документа — законное состояние, а не отказ.
- Проекция дополняет ссылки до адресов набора: читателю нужен адрес, по которому можно спуститься, а не строка платформы.
- Поле допущено в закрытый список читателя `Configuration` — он же сразу и поймал расхождение, когда список ещё не был дополнен.

## Проверено

`cargo fmt --check`, `cargo clippy --all-features --all-targets` — чисто; 4371 тест Rust, 127 arch, 852 CI — зелёные.