### PR TITLE
fix(daemon): ординарная выдача handoff отбивает staged-предшественника

### DIFF
--- a/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5/dispatch.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5/dispatch.rs
@@ -2227,6 +2227,29 @@ pub(crate) fn run_supported_receipt_scenario_for_test(request: &str) -> Result<S
                 )?);
                 bulk_receipt_catalog = Some(catalog);
             }
+            ReceiptScenarioAction::AttemptUnstagedTaskBindAgainstStagedTerminal { label } => {
+                control.arm_skip_next_startup_reconciliation();
+                let daemon_state = DaemonStateDirectory::open(state.path(), &identity)?;
+                let config = scenario_server_config_with_clock(
+                    state.path(),
+                    &identity,
+                    Some(&control),
+                    &clock,
+                );
+                let runtime =
+                    V5ReceiptRuntime::open_with_epoch_clock(&daemon_state, &config, clock.clone())?
+                        .with_hooks_for_test(ScenarioHooks::install(
+                            Arc::clone(&telemetry),
+                            Some(Arc::clone(&control)),
+                        ));
+                control.record_operation_event(&label, "spawned");
+                let refused = runtime.attempt_unstaged_task_bind_against_staged_terminal_for_test(
+                    &exact_key,
+                    Instant::now() + SCENARIO_OPERATION_TIMEOUT,
+                )?;
+                control
+                    .record_operation_event(&label, if refused { "refused" } else { "completed" });
+            }
             ReceiptScenarioAction::AttemptTaskStoreBindUnderGate { label } => {
                 control.arm_skip_next_startup_reconciliation();
                 let daemon_state = DaemonStateDirectory::open(state.path(), &identity)?;

--- a/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5/scenario_probes.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5/scenario_probes.rs
@@ -400,6 +400,50 @@ impl V5ReceiptRuntime {
         Ok(())
     }
 
+    /// Drives the unstaged completed-handoff bind against a predecessor that already
+    /// carries a certified staged terminal — the shape every caller that routes on the
+    /// `ReceiptState` variant alone produces. Reports whether the ledger refused it.
+    pub(super) fn attempt_unstaged_task_bind_against_staged_terminal_for_test(
+        &self,
+        key: &ReceiptKey,
+        deadline: Instant,
+    ) -> Result<bool, String> {
+        let handoff = match self
+            .receipt_ledger
+            .recover(key.clone(), deadline)
+            .map_err(|error| format!("recover staged handoff before unstaged bind: {error}"))?
+        {
+            ReceiptState::TaskHandoffActorBound(handoff)
+                if matches!(
+                    handoff.terminal_stage(),
+                    HandoffTerminalStage::Staged { .. }
+                ) =>
+            {
+                handoff
+            }
+            other => {
+                return Err(format!(
+                    "unstaged bind attempt requires a staged Task handoff, found {}",
+                    other.kind().diagnostic_name()
+                ))
+            }
+        };
+        let (_, bound) = self
+            .task_projection
+            .materialize_bound_handoff(&handoff, self.epoch_ms(), deadline, self.hooks.as_ref())
+            .map_err(|failure| format!("materialize unstaged bound Task: {}", failure.error))?;
+        match self.receipt_ledger.complete_bound_task_handoff(
+            handoff.key().clone(),
+            handoff.record_version(),
+            bound,
+            deadline,
+        ) {
+            Ok(_) => Ok(false),
+            Err(ReceiptLedgerError::ReceiptRowPresentUnsupported) => Ok(true),
+            Err(error) => Err(format!("attempt unstaged Task handoff completion: {error}")),
+        }
+    }
+
     pub(super) fn inject_task_store_capacity_invariant_for_test(
         &self,
         key: &ReceiptKey,

--- a/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5/wire.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/runtime_v5/receipt_scenario_v5/wire.rs
@@ -173,6 +173,9 @@ pub(super) enum ReceiptScenarioAction {
     AttemptTaskStoreBindUnderGate {
         label: String,
     },
+    AttemptUnstagedTaskBindAgainstStagedTerminal {
+        label: String,
+    },
     ContinueReceiptOwnedAttempt {
         terminal: ScenarioTerminalFixture,
         label: String,

--- a/crates/unica-coder/src/infrastructure/receipt_ledger.rs
+++ b/crates/unica-coder/src/infrastructure/receipt_ledger.rs
@@ -3618,12 +3618,23 @@ impl ReceiptLedgerStore {
                     AttemptPhase::NotBegun,
                     promised.cancel_requested(),
                 ),
-                Ok(ReceiptState::TaskHandoffActorBound(handoff)) => (
-                    handoff.link().clone(),
-                    handoff.task().clone(),
-                    handoff.phase(),
-                    handoff.cancel_requested(),
-                ),
+                Ok(ReceiptState::TaskHandoffActorBound(handoff)) => {
+                    // A staged predecessor already owns a certified terminal. Completing it
+                    // here would retire the receipt through the unstaged witness and drop
+                    // that evidence, so refuse and leave it to complete_staged_task_handoff.
+                    if matches!(
+                        handoff.terminal_stage(),
+                        HandoffTerminalStage::Staged { .. }
+                    ) {
+                        return Err(ReceiptLedgerError::ReceiptRowPresentUnsupported);
+                    }
+                    (
+                        handoff.link().clone(),
+                        handoff.task().clone(),
+                        handoff.phase(),
+                        handoff.cancel_requested(),
+                    )
+                }
                 Ok(_) => return Err(ReceiptLedgerError::ReceiptRowPresentUnsupported),
                 Err(error) => return latch_catalog_error(&mut catalog, error),
             };

--- a/crates/unica-coder/src/infrastructure/receipt_ledger/records.rs
+++ b/crates/unica-coder/src/infrastructure/receipt_ledger/records.rs
@@ -311,6 +311,7 @@ pub(super) fn build_completed_task_handoff_deletion_record(
             workspace_identity_hash,
             task_link_digest,
             phase,
+            terminal_stage: StoredHandoffTerminalStageV1::NoTerminal,
             ..
         } => (
             *created_at_epoch_ms,
@@ -319,11 +320,9 @@ pub(super) fn build_completed_task_handoff_deletion_record(
             task_link_digest.clone(),
             *phase,
         ),
-        _ => {
-            return Err(ReceiptLedgerError::Corrupt(
-                "completed handoff deletion witness requires an actor-bound Task predecessor",
-            ))
-        }
+        _ => return Err(ReceiptLedgerError::Corrupt(
+            "completed handoff deletion witness requires an unstaged actor-bound Task predecessor",
+        )),
     };
     let record_version =
         expected

--- a/crates/unica-coder/tests/daemon_receipt_ledger.rs
+++ b/crates/unica-coder/tests/daemon_receipt_ledger.rs
@@ -233,6 +233,9 @@ enum Action {
     AttemptTaskStoreBindUnderGate {
         label: String,
     },
+    AttemptUnstagedTaskBindAgainstStagedTerminal {
+        label: String,
+    },
     ContinueReceiptOwnedAttempt {
         terminal: TerminalFixture,
         label: String,
@@ -1695,6 +1698,7 @@ enum OperationEventState {
     Spawned,
     Blocked,
     Completed,
+    Refused,
     Joined,
 }
 
@@ -3974,6 +3978,7 @@ fn assert_report_raw_bounds(report: &ScenarioReport) {
             OperationEventState::Spawned
             | OperationEventState::Blocked
             | OperationEventState::Completed
+            | OperationEventState::Refused
             | OperationEventState::Joined => {}
         }
     }
@@ -11975,6 +11980,54 @@ fn link_capacity_before_begun_terminalizes_receipt_backed_without_callback() {
     assert_eq!(
         count_event(&report, EventKind::TaskLinkReservationReleased),
         0
+    );
+}
+
+#[test]
+fn unstaged_task_bind_is_refused_against_a_staged_handoff_predecessor() {
+    let report = execute(Scenario::fake(vec![
+        Action::SeedReceipt {
+            state: SeedReceiptState::TaskHandoffActorBoundBegun,
+            cancel_requested: false,
+            staged_terminal: Some(success_payload()),
+        },
+        checkpoint_action("staged"),
+        Action::AttemptUnstagedTaskBindAgainstStagedTerminal {
+            label: "unstaged-bind".to_string(),
+        },
+        checkpoint_action("after-unstaged-bind"),
+    ]));
+
+    let staged = checkpoint(&report, "staged");
+    let staged_receipt = only_receipt(staged);
+    let staged_terminal = staged_receipt
+        .staged_terminal
+        .as_ref()
+        .expect("the fixture must stage a certified terminal on the handoff");
+    assert!(completed_result(staged_terminal).ok);
+
+    // The unstaged witness carries no staged evidence: retiring a staged predecessor
+    // through it would drop the certified terminal, so the ledger must refuse and leave
+    // the receipt for the staged completion.
+    assert_operation_trace(
+        &report,
+        "unstaged-bind",
+        &[OperationEventState::Spawned, OperationEventState::Refused],
+    );
+
+    let after = checkpoint(&report, "after-unstaged-bind");
+    let retained = only_receipt(after);
+    assert_eq!(retained.key, staged_receipt.key);
+    assert_eq!(
+        retained.state,
+        SeedReceiptState::TaskHandoffActorBoundBegun,
+        "a refused bind must not retire the receipt into a deletion witness"
+    );
+    assert_eq!(retained.staged_terminal.as_ref(), Some(staged_terminal));
+    assert_eq!(retained.version, staged_receipt.version);
+    assert_eq!(
+        after.receipt_store_mutations, staged.receipt_store_mutations,
+        "a refused bind must not mutate the durable receipt store"
     );
 }
 


### PR DESCRIPTION
Ревью CoderRabbit на #808 указало на два возможных дефекта в durable-валидации. Обе заявки — поведение, которое #808 только перенёс дословно, поэтому в тот PR они не входили. Проверил каждую против кода на `main`.

На момент разбора #808 ещё не был влит, и обе функции жили в монолитном `receipt_ledger.rs` — путей из ревью
(`receipt_ledger/catalog.rs`, `receipt_ledger/records.rs`) тогда не существовало; номера строк вызывающих (3666, 3791) при этом совпали.
С тех пор #808 влит, ветка перебазирована на разрез, и правки лежат по адресам из ревью: строитель — в
`receipt_ledger/records.rs`, валидатор пакета — в `receipt_ledger/catalog.rs`, входная точка осталась в `receipt_ledger.rs`.

## Заявка про intra-batch дубли — недостижима, правки нет

Описание кода верное: `validate_catalog_insert_batch` внутри пакета дедуплицирует только `mutation_sequence`, тогда как `validate_catalog_replace_batch` держит ещё и набор `digests`. Но у валидатора всего два вызывающих, и ни один не может подать дубль:

- `reserve_batch` — единственный продуктовый путь (через него идут и `submit_direct_batch_for_load`, и зонды засева пула) — **сам** ведёт `unique_digests`/`unique_invocations`/`unique_tasks` и отбивает совпадение как `ReceiptRowPresentUnsupported` **до** сборки entries;
- `seed_tombstones_for_test` закрыт `#[cfg(feature = "receipt-ledger-test-support")]`, а его единственный вызывающий `fill_tombstone_pool` чеканит `InvocationId::new()`/`TaskId::new()` на каждую запись.

Асимметрия объясняется тем же: у `transition_reserved_batch` дедупликация тоже своя, так что наборы в обоих валидаторах — второй рубеж, а не защита от достижимого дубля.

## Заявка про staged-предшественника — достижима, исправлена

По сути ревью право, но не по предлагаемому лечению.

Решает `CatalogEntry::state`: handoff со `Staged` отображается в **тот же** вариант `ReceiptState::TaskHandoffActorBound`, что и `NoTerminal`, а не в отдельный. Поэтому гейт в `complete_bound_task_handoff` его пропускал, остальные предусловия ступень не смотрят, а `materialize_bound_handoff` игнорирует `terminal_stage` вовсе — то есть подходящий `TaskBoundReceipt` строился без труда. Ординарная выдача ретировала квитанцию в свидетель `terminal_staged: false` и роняла заверенный терминал. Зеркальный `complete_staged_task_handoff` при этом давно отбивает `NoTerminal`; обратной проверки не было.

Перенаправить такого предшественника на `build_completed_staged_task_handoff_deletion_record`, как предлагает ревью, нельзя: у него другой свидетель — `TaskTerminalBoundReceipt` с epoch и digest, которого в ординарной точке просто нет. Поэтому правка — типизированный отказ, зеркальный сиблингу:

- `complete_bound_task_handoff` отбивает staged-предшественника тем же `ReceiptRowPresentUnsupported`, без защёлкивания каталога: вызывающий перечитает состояние и уйдёт на staged-путь;
- ветка `build_completed_task_handoff_deletion_record` сужена до `terminal_stage: NoTerminal` — по идиоме, уже принятой в `validate_persisted_reserved_record_bytes`.

## Тест

`unstaged_task_bind_is_refused_against_a_staged_handoff_predecessor` сеет staged-handoff, гонит ординарный bind и проверяет, что отказ получен, заверенный терминал уцелел, а версия и число мутаций хранилища не сдвинулись.

Достижимость подтверждена прогоном до правки — падал именно так:

```
assertion `left == right` failed: operation trace for unstaged-bind
  left: [Spawned, Completed]
 right: [Spawned, Refused]
```

то есть леджер **принимал** staged-предшественника на ординарном пути.

## Проверки

| Прогон | Итог |
|---|---|
| `daemon_receipt_ledger` (56 + новый) | 57 passed |
| `cargo nextest run --workspace` | 4431 passed (1 flaky — `bsl_session_replaces_reader_terminal_session`, не связан) |
| `cargo fmt --check`, `clippy --all-features --all-targets` | чисто |
| `tests/ci` + `tests/arch` | 985 passed, 5188 subtests |

## Реестр

Решения не требуется: правка восстанавливает симметрию, которую кодовая база уже объявила в staged-сиблинге, — это дефект, а не новый выбор. Стражи `arch/` зелёные. К `check:` существующего инварианта тест не привязывал: ни один из них в прозе не говорит про staged-свидетеля, а расширять нормативный текст — уже уровень решения.

## Находка по пути — снята

При разборе на дорезовой базе страж `scripts/ci/check-receipt-harness-boundary.py` читал только `receipt_scenario_v5.rs` и не видел писателей, уехавших в соседние файлы. В самом #808 это уже закрыто: страж читает каждый файл обвязки, незнакомый `.rs` рядом с обвязкой его роняет, а опись владельцев расширена. Инвариант `INV.TEST.LEDGER-HARNESS-OBSERVES` переписан под это. Отдельная правка не нужна.

Зонд из этого PR страж проходит: `complete_bound_task_handoff` в списке писателей не числится.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented task handoffs from being completed through the wrong workflow when a staged terminal is present.
  * Staged handoffs now remain intact when an incompatible completion attempt is refused.
  * Ensured receipt records are not modified after an invalid handoff completion attempt.

* **Tests**
  * Added coverage for rejected handoff completion attempts and preservation of staged receipt state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
