### PR TITLE
refactor(daemon): порты приложения живут со службой, а не с вызовом

### DIFF
--- a/crates/unica-coder/src/infrastructure/daemon/v13_service.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/v13_service.rs
@@ -32,6 +32,12 @@ use std::sync::Arc;
 pub(crate) struct CanonicalV13ReadService {
     cursors: Arc<ViewCursorStore>,
     find_builder: WorkspaceFindDirectoryBuilder,
+    /// Порты приложения живут столько же, сколько служба, а не сколько вызов.
+    /// Внутри них стол доставок: он принадлежит серверу и переживает вызов,
+    /// который доставку начал, чтобы её получил следующий. Порты на каждый
+    /// вызов означали бы стол на каждый вызов — и доставки перестали бы
+    /// делиться.
+    ports: Arc<crate::infrastructure::application_ports::InfrastructureApplicationPorts>,
 }
 
 impl Default for CanonicalV13ReadService {
@@ -39,6 +45,9 @@ impl Default for CanonicalV13ReadService {
         Self {
             cursors: Arc::new(ViewCursorStore::default()),
             find_builder: WorkspaceFindDirectoryBuilder::default(),
+            ports: Arc::new(
+                crate::infrastructure::application_ports::InfrastructureApplicationPorts::new(),
+            ),
         }
     }
 }
@@ -703,8 +712,14 @@ impl CanonicalV13ReadService {
                 .and_then(Value::as_str)
                 .unwrap_or_default()
                 .to_string();
-            let mut result =
-                run_node_checks(invocation, at, &kind, viewed.data.as_ref(), cancellation);
+            let mut result = run_node_checks(
+                &self.ports,
+                invocation,
+                at,
+                &kind,
+                viewed.data.as_ref(),
+                cancellation,
+            );
             if result.ok {
                 result.rev = viewed.rev;
             }
@@ -1068,6 +1083,7 @@ fn bounded_usize(value: &Value) -> Option<usize> {
 /// доставок не трогает, бинарь анализатора берётся из поставляемых
 /// инструментов, — и потому общий стол сервера не нужен.
 fn run_bsl_diagnostics(
+    ports: &crate::infrastructure::application_ports::InfrastructureApplicationPorts,
     address: &QualifiedAddress,
     context: &crate::domain::workspace::WorkspaceContext,
     cancellation: &CancellationToken,
@@ -1076,7 +1092,6 @@ fn run_bsl_diagnostics(
     use crate::application::ports::ApplicationPorts;
     use crate::domain::diagnostics::{DiagnosticAction, DiagnosticFilter, DiagnosticRequest};
 
-    let ports = crate::infrastructure::application_ports::InfrastructureApplicationPorts::new();
     let registry = match ports.diagnostic_provider_registry() {
         Ok(registry) => registry,
         Err(error) => {
@@ -1116,7 +1131,7 @@ fn run_bsl_diagnostics(
             .unwrap_or_else(|_| std::time::Duration::from_secs(60)),
         ),
     };
-    match DiagnosticCoordinator::new(registry, &ports).execute(&request, context, cancellation) {
+    match DiagnosticCoordinator::new(registry, ports).execute(&request, context, cancellation) {
         Ok(result) => {
             let findings: Vec<Value> = result
                 .items
@@ -1134,6 +1149,7 @@ fn run_bsl_diagnostics(
 }
 
 fn run_node_checks(
+    ports: &crate::infrastructure::application_ports::InfrastructureApplicationPorts,
     invocation: &ActorBoundExecution,
     at: &str,
     kind: &str,
@@ -1176,7 +1192,7 @@ fn run_node_checks(
                 run_native_validator(&address, kind, validator, context)
             }
             CheckStep::Meta => run_meta_validator(&address, at, context, cancellation),
-            CheckStep::Bsl => run_bsl_diagnostics(&address, context, cancellation),
+            CheckStep::Bsl => run_bsl_diagnostics(ports, &address, context, cancellation),
         };
         match verdict {
             Err(refusal) => return *refusal,


### PR DESCRIPTION
Основание под пункт **P** из #717 — то, без чего роли `search` подключать нельзя.

## Зачем

Внутри `InfrastructureApplicationPorts` живёт **стол доставок**, и он принадлежит серверу: доставка переживает вызов, который её начал, чтобы её получил следующий. Порты, построенные на каждый вызов, означали бы стол на каждый вызов — и доставки перестали бы делиться.

Диагностика BSL этого пока не замечала: бинарь анализатора берётся из поставляемых инструментов через `bundled_tool_version`, стола он не трогает. **Роли `search` пойдут через доставку**, и там разделение обязательно. Поэтому основание кладётся до них, а не после.

Служба создаётся один раз на демона, поэтому порты теперь живут ровно столько же.

## Проверено

`cargo fmt --check`, `cargo clippy --all-features --all-targets` — чисто; 4249 тестов Rust, 127 arch — зелёные. Приёмочный корпус зелёный в одиночном прогоне; в полном наборе даёт известный нагрузочный отказ соединения с демоном.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal sharing and reuse of infrastructure services during node checks and diagnostics.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->