### PR TITLE
docs(skills): роль создаётся через apply, пресет разворачивает скилл

### DIFF
--- a/plugins/unica/skills/role-compile/SKILL.md
+++ b/plugins/unica/skills/role-compile/SKILL.md
@@ -13,38 +13,37 @@ allowed-tools:
 
 ## MCP routing
 
-- Preferred path: use MCP `unica` tool `unica.role.compile`; `unica` owns XML/JSON DSL work and refreshes related workspace caches after mutations.
-- Do not call internal MCP/CLI adapters directly. They are hidden behind `unica` and synchronized by the orchestrator.
-- Execution path: call MCP `unica` tool `unica.role.compile`; skill-local operation scripts are not part of the workflow.
-- For mutating operations, pass `dryRun: false` only when the user explicitly requested the change; otherwise keep the default dry run.
-- Vendor support guard runs inside `unica`; if it blocks a locked/read-only supported object, prefer CFE/release-support or an explicit support-state change plan instead of editing raw support metadata.
+- Preferred path: use MCP `unica` tool `unica.apply` с операциями
+  `role.create` и `right.set`.
+- Do not call internal MCP/CLI adapters directly. They are hidden behind
+  `unica` and synchronized by the orchestrator.
+- **Создание метит в корень конфигурации:** `args.at` — это
+  `<набор>:Configuration`, имя роли лежит в `values.name`. Адреса, которого
+  ещё нет, назвать нельзя. Дальнейшие права метят уже в саму роль.
+- Всегда сначала `dryRun: true`. Применяй `dryRun: false` только когда
+  пользователь явно попросил внести именно эту правку, и только с `ifRev` из
+  предпросмотра.
+- Роль и все её права публикуются одной транзакцией: либо роль появляется
+  настроенной, либо не появляется вовсе.
+- Каталогов выгрузки и путей к `Rights.xml` тут нет — их место занял адрес.
 
-Принимает JSON-определение роли → генерирует `Roles/Имя.xml` (метаданные) и `Roles/Имя/Ext/Rights.xml` (права). UUID автоматически.
+### Пресеты разворачивает скилл, а не инструмент
 
-## MCP параметры
+`right.set` принимает одно право: `values` с `object`, `right` и хотя бы одним
+из `value` и `rls`. Пресета `@view` инструмент не знает — разверни его сам по
+таблице ниже в набор операций. Так видно, какие именно права выданы, и
+предпросмотр показывает их поимённо, а не имя пресета.
 
-| Параметр | Описание |
-|----------|----------|
-| `JsonPath` | Путь к JSON-определению роли |
-| `OutputDir` | Корень выгрузки конфигурации (где `Configuration.xml`, `Roles/` и т.д.) |
+Объект, ещё не перечисленный в роли, добавляется сам: заводить его отдельно не
+нужно.
 
-```json
-{
-  "jsonrpc": "2.0",
-  "method": "tools/call",
-  "params": {
-    "name": "unica.role.compile",
-    "arguments": {
-      "cwd": "<workspace>",
-      "JsonPath": "roles/read-products.json",
-      "OutputDir": "src",
-      "dryRun": false
-    }
-  }
-}
-```
+### Чего на канонической поверхности нет
 
-Создаёт `{OutputDir}/Roles/Имя.xml` и `{OutputDir}/Roles/Имя/Ext/Rights.xml`. Регистрирует `<Role>` в `Configuration.xml`.
+**Шаблоны RLS.** Операции, создающей `restrictionTemplate`, в реестре нет.
+`right.set` их сохраняет — существующие шаблоны при правке прав не страдают, —
+но объявить новый нечем. Условие ограничения пиши прямо в `values.rls`; если
+нужен именно переиспользуемый шаблон, скажи о пробеле контракта, а не
+подставляй ссылку на шаблон, которого не создашь.
 
 ## JSON DSL
 
@@ -121,6 +120,88 @@ allowed-tools:
 
 Подробные таблицы пресетов, русских синонимов и дополнительные примеры — в `dsl-reference.md`.
 
+## Порядок
+
+1. Имя набора: `unica.view {}`.
+2. Разверни пресеты в явные права по таблице выше.
+3. Предпросмотр: `unica.apply` с `dryRun: true`, `at` в корень конфигурации.
+4. Применение: тот же вызов с `dryRun: false` и `ifRev` из предпросмотра.
+5. Проверка: `unica.check {at}` уже по адресу роли.
+
+## Примеры вызова
+
+### Роль с правами одним пакетом
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "unica.apply",
+    "arguments": {
+      "at": "main:Configuration",
+      "ops": [
+        {
+          "op": "role.create",
+          "args": {
+            "at": "main:Configuration",
+            "values": {"name": "ЧтениеНоменклатуры"}
+          }
+        },
+        {
+          "op": "right.set",
+          "args": {
+            "at": "main:Role.ЧтениеНоменклатуры",
+            "values": {"object": "Catalog.Номенклатура", "right": "Read", "value": true}
+          }
+        },
+        {
+          "op": "right.set",
+          "args": {
+            "at": "main:Role.ЧтениеНоменклатуры",
+            "values": {"object": "Catalog.Номенклатура", "right": "View", "value": true}
+          }
+        }
+      ],
+      "dryRun": true
+    }
+  }
+}
+```
+
+### Право с ограничением записей
+
+Условие пишется прямо в `values.rls`: шаблон объявить нечем.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "unica.apply",
+    "arguments": {
+      "at": "main:Role.ЧтениеПоОрганизации",
+      "ops": [
+        {
+          "op": "right.set",
+          "args": {
+            "at": "main:Role.ЧтениеПоОрганизации",
+            "values": {
+              "object": "Document.РеализацияТоваровУслуг",
+              "right": "Read",
+              "value": true,
+              "rls": "ГДЕ Организация = &ТекущаяОрганизация"
+            }
+          }
+        }
+      ],
+      "dryRun": false,
+      "ifRev": "<rev из предпросмотра>"
+    }
+  }
+}
+```
+
 ## Верификация
 
 ### Проверка корректности XML, прав и RLS
@@ -132,7 +213,7 @@ allowed-tools:
   "params": {
     "name": "unica.check",
     "arguments": {
-      "at": "<sourceSet>:Role.<Name>"
+      "at": "<набор>:Role.<ИмяРоли>"
     }
   }
 }
@@ -147,7 +228,6 @@ allowed-tools:
   "params": {
     "name": "unica.view",
     "arguments": {
-      "cwd": "<workspace>",
       "at": "<набор>:Role.<ИмяРоли>"
     }
   }

--- a/tests/ci/test_unica_skills.py
+++ b/tests/ci/test_unica_skills.py
@@ -367,7 +367,7 @@ IN_SCOPE_TOOLS = {
     "mxl-compile": "unica.mxl.compile",
     "mxl-decompile": "unica.mxl.decompile",
     "mxl-info": "unica.view",
-    "role-compile": "unica.role.compile",
+    "role-compile": "unica.apply",
     "role-edit": "unica.apply",
 }
 
@@ -796,7 +796,7 @@ TASK_EXAMPLE_ARGUMENT_KEYS = {
     "mxl-decompile": ["TemplatePath"],
     # Читающий макет адресуется логически: файлового селектора у `view` нет.
     "mxl-info": ["at"],
-    "role-compile": ["JsonPath", "OutputDir"],
+    "role-compile": ["at", "ops"],
     "role-edit": ["at", "ops"],
 }
 
@@ -817,7 +817,7 @@ SCENARIO_PRESERVING_MIN_MCP_CALLS = {
     "mxl-info": 3,
     "role-edit": 1,
     "dcs-edit": 4,
-    "role-compile": 3,
+    "role-compile": 4,
 }
 
 ALLOWED_ADDITIONAL_MCP_TOOL_NAMES = {
@@ -932,9 +932,14 @@ SCENARIO_PRESERVING_TOKENS = {
         '"op": "childSubsystem.add"',
         '"op": "props.set"',
     ],
+    # Пресет разворачивает скилл: инструмент принимает одно право за
+    # операцию, и предпросмотр показывает их поимённо, а не имя пресета.
     "role-compile": [
+        '"op": "role.create"',
+        '"op": "right.set"',
         '"name": "unica.check"',
         '"name": "unica.view"',
+        "Шаблоны RLS",
     ],
     "dcs-compile": [
         '"DefinitionFile": "<json>"',


### PR DESCRIPTION
Продолжение волны 2 зонтика #717.

## Что сделано

`role-compile` переведён с `unica.role.compile` на `unica.apply` с операциями `role.create` и `right.set`.

| Было | Стало |
|---|---|
| `JsonPath` + `OutputDir` | адрес: создание метит в `main:Configuration`, права — в `main:Role.<Имя>` |
| одно определение JSON | пакет операций одной транзакции |
| пресет `@view` разворачивал инструмент | разворачивает скилл |

**Пресет разворачивает скилл, а не инструмент.** `right.set` принимает одно право за операцию. Это дороже в написании и честнее в чтении: видно, какие именно права выданы, и предпросмотр показывает их поимённо, а не имя пресета. Таблица пресетов и русских синонимов остаётся в скилле — она и была прозой.

Объект, ещё не перечисленный в роли, `right.set` добавляет сам.

## Найденный пробел: шаблоны RLS

Операции, создающей `restrictionTemplate`, в реестре `apply` **нет**. Проверено по коду: `right.set` существующие шаблоны сохраняет — вставляет объект перед ними, — но объявить новый нечем.

Скилл говорит это прямо: условие ограничения пиши в `values.rls`; если нужен именно переиспользуемый шаблон, сообщи о пробеле контракта, а не подставляй ссылку на шаблон, которого не создашь.

Это третий предмет с тем же диагнозом после `code.graph` и командного интерфейса: дом назван проектом и не наполнен. Первые два уже разведены — командный интерфейс закрыт целиком в #825→#831.

## Проверки

- `tests/ci` — 890 прошло
