### PR TITLE
docs(skills): подсистема создаётся через apply, родителя называет адрес

### DIFF
--- a/plugins/unica/skills/subsystem-compile/SKILL.md
+++ b/plugins/unica/skills/subsystem-compile/SKILL.md
@@ -1,68 +1,46 @@
 ---
 name: subsystem-compile
-description: Создать подсистему 1С — XML-исходники из JSON-определения. Используй когда нужно добавить подсистему (раздел) в конфигурацию
-argument-hint: "[-DefinitionFile <json> | -Value <json-string>] -OutputDir <ConfigDir> [-Parent <path>]"
+description: Создать подсистему 1С — XML-исходники из типизированного определения. Используй когда нужно добавить подсистему (раздел) в конфигурацию
+argument-hint: <at> <name> [content]
 allowed-tools:
-  - Bash
   - Read
-  - Write
   - Glob
 ---
 
-# /subsystem-compile — генерация подсистемы из JSON
+# /subsystem-compile — создание подсистемы
 
 ## MCP routing
 
-- Preferred path: use MCP `unica` tool `unica.subsystem.compile`; `unica` owns XML/JSON DSL work and refreshes related workspace caches after mutations.
-- Do not call internal MCP/CLI adapters directly. They are hidden behind `unica` and synchronized by the orchestrator.
-- Execution path: call MCP `unica` tool `unica.subsystem.compile`; skill-local operation scripts are not part of the workflow.
-- For mutating operations, pass `dryRun: false` only when the user explicitly requested the change; otherwise keep the default dry run.
-- Vendor support guard runs inside `unica`; if it blocks a locked/read-only supported object, prefer CFE/release-support or an explicit support-state change plan instead of editing raw support metadata.
+- Preferred path: use MCP `unica` tool `unica.apply` с операциями
+  `subsystem.create`, `props.set` и `content.add`.
+- Do not call internal MCP/CLI adapters directly. They are hidden behind
+  `unica` and synchronized by the orchestrator.
+- Всегда сначала `dryRun: true`. Применяй `dryRun: false` только когда
+  пользователь явно попросил внести именно эту правку, и только с `ifRev` из
+  предпросмотра.
+- Проверка поддержки поставщика работает внутри `unica`.
 
-Принимает JSON-определение подсистемы → генерирует XML + файловую структуру + регистрирует в родителе (Configuration.xml или родительская подсистема).
+**Куда метит создание.** Подсистемы верхнего уровня — `args.at` вида
+`<набор>:Configuration`. Вложенной подсистемы — адрес родителя
+`<набор>:Subsystem.<Родитель>`. Имя новой подсистемы лежит в `values.name`:
+адреса, которого ещё нет, назвать нельзя. Каталогов выгрузки и путей к XML
+родителя тут нет — их место занял адрес.
 
-## MCP параметры
+Создание заводит и файл подсистемы, и запись о ней у родителя. Это одна
+правка, а не две.
 
-| Параметр | Описание |
-|----------|----------|
-| `DefinitionFile` | Путь к JSON-файлу определения |
-| `Value` | Инлайн JSON-строка (альтернатива DefinitionFile) |
-| `OutputDir` | Корень выгрузки (где `Subsystems/`, `Configuration.xml`) |
-| `Parent` | Путь к XML родительской подсистемы (для вложенных) |
-| `NoValidate` | Скрыть подробный отчёт авто-валидации; обязательная проверка корректности 8.3.27 перед фиксацией остаётся включённой |
+## Что задаётся чем
 
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "tools/call",
-  "params": {
-    "name": "unica.subsystem.compile",
-    "arguments": {
-      "cwd": "<workspace>",
-      "Value": "{\"name\":\"Продажи\",\"synonym\":\"Продажи\",\"content\":[\"Catalog.Номенклатура\"]}",
-      "OutputDir": "src",
-      "dryRun": false
-    }
-  }
-}
-```
+| Что | Операция | `args` |
+|---|---|---|
+| Сама подсистема | `subsystem.create` | `values: {name}` |
+| Синоним, комментарий, пояснение, картинка, `IncludeInCommandInterface`, `UseOneCommand` | `props.set` | `values: {…}` |
+| Состав | `content.add` | `items: [{object}]` |
 
-## JSON-определение
+Минимально нужно только имя. Всё остальное — умолчания платформы.
 
-```json
-{
-  "name": "МояПодсистема",
-  "synonym": "Моя подсистема",
-  "comment": "",
-  "includeInCommandInterface": true,
-  "useOneCommand": false,
-  "explanation": "Описание раздела",
-  "picture": "CommonPicture.МояКартинка",
-  "content": ["Catalog.Товары", "Document.Заказ"]
-}
-```
-
-Минимально: только `name`. Остальное — дефолты.
+Операции одного вызова публикуются одной транзакцией: подсистема со своим
+составом и свойствами появляется целиком либо не появляется вовсе.
 
 ## Примеры
 
@@ -73,30 +51,63 @@ allowed-tools:
   "jsonrpc": "2.0",
   "method": "tools/call",
   "params": {
-    "name": "unica.subsystem.compile",
+    "name": "unica.apply",
     "arguments": {
-      "cwd": "<workspace>",
-      "Value": "{\"name\":\"Тест\"}",
-      "OutputDir": "config/",
-      "dryRun": false
+      "at": "main:Configuration",
+      "ops": [
+        {
+          "op": "subsystem.create",
+          "args": {
+            "at": "main:Configuration",
+            "values": {"name": "Тест"}
+          }
+        }
+      ],
+      "dryRun": true
     }
   }
 }
 ```
 
-### С составом и картинкой
+### С составом и свойствами
 
 ```json
 {
   "jsonrpc": "2.0",
   "method": "tools/call",
   "params": {
-    "name": "unica.subsystem.compile",
+    "name": "unica.apply",
     "arguments": {
-      "cwd": "<workspace>",
-      "Value": "{\"name\":\"Продажи\",\"content\":[\"Catalog.Товары\",\"Report.Продажи\"],\"picture\":\"CommonPicture.Продажи\"}",
-      "OutputDir": "config/",
-      "dryRun": false
+      "at": "main:Configuration",
+      "ops": [
+        {
+          "op": "subsystem.create",
+          "args": {
+            "at": "main:Configuration",
+            "values": {"name": "Продажи"}
+          }
+        },
+        {
+          "op": "props.set",
+          "args": {
+            "at": "main:Subsystem.Продажи",
+            "values": {
+              "Synonym": "Продажи",
+              "Picture": "CommonPicture.Продажи",
+              "IncludeInCommandInterface": true
+            }
+          }
+        },
+        {
+          "op": "content.add",
+          "args": {
+            "at": "main:Subsystem.Продажи",
+            "items": [{"object": "Catalog.Товары"}, {"object": "Report.Продажи"}]
+          }
+        }
+      ],
+      "dryRun": false,
+      "ifRev": "<rev из предпросмотра>"
     }
   }
 }
@@ -104,18 +115,26 @@ allowed-tools:
 
 ### Вложенная подсистема
 
+Родителя называет адрес, а не путь к его XML.
+
 ```json
 {
   "jsonrpc": "2.0",
   "method": "tools/call",
   "params": {
-    "name": "unica.subsystem.compile",
+    "name": "unica.apply",
     "arguments": {
-      "cwd": "<workspace>",
-      "Value": "{\"name\":\"Дочерняя\"}",
-      "OutputDir": "config/",
-      "Parent": "config/Subsystems/Продажи.xml",
-      "dryRun": false
+      "at": "main:Subsystem.Продажи",
+      "ops": [
+        {
+          "op": "childSubsystem.add",
+          "args": {
+            "at": "main:Subsystem.Продажи",
+            "items": [{"name": "Дочерняя"}]
+          }
+        }
+      ],
+      "dryRun": true
     }
   }
 }

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -360,7 +360,7 @@ IN_SCOPE_TOOLS = {
     "form-compile": "unica.form.compile",
     "form-edit": "unica.form.edit",
     "interface-edit": "unica.interface.edit",
-    "subsystem-compile": "unica.subsystem.compile",
+    "subsystem-compile": "unica.apply",
     "subsystem-edit": "unica.apply",
     "dcs-compile": "unica.dcs.compile",
     "dcs-edit": "unica.dcs.edit",
@@ -788,7 +788,7 @@ TASK_EXAMPLE_ARGUMENT_KEYS = {
     "form-compile": ["JsonPath", "OutputPath"],
     "form-edit": ["FormPath", "JsonPath"],
     "interface-edit": ["CIPath", "Operation", "Value"],
-    "subsystem-compile": ["Value", "OutputDir"],
+    "subsystem-compile": ["at", "ops"],
     "subsystem-edit": ["at", "ops"],
     "dcs-compile": ["DefinitionFile", "OutputPath"],
     "dcs-edit": ["TemplatePath", "Operation", "Value"],
@@ -811,7 +811,7 @@ SCENARIO_PRESERVING_MIN_MCP_CALLS = {
     "meta-info": 6,
     "form-compile": 4,
     "interface-edit": 8,
-    "subsystem-compile": 4,
+    "subsystem-compile": 3,
     "subsystem-edit": 2,
     "dcs-compile": 5,
     "mxl-info": 3,
@@ -918,10 +918,12 @@ SCENARIO_PRESERVING_TOKENS = {
         '"CreateIfMissing": true',
         '"name": "unica.check"',
     ],
+    # Определение стало типизированными операциями, а родитель — адресом:
+    # JSON-строки внутри JSON и путей к XML на канонической поверхности нет.
     "subsystem-compile": [
-        '"Value": "{\\"name\\":\\"Тест\\"}"',
+        '"op": "subsystem.create"',
         'CommonPicture.Продажи',
-        '"Parent": "config/Subsystems/Продажи.xml"',
+        '"at": "main:Subsystem.Продажи"',
     ],
     # Операция стала именем операции, а не значением поля `Operation`.
     "subsystem-edit": [


### PR DESCRIPTION
Продолжение волны 2 зонтика #717 — и одна проверка, которая вычеркнула скилл из списка переводимых.

## Что сделано

`subsystem-compile` переведён с `unica.subsystem.compile` на `unica.apply` с операциями `subsystem.create`, `props.set` и `content.add`.

Ушли три вещи разом:

| Было | Стало |
|---|---|
| `Value: "{\"name\":\"Продажи\",\"content\":[…]}"` — JSON строкой внутри JSON | типизированные операции одного пакета |
| `OutputDir: "config/"` | внутренняя деталь |
| `Parent: "config/Subsystems/Продажи.xml"` | адрес `main:Subsystem.Продажи` |

Создание метит в корень конфигурации либо в адрес родителя: имя новой подсистемы лежит в `values.name`, потому что адреса, которого ещё нет, назвать нельзя.

## `interface-edit` перевести нельзя

Он входил в мой список семнадцати, потому что не зовёт имён половины `run`. Проверка реестра показала другое: **канонической операции для командного интерфейса нет вовсе**. В `apply` есть `command.add`, `command.set`, `command.remove` — это команды объекта, а не видимость, размещение и порядок в `CommandInterface.xml`. Единственное упоминание `CommandInterface.xml` в семействах — цепочка инвалидации, то есть какие файлы затронуты правкой, а не писатель.

Так что `interface-edit` стоит рядом с `code.graph`: дом назван проектом, но не наполнен. Переводимых остаётся шестнадцать.

## Проверки

- `tests/ci` — 884 прошло


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the subsystem compilation workflow to use address-based operations through the unified apply interface.
  * Revised setup guidance, parameter descriptions, examples, validation behavior, and dry-run/revision controls.
  * Replaced file-based and JSON payload examples with typed operation examples.

* **Tests**
  * Updated validation checks to reflect the new subsystem compilation workflow and operation syntax.
  * Updated the reference validation process to use the Python-based implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->