### PR TITLE
chore(python): убран мёртвый код, найденный разовым прогоном ruff

### DIFF
--- a/scripts/ci/generate-tool-surface.py
+++ b/scripts/ci/generate-tool-surface.py
@@ -14,10 +14,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import queue
 import subprocess
 import sys
-import threading
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]

--- a/scripts/ci/smoke-unica-mcp.py
+++ b/scripts/ci/smoke-unica-mcp.py
@@ -8,9 +8,9 @@ import contextlib
 import importlib.util
 import json
 import os
-import queue
+import queue  # шов подмены: tests/ci/test_smoke_unica_mcp.py
 import socket
-import subprocess
+import subprocess  # шов подмены: tests/ci/test_smoke_unica_mcp.py
 import tempfile
 import threading
 import time
@@ -2179,7 +2179,7 @@ def smoke(
                     deadline,
                 )
                 next_id = _exercise_reader_bridge(session, next_id, workspace)
-                success = _meta_payload(
+                _meta_payload(
                     session.request(
                         {
                             "jsonrpc": "2.0",

--- a/scripts/dev/verify-8-3-27-platform.py
+++ b/scripts/dev/verify-8-3-27-platform.py
@@ -121,7 +121,6 @@ XML_FAMILY_BY_ROOT_QNAME = {
     "{http://v8.1c.ru/8.2/data/spreadsheet}document": "mxl",
     "{http://v8.1c.ru/8.2/managed-application/core}ClientApplicationInterface": "client-application-interface",
     "{http://v8.1c.ru/8.2/roles}Rights": "roles",
-    "{http://v8.1c.ru/8.1/xdto}package": "xdto-package",
     "{http://v8.1c.ru/8.3/xcf/predef}PredefinedData": "predefined-data",
     "{http://v8.1c.ru/8.3/MDClasses}MetaDataObject": "metadata",
     "{http://v8.1c.ru/8.3/xcf/scheme}GraphicalSchema": "flowchart",
@@ -202,7 +201,6 @@ MANDATORY_CASE_IDS = frozenset(
         "cfe-init-default",
         "cfe-borrow-object",
         "cfe-borrow-managed-form",
-        "xdto-add-nested-property",
     }
 )
 FORBIDDEN_CREDENTIAL_OPTIONS = {

--- a/scripts/dev/verify-8-3-27-xml.py
+++ b/scripts/dev/verify-8-3-27-xml.py
@@ -394,7 +394,6 @@ def verified_runtime(path: Path | str, profile: dict) -> dict:
                 relative = declaration.get("file")
                 if not _is_canonical_relative_path(relative, suffix=".xsd"):
                     raise SourceError("runtime schema declaration has no file")
-                pure = PurePosixPath(relative)
                 member = prefix + relative
                 if member in declared_names:
                     raise SourceError(f"duplicate runtime schema declaration: {relative}")

--- a/tests/ci/test_python_sizes.py
+++ b/tests/ci/test_python_sizes.py
@@ -11,7 +11,6 @@ import ast
 import importlib.util
 import io
 import contextlib
-import json
 import re
 import tempfile
 import tomllib

--- a/tests/ci/test_unica_mcp_script_parity.py
+++ b/tests/ci/test_unica_mcp_script_parity.py
@@ -1922,7 +1922,6 @@ EndProcedure
     )
     register_configuration_child(source_roots["main"] / "Configuration.xml", "CommonModule", "ParitySearch")
 
-    interface_fixture = "interface-validate/Sales/Ext/CommandInterface.xml"
     role_rights_fixture = BSP_ROLE_ADMIN_RIGHTS_FIXTURE
     materialise_logical_reader_target(source_roots["main"])
 

--- a/tests/ci/test_unica_mcp_smoke.py
+++ b/tests/ci/test_unica_mcp_smoke.py
@@ -5,7 +5,6 @@ import json
 import os
 import queue
 import subprocess
-import tempfile
 import threading
 import time
 import unittest


### PR DESCRIPTION
## Что это

Разовый замер ruff по `scripts` и `tests` — чтобы решить, заводить ли линтер в проект. **Решение: не заводить.** Ни `pyproject.toml`, ни `ruff.toml`, ни правок `.github/workflows/` в этом PR нет. Остаётся только уборка мёртвого кода, который замер попутно нашёл.

## Почему линтер не заводим

- **`RUF001/002/003` нет в дефолтном наборе ruff ни одной версии.** Голый `ruff check` русскую прозу не трогает вообще: 1589 срабатываний (RUF003 716, RUF001 461, RUF002 412) вылезают только под явным `--select`. Отсюда следствие: конфиг с `ignore = ["RUF001", ...]` был бы пустышкой — гасил бы то, что и так выключено.
- **Дефолт ruff не контракт.** Те же настройки `--isolated` дают **153** находки на ruff 0.6.9 (10 семейств) и **756** на 0.16.6 (50 семейств). Гейт — это обязанность пинить версию, а не разовый конфиг.
- **Настоящего сигнала мало.** Из 756 находок 281 в вендоренных фикстурах `tests/fixtures/unica_mcp_script_parity/`, которые править нельзя. В своём коде 477, из них после триажа настоящих 11, и ни одна не меняет поведение. Крупные классы проверены вблизи и отвергнуты: **B023** (27) — ложные, замыкание потребляется синхронно в той же итерации; **EXE001** (43) — скрипты всегда зовут как `python scripts/ci/x.py`, режим 644 единообразен по дереву.

## Что убрано (9 из 11)

**Неиспользуемые импорты:** `queue` и `threading` в `generate-tool-surface.py`, `json` в `test_python_sizes.py`, `tempfile` в `test_unica_mcp_smoke.py`.

**Мёртвые присваивания:** `success` в `smoke-unica-mcp.py` — `_meta_payload` сам возбуждает `SystemExit` на каждом отказе и проверяет `expected_ok`, так что вызов и есть проверка, а возвращаемое значение не нужно; `pure` в `verify-8-3-27-xml.py`; брошенный `interface_fixture` в `test_unica_mcp_script_parity.py`, где соседний `role_rights_fixture` используется, а этот нигде.

**Дубликаты в литералах** `verify-8-3-27-platform.py`: повтор ключа `{http://v8.1c.ru/8.1/xdto}package` в `XML_FAMILY_BY_ROOT_QNAME` и повтор `xdto-add-nested-property` в `MANDATORY_CASE_IDS`. Оба вели к тому же значению — состав словаря и множества не изменился.

## Две находки оказались ложными

`queue` и `subprocess` в `smoke-unica-mcp.py` напрямую не вызываются, но `tests/ci/test_smoke_unica_mcp.py` подменяет их через пространство имён модуля (`module.queue.Queue()`, `module.subprocess.Popen`). Удаление уронило три теста. Импорты возвращены и помечены комментарием, чтобы следующая уборка не наступила на то же место. Тот же приём подмены живёт ещё в пяти тестовых модулях.

Это заодно довод против гейта: два ложных из одиннадцати уронили бы CI.

## Проверки

Локально на этой базе: `tests/ci` — 871 OK, `tests/arch` — 127 OK, `tests/dev` — 256 OK. Полный cargo-гейт (`fmt --check`, `clippy --workspace --all-targets --all-features -D warnings`, `cargo test --workspace --test-threads=1` — 4431 тест) прошёл зелёным на предыдущей базе; Rust этот PR не трогает.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated platform corpus validation so XDTO package files are no longer recognized as a supported XML family.
  - Removed the XDTO nested-property scenario from the set of mandatory verification cases.

- **Refactor**
  - Removed unused imports, variables, and assignments from validation scripts and automated tests.
  - Clarified smoke-test metadata handling without changing test behavior.

- **Tests**
  - Maintained existing verification and smoke-test coverage while simplifying test setup code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->