### PR TITLE
fix(ci): страж размера сверяет встроенные модули тестов, а не только префикс

### DIFF
--- a/scripts/ci/size-filters.py
+++ b/scripts/ci/size-filters.py
@@ -11,7 +11,8 @@
 `--write` переписывает выражение в `.config/nextest.toml` между метками, беря
 имена тестов из `cargo nextest list --message-format json` (нужен `cargo`);
 страж размера в `tests/ci` читает то же выражение без `cargo` и проверяет, что
-каждый файл с процессом или сокетом в нём назван.
+каждый файл с процессом или сокетом в нём назван, а внутри терма названы все
+встроенные модули тестов этого файла.
 """
 
 from __future__ import annotations
@@ -68,15 +69,19 @@ def declared(module: tuple[str, ...], sources: dict[tuple[str, ...], tuple[bool,
     return any(pattern.search(path.read_text(encoding="utf-8", errors="replace")) for _, path in sources.values())
 
 
-def flagged_modules(root: Path) -> list[tuple[str, str]]:
-    """(крейт, модуль) файлов дерева с процессом или сокетом, в которых есть тесты."""
+def flagged_modules(root: Path) -> list[tuple[str, str, Path]]:
+    """(крейт, модуль, файл) файлов дерева с процессом или сокетом, в которых есть тесты.
+
+    Файл отдаётся вместе с модулем: страж размера разбирает его исходник, чтобы
+    сверить с термом встроенные модули тестов.
+    """
     flagged = []
     for crate, modules in source_modules(root).items():
         for module, (marked, path) in modules.items():
             text = path.read_text(encoding="utf-8", errors="replace")
             # Тест — атрибут в начале строки; упоминание в строке или комментарии не в счёт.
             if marked and re.search(r"^\s*#\[test\]", text, re.M) and declared(module, modules):
-                flagged.append((crate, "::".join(module)))
+                flagged.append((crate, "::".join(module), path))
     return flagged
 
 

--- a/tests/ci/test_size_guard.py
+++ b/tests/ci/test_size_guard.py
@@ -3,6 +3,18 @@
 Страж не знает наших имён: признак — конструкции стандартной библиотеки и
 Cargo. Выражение объявлено в `.config/nextest.toml` дважды — воротами `pr`
 и сроком `medium` — и обе копии обязаны совпадать.
+
+Покрытие проверяется на двух глубинах. Файл обязан быть назван в выражении, а
+внутри своего терма обязан перечислить все встроенные модули тестов: новый
+`mod *_tests` в уже помеченном файле меняет вывод генератора, и без второй
+проверки его тесты молча остаются в воротах `pr`.
+
+Вторая проверка читает исходники, а не `cargo`, поэтому тестов, порождённых
+макросом, она не видит — это та же цена, что страж уже платит за отказ от
+`cargo`; недосмотр безопасен, страж лишь недосчитается модуля. Обратная
+сторона опаснее: модуль тестов за `cfg(feature = …)` страж потребует назвать,
+а генератор с фичами по умолчанию его не выведет. Сегодня таких модулей в
+крейтах нет; если появятся — сверять придётся по одному набору фич.
 """
 
 from __future__ import annotations
@@ -13,9 +25,18 @@ import tomllib
 import unittest
 from pathlib import Path
 
+from tree_sitter import Language, Parser
+import tree_sitter_rust
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 NEXTEST_TOML = REPO_ROOT / ".config" / "nextest.toml"
+# `#[test]` и `#[tokio::test]` дают тест-кейс; `#[cfg(test)]` — нет: у него скобки.
+TEST_ATTRIBUTE = re.compile(r"#\[(?:[A-Za-z0-9_]+::)*test\]")
+# Терм перечисления: `test(/^модуль::(a|b)::/)`. Второй вид — тесты на верхнем
+# уровне файла: `test(/^модуль::[^:]+$/)`.
+ENUMERATED_TERM = re.compile(r"test\(/\^([A-Za-z0-9_:]+)::\(([^)]*)\)::/\)")
+DIRECT_TERM = re.compile(r"test\(/\^([A-Za-z0-9_:]+)::\[\^:\]\+\$/\)")
 
 
 def load_size_filters():
@@ -23,6 +44,68 @@ def load_size_filters():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def inline_test_modules(source: bytes) -> tuple[set[str], bool]:
+    """Встроенные модули файла с тестами внутри и признак тестов на его верхнем уровне.
+
+    Генератор относит тест к первому сегменту после модуля файла, поэтому
+    вложенный модуль засчитывается внешнему, а не называется отдельно.
+    """
+    tree = Parser(Language(tree_sitter_rust.language())).parse(source)
+
+    def is_test_attribute(node) -> bool:
+        if node.type != "attribute_item":
+            return False
+        compact = re.sub(r"\s+", "", source[node.start_byte : node.end_byte].decode())
+        return TEST_ATTRIBUTE.fullmatch(compact) is not None
+
+    def holds_test(node) -> bool:
+        stack = [node]
+        while stack:
+            current = stack.pop()
+            if is_test_attribute(current):
+                return True
+            stack.extend(current.children)
+        return False
+
+    modules: set[str] = set()
+    top_level = False
+    children = tree.root_node.named_children
+    for index, child in enumerate(children):
+        # Модуль без тела — отдельный файл; его тесты принадлежат не этому терму.
+        if child.type == "mod_item" and child.child_by_field_name("body") is not None:
+            if holds_test(child):
+                modules.add(child.child_by_field_name("name").text.decode())
+        elif child.type == "function_item":
+            # Атрибут — сиблинг перед элементом, а не его ребёнок.
+            back = index - 1
+            while back >= 0 and children[back].type == "attribute_item":
+                top_level = top_level or is_test_attribute(children[back])
+                back -= 1
+    return modules, top_level
+
+
+class InlineTestModuleReadingTests(unittest.TestCase):
+    """Разбор исходника закреплён: молча ослепший разбор снова обнулил бы стража."""
+
+    def test_reads_what_the_generator_would_name(self) -> None:
+        cases = {
+            "встроенный модуль с тестами": (b"mod a_tests { #[test] fn t() {} }", ({"a_tests"}, False)),
+            "тесты tokio внутри модуля": (b"mod b_tests { #[tokio::test] async fn t() {} }", ({"b_tests"}, False)),
+            "cfg(test) сам по себе не тест": (b"#[cfg(test)] mod c { fn helper() {} }", (set(), False)),
+            "модуль-файл без тела": (b"mod d;", (set(), False)),
+            "модуль без тестов": (b"mod e { fn helper() {} }", (set(), False)),
+            "тест на верхнем уровне": (b"#[test]\nfn t() {}", (set(), True)),
+            "тест tokio на верхнем уровне": (b"#[tokio::test]\nasync fn t() {}", (set(), True)),
+            "тест за чужим атрибутом": (b'#[cfg(feature="x")]\n#[test]\nfn t() {}', (set(), True)),
+            "вложенный модуль засчитан внешнему": (b"mod outer { mod inner { #[test] fn t() {} } }", ({"outer"}, False)),
+            "функция без атрибута": (b"fn plain() {}", (set(), False)),
+        }
+
+        for name, (source, expected) in cases.items():
+            with self.subTest(case=name):
+                self.assertEqual(inline_test_modules(source), expected)
 
 
 class SizeGuardTests(unittest.TestCase):
@@ -43,9 +126,29 @@ class SizeGuardTests(unittest.TestCase):
         module = load_size_filters()
         declared = set(re.findall(r"test\(/\^([A-Za-z0-9_:]+)::", self.medium))
 
-        for crate, path in module.flagged_modules(REPO_ROOT):
+        for crate, path, _ in module.flagged_modules(REPO_ROOT):
             with self.subTest(module=f"{crate}::{path}"):
                 self.assertIn(path, declared)
+
+    def test_every_inline_test_module_is_named_in_its_term(self) -> None:
+        """Новый `mod *_tests` в помеченном файле не уезжает в ворота `pr` молча."""
+        module = load_size_filters()
+        enumerated: dict[str, set[str]] = {}
+        for match in ENUMERATED_TERM.finditer(self.medium):
+            enumerated.setdefault(match.group(1), set()).update(match.group(2).split("|"))
+        direct = set(DIRECT_TERM.findall(self.medium))
+        remedy = "перезапустите `python3 scripts/ci/size-filters.py --write`"
+
+        for crate, path, source in module.flagged_modules(REPO_ROOT):
+            modules, top_level = inline_test_modules(source.read_bytes())
+            with self.subTest(module=f"{crate}::{path}"):
+                self.assertEqual(
+                    sorted(modules - enumerated.get(path, set())),
+                    [],
+                    f"встроенные модули тестов не названы в терме — {remedy}",
+                )
+                if top_level:
+                    self.assertIn(path, direct, f"тесты верхнего уровня не названы термом — {remedy}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #812.

## Что было не так

`tests/ci/test_size_guard.py` снимал из выражения только префикс модуля
(`…::cf`) и не смотрел список встроенных модулей внутри терма. Новый
`mod *_tests` в уже помеченном файле меняет вывод генератора, но страж
оставался зелёным по обе стороны правки, а тесты молча оставались в воротах
`pr`. Так утёк `configuration_interface_tests` из #779 — заметили вручную,
починили #810.

## Что проверяет теперь

Для каждого помеченного файла разбираются исходники и собираются:

- внешние встроенные модули, внутри которых есть тесты, — обязаны быть названы
  в терме перечисления `test(/^M::(a|b)::/)`;
- признак тестов на верхнем уровне файла — обязан быть покрыт термом второго
  вида `test(/^M::[^:]+$/)`.

Разбор через tree-sitter — приём, уже принятый в этом каталоге
(`test_product_contracts.py`), обе зависимости давно лежат в
`tests/ci/requirements.txt`. Сообщение при падении называет лечение:
«перезапустите `python3 scripts/ci/size-filters.py --write`».

`flagged_modules` отдаёт теперь и путь файла — иначе разбирать нечего.
Единственный потребитель у него — сам страж.

## Доказательство, что страж умеет краснеть

Проверка, которая не может упасть, бесполезна, поэтому обе ветки проверены на
подменённом конфиге:

| прогон | итог |
| --- | --- |
| текущий `main` | зелено, 4 теста |
| `.config/nextest.toml` до #810 | падает: `['configuration_interface_tests'] != []` |
| терм `meta_add_surface_tests::[^:]+$` подменён на перечисление | падает: `'application::meta_add_surface_tests' not found in {...}` |

То есть страж ловит ровно тот исторический дрейф, ради которого заведён, и
вторую половину проверки тоже.

## Разбор закреплён тестами

Десять случаев: `#[tokio::test]` считается тестом, `#[cfg(test)]` — нет
(у него скобки), вложенный модуль засчитывается внешнему (генератор берёт
первый сегмент после модуля файла), модуль-файл без тела не в счёт, атрибут
теста находится и за чужим атрибутом впереди. Без такого набора молча
ослепший разбор снова обнулил бы стража — ровно та поломка, о которой задача.

## Границы, названные в докстроке

- Тестов, порождённых макросом, статический разбор не видит. Это та же цена,
  что страж уже платит за отказ от `cargo`; недосмотр безопасен — страж лишь
  недосчитается модуля, но лишнего не потребует.
- Обратная сторона опаснее: модуль тестов за `cfg(feature = …)` страж
  потребовал бы назвать, а генератор с фичами по умолчанию его не выведет.
  Проверено — сегодня таких модулей в крейтах нет.

## Проверено локально

- `tests/ci` целиком — 871 тест, OK (11 skipped)
- `tests/arch` целиком — 127 тестов, OK
- `python3 scripts/ci/size-filters.py --write` после правки — **пустой диф**:
  вывод генератора не изменился, правка `flagged_modules` чисто расширяющая


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved size-guard validation to ensure inline test modules are explicitly covered by their configured filters.
  * Added detection for inline test modules and their test attributes, improving enforcement of test coverage rules.

* **Tests**
  * Added automated checks for inline test module parsing and filter-term coverage.
  * Expanded existing size-guard tests to validate source-level module information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->