### PR TITLE
ci: модель горизонта нагрузки снята с Windows-ночи

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -177,9 +177,13 @@ binary(daemon_receipt_ledger) & (
 
 # Ночью Windows гоняет весь набор: с матрицы pull request и main он снят за
 # нестабильность раннера, а в ночном ярусе сбой виден и никого не блокирует.
+# Исключение одно: детерминированная модель горизонта нагрузки — тест с
+# управляемыми часами, платформе безразличный; на двухъядерном Windows он не
+# укладывается и в два срока `large` (замер 07.09.2026: ubuntu 415 с, macOS
+# 465 с, Windows — остановлен на 1800 с), а доказан он двумя другими ОС.
 [[profile.large.overrides]]
 platform = 'cfg(windows)'
-default-filter = 'all()'
+default-filter = 'all() - test(/^deterministic_horizon_load_does_not_saturate$/)'
 
 # Срок `medium` — 300 с, остановка после второго периода; `small` остаётся на
 # сроке `default`. Выражение — то же, что у ворот `pr`.

--- a/tests/ci/test_gate_profiles.py
+++ b/tests/ci/test_gate_profiles.py
@@ -54,8 +54,16 @@ class GateProfileCompositionTests(unittest.TestCase):
         self.assertEqual(deadline["filter"].strip(), large)
         self.assertEqual(deadline["slow-timeout"], {"period": "900s", "terminate-after": 2})
         self.assertEqual(deadline["threads-required"], "num-cpus")
-        # Ночью Windows гоняет всё: переопределение по платформе в профиле large.
-        self.assertEqual(profiles["large"]["overrides"], [{"platform": "cfg(windows)", "default-filter": "all()"}])
+        # Ночью Windows гоняет всё, кроме детерминированной модели горизонта
+        # нагрузки: она платформе безразлична и на двух ядрах не укладывается
+        # в два срока `large`.
+        self.assertEqual(
+            profiles["large"]["overrides"],
+            [{
+                "platform": "cfg(windows)",
+                "default-filter": "all() - test(/^deterministic_horizon_load_does_not_saturate$/)",
+            }],
+        )
         for command in self.run_tests.rust_commands("large"):
             self.assertIn("--no-tests=pass", command)
 


### PR DESCRIPTION
## Что

Ночной прогон 34152595981 после переключения daemon на v5:

- ubuntu и macOS — все девять тестов яруса `large` зелёные; настенные ворота
  `wall_clock_writer_sustains_32_receipts_per_second_on_posix` держат
  32 квитанции в секунду на обоих раннерах (открытый вопрос записки закрыт);
- Windows уложился в 85 минут при новом сроке 180 (#777): контракт ledger
  64 из 65 — не влезла в два срока `large` только детерминированная модель
  горизонта `deterministic_horizon_load_does_not_saturate` (415 с на ubuntu,
  465 с на macOS, на Windows остановлена на 1800 с).

Модель идёт на управляемых часах и платформе безразлична; доказана двумя ОС
каждую ночь. С Windows-ночи она снята выражением
`all() - test(/^deterministic_horizon_load_does_not_saturate$/)`; страж
состава ждёт ровно его.

Два других красных теста Windows-ночи — `invocation_protocol_round_trips…`
и `truncated_handshake_transport_closes…` из `daemon/mod.rs` — тесты v3,
красные там и до перехода (прогон 34052206875 от 06.09); уходят с шагом E.

Итог ночи в записке шага D идёт вместе с #780 (там же лежит текст шага).

## Проверено

`tests/ci`: стражи состава, размера, шва и записок — зелёные; `nextest list`
профиля `large` по-прежнему перечисляет девять тестов контракта на macOS.
