### PR TITLE
fix(ci): один ответ на вопрос, что считать тестом

### DIFF
--- a/scripts/ci/size-filters.py
+++ b/scripts/ci/size-filters.py
@@ -12,7 +12,8 @@
 имена тестов из `cargo nextest list --message-format json` (нужен `cargo`);
 страж размера в `tests/ci` читает то же выражение без `cargo` и проверяет, что
 каждый файл с процессом или сокетом в нём назван, а внутри терма названы все
-встроенные модули тестов этого файла.
+встроенные модули тестов этого файла. Что считать тестом, решает разбор в
+страже — здесь второго ответа на этот вопрос нет.
 """
 
 from __future__ import annotations
@@ -70,17 +71,17 @@ def declared(module: tuple[str, ...], sources: dict[tuple[str, ...], tuple[bool,
 
 
 def flagged_modules(root: Path) -> list[tuple[str, str, Path]]:
-    """(крейт, модуль, файл) файлов дерева с процессом или сокетом, в которых есть тесты.
+    """(крейт, модуль, файл) файлов дерева с процессом или сокетом.
 
-    Файл отдаётся вместе с модулем: страж размера разбирает его исходник, чтобы
-    сверить с термом встроенные модули тестов.
+    Есть ли в файле тесты, здесь не решается: файл отдаётся вместе с путём, а
+    ответ страж берёт из своего разбора. Регулярка на этом месте была второй
+    копией правила «что считать тестом» и расходилась со стражем — она не видела
+    `#[tokio::test]`, и такой файл выпадал из проверки целиком.
     """
     flagged = []
     for crate, modules in source_modules(root).items():
         for module, (marked, path) in modules.items():
-            text = path.read_text(encoding="utf-8", errors="replace")
-            # Тест — атрибут в начале строки; упоминание в строке или комментарии не в счёт.
-            if marked and re.search(r"^\s*#\[test\]", text, re.M) and declared(module, modules):
+            if marked and declared(module, modules):
                 flagged.append((crate, "::".join(module), path))
     return flagged
 

--- a/tests/ci/test_size_guard.py
+++ b/tests/ci/test_size_guard.py
@@ -9,6 +9,10 @@ Cargo. Выражение объявлено в `.config/nextest.toml` дваж�
 `mod *_tests` в уже помеченном файле меняет вывод генератора, и без второй
 проверки его тесты молча остаются в воротах `pr`.
 
+Что считать тестом, решает разбор ниже — один раз на обе глубины. Второй
+копии этого правила нет нигде: `flagged_modules` отдаёт все файлы с процессом
+или сокетом, а те, где тестов не нашлось, отсеиваются здесь.
+
 Вторая проверка читает исходники, а не `cargo`, поэтому тестов, порождённых
 макросом, она не видит — это та же цена, что страж уже платит за отказ от
 `cargo`; недосмотр безопасен, страж лишь недосчитается модуля. Обратная
@@ -23,6 +27,7 @@ import importlib.util
 import re
 import tomllib
 import unittest
+from functools import cache
 from pathlib import Path
 
 from tree_sitter import Language, Parser
@@ -87,6 +92,23 @@ def inline_test_modules(source: bytes) -> tuple[set[str], bool]:
     return modules, top_level
 
 
+@cache
+def flagged_sources() -> tuple[tuple[str, str, frozenset[str], bool], ...]:
+    """Помеченные файлы, в которых нашлись тесты: (крейт, модуль, модули, верхний уровень).
+
+    Файл без тестов пропускается: генератор не выпишет ему терм, объявлять
+    нечего. Разбор идёт один раз на обе проверки — их у стража две, а дерево
+    одно.
+    """
+    module = load_size_filters()
+    found = []
+    for crate, path, source in module.flagged_modules(REPO_ROOT):
+        modules, top_level = inline_test_modules(source.read_bytes())
+        if modules or top_level:
+            found.append((crate, path, frozenset(modules), top_level))
+    return tuple(found)
+
+
 class InlineTestModuleReadingTests(unittest.TestCase):
     """Разбор исходника закреплён: молча ослепший разбор снова обнулил бы стража."""
 
@@ -132,24 +154,21 @@ class SizeGuardTests(unittest.TestCase):
 
     def test_every_module_with_a_process_or_socket_is_declared_medium(self) -> None:
         """Файл с `std::process` или `std::net` не бывает `small` молча."""
-        module = load_size_filters()
         declared = set(re.findall(r"test\(/\^([A-Za-z0-9_:]+)::", self.medium))
 
-        for crate, path, _ in module.flagged_modules(REPO_ROOT):
+        for crate, path, _, _ in flagged_sources():
             with self.subTest(module=f"{crate}::{path}"):
                 self.assertIn(path, declared)
 
     def test_every_inline_test_module_is_named_in_its_term(self) -> None:
         """Новый `mod *_tests` в помеченном файле не уезжает в ворота `pr` молча."""
-        module = load_size_filters()
         enumerated: dict[str, set[str]] = {}
         for match in ENUMERATED_TERM.finditer(self.medium):
             enumerated.setdefault(match.group(1), set()).update(match.group(2).split("|"))
         direct = set(DIRECT_TERM.findall(self.medium))
         remedy = "перезапустите `python3 scripts/ci/size-filters.py --write`"
 
-        for crate, path, source in module.flagged_modules(REPO_ROOT):
-            modules, top_level = inline_test_modules(source.read_bytes())
+        for crate, path, modules, top_level in flagged_sources():
             with self.subTest(module=f"{crate}::{path}"):
                 self.assertEqual(
                     sorted(modules - enumerated.get(path, set())),


### PR DESCRIPTION
Closes #816.

## Что было не так

`flagged_modules` решал, брать ли файл в расчёт, своей регуляркой
`^\s*#\[test\]`. `#[tokio::test]` она не видит, поэтому файл с процессом, все
тесты которого объявлены так, выпадал из проверки **целиком** — не проверялось
ни то, что он назван в выражении, ни то, что в его терме перечислены встроенные
модули.

Вывод генератора при этом оставался верным: `medium_terms` идёт по списку тестов
от `cargo nextest list` и той регулярки не касается. Страдало только покрытие
стража — потребитель у `flagged_modules` ровно один, и это он.

## Почему регулярка убрана, а не расширена

Расширить было бы на один символьный класс, но тогда в репозитории осталось бы
**два** правила «что считать тестом»: узкое в генераторе и полное в страже. Их
расхождение и есть этот дефект. Страж и так разбирает те же файлы, поэтому
ответ теперь один и живёт в одном месте: `flagged_modules` отдаёт все файлы с
процессом или сокетом, а файлы без тестов отсеивает страж по своему разбору.

Побочно: разбор идёт один раз на обе проверки (`flagged_sources`), а не по разу
на каждую — время стража 12 → 6 с.

## Доказательство

Синтетический зонд: файл с `std::process::id()`, у которого единственный тест —
`#[tokio::test]` во встроенном модуле, вписанный в дерево модулей и не названный
в выражении.

| `flagged_modules` | итог |
| --- | --- |
| с этой правки | **падает**, обе проверки: `module='unica-coder::infrastructure::probe_tokio_only'` |
| версия с `origin/main` | **OK** — зонд проходит молча, это и есть дыра |

Зонд после прогона убран, дерево чистое.

## Что не сдвинулось

- **Охват — ни на файл**: 55 модулей до правки, 55 после; `пропало: []`,
  `добавилось: []`. `flagged_modules` теперь отдаёт 58 файлов, из них 55 с
  тестами — три файла без тестов страж корректно пропускает (генератор им терма
  не выпишет, объявлять нечего).
- **Вывод генератора** — `python3 scripts/ci/size-filters.py --write` после
  правки даёт пустой диф.
- **Старая регрессия ловится по-прежнему**: против `.config/nextest.toml` до
  #810 страж падает на `configuration_interface_tests`.

## Проверено локально

- `tests/ci` целиком — 871 тест, OK (11 skipped)
- `tests/arch` целиком — 127 тестов, OK
