### PR TITLE
docs(skills): правка кода идёт через apply, селектором стал адрес

### DIFF
--- a/plugins/unica/skills/code-patch/SKILL.md
+++ b/plugins/unica/skills/code-patch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: code-patch
-description: Точечно вставить или заменить BSL-код в логически адресованном модуле XML-выгрузки Configuration или Extension 1С. Используй для одной проверяемой операции insert или replace; insert без селектора дописывает содержимое в конец модуля
-argument-hint: <sourceSet> <metadataPath> <insert|replace> <content> [method|anchor] [before|after]
+description: Точечно вставить или заменить BSL-код в логически адресованном модуле XML-выгрузки Configuration или Extension 1С. Используй для одной проверяемой операции insert или replace.
+argument-hint: <at> <insert|replace> <text>
 allowed-tools:
   - Read
   - Glob
@@ -11,94 +11,102 @@ allowed-tools:
 
 ## MCP routing
 
-- Preferred path: use MCP `unica` tool `unica.code.patch`; `unica` validates the source set, supported-object state, selector, and exact in-memory BSL postimage before staging and atomic publication.
-- Do not call internal MCP/CLI adapters directly. They are hidden behind `unica` and synchronized by the orchestrator.
-- Always call `unica.code.patch` with `dryRun: true` first. Call it with `dryRun: false` only after the user explicitly asked to apply this exact change.
+- Preferred path: use MCP `unica` tool `unica.apply` с операциями
+  `code.insert` и `code.replace`.
+- Do not call internal MCP/CLI adapters directly. They are hidden behind
+  `unica` and synchronized by the orchestrator.
+- Всегда сначала `dryRun: true`. Применяй `dryRun: false` только после того,
+  как пользователь явно попросил внести именно эту правку, и только с `ifRev`
+  из предпросмотра.
 
-`unica.code.patch` edits only a module of an existing metadata object in a supported canonical layout, with its descriptors present, inside the selected Platform XML Configuration or Extension source set. The physical `*Module.bsl` path is resolved privately from `sourceSet + metadataPath`; the removed `path` and `sourceDir` selector fields fail with `legacy_target_removed`. The tool performs exactly one `insert` or one `replace` — `insert` places `content` before or after the selected method or anchor, and `replace` overwrites the selected span itself and does not accept `position`. `selector` is optional for `insert`: without it the content goes to the end of the module, `position` is refused, and a module that holds no method yet is served by that same path. A module file the platform never exported is created on apply, never on preview, and only when the role is one the metadata kind owns and the owner descriptor is proven. The tool cannot create a metadata object, batch-edit files, delete a whole module, edit EDT/external files, or synchronize source with an infobase.
+**Селектор — это адрес.** Отдельного `selector` с `method` или `anchor` нет:
+что править, называет `args.at`. Узел метода — `…Module.<Роль>.Method.<Имя>`,
+тело модуля целиком — `…Module.<Роль>.Body`. Адрес и точнее селектора, и
+переживает переименование файла, и уже проверен чтением.
 
-If the requested BSL change cannot be expressed as one safe insertion and needs
-a full existing-module replacement, stop this route and use the
-`source-access` skill to inspect the target through the read-only
-`unica.view` on the module node and its `Method` and `Body` branches, then
-come back with a narrower `insert` or `replace`.
+Правится модуль существующего объекта метаданных в допущенном наборе
+исходников формата платформы. Физический путь к `*Module.bsl` остаётся
+внутренней деталью: наружу его отдаёт только аварийный `unica.resolve`, и в
+обычном ходе работы он не нужен. Создать объект метаданных, удалить модуль
+целиком, править EDT или внешние файлы, синхронизировать исходники с базой
+этим путём нельзя.
 
-## Parameters
+Если правку нельзя выразить одной безопасной операцией, остановись: прочитай
+предмет через `unica.view {at}` на узле модуля — ветвь `Method` перечисляет
+методы, ветвь `Body` отдаёт строки парами `{line, text}` — и вернись с более
+узкой операцией.
 
-| Parameter | Required | Description |
-|---|:---:|---|
-| `sourceSet` | yes | Exact configured name of a Platform XML Configuration or Extension source set |
-| `metadataPath` | yes | Canonical logical module address, for example `CommonModule.Example.Module` |
-| `operation` | yes | `insert` or `replace` |
-| `selector` | replace | Exactly one of `{ "method": "Name" }` or `{ "anchor": "text" }`; optional for `insert`, and omitting it appends to the end of the module |
-| `content` | yes | Non-empty BSL text to write |
-| `position` | insert+selector | `before` or `after`; refused when `insert` names no selector |
+## Операции
 
-Method selectors match an entire procedure or function, including its annotations. Anchor selectors must match exactly once inside a BSL method; LF/CRLF differences in multiline anchors are normalized while returned ranges remain byte-exact. A request is rejected before writing if the resulting selector would become ambiguous and the next identical call could not be proven a no-op. In `OperationResult.data`, read the pre/post hashes, changed range, byte-exact diff, affected owner/module role, and terminal `validation.status` before applying. Preview, no-op, and failed validation do not publish a module-change event.
+| Операция | Что делает | `args` |
+|---|---|---|
+| `code.insert` | Вставляет текст в узел по адресу | `at`, `text` |
+| `code.replace` | Заменяет содержимое узла по адресу | `at`, `text` |
 
-### Append to the end of a module
+Несколько операций одного вызова применяются как одна правка: либо все, либо
+ни одной.
 
-Omit `selector` when the content belongs at the end — including the first body of a module that holds no method yet. Preview first; the preview returns the exact diff, pre/post hashes, and BSL parse status without writing.
+## Порядок
 
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "tools/call",
-  "params": {
-    "name": "unica.code.patch",
-    "arguments": {
-      "cwd": "<workspace>",
-      "sourceSet": "main",
-      "metadataPath": "CommonModule.Example.Module",
-      "operation": "insert",
-      "content": "Procedure Run()\nEndProcedure",
-      "dryRun": true
-    }
-  }
-}
-```
+1. Найди адрес: `unica.search {corpus: "names"}` по имени объекта, затем
+   `unica.view {at}` вниз по ветвям `Module` и `Method`.
+2. Прочти предмет: `unica.view {at}` на узле метода даёт подпись, контекст
+   компиляции и собственные строки.
+3. Предпросмотр: `unica.apply` с `dryRun: true`. Ответ несёт план правки и
+   `next` с готовым `ifRev`.
+4. Применение: тот же вызов с `dryRun: false` и этим `ifRev`. Без него правка
+   отказывает — забор ревизии связывает предпросмотр с применением.
+5. Проверка: `unica.check {at}` на модуле. Новые находки важности `error`
+   блокируют.
 
 ## MCP examples
 
-### Dry run before a method
+### Предпросмотр замены тела метода
 
 ```json
 {
   "jsonrpc": "2.0",
   "method": "tools/call",
   "params": {
-    "name": "unica.code.patch",
+    "name": "unica.apply",
     "arguments": {
-      "cwd": "<workspace>",
-      "sourceSet": "main",
-      "metadataPath": "CommonModule.Example.Module",
-      "operation": "insert",
-      "selector": { "method": "ПриСозданииНаСервере" },
-      "content": "// TODO: добавить проверку",
-      "position": "before",
+      "at": "main:CommonModule.Пример",
+      "ops": [
+        {
+          "op": "code.replace",
+          "args": {
+            "at": "main:CommonModule.Пример.Module.Manager.Method.Выполнить.Body",
+            "text": "    Возврат Истина;"
+          }
+        }
+      ],
       "dryRun": true
     }
   }
 }
 ```
 
-### Apply after an anchor
+### Применение с забором ревизии
 
 ```json
 {
   "jsonrpc": "2.0",
   "method": "tools/call",
   "params": {
-    "name": "unica.code.patch",
+    "name": "unica.apply",
     "arguments": {
-      "cwd": "<workspace>",
-      "sourceSet": "myExtension",
-      "metadataPath": "CommonModule.Example.Module",
-      "operation": "insert",
-      "selector": { "anchor": "Сообщить(\"Готово\");" },
-      "content": "Лог.Информация(\"Операция завершена\");",
-      "position": "after",
-      "dryRun": false
+      "at": "main:CommonModule.Пример",
+      "ops": [
+        {
+          "op": "code.insert",
+          "args": {
+            "at": "main:CommonModule.Пример.Module.Manager.Body",
+            "text": "Процедура Выполнить() Экспорт\nКонецПроцедуры"
+          }
+        }
+      ],
+      "dryRun": false,
+      "ifRev": "<rev из предпросмотра>"
     }
   }
 }

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -2792,19 +2792,31 @@ Use `.claude/commands/xdto.md` as the execution route.
         for block in re.findall(r"```json\s*(.*?)```", text, re.DOTALL):
             payload = json.loads(block)
             params = payload.get("params", {})
-            if params.get("name") == "unica.code.patch":
+            if params.get("name") == "unica.apply":
                 calls.append(params.get("arguments", {}))
 
         self.assertGreaterEqual(len(calls), 2)
+        previews = 0
         for arguments in calls:
             with self.subTest(arguments=arguments):
-                self.assertIn("sourceSet", arguments)
-                self.assertIn("metadataPath", arguments)
+                # Цель называет адрес, а не пара селекторов и уж точно не путь.
+                self.assertRegex(arguments["at"], r"^[^:]+:.+")
                 self.assertNotIn("path", arguments)
                 self.assertNotIn("sourceDir", arguments)
-        self.assertRegex(text, r"Configuration.{0,120}Extension")
-        self.assertIn("sourceSet", text)
-        self.assertIn("metadataPath", text)
+                self.assertNotIn("sourceSet", arguments)
+                self.assertNotIn("metadataPath", arguments)
+                for operation in arguments["ops"]:
+                    self.assertIn(operation["op"], {"code.insert", "code.replace"})
+                    self.assertRegex(operation["args"]["at"], r"^[^:]+:.+")
+                    self.assertTrue(operation["args"]["text"])
+                if arguments.get("dryRun") is True:
+                    previews += 1
+                    self.assertNotIn("ifRev", arguments)
+                else:
+                    # Применение связано с предпросмотром забором ревизии.
+                    self.assertTrue(arguments["ifRev"])
+        self.assertTrue(previews, "скилл обязан показать предпросмотр")
+        self.assertRegex(text, r"Configuration.{0,200}Extension")
 
     def test_code_patch_prompt_metadata_covers_every_public_operation(self) -> None:
         """Prompt metadata names the published operations and only those.
@@ -2834,10 +2846,11 @@ Use `.claude/commands/xdto.md` as the execution route.
                 with self.subTest(field=field, retired=operation):
                     self.assertNotRegex(value, rf"\b{operation}\b")
 
-        # A selector-less insert is the whole point of the current surface, so
-        # the body must say where the content lands when the selector is absent.
-        self.assertRegex(text, r"(?is)`selector` is optional for `insert`")
-        self.assertIn("end of the module", text)
+        # Селектором стал адрес, и это надо сказать прямо: иначе модель будет
+        # искать поле `selector`, которого на канонической поверхности нет.
+        self.assertIn("Селектор — это адрес", text)
+        # Куда ляжет вставка, обязано быть сказано: у тела модуля свой адрес.
+        self.assertIn("тело модуля целиком", text)
 
     def test_xdto_skill_uses_one_confirmed_info_preview_apply_mcp_flow(self) -> None:
         path = self.skill_root() / "xdto" / "SKILL.md"


### PR DESCRIPTION
Продолжение волны 2 зонтика #717 — и исправление вчерашнего измерения.

## Что было измерено неверно

Вчера я написал в задаче, что переводимы ровно три скилла из 55, потому что остальные ждут словаря `run` **и** семейств `apply`. Первое верно, второе нет: реестр `apply` объявляет 82 операции в одиннадцати семействах, и `code.insert`, `code.replace`, `object.create`, `props.set`, `mxl.set`, `dcs.*`, `role.create`, `right.set`, `subsystem.create`, `form.create` уже на проводе. План 04.09 говорил это прямо, а я не проверил реестр, прежде чем записать вывод.

**Переводимы семнадцать скиллов, а не три.** Ждут словаря `run` только те, что зовут `runtime.execute`, `build.*`, `cf*`, `epf/erf.init`.

Список переводимых сегодня: `cfe-diff`, `code-patch`, `dcs-compile`, `dcs-edit`, `form-edit`, `form-patterns`, `interface-edit`, `meta-add`, `meta-edit`, `meta-info`, `mxl-compile`, `mxl-decompile`, `role-compile`, `role-edit`, `source-access`, `subsystem-compile`, `subsystem-edit`.

## Что сделано здесь

`code-patch` переведён с `unica.code.patch` на `unica.apply` с операциями `code.insert` и `code.replace`.

Главное — не имя, а исчезновение пары селекторов:

| Было | Стало |
|---|---|
| `sourceSet` + `metadataPath` | адрес в `args.at` |
| `selector: {method}` / `{anchor}` | адрес узла метода |
| `position: before/after` | адрес тела: `…Module.<Роль>.Body` |

Адрес точнее селектора, переживает переименование файла и уже проверен чтением. Скилл теперь называет и протокол целиком: предпросмотр → забор ревизии из него → применение с этим забором → `check {at}` после.

## Проверки

- `tests/ci` — 858 прошло, включая 84 проверки маршрутизации скиллов
