### PR TITLE
fix(ci): корень крейта — за lib.rs, а не за main.rs

### DIFF
--- a/scripts/ci/size-filters.py
+++ b/scripts/ci/size-filters.py
@@ -38,8 +38,16 @@ TERM = re.compile(r"test\(/\^([A-Za-z0-9_:]+)::")
 
 
 def module_of(path: Path, src: Path) -> tuple[str, ...]:
+    """Модуль файла в дереве библиотеки; пустой кортеж — корень, и он за `lib.rs`.
+
+    `main.rs` — корень другой цели, двоичной, и делить пустой кортеж с `lib.rs`
+    ему нельзя: словарь модулей один на крейт, а `main.rs` идёт по сортировке
+    позже и затирал бы `lib.rs` со всеми объявлениями `mod ...;` в нём. Со своим
+    ключом файл остаётся виден `declared`, но термов не получает: `mod main;`
+    никто не объявляет, а размер считается только по целям `kind == "lib"`.
+    """
     parts = list(path.relative_to(src).with_suffix("").parts)
-    if parts[-1] in ("mod", "lib", "main"):
+    if parts[-1] in ("mod", "lib"):
         parts = parts[:-1]
     return tuple(parts)
 

--- a/tests/ci/test_size_guard.py
+++ b/tests/ci/test_size_guard.py
@@ -152,6 +152,24 @@ class SizeGuardTests(unittest.TestCase):
         self.assertEqual(self.deadline["slow-timeout"], {"period": "300s", "terminate-after": 2})
         self.assertTrue(self.medium.startswith("kind(test)"))
 
+    def test_crate_root_belongs_to_lib_and_main_is_not_lost(self) -> None:
+        """Корень крейта — за `lib.rs`, и `main.rs` не пропадает из разбора.
+
+        Один ключ на оба корня стоил бы `declared` всех объявлений `mod ...;`,
+        живущих в `lib.rs`, а стражу — модулей, объявленных только там.
+        """
+        module = load_size_filters()
+
+        for crate, modules in module.source_modules(REPO_ROOT).items():
+            src = REPO_ROOT / "crates" / crate / "src"
+            paths = {path for _, path in modules.values()}
+            if (src / "lib.rs").exists():
+                with self.subTest(crate=crate, root="lib.rs"):
+                    self.assertEqual(modules[()][1], src / "lib.rs")
+            if (src / "main.rs").exists():
+                with self.subTest(crate=crate, root="main.rs"):
+                    self.assertIn(src / "main.rs", paths)
+
     def test_every_module_with_a_process_or_socket_is_declared_medium(self) -> None:
         """Файл с `std::process` или `std::net` не бывает `small` молча."""
         declared = set(re.findall(r"test\(/\^([A-Za-z0-9_:]+)::", self.medium))


### PR DESCRIPTION
Closes #820.

## Что было не так

`module_of` срезал хвост `main` наравне с `lib` и `mod`, поэтому оба корня
крейта получали пустой кортеж. Словарь модулей один на крейт, обход идёт по
`sorted(...)`, `main.rs` стоит позже `lib.rs` — и затирал его целиком.

Бил не по генератору, а по `declared`: он ищет `mod ...;` по файлам того же
словаря, то есть уже без `lib.rs`. Модуль, объявленный только там, в дерево не
входил, в `flagged_modules` не попадал и стражем **не проверялся ни на одной из
двух глубин**.

## Правка

Хвост `main` больше не срезается. Файл остаётся в разборе со своим ключом,
поэтому `declared` по-прежнему видит его содержимое, но термов он не получает:
`mod main;` никто не объявляет, а размер считается только по целям
`kind == "lib"` — тесты двоичной цели терма и не должны получать.

Почему именно так, записано в докстроке `module_of`: без неё «восстановление
симметрии» вернёт дефект.

## Счёт сошёлся

Критерий приёмки из задачи выполнен:

| | до | после |
| --- | --- | --- |
| названо термами | 58 | 58 |
| проверяет страж | 55 | **58** |
| названо, но не проверяется | `application`, `composition`, `download` | пусто |
| проверяется, но не названо | пусто | пусто |

## Инвариант закреплён тестом

`test_crate_root_belongs_to_lib_and_main_is_not_lost`: корень крейта
принадлежит `lib.rs`, а `main.rs` из разбора не пропадает. Против версии
`module_of` до правки тест падает на обоих крейтах с двумя корнями:

```
FAIL (crate='unica-bootstrap', root='lib.rs'): …/src/main.rs != …/src/lib.rs
FAIL (crate='unica-coder',     root='lib.rs'): …/src/main.rs != …/src/lib.rs
```

Тест намеренно узкий — он запирает именно этот дефект. Более широкий инвариант
«всё названное проверяется» я не стал закреплять: он законно ломается на тестах
из макросов, которые разбор не видит по документированной причине.

## Проверено локально

- `tests/ci` целиком — 884 теста, OK (11 skipped)
- `tests/arch` целиком — 132 теста, OK
- `python3 scripts/ci/size-filters.py --write` — **пустой диф**: вывод
  генератора не изменился, хотя `module_of` питает и его
