### PR TITLE
fix(run): отказ платформы зовёт человека, а не сообщает тупик

### DIFF
--- a/crates/unica-coder/src/infrastructure/daemon/v13_infobase_exports.rs
+++ b/crates/unica-coder/src/infrastructure/daemon/v13_infobase_exports.rs
@@ -737,14 +737,48 @@ fn parse_runner_output(
     Ok(envelope)
 }
 
+/// Полный словарь кодов, которые раннер кладёт в `error.code`.
+///
+/// Он закрытый и короткий: девять значений из `cli_error_contract` раннера, одни и те
+/// же у CLI и у его MCP-поверхности. Набор существует только для стража ниже: в
+/// продуктовом пути отображение обязано иметь запасную ветку на случай кода, которого
+/// мы ещё не знаем, поэтому сам список ему не нужен.
+#[cfg(test)]
+const RUNNER_WIRE_CODES: [&str; 9] = [
+    "capability_unavailable",
+    "cancelled",
+    "environment_unavailable",
+    "invalid_argument",
+    "invalid_output",
+    "platform_failure",
+    "runtime_failure",
+    "timed_out",
+    "workspace_busy",
+];
+
+/// Отображает код раннера в наш отказ, а значит и в исход для агента.
+///
+/// **Платформа отказала — это «нужен человек», и дальше мы не разбираем.** Отказ
+/// авторизации, отсутствие права и отсутствие лицензии приходят от платформы одним
+/// `platform_failure`, и различать их Unica не должна: ни один из трёх не решается
+/// ни повтором, ни правкой вызова — нужен человек. Поэтому прав мы заранее не
+/// проверяем: факта отказа платформы достаточно.
 fn map_runner_code(code: &str) -> RefusalCode {
     match code {
-        "environment_unavailable" | "platform_error" | "provider_unavailable" => {
-            RefusalCode::ProviderUnavailable
-        }
-        "workspace_busy" | "concurrent_change" => RefusalCode::ConcurrentChange,
-        "validation_error" | "invalid_argument" | "invalid_output" => RefusalCode::BadValue,
-        "timeout" | "deadline_exceeded" => RefusalCode::DeadlineExceeded,
+        // Платформа сказала нет: авторизация, права, лицензия, занятая база.
+        "platform_failure" => RefusalCode::ProviderUnavailable,
+        // Бинарник, версия или соединение не готовы.
+        "environment_unavailable" => RefusalCode::ProviderUnavailable,
+        // У раннера нет адаптера под эту операцию: повторять и править вызов незачем.
+        "capability_unavailable" => RefusalCode::UnsupportedOperation,
+        "workspace_busy" => RefusalCode::ConcurrentChange,
+        "invalid_argument" => RefusalCode::BadValue,
+        // Раннер отдал негодный результат: аргументы вызывающего тут не виноваты.
+        "invalid_output" => RefusalCode::InvalidResult,
+        "timed_out" => RefusalCode::DeadlineExceeded,
+        "cancelled" => RefusalCode::Cancelled,
+        // Неклассифицированный сбой самого раннера.
+        "runtime_failure" => RefusalCode::ProviderFailed,
         _ => RefusalCode::ProviderFailed,
     }
 }
@@ -1050,9 +1084,70 @@ fn reject(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::refusal::Outcome;
     use crate::infrastructure::internal_adapters::ProcessOutput;
     use std::fs;
     use std::sync::Mutex;
+
+    /// Страж отображения кодов раннера.
+    ///
+    /// Корень прежнего дефекта: карта перечисляла имена, которых раннер не пишет
+    /// (`platform_error`, `validation_error`, `timeout`), а его настоящие имена
+    /// (`platform_failure`, `timed_out`) в неё не попадали и уходили в запасную ветку.
+    /// Владелец словаря один — [`RUNNER_WIRE_CODES`]; если раннер добавит код, этот
+    /// тест покажет его, а не запасная ветка молча.
+    #[test]
+    fn every_runner_wire_code_maps_away_from_the_fallback() {
+        for code in RUNNER_WIRE_CODES {
+            let mapped = map_runner_code(code);
+            if code == "runtime_failure" {
+                // Единственный код, для которого запасной отказ и есть верный ответ.
+                assert_eq!(mapped, RefusalCode::ProviderFailed, "{code}");
+                continue;
+            }
+            assert_ne!(
+                mapped,
+                RefusalCode::ProviderFailed,
+                "{code} uses the fallback refusal"
+            );
+        }
+    }
+
+    /// Отказ платформы — авторизация, права, лицензия — обязан звать человека.
+    ///
+    /// Исход `DeadEnd` здесь самый дорогой из возможных: агент бросает работу там, где
+    /// хватило бы одной фразы пользователю — дать пароль, выдать право, поставить
+    /// лицензию.
+    #[test]
+    fn a_platform_refusal_asks_for_a_human_rather_than_reporting_a_dead_end() {
+        let mapped = map_runner_code("platform_failure");
+
+        assert_eq!(mapped, RefusalCode::ProviderUnavailable);
+        assert_eq!(mapped.outcome(), Outcome::NeedsHuman);
+    }
+
+    #[test]
+    fn runner_outcomes_follow_the_codes_rather_than_the_fallback() {
+        for (code, expected) in [
+            ("environment_unavailable", Outcome::NeedsHuman),
+            ("capability_unavailable", Outcome::GoElsewhere),
+            ("workspace_busy", Outcome::RetryAsIs),
+            ("timed_out", Outcome::RetryAsIs),
+            ("invalid_argument", Outcome::FixCall),
+            ("invalid_output", Outcome::DeadEnd),
+            ("cancelled", Outcome::DeadEnd),
+        ] {
+            assert_eq!(map_runner_code(code).outcome(), expected, "{code}");
+        }
+    }
+
+    #[test]
+    fn an_unknown_runner_code_stays_on_the_fallback() {
+        assert_eq!(
+            map_runner_code("something-the-runner-never-wrote"),
+            RefusalCode::ProviderFailed
+        );
+    }
 
     struct SequenceRunner {
         outputs: Mutex<Vec<ProcessOutput>>,


### PR DESCRIPTION
## Дефект

Решение по трём отказам платформы — **ошибка авторизации, нет прав, нет лицензии** — одно: это всё «нужен человек», Unica их не разбирает, и заранее проверять права не надо: достаточно факта, что отказ от платформы пришёл.

Проверка показала, что до агента этот отказ доходил **не тем исходом**. Полный словарь кодов раннера — девять имён из его `cli_error_contract`, одинаковых у CLI и у MCP:

```
capability_unavailable  environment_unavailable  workspace_busy  invalid_output
cancelled  timed_out  invalid_argument  runtime_failure  platform_failure
```

Карта `map_runner_code` перечисляла `platform_error`, `validation_error`, `timeout`, `provider_unavailable`, `concurrent_change`, `deadline_exceeded` — **ни одного из них раннер не пишет**. А его настоящие имена в карту не попадали и уходили в запасную ветку `_ => ProviderFailed`.

| код раннера | было | стало |
|---|---|---|
| `platform_failure` — авторизация, права, лицензия, занятая база | **тупик** | **нужен человек** |
| `timed_out` | тупик | повторить как есть |
| `capability_unavailable` | тупик | пойти иначе |
| `invalid_output` | исправить вызов | тупик |
| `cancelled` | тупик кодом `provider_failed` | тупик кодом `cancelled` |

Дороже всего обходилась первая строка, и ровно про неё сказано в зонтике: «дороже всего обходится „нужен человек“: агент бросает работу там, где хватило бы одной фразы пользователю». Дать пароль, выдать право, поставить лицензию — каждое из трёх решается одной фразой, а агент получал «тупик, делать нечего».

## Что изменено

- `platform_failure` и `environment_unavailable` → `provider_unavailable` → **нужен человек**;
- `capability_unavailable` → `unsupported_operation` → пойти иначе: адаптера нет, повторять и править вызов незачем;
- `invalid_output` → `invalid_result` → тупик: раннер отдал негодный результат, аргументы вызывающего тут ни при чём, поэтому «исправить вызов» было неверно;
- `timed_out` → `deadline_exceeded`, `cancelled` → `cancelled`, `workspace_busy` → `concurrent_change`, `invalid_argument` → `bad_value`, `runtime_failure` → `provider_failed`;
- мёртвые имена из карты убраны: они создавали видимость покрытия.

Запасная ветка на неизвестный код осталась — она нужна на случай кода, которого мы ещё не знаем.

## Страж

Словарь кодов раннера объявлен одним владельцем, и тест падает, если какое-то из девяти имён уходит в запасную ветку. Это и есть защита от повторения: корень дефекта был в том, что два списка (у раннера и у нас) расходились молча.

Ещё три теста пришпиливают смысл: отказ платформы обязан давать исход «нужен человек»; исходы остальных кодов перечислены поимённо; неизвестный код остаётся на запасной ветке.

## Проверка

- `cargo test -p unica-coder --lib v13_infobase_exports` — 13 из 13.
- `cargo clippy -p unica-coder --lib --all-features -- -D warnings` — чисто.
- Полный `cargo test -p unica-coder --lib` — 4286 из 4287. Единственное падение, `receipt_ledger::…::direct_terminal_reader_accepts_payload_above_the_legacy_64_kib_bound`, **воспроизводится на чистом `origin/main`** (проверено отдельным прогоном на состоянии без этой правки) и к ней отношения не имеет.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated error handling to accurately distinguish platform, environment, capability, workspace, argument, output, timeout, cancellation, and runtime failures.
  * Preserved a fallback response for unrecognized failure codes.

* **Tests**
  * Added coverage for all supported error codes, platform outcomes, refusal outcomes, and unknown-code handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->