### PR TITLE
fix(daemon): счётчик продолжений, один cutoff, исполнение материализованного Task

### DIFF
--- a/crates/unica-coder/src/infrastructure/daemon/runtime_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/runtime_v5.rs
@@ -2579,6 +2579,10 @@ impl V5ReceiptRuntime {
                 })?
         };
         let mut state = slot.lock();
+        // The cutoff is answered once. A second `promote_at_cutoff` would only
+        // enqueue another recover on the single ledger actor and delay the very
+        // report it is waiting for.
+        let mut cutoff_settled = false;
         loop {
             if let Some(report) = state.report.take() {
                 let owned = !matches!(state.decision, PipelineDecision::PromotedByOwner);
@@ -2604,7 +2608,10 @@ impl V5ReceiptRuntime {
                 let _ = worker.join();
                 return Err(ReceiptLedgerError::StoreUnavailable);
             }
-            if matches!(state.decision, PipelineDecision::PromotedByOwner) || state.begun {
+            if matches!(state.decision, PipelineDecision::PromotedByOwner)
+                || state.begun
+                || cutoff_settled
+            {
                 // Either the handler already answered, or the worker's drive
                 // claimed the cutoff: nothing to time here, wait for the report.
                 state = slot
@@ -2622,13 +2629,16 @@ impl V5ReceiptRuntime {
                 let mut next = slot.lock();
                 match promotion {
                     Ok(Some(reply)) => {
+                        // The worker continues this promoted attempt off the
+                        // reply thread; the harness waits on the count to see
+                        // the Task the runtime finishes for it. Count it before
+                        // the decision becomes visible: the worker decrements as
+                        // soon as it observes `PromotedByOwner`, and a decrement
+                        // that overtook this increment would wrap the count.
+                        self.promoted_continuations.fetch_add(1, Ordering::AcqRel);
                         next.decision = PipelineDecision::PromotedByOwner;
                         slot.changed.notify_all();
                         drop(next);
-                        // The worker continues this promoted attempt off the
-                        // reply thread; the harness waits on the count to see
-                        // the Task the runtime finishes for it.
-                        self.promoted_continuations.fetch_add(1, Ordering::AcqRel);
                         self.task_execution_threads
                             .lock()
                             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -2637,7 +2647,8 @@ impl V5ReceiptRuntime {
                     }
                     Ok(None) => {
                         // The worker already ended the attempt: its reply is
-                        // on the way.
+                        // on the way, so stop timing the cutoff and wait.
+                        cutoff_settled = true;
                         next.decision = PipelineDecision::Waiting;
                         slot.changed.notify_all();
                         state = next;
@@ -3033,25 +3044,26 @@ impl V5ReceiptRuntime {
         self.hooks
             .event(V5ReceiptRuntimeEventKind::PrepareEntered, epoch_ms);
         self.hooks.pause(V5PausePoint::PrepareEntered, deadline)?;
+        // The session handler may have materialized this Task at the begun
+        // cutoff while the attempt was between `Begun` and the drive. Nobody
+        // else executes it, so this attempt does — with or without an observer.
+        if let Some((task_record, bound)) = slot.take_owner_materialized() {
+            let deadline = Self::continuation_deadline();
+            let (cancellation, cancellation_guard) = self
+                .active_task_cancellations
+                .register(task_record.task_id)?;
+            return self.drive_prepared_bound_task(
+                actor_bound,
+                task_record,
+                bound,
+                reservation.key().invocation_id(),
+                cancellation,
+                cancellation_guard,
+                epoch_ms,
+                deadline,
+            );
+        }
         if self.hooks.observing() {
-            if let Some((task_record, bound)) = slot.take_owner_materialized() {
-                // The session handler materialized this Task at the begun
-                // cutoff while this attempt was paused; execute into it.
-                let deadline = Self::continuation_deadline();
-                let (cancellation, cancellation_guard) = self
-                    .active_task_cancellations
-                    .register(task_record.task_id)?;
-                return self.drive_prepared_bound_task(
-                    actor_bound,
-                    task_record,
-                    bound,
-                    reservation.key().invocation_id(),
-                    cancellation,
-                    cancellation_guard,
-                    epoch_ms,
-                    deadline,
-                );
-            }
             if let Some((record, bound_task)) = self.hooks.bound_task_override() {
                 if self.hooks.prepare_rejects() {
                     let terminal =

--- a/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5.rs
@@ -95,6 +95,10 @@ pub(super) struct ReceiptScenarioControl {
     drop_ack_response_after_commit: AtomicBool,
     drop_submit_response_after_commit: AtomicBool,
     skip_next_startup_reconciliation: AtomicBool,
+    /// Whether the fail-stop of the current process life was already cleaned up.
+    /// `restart_requested` is never cleared, so without this latch every later
+    /// quiesce would spend both deadlines again on an already-handled exit.
+    fail_stop_reclaimed: AtomicBool,
     validation_reject: AtomicBool,
     admission_rejection: Mutex<Option<ScenarioWorkspaceAdmissionFailure>>,
     prepare_reject: AtomicBool,
@@ -161,6 +165,7 @@ impl ReceiptScenarioControl {
             drop_ack_response_after_commit: AtomicBool::new(false),
             drop_submit_response_after_commit: AtomicBool::new(false),
             skip_next_startup_reconciliation: AtomicBool::new(false),
+            fail_stop_reclaimed: AtomicBool::new(false),
             validation_reject: AtomicBool::new(false),
             admission_rejection: Mutex::new(None),
             prepare_reject: AtomicBool::new(false),
@@ -1471,6 +1476,19 @@ impl ReceiptScenarioControl {
             .store(true, Ordering::Release);
     }
 
+    fn fail_stop_reclaimed(&self) -> bool {
+        self.fail_stop_reclaimed.load(Ordering::Acquire)
+    }
+
+    fn mark_fail_stop_reclaimed(&self) {
+        self.fail_stop_reclaimed.store(true, Ordering::Release);
+    }
+
+    /// A restart begins a new process life: a later fail-stop is cleaned again.
+    fn clear_fail_stop_reclaimed(&self) {
+        self.fail_stop_reclaimed.store(false, Ordering::Release);
+    }
+
     fn arm_skip_next_startup_reconciliation(&self) {
         self.skip_next_startup_reconciliation
             .store(true, Ordering::Release);
@@ -1642,6 +1660,7 @@ impl ReceiptScenarioControl {
             .expect("scenario actor authorization mutex poisoned")
             .clear();
         self.process_exit_elapsed_ms.store(0, Ordering::Release);
+        self.fail_stop_reclaimed.store(false, Ordering::Release);
         self.crash_after_side_effect.store(false, Ordering::Release);
     }
 
@@ -3431,6 +3450,7 @@ pub(crate) fn run_supported_receipt_scenario_for_test(request: &str) -> Result<S
                 }
             }
             ReceiptScenarioAction::Restart => {
+                control.clear_fail_stop_reclaimed();
                 startup_listener_override = true;
                 if pending_submit.is_some() {
                     if !control.process_exited() {
@@ -6991,7 +7011,11 @@ fn quiesce_promoted_continuation(
             thread::sleep(Duration::from_millis(2));
         }
     }
-    if telemetry.snapshot().restart_requested {
+    // Clean up one fail-stop once. `restart_requested` is never cleared, so
+    // without the latch every later quiesce would spend both deadlines again on
+    // an exit that was already handled.
+    if telemetry.snapshot().restart_requested && !control.fail_stop_reclaimed() {
+        control.mark_fail_stop_reclaimed();
         // A fail-stopped attempt exits the process on the runtime's own clock;
         // wait for that close so a checkpoint sees the closed listener.
         let deadline = Instant::now() + SCENARIO_OPERATION_TIMEOUT;


### PR DESCRIPTION
Три дефекта владельца срока из #799 и одна экономия в обвязке. Правки были
готовы к #799, но очередь слияния сняла его состояние на предыдущей вершине
(`778201b5`), и в main они не попали. Здесь они отдельным шагом.

## Дефекты

**Счётчик продолжений заворачивался.** `promoted_continuations` увеличивался
после публикации решения `PromotedByOwner`, а рабочий поток уменьшает его сразу,
как это решение увидит. Уменьшение, обогнавшее увеличение, заворачивало
`AtomicUsize` в `usize::MAX`, после чего ожидание нуля не кончалось бы никогда.
Увеличение перенесено под замок слота, до публикации решения.

**Материализованный Task никто не исполнял.** Потребление
`take_owner_materialized()` стояло под `hooks.observing()`, а у production
`NoHooks` он ложен. Если владелец материализовал Task на cutoff, пока попытка
была между `Begun` и drive, исполнить его было некому: Task остался бы `Working`
навсегда. Теперь потребляется безусловно, до блока наблюдателя.

**Лишний recover в очереди актора.** После `Ok(None)` владелец снова входил в
`promote_at_cutoff` при нулевом остатке и ставил ещё один `recover` в очередь
единственного актора ledger, задерживая тот самый отчёт, которого ждал. Защёлка
`cutoff_settled` оставляет ожидание отчёта.

## Обвязка

Очистка после fail-stop стала одноразовой на жизнь процесса:
`restart_requested` никогда не сбрасывается, поэтому каждая последующая проверка
осадки тратила оба срока заново. Защёлка `fail_stop_reclaimed` сбрасывается на
`Restart`. Гейт по состоянию слушателя тут не годится: именно `Listening` и надо
дождаться, пока закроется, и в том же блоке снимается застрявший endpoint.

## Проверка

Контракт ledger 56/56, полоса lib без признака 4258/4258, `fmt` и `clippy`
с признаком и без — чисто.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cutoff handling to prevent duplicate recovery actions and ensure completed attempts are not reprocessed.
  - Fixed execution of tasks prepared at the cutoff so they run consistently, regardless of monitoring configuration.
  - Prevented continuation tracking from becoming inconsistent during rapid worker state changes.
  - Improved restart cleanup so fail-stop resources are reclaimed once and do not trigger repeated shutdown handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->