### PR TITLE
docs(skills): читающие скиллы переведены на канонические имена

### DIFF
--- a/plugins/unica/skills/code-diagnostics/SKILL.md
+++ b/plugins/unica/skills/code-diagnostics/SKILL.md
@@ -7,47 +7,73 @@ description: "Диагностика BSL и объяснение отключе�
 
 ## MCP routing
 
-- Preferred path: use MCP `unica` tools `unica.code.diagnostics`, `unica.resolve`, `unica.view {}`, `unica.code.graph`, `unica.code.definition`, `unica.code.search`, `unica.docs`, and `unica.runtime.execute`.
-- По INV-MCP-RUNTIME-RECEIPT и ADR-0074: `unica.runtime.execute` с `dryRun: true`
-показывает запланированную команду без побочных эффектов, а с `dryRun: false`
-исполняет классифицированную операцию и отвечает её терминальным результатом в
-том же вызове, приложив названную причину риска (`runtime_risk_*`)
-предупреждением; неклассифицированная операция по-прежнему отказывает
-`runtime_operation_unbounded` до обнаружения рабочего пространства. Preview
-исполнением не является. Работу, которую вызов ждать не должен, запускай через
-`unica.runtime.job.start`. Не обходи контракт прямым runner-ом или через
-`unica.build.*`.
-- Every diagnostics call names an exact `sourceSet`; `cwd` selects the workspace only and never identifies the target. Use `unica.view {}` when the source-set name is unknown.
-- Use `action=status` before resident `findings` when readiness is uncertain. A completed status request is not proof that a provider is ready: read each `providers[].readiness.state` and call `findings` only for `ready`; `building`, `notStarted`, and `stale` are not clean results.
-- Use `action=findings` with a logical `metadataPath` for one module or metadata object, `action=analyze` for a complete one-shot source-set scan, and `action=catalog` to discover provider-qualified rules. Provider execution is routed internally; do not pass a provider selector. The current live provider `bsl-analyzer` supports module findings only. Until a metadata provider is registered, a metadata-object request fails at request level with `no_applicable_provider`; this means neither clean metadata nor a bad logical address.
-- `action=analyze` may set `timeoutSeconds` from 30 to 3600. Without it the call uses `operational.code_diagnostics.analyze_timeout_seconds` from `<workspaceRoot>/unica.local.toml`, then `unica.toml`, then the compiled 120-second fallback. `findings`, `status`, and `catalog` do not read this operational config, do not accept `timeoutSeconds`, and run on that same compiled 120-second budget.
-- Put severity and exact case-sensitive codes under `filter`. Every code is `{provider, code}`; obtain provider ids and codes from `catalog`. `limit` is global across providers after normalization and deterministic ordering.
-- Read `location` as the shared logical navigation target and `focus` as the position inside it. `location.kind=addressed` carries `sourceSet`, optional `metadataPath`, and derived `targetKind`; `location.kind=unaddressable` carries a safe relative `path` and the item carries `locationReason`. `focus.kind` is `target`, `sourceRange`, or `metadata`.
-- Treat `state=partial` as useful but incomplete. A `resourceFailure` is one provider's failure for one logical resource. `location.kind=unaddressable` means the observation is safe to report but cannot be navigated as its own logical target. A provider section with `complete=false` and an error may still carry proven items: one resource the mapper could not place never withdraws the rest. Neither means clean code.
-- For actions that return `items`, only `state=completed`, `complete=true`, `truncated=false`, and provider sections without failures prove an exhaustive answer. Check `itemsTotal` and `itemsReturned` before treating `items` as complete. `status` has no `truncated` field; its evidence is each provider's readiness.
-- `unica.code.definition` returns `index_pending:` only while an RLM index is building and `index_unavailable:` for missing, stale, failed, or unavailable indexes. Neither means “no definitions”.
-- Use `unica.code.graph` only for diagnostic impact context. v8std access goes only through `unica.docs` with `source: "development-standard"`. Do not call internal analyzer, standards, or package adapters directly.
+- Диагностику узла даёт `unica.check {at}`. Валидаторы следуют из вида узла:
+  у модуля это BSL-анализатор, у объекта метаданных — его собственные проверки.
+  Выбирать провайдера или действие не нужно и нечем: `check` принимает только
+  адрес.
+- Ответ несёт `status` (`passed` или `failed`), `validators` — какие проверки
+  отработали, и `diagnostics` — находки с кодом, важностью, местом и стандартом.
+  Провалом считается `error`, а не всякая пометка: подсказка по стилю модуль не
+  ломает.
+- **Пустой `diagnostics` при `status: passed` — доказательство.** Если анализ
+  не завершился, `check` отказывает `provider_unavailable` и прямо говорит, что
+  модуль не проверен. Отдельного вопроса о готовности провайдера больше нет:
+  чистый ответ и неотработавший провайдер теперь различимы по самому ответу.
+- Адрес узла даёт `unica.view {at}` по дереву или `unica.search {corpus: "names"}`
+  по имени. Если отправная точка — путь из диффа или лога сборки, переведи его
+  в адрес аварийным `unica.resolve`; в обычном ходе работы он не нужен.
+- Стандарт v8std спрашивается только через `unica.docs` с
+  `source: "development-standard"`. Не зови анализатор, стандарты или пакетные
+  адаптеры напрямую.
+- Код ищется `unica.search`: `role` выбирает, чем искать — `lexical` буквально,
+  `symbol` по индексу символов, `semantic` по смыслу. Без `role` Unica ищет
+  литерал сама.
+
+### Чего на канонической поверхности пока нет
+
+Называй это пробелом контракта, а не обходи стороной:
+
+- **сплошной прогон по всему набору** — `check` проверяет один адрес; обхода
+  всех модулей одним вызовом нет;
+- **отбор по важности и кодам, ограничение выдачи** — `check` принимает только
+  `at`;
+- **каталог правил провайдера** — коды берутся из находок и из `unica.docs`;
+- **граф вызовов для оценки влияния** — ветвей `Caller`/`Callee` у узла метода
+  ещё нет.
 
 ## Workflow
 
-1. Resolve the exact `sourceSet`. If the starting point is a physical file, use `unica.resolve` to obtain its logical `metadataPath`.
-2. Call `status` when resident readiness matters and `catalog` when rule ids need classification. Use `findings` for one logical target or `analyze` for the whole source set.
-3. Group diagnostics by logical `location`, provider-qualified code, and root cause. Follow `focus` for the exact source range or metadata element.
-4. Inspect the target with `unica.view` on the module node (its `Method` branch lists the methods), `unica.code.definition`, or `unica.code.search`. Use `unica.code.graph` before changing shared or exported behavior.
-5. Call `unica.docs` with `source: "development-standard"` with explicit codes; otherwise use `unica.docs` with `source: "development-standard"` by diagnostic name, АПК/EDT/BSL LS token, or nearby snippet.
-6. Report source cause, impacted diagnostics, logical target and focus, standard evidence, and verification result.
+1. Получи адрес узла: `unica.view {}` называет наборы исходников,
+   `unica.search {corpus: "names"}` находит объект по имени, `unica.view {at}`
+   спускается по дереву. У владельца есть ветвь `Module`, у модуля — `Method`.
+2. Вызови `unica.check {at}` на модуле или объекте. Прочти `status`,
+   `validators` и `diagnostics`.
+3. Сгруппируй находки по месту, коду и первопричине. Иди за точным диапазоном
+   в самой находке.
+4. Разгляди предмет: `unica.view {at}` на узле метода даёт подпись, контекст
+   компиляции и собственные строки; `unica.search` находит вхождения.
+5. Спроси стандарт: `unica.docs` с `source: "development-standard"` по коду,
+   имени диагностики, токену АПК/EDT/BSL LS или соседнему фрагменту.
+6. Отчитайся: причина в исходнике, затронутые диагностики, логический адрес и
+   место, доказательство из стандарта, результат перепроверки.
 
 ## Verification gate
 
 This verification gate is mandatory:
 
-- Run diagnostics after syntax-sensitive edits and treat new `error` findings as blocking.
-- Run impact analysis when an exported method, metadata handler, public API, query path, or shared module contract changes.
-- If public MCP `unica` cannot expose required evidence, report a contract gap instead of claiming full verification.
+- Проверяй `unica.check {at}` после правок, чувствительных к синтаксису, и
+  считай новые находки важности `error` блокирующими.
+- Оценивай влияние при изменении экспортного метода, обработчика метаданных,
+  публичного API, пути запроса или контракта общего модуля. Пока графа вызовов
+  на поверхности нет, доказательством служит `unica.search` по имени символа —
+  и скажи, что доказательство неполное.
+- Если публичный MCP `unica` не может показать нужное доказательство, сообщи о
+  пробеле контракта вместо заявления о полной проверке.
 
 ## Suppression and range-disable comments
 
-Когда inline/range disable markers или suppression-комментарии отключают диагностику строки или диапазона, считайте точный маркер частью доказательства.
+Когда inline/range disable markers или suppression-комментарии отключают
+диагностику строки или диапазона, считайте точный маркер частью доказательства.
 
 - Extract literal rule codes from АПК, EDT, BSL LS, analyzer, or suppression comments.
 - Explain an отключение only when the code, surrounding range, and standard support the reason.
@@ -55,48 +81,20 @@ This verification gate is mandatory:
 
 ## MCP examples
 
-One logical module, narrowed to one rule. Remove `filter.codes` to include all codes at the selected severity threshold; set `filter.minSeverity=hint` for every severity and still inspect `truncated`:
+Проверка одного модуля:
 
 ```jsonc
 {
   "jsonrpc": "2.0",
   "method": "tools/call",
   "params": {
-    "name": "unica.code.diagnostics",
-    "arguments": {
-      "cwd": "<workspace>",
-      "action": "findings",
-      "sourceSet": "main",
-      "metadataPath": "CommonModule.Продажи.Module",
-      "filter": {
-        "minSeverity": "warning",
-        "codes": [
-          {"provider": "bsl-analyzer", "code": "UnusedLocalVariable"}
-        ]
-      },
-      "limit": 100
-    }
+    "name": "unica.check",
+    "arguments": { "at": "main:CommonModule.Продажи.Module.Manager" }
   }
 }
 ```
 
-Complete source-set scan:
-
-```jsonc
-{
-  "jsonrpc": "2.0",
-  "method": "tools/call",
-  "params": {
-    "name": "unica.code.diagnostics",
-    "arguments": {
-      "cwd": "<workspace>",
-      "action": "analyze",
-      "sourceSet": "main",
-      "timeoutSeconds": 900
-    }
-  }
-}
-```
+Стандарт за диагностикой:
 
 ```jsonc
 {
@@ -112,17 +110,18 @@ Complete source-set scan:
 }
 ```
 
-```json
+Вхождения символа перед правкой общего кода:
+
+```jsonc
 {
   "jsonrpc": "2.0",
   "method": "tools/call",
   "params": {
-    "name": "unica.runtime.execute",
+    "name": "unica.search",
     "arguments": {
-      "cwd": "<workspace>",
-      "operation": "syntax",
-      "mode": "designer-modules",
-      "dryRun": true
+      "query": "ПередЗаписью",
+      "role": "symbol",
+      "scope": "main:Configuration"
     }
   }
 }

--- a/plugins/unica/skills/code-search/SKILL.md
+++ b/plugins/unica/skills/code-search/SKILL.md
@@ -7,58 +7,67 @@ description: "Поиск и исследование BSL-кода и точек 
 
 ## MCP routing
 
-- Preferred path: use MCP `unica` tools `unica.code.search`, `unica.code.definition`, `unica.code.graph`, `unica.meta.info`, and `unica.view {}`.
-- Use object-specific `unica.*.info` tools when code behavior depends on metadata, forms, DCS, roles, or HTTP service structure.
-- Do not call internal code-index, analyzer, or package adapters directly. They are hidden behind MCP `unica`.
-- `sourceSet` — это имя набора исходников из `v8project.yaml`, а не
-  константа. Получите его через `unica.view {}`; `"main"` в примерах
-  ниже — иллюстрация, а не значение по умолчанию.
+- Preferred path: use MCP `unica` tools `unica.search`, `unica.view`, and
+  `unica.check`.
+- Не зови индекс кода, анализатор или пакетные адаптеры напрямую: они спрятаны
+  за MCP `unica`.
+- Имя набора исходников — не константа. Его называет `unica.view {}`;
+  `"main"` в примерах ниже иллюстрация, а не умолчание. В адресе имя стоит до
+  двоеточия: `main:Document.Заказ`.
 
 ## Tool choice
 
-- MCP-first discipline: prefer the public `unica.*` project-index tools before
-  shell search for 1C source. Use shell search only after the relevant
-  `unica.code.*` / `unica.meta.*` attempts did not close the context gap, and
-  report what was tried when that fallback matters to the answer.
-- Use `unica.code.definition` for an exact procedure/function definition by name, especially exported methods.
-- Use `unica.view` on the module node (its `Method` branch lists the methods) before reading a large module; it gives regions, header context, and method ranges.
-- Use `unica.code.search` for arbitrary text, XML, query fragments, string literals, captions, and non-method tokens. Read its role sections independently: `semantic`, `symbol`, then `lexical`; `provider` only reports the replaceable implementation that produced a section.
-- `unica.code.search.limit` is the per-provider result cap: `1..50`, default `20`.
-- Prefer the logical selector `sourceSet` from `unica.view {}`; add
-  `metadataPath` to constrain the search to one logical object. The migration
-  selector `sourceDir` is accepted only instead of `sourceSet`, never together
-  with it, and cannot be combined with `metadataPath`.
-- While a search is running, treat `notifications/progress` with typed
-  `io.unica/searchProgress` metadata as proof of life. Wait for the terminal
-  result from all three roles; do not poll by starting another search.
-- Interpret `searchComplete`, `matches.relation`, `ranking`, and `ordering`
-  together. `empty` proves exact zero; `limitReached` and `timedOut` preserve a
-  lower-bound prefix and are not empty. The lexical role is deliberately
-  unranked (`ranking: none`, `ordering: providerTraversal`).
-- Inspect `termination` instead of parsing diagnostics: it is `null` for
-  `ok`/`empty`, otherwise its provider-neutral `code` explains the terminal
-  condition and `retryable` says whether repeating later can help. In
-  particular, `dependencyPending` with `detailCode: buildingIndex` means the
-  RLM deadline ended while the index was still building; keep results from the
-  other roles and retry search later only if semantic evidence is still needed.
-- Reuse an `addressed` hit through its `sourceSet` and `metadataPath`.
-  `unaddressable` is an observable source-relative location, not a logical
-  target for a following mutation or subject reader.
-- Use `unica.code.graph` for callers, callees, neighbors, graph overview, and impact analysis when a method or metadata node id is known or can be resolved.
-- Use `unica.meta.info` for a compact metadata object profile: structure, modules, roles, event subscriptions, functional options, and predefined items.
+- MCP-first discipline: держись публичных `unica.*` до того, как спускаться к
+  оболочке. К поиску по файлам переходи, только когда вызовы выше не закрыли
+  пробел, и сообщай what was tried, если это важно для ответа.
+- **Что искать** выбирает свод. `unica.search` с `corpus: "text"` (умолчание)
+  ищет по тексту модулей BSL и отвечает `scope`, `line`, `column`, `snippet`.
+  С `corpus: "names"` ищет по именам и синонимам метаданных и отвечает `at`,
+  `kind`, `title`. Физического пути нет ни у одного свода — работа идёт
+  адресами.
+- **Чем искать** выбирает `role` в текстовом своде: `lexical` совпадает
+  буквально, `symbol` идёт по индексу символов, `semantic` — по смыслу. Без
+  `role` Unica ищет литерал сама и провайдеров не поднимает.
+- `scope` сужает поиск до одного логического поддерева; `limit` ограничивает
+  выдачу.
+- Признак `approximate` у попадания по имени означает совпадение по близости,
+  а не точное. Пустая выдача — это ноль, а не отказ.
+- **Читать узел** — `unica.view {at}`. У владельца есть ветвь `Module`, у
+  модуля — `Method`, у метода — подпись, контекст компиляции, собственные
+  строки и ветвь `Body` парами `{line, text}`. Это дешевле, чем читать модуль
+  целиком, и точнее, чем догадываться по совпадению.
+- Профиль объекта метаданных — тот же `unica.view {at}`: состав, модули, права,
+  подписки и функциональные опции лежат в его `props` и ветвях.
+- Путь к файлу нужен только когда он пришёл снаружи — из диффа, лога сборки
+  или трассы. Тогда его переводит в адрес аварийный `unica.resolve`. В обычном
+  ходе работы он не нужен.
+
+### Чего на канонической поверхности пока нет
+
+- **граф вызовов и impact analysis** — ветвей `Caller`/`Callee` у узла метода
+  ещё нет. Пока доказательством потока служит `unica.search` с
+  `role: "symbol"` по имени метода, и это доказательство неполное: скажи об
+  этом, а не выдавай его за полный обход вызовов.
 
 ## Workflow
 
-1. Map the workspace with `unica.view {}` when the active source-set or source format is unclear.
-2. For an exact metadata object name, call `unica.meta.info` before broad search to identify related modules, rights, subscriptions, and functional options.
-3. Resolve exact method names with `unica.code.definition`; inspect large candidate modules with `unica.view` on the module node (its `Method` branch lists the methods).
-4. For flow questions, resolve the node and ask `unica.code.graph` for callers, callees, or neighbors before treating lexical hits as execution flow.
-5. Search exact identifiers next: object names, module names, event handlers, exported procedures, command names, URL templates.
-6. Use `unica.code.search` for raw text fragments that are not BSL method names and inspect its role-local sections independently, including incomplete or unavailable roles.
-7. Broaden only after exact search fails: synonyms, business terms, common module prefixes, form command captions.
-8. Fall back to local `rg` only for repository files outside the public Unica index or after the MCP-first attempts above were insufficient.
-9. For every result, separate declaration, caller, handler, graph edge, and dead-looking match. Do not infer flow from one hit.
-10. Report concrete file paths and line anchors; include the query that produced each important hit when the search was non-obvious.
+1. Разметь пространство: `unica.view {}` называет наборы исходников и их
+   формат, когда набор или формат неясен.
+2. Найди предмет по имени: `unica.search {corpus: "names"}` с необязательным
+   `kind`. Точное имя объекта закрывает вопрос быстрее любого текстового
+   поиска.
+3. Прочти узел: `unica.view {at}`. Ветвь `Module` ведёт к модулям владельца,
+   ветвь `Method` — к его методам; узел метода даёт подпись и строки.
+4. Ищи по тексту то, что именем не находится: фрагменты запросов, строковые
+   литералы, заголовки, нестандартные токены. `role` выбирай под вопрос.
+5. Расширяй только после неудачи точного поиска: синонимы, деловые термины,
+   префиксы общих модулей, заголовки команд форм.
+6. К локальному `rg` спускайся только за файлами вне индекса Unica или когда
+   попытки выше не закрыли пробел — и скажи, что было испробовано.
+7. Разделяй объявление, вызов, обработчик и мёртвое совпадение. Поток по
+   одному попаданию не выводится.
+8. Отчитывайся логическими адресами и строками внутри узла, а не путями к
+   файлам; приводи запрос, которым получено важное попадание.
 
 ## Common searches
 
@@ -80,81 +89,81 @@ description: "Поиск и исследование BSL-кода и точек 
 }
 ```
 
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "tools/call",
-  "params": {
-    "name": "unica.code.search",
-    "arguments": {
-      "cwd": "<workspace>",
-      "sourceSet": "main",
-      "query": "ОбработкаПроведения",
-      "limit": 20
-    }
-  }
-}
-```
+Объект по имени:
 
 ```json
 {
   "jsonrpc": "2.0",
   "method": "tools/call",
   "params": {
-    "name": "unica.code.graph",
+    "name": "unica.search",
     "arguments": {
-      "cwd": "<workspace>",
-      "mode": "callers",
-      "id": "method:CommonModule.Продажи.ОбработкаПроведения",
+      "query": "Заказ",
+      "corpus": "names",
+      "kind": "Document",
+      "limit": 20
+    }
+  }
+}
+```
+
+Текст внутри поддерева:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "unica.search",
+    "arguments": {
+      "query": "ОбработкаПроведения",
+      "scope": "main:Configuration",
+      "limit": 20
+    }
+  }
+}
+```
+
+Символ по индексу — ближайшее, чем сегодня заменяется граф вызовов:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "unica.search",
+    "arguments": {
+      "query": "ОбработкаПроведения",
+      "role": "symbol",
+      "scope": "main:Configuration",
       "limit": 25
     }
   }
 }
 ```
 
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "tools/call",
-  "params": {
-    "name": "unica.meta.info",
-    "arguments": {
-      "sourceSet": "main",
-      "metadataPath": "Document.SalesOrder",
-      "sections": ["roles", "subscriptions", "functionalOptions"],
-      "limit": 20
-    }
-  }
-}
-```
+Профиль объекта метаданных:
 
 ```json
 {
   "jsonrpc": "2.0",
   "method": "tools/call",
   "params": {
-    "name": "unica.code.definition",
-    "arguments": {
-      "cwd": "<workspace>",
-      "name": "ОбработкаПроведения",
-      "limit": 10
-    }
+    "name": "unica.view",
+    "arguments": { "at": "main:Document.Заказ" }
   }
 }
 ```
+
+Метод целиком: подпись в узле, текст в ветви `Body`:
 
 ```json
 {
   "jsonrpc": "2.0",
   "method": "tools/call",
   "params": {
-    "name": "unica.code.search",
-    "arguments": {
-      "cwd": "<workspace>",
-      "sourceSet": "main",
-      "query": "ВЫБРАТЬ",
-      "limit": 20
-    }
+    "name": "unica.view",
+    "arguments": { "at": "main:CommonModule.Продажи.Method.ОбработкаПроведения" }
   }
 }
 ```

--- a/plugins/unica/skills/mxl-info/SKILL.md
+++ b/plugins/unica/skills/mxl-info/SKILL.md
@@ -12,150 +12,111 @@ allowed-tools:
 
 ## MCP routing
 
-- Preferred path: use MCP `unica` tool `unica.mxl.info`; `unica` owns XML/JSON DSL work and refreshes related workspace caches after mutations.
-- Do not call internal MCP/CLI adapters directly. They are hidden behind `unica` and synchronized by the orchestrator.
-- Execution path: call MCP `unica` tool `unica.mxl.info`; skill-local operation scripts are not part of the workflow.
-- For mutating operations, pass `dryRun: false` only when the user explicitly requested the change; otherwise keep the default dry run.
+- Preferred path: use MCP `unica` tools `unica.view` and `unica.search`.
+- Do not call internal MCP/CLI adapters directly. They are hidden behind
+  `unica` and synchronized by the orchestrator.
+- Макет — узел логического дерева: `unica.view {at}` по адресу
+  `<набор>:<Вид>.<Имя>.Template.<Макет>`. Файлового селектора у чтения нет;
+  путь, пришедший снаружи, переводит в адрес аварийный `unica.resolve`.
 
-Читает Template.xml табличного документа и выводит компактную сводку: именованные области, параметры, наборы колонок. Заменяет необходимость читать тысячи строк XML.
+Узел макета отдаёт компактную сводку: именованные области, параметры, наборы
+колонок. Читать тысячи строк XML не нужно.
 
-В текстовом выводе показывает `Поддержка` для объекта-владельца макета по `Ext/ParentConfigurations.bin`. JSON-режим сохраняет структурный контракт; состояние поддержки учитывай перед mutating `unica.mxl.*`.
+Поддержка объекта-владельца приходит полем `support`; учитывай её состояние
+перед правкой макета.
 
-## Использование
+## Адресация
 
-```
-/mxl-info <TemplatePath>
-```
+| Что | Как |
+|-----|-----|
+| Имя набора исходников | `unica.view {}` |
+| Адрес макета по имени | `unica.search {corpus: "names", kind: "Template"}` |
+| Адрес по пути извне | `unica.resolve {path}` |
+| Сам макет | `unica.view {at: "<набор>:<Вид>.<Имя>.Template.<Макет>"}` |
+| Область макета | `unica.view {at: "…Template.<Макет>.Area.<Область>"}` |
+| Содержимое ячеек области | `unica.view {at: "…Area.<Область>.Body"}` |
 
-## Параметры
-
-| Параметр | Описание |
-|----------|----------|
-| `TemplatePath` | Путь к `Template.xml` макета или к каталогу макета |
-| `sourceSet`    | Имя набора исходников из `v8project.yaml`          |
-| `metadataPath` | Логический адрес, например `Report.<Отчёт>.Template.<Макет>` |
-| `WithText` | Включить текстовое содержимое ячеек в `texts` и `templates` |
-
-Селектор цели ровно один: либо `sourceSet` + `metadataPath`, либо
-`TemplatePath`. Оба сразу отклоняются кодом `selector_conflict` (ADR-0049).
-
-`Format`, `MaxParams`, `Limit` и `Offset` сняты: результат приходит
-типизированным в `data` (ADR-0023), поэтому режим вывода, обрезка списков
-параметров и постраничная печать больше не нужны. `SrcDir`,
-`ProcessorName` и `TemplateName` сняты по ADR-0048: составной адрес требовал
-всех трёх, а `TemplatePath` был обязателен всегда, поэтому до этой ветки
-вызов не доходил. Макет адресуется одним `TemplatePath`.
-
-## Поля `data`
+## Поля узла
 
 | Поле | Что содержит |
 |------|--------------|
-| `name` | Имя макета |
-| `support` | Поддержка по `Ext/ParentConfigurations.bin` |
-| `rows`, `columns` | Логическая высота и ширина по умолчанию |
-| `columnSets` | Дополнительные наборы колонок: `id` и `size` |
-| `areas` | Именованные области: `name`, `kind` (`Rows`, `Columns`, `Rectangle`, `Drawing`), границы, `columnsId`, `drawingId`, `params`, `details` |
-| `areas[].texts`, `areas[].templates` | Содержимое ячеек — `null`, пока не запрошен `WithText` |
-| `outside` | Параметры, детали и тексты вне именованных областей |
-| `mergeCount`, `drawingCount` | Счётчики объединений и рисунков |
+| `title` | Имя макета |
+| `props.support` | Поддержка по `Ext/ParentConfigurations.bin` |
+| `props.rows`, `props.columns` | Логическая высота и ширина по умолчанию |
+| `props.columnSets` | Дополнительные наборы колонок: `id` и `size` |
+| ветвь `Area` | Именованные области; счёт ветви равен их числу |
+| `props.mergeCount`, `props.drawingCount` | Счётчики объединений и рисунков |
+
+У узла области в `props` лежат `kind` (`Rows`, `Columns`, `Rectangle`,
+`Drawing`), границы, `columnsId`, `drawingId` и `contentCount` — число непустых
+ячеек. Ветвь `Parameter` перечисляет параметры области, ветвь `Body` — её
+содержимое.
 
 Пересечения строчных и колоночных областей для `ПолучитьОбласть` строятся из
-`areas`: возьми `kind: "Rows"` и `kind: "Columns"` и перемножь имена.
+ветви `Area`: возьми области `kind: "Rows"` и `kind: "Columns"` и перемножь
+имена.
 
 ## MCP вызов
 
-### Прямой путь к Template.xml
+### Макет целиком
 
 ```json
 {
   "jsonrpc": "2.0",
   "method": "tools/call",
   "params": {
-    "name": "unica.mxl.info",
-    "arguments": {
-      "cwd": "<workspace>",
-      "TemplatePath": "<путь>/Ext/Template.xml"
-    }
+    "name": "unica.view",
+    "arguments": { "at": "main:Report.Продажи.Template.Печать" }
   }
 }
 ```
 
-### Каталог макета вместо файла
-
-Каталог макета сам разрешается в `Ext/Template.xml`, поэтому путь из состава
-объекта можно передать как есть, не дописывая хвост.
+### Одна область
 
 ```json
 {
   "jsonrpc": "2.0",
   "method": "tools/call",
   "params": {
-    "name": "unica.mxl.info",
-    "arguments": {
-      "cwd": "<workspace>",
-      "TemplatePath": "<каталог объекта>/Templates/<макет>"
-    }
+    "name": "unica.view",
+    "arguments": { "at": "main:Report.Продажи.Template.Печать.Area.Шапка" }
   }
 }
 ```
 
-### Включить текстовое содержимое ячеек
+### Содержимое ячеек области
 
-`WithText` — единственный оставшийся селектор состава: без него `texts` и
-`templates` равны `null`, то есть «не запрашивали», а не «пусто».
+Текст ячеек — отдельный адрес, а не признак в аргументах: структурное чтение
+области за текст не платит, а ветвь `Body` честно объявляет свою длину полем
+`contentCount`.
 
 ```json
 {
   "jsonrpc": "2.0",
   "method": "tools/call",
   "params": {
-    "name": "unica.mxl.info",
-    "arguments": {
-      "cwd": "<workspace>",
-      "TemplatePath": "<путь>",
-      "WithText": true
-    }
+    "name": "unica.view",
+    "arguments": { "at": "main:Report.Продажи.Template.Печать.Area.Шапка.Body" }
   }
 }
 ```
+
+Каждая ячейка приходит в порядке чтения и несёт `index`, `text` и признак
+`template` — стоят ли в ней подстановки `[Параметр]`.
 
 ## Чтение данных
 
 ### Области отсортированы сверху вниз
 
-`areas` идут в порядке `beginRow` для строчных областей и `beginColumn` для
-колоночных, поэтому порядок в массиве совпадает с порядком в макете.
+Элементы ветви `Area` идут в порядке `beginRow` для строчных областей и
+`beginCol` для колоночных, поэтому порядок совпадает с порядком в макете.
 
 ### Параметры и detailParameter
 
-`params` — параметры области, `details` — её `detailParameter`. Параметры,
-пришедшие из шаблонов ячеек, помечены суффиксом `[tpl]`.
+Ветвь `Parameter` перечисляет параметры области. Параметры, пришедшие из
+шаблонов ячеек, помечены суффиксом `[tpl]`.
 
 ### Параметры вне областей
 
-Всё, что лежит за пределами именованных областей, собрано в `outside`, а не
+Всё, что лежит за пределами именованных областей, собрано отдельно, а не
 растворено среди областей.
-
-## Логический адрес вместо пути
-
-`unica.mxl.info` принимает либо логический селектор, либо файловый путь —
-ровно один из двух. Оба сразу отклоняются кодом `selector_conflict`.
-
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "tools/call",
-  "params": {
-    "name": "unica.mxl.info",
-    "arguments": {
-      "cwd": "<workspace>",
-      "sourceSet": "<имя набора>",
-      "metadataPath": "Report.<Отчёт>.Template.<Макет>"
-    }
-  }
-}
-```
-
-Имя набора даёт `unica.view {}`, адрес — `unica.search {corpus: "names"}`, а
-`unica.resolve` переводит в адрес путь, найденный иначе. Файловый селектор сохраняется до
-отдельного среза его снятия (ADR-0049).

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -13,7 +13,7 @@ MIN_RUNTIME_GUIDANCE_DOCS = 31
 # The retired v8-runner skill carried eleven duplicate examples. Remaining
 # examples belong to subject skills and shared references until their v0.13
 # operation is implemented and migrated to unica.run.
-MIN_RUNTIME_EXECUTE_EXAMPLES = 10
+MIN_RUNTIME_EXECUTE_EXAMPLES = 9
 
 
 # Both ways a document points at another one: a backticked path, where the
@@ -366,7 +366,7 @@ IN_SCOPE_TOOLS = {
     "dcs-edit": "unica.dcs.edit",
     "mxl-compile": "unica.mxl.compile",
     "mxl-decompile": "unica.mxl.decompile",
-    "mxl-info": "unica.mxl.info",
+    "mxl-info": "unica.view",
     "role-compile": "unica.role.compile",
     "role-edit": "unica.role.edit",
 }
@@ -381,17 +381,20 @@ SCENARIO_SKILLS = {
         "unica.docs",
         "unica.runtime.execute",
     ],
+        # Поиск по тексту и по именам — один `search`, различается свод;
+    # чтение узла и профиль объекта — один `view`.
     "code-search": [
-        "unica.code.search",
-        "unica.code.definition",
-        "unica.meta.info",
+        "unica.search",
         "unica.view",
+        "unica.resolve",
     ],
+    # Диагностика узла — канонический `check`; поиск — `search`; стандарт —
+    # `docs`. Прогон платформы этому скиллу не нужен: он читает и судит.
     "code-diagnostics": [
-        "unica.code.diagnostics",
-        "unica.code.search",
+        "unica.check",
+        "unica.search",
         "unica.docs",
-        "unica.runtime.execute",
+        "unica.view",
     ],
     "code-review": [
         "unica.code.search",
@@ -791,7 +794,8 @@ TASK_EXAMPLE_ARGUMENT_KEYS = {
     "dcs-edit": ["TemplatePath", "Operation", "Value"],
     "mxl-compile": ["JsonPath", "OutputPath"],
     "mxl-decompile": ["TemplatePath"],
-    "mxl-info": ["TemplatePath", "WithText"],
+    # Читающий макет адресуется логически: файлового селектора у `view` нет.
+    "mxl-info": ["at"],
     "role-compile": ["JsonPath", "OutputDir"],
     "role-edit": ["sourceSet", "metadataPath", "operations"],
 }
@@ -944,10 +948,12 @@ SCENARIO_PRESERVING_TOKENS = {
     # Eleven `Mode` values selected eleven reports. The typed answer carries
     # every section at once, so the scenarios are preserved by the sections the
     # skill names, not by the selector that no longer exists (ADR-0023).
+    # Содержимое ячеек стало отдельным адресом, а не признаком в аргументах,
+    # поэтому сценарий сохраняется адресом ветви, а не селектором состава.
     "mxl-info": [
-        '"WithText": true',
-        "`columnSets`",
-        "`outside`",
+        "Area.Шапка.Body",
+        "columnSets",
+        "contentCount",
     ],
 }
 
@@ -957,7 +963,14 @@ SCENARIO_PRESERVING_TOKENS = {
 SCENARIO_RETIRED_TOKENS = {
     "meta-add": ['"JsonPath"', '"OutputDir"', '"DefinitionFile"'],
     "meta-edit": ['"ObjectPath"', '"Operation"', '"Value"', '"DefinitionFile"'],
-    "mxl-info": ['"Format"', '"MaxParams"', '"Limit"', '"Offset"'],
+    "mxl-info": [
+        '"Format"',
+        '"MaxParams"',
+        '"Limit"',
+        '"Offset"',
+        '"TemplatePath"',
+        '"WithText"',
+    ],
     "meta-info": ['"ObjectPath"', '"objectPath"', '"Detailed"', '"detailed"'],
 }
 
@@ -1540,94 +1553,69 @@ class UnicaSkillRoutingTests(unittest.TestCase):
 
         self.assertEqual(offenders, [])
 
-    def test_code_diagnostics_describes_operational_config_fallback(self) -> None:
+    def test_code_diagnostics_names_the_gaps_it_cannot_cover(self) -> None:
+        """Пробел контракта называется, а не обходится стороной.
+
+        Канонический `check` принимает только адрес: ни сплошного прогона по
+        набору, ни отбора по важности и кодам, ни каталога правил у него нет.
+        Скилл, умолчавший об этом, толкает модель выдумывать аргументы.
+        """
         text = (self.skill_root() / "code-diagnostics" / "SKILL.md").read_text(
             encoding="utf-8"
         )
 
-        self.assertIn("operational.code_diagnostics.analyze_timeout_seconds", text)
-        self.assertIn("unica.local.toml", text)
-        self.assertIn("unica.toml", text)
-        self.assertIn("compiled 120-second fallback", text)
-        self.assertIn("do not read this operational config", text)
+        self.assertIn("Чего на канонической поверхности пока нет", text)
+        for gap in (
+            "сплошной прогон по всему набору",
+            "отбор по важности и кодам",
+            "каталог правил провайдера",
+            "граф вызовов",
+        ):
+            self.assertIn(gap, text)
 
     def test_code_diagnostics_routes_providers_internally(self) -> None:
         text = (self.skill_root() / "code-diagnostics" / "SKILL.md").read_text(
             encoding="utf-8"
         )
 
-        self.assertIn("no_applicable_provider", text)
-        self.assertIn("Provider execution is routed internally", text)
+        # Валидатор следует из вида узла, и выбрать его вызывающему нечем.
+        self.assertIn("Валидаторы следуют из вида узла", text)
         self.assertNotIn('providers: ["bsl-analyzer"]', text)
+        # Чистый ответ и неотработавший провайдер обязаны быть различимы:
+        # пустой список находок при незавершённом прогоне выглядел бы как
+        # «проверено и чисто».
+        self.assertIn("provider_unavailable", text)
         self.assertIn("inline/range disable markers", text)
         self.assertIn("suppression-комментарии", text)
 
-    def test_code_diagnostics_examples_use_logical_action_contract(self) -> None:
+    def test_code_diagnostics_examples_call_the_canonical_check(self) -> None:
+        """Пример — это маршрут, по которому пойдёт модель.
+
+        Пример на снятое имя учит звать то, чего на проводе нет: любое имя
+        v0.12 отвечает `-32602`. Проверка требует, чтобы примеры скилла звали
+        `unica.check` одним логическим адресом и ничем больше.
+        """
+        text = (self.skill_root() / "code-diagnostics" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
         calls = []
-        for path in sorted(self.skill_root().glob("*/SKILL.md")):
-            text = path.read_text(encoding="utf-8")
-            for block in re.findall(r"```(?:json|jsonc)\n(.*?)\n```", text, flags=re.S):
-                try:
-                    payload = json.loads(block)
-                except json.JSONDecodeError:
-                    continue
-                if not isinstance(payload, dict):
-                    continue
-                params = payload.get("params", {})
-                if params.get("name") == "unica.code.diagnostics":
-                    calls.append((path, params.get("arguments", {})))
+        for block in re.findall(r"```(?:json|jsonc)\n(.*?)\n```", text, flags=re.S):
+            try:
+                payload = json.loads(block)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                calls.append(payload.get("params", {}))
 
-        self.assertGreaterEqual(len(calls), 2)
-        forbidden = {
-            "mode",
-            "sourceDir",
-            "path",
-            "codes",
-            "minSeverity",
-            "rangeStart",
-            "rangeEnd",
-            "config",
-            "format",
-            "detail",
-            "maxFiles",
-        }
-        for path, arguments in calls:
-            with self.subTest(
-                path=path.relative_to(self.repo_root()), arguments=arguments
-            ):
-                self.assertIn(
-                    arguments.get("action"),
-                    {"analyze", "findings", "status", "catalog"},
-                )
-                self.assertIsInstance(arguments.get("sourceSet"), str)
-                self.assertTrue(arguments["sourceSet"].strip())
-                self.assertEqual(forbidden.intersection(arguments), set())
-                if arguments["action"] == "findings":
-                    self.assertRegex(
-                        arguments.get("metadataPath", ""),
-                        r"^[^.]+\.[^.]+(?:\..+)?$",
-                    )
-                for code in arguments.get("filter", {}).get("codes", []):
-                    self.assertEqual(set(code), {"provider", "code"})
-                    self.assertTrue(code["provider"])
-                    self.assertTrue(code["code"])
+        checks = [call for call in calls if call.get("name") == "unica.check"]
+        self.assertTrue(checks, "скилл диагностик обязан показать вызов check")
+        for call in checks:
+            arguments = call.get("arguments", {})
+            self.assertEqual(set(arguments), {"at"})
+            self.assertRegex(arguments["at"], r"^[^:]+:.+")
 
-        code_diagnostics_calls = [
-            arguments
-            for path, arguments in calls
-            if path.parent.name == "code-diagnostics"
-        ]
-        self.assertTrue(
-            any(call["action"] == "analyze" for call in code_diagnostics_calls)
-        )
-        findings = next(
-            call
-            for call in code_diagnostics_calls
-            if call["action"] == "findings"
-        )
-        self.assertEqual(findings["sourceSet"], "main")
-        self.assertIn("metadataPath", findings)
-        self.assertTrue(findings.get("filter", {}).get("codes"))
+        for call in calls:
+            self.assertNotEqual(call.get("name"), "unica.code.diagnostics")
 
     def test_unica_owned_guidance_contains_required_operational_concepts(self) -> None:
         docs = {
@@ -3213,8 +3201,10 @@ class PlatformHelpRoutingTests(unittest.TestCase):
 # unconditionally required — contradicts the schema the tool publishes.
 CONDITIONAL_MARKER = "один из двух"
 
+# Скилл покидает этот список, когда его инструмент перестаёт принимать
+# файловый селектор: у канонического `view` его нет вовсе, а путь, пришедший
+# снаружи, переводит в адрес аварийный `resolve`.
 BRIDGED_SKILL_SELECTORS = {
-    "mxl-info": ("TemplatePath", True),
     "mxl-decompile": ("TemplatePath", True),
 }
 


### PR DESCRIPTION
Первый срез волны 2 зонтика #717 — и заодно измерение, которое меняет её порядок.

## Что сделано

Три скилла, чья каноническая цель реализована целиком:

| Скилл | Было | Стало |
|---|---|---|
| `code-diagnostics` | `unica.code.diagnostics` | `unica.check {at}` |
| `code-search` | `unica.code.search`, `code.definition`, `meta.info` | `unica.search`, `unica.view {at}` |
| `mxl-info` | `unica.mxl.info` | `unica.view {at}` |

## Это не переименование

Скиллы написаны вокруг словаря аргументов v0.12, которого на проводе нет: `action=findings|analyze|status|catalog`, `metadataPath`, `filter` по важности и кодам, `limit`, `timeoutSeconds`, `TemplatePath`, `WithText`. Канонические инструменты принимают адрес и ничего больше. Переписаны рабочие указания, а не токены; вместе с ними переписаны и проверки, которые прикалывали старый контракт.

## Пробелы названы, а не обойдены

Каждый переведённый скилл прямо говорит, чего каноническая поверхность пока не умеет: сплошного прогона по набору, отбора по важности и кодам, каталога правил провайдера, графа вызовов. Умолчание толкало бы модель выдумывать аргументы — ровно то, ради чего волна и затевалась.

Побочно снят вопрос готовности провайдера у диагностик. `check` отказывает `provider_unavailable`, когда анализ не завершился, поэтому пустой список находок при `status: passed` теперь доказательство, а не повод перепроверять готовность.

Скилл `mxl-info` покинул список инструментов с двойным селектором: у `view` файлового селектора нет вовсе.

## Измерение: волна 2 упирается не в волну 1

Зонтик говорил «после волны 1». Замер по всем 55 скиллам показал другое: **сегодня переводимы ровно три**. Остальные 52 упоминают `unica.runtime.execute`, `unica.build.*`, `unica.cf*`, `unica.epf/erf.init` либо семейства правки (`meta.add`, `meta.edit`, `code.patch`, `form.*`, `dcs.*`, `role.*`, `subsystem.*`, `interface.*`, `template.*`). У этих имён канонического дома ещё нет: словарь `run` (пункт L) и семейства `apply` (5.1) открыты.

Перевести их сейчас значило бы заменить «имя вне провода» на «имя на проводе, которое откажет» — не лучше.

Порядок волны 2 поэтому такой: **после словаря `run` и семейств `apply`**, а не после волны 1. Два оставшихся упоминания `unica.code.graph` ждут пункта 4.2.

## Цена перевода одного скилла

Измерена на этих трёх: переписать сам скилл и от трёх до пяти проверок, которые прикалывали снятый контракт. Волна целиком — отдельная работа на несколько заходов, а не один PR.

## Проверки

- `tests/ci` — 858 прошло, включая 84 проверки маршрутизации скиллов
