### PR TITLE
chore(toolchain): поднять закреплённый v8-runner до 0.8.0

### DIFF
--- a/plugins/unica/ATTRIBUTIONS.md
+++ b/plugins/unica/ATTRIBUTIONS.md
@@ -47,8 +47,8 @@ Unica поставляет LSP-бинарник `bsl-analyzer`. Его лице�
 - Репозиторий: [IngvarConsulting/v8-runner-rust](https://github.com/IngvarConsulting/v8-runner-rust)
 - Автор: [v8-runner contributors](https://github.com/alkoleft/v8-runner-rust/graphs/contributors)
 - Исходный проект: [alkoleft/v8-runner-rust](https://github.com/alkoleft/v8-runner-rust)
-- Закреплённая версия: `0.7.1`, source tag и asset tag `v0.7.1`,
-  commit `d081dfcdc10a63dcff4cb6a854e19f7ea22243c4`
+- Закреплённая версия: `0.8.0`, source tag и asset tag `v0.8.0`,
+  commit `2c396444716b590ce59cbbc75a75abfd42772461`
 - Лицензия: [AGPL-3.0-only](third-party/licenses/v8-runner/LICENSE)
 
 `v8-runner` запускается Unica как отдельный внутренний процесс. На его

--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -58,27 +58,27 @@
     },
     {
       "name": "v8-runner",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "repository": "https://github.com/IngvarConsulting/v8-runner-rust",
-      "sourceTag": "v0.7.1",
-      "sourceCommit": "d081dfcdc10a63dcff4cb6a854e19f7ea22243c4",
+      "sourceTag": "v0.8.0",
+      "sourceCommit": "2c396444716b590ce59cbbc75a75abfd42772461",
       "assetRepository": "https://github.com/IngvarConsulting/v8-runner-rust",
-      "assetTag": "v0.7.1",
+      "assetTag": "v0.8.0",
       "license": "AGPL-3.0-only",
       "assetStrategy": "direct-release-asset",
       "binaryName": "v8-runner",
       "assets": {
         "darwin-arm64": {
           "assetName": "v8-runner-darwin-arm64",
-          "sha256": "60c6e7f307d4aaaf42583baf98e17fa658547b021cd314e8772e7660eb56280d"
+          "sha256": "376f7b0657dfb9ce461c87fa5667ff96479f6e8f0fbcb755ff03ac911fd051c1"
         },
         "linux-x64": {
           "assetName": "v8-runner-linux-x64",
-          "sha256": "e3ba9fc8495daf18895b60fc0203b0fd5841e1a4d4cc20ef037a2b6fcfece83f"
+          "sha256": "f7e3b7b7c5a2b85d696c100b4dcd20aa768c1d88431a39d25236c45cd1c6c614"
         },
         "win-x64": {
           "assetName": "v8-runner-win-x64.exe",
-          "sha256": "e10f88297de4e8991a1d0195024d6dd8b881246075df1b29474cf0d2ba7de43e"
+          "sha256": "88385be792afd8389ebcae7360d0047054cddd8e141dc3d2e27609885b457772"
         }
       }
     },

--- a/tests/ci/test_build_unica_tools.py
+++ b/tests/ci/test_build_unica_tools.py
@@ -314,28 +314,27 @@ class BuildUnicaToolsTests(unittest.TestCase):
 
         self.assertEqual(runner["repository"], "https://github.com/IngvarConsulting/v8-runner-rust")
         self.assertEqual(runner["assetRepository"], runner["repository"])
-        self.assertEqual(runner["sourceTag"], "v0.7.1")
+        self.assertEqual(runner["sourceTag"], "v0.8.0")
         self.assertEqual(runner["assetTag"], runner["sourceTag"])
         self.assertEqual(
             runner["sourceCommit"],
-            "d081dfcdc10a63dcff4cb6a854e19f7ea22243c4",
+            "2c396444716b590ce59cbbc75a75abfd42772461",
         )
 
-    def test_infobase_export_decision_names_the_locked_runner_version(self) -> None:
+    def test_infobase_export_decision_names_the_runner_it_chose(self) -> None:
+        """Решение называет раннер, выбранный на его дату, а не текущий пин.
+
+        Прежняя проверка сверяла прозу решения с `tools.lock.json`. Это требовало
+        править неизменяемую продуктовую запись при каждом поднятии раннера, чего
+        реестр не разрешает: решение заменяют преемником, а не редактируют. Версия
+        в прозе — исторический факт, и проверять надо её сохранность.
+        """
         repo_root = Path(__file__).resolve().parents[2]
-        lock = json.loads(
-            (repo_root / "plugins/unica/third-party/tools.lock.json").read_text(
-                encoding="utf-8"
-            )
-        )
-        runner = next(
-            tool for tool in lock["tools"] if tool["name"] == "v8-runner"
-        )
         decision = (
             repo_root / "arch/decisions/2026-09-03-infobase-export-run-slice.md"
         ).read_text(encoding="utf-8")
 
-        self.assertIn(f"`v8-runner` версии {runner['version']}", decision)
+        self.assertIn("`v8-runner` версии 0.7.1", decision)
 
     def test_historical_build_2_release_provenance_is_immutable(self) -> None:
         repo_root = Path(__file__).resolve().parents[2]

--- a/tests/ci/test_skill_provenance.py
+++ b/tests/ci/test_skill_provenance.py
@@ -639,10 +639,10 @@ class SkillProvenanceTests(unittest.TestCase):
 
         self.assertEqual(runtime_source["toolLockRef"], "v8-runner")
         self.assertIn(runtime_source["toolLockRef"], locked_tools)
-        self.assertEqual(locked_tools["v8-runner"]["sourceTag"], "v0.7.1")
+        self.assertEqual(locked_tools["v8-runner"]["sourceTag"], "v0.8.0")
         self.assertEqual(
             locked_tools["v8-runner"]["sourceCommit"],
-            "d081dfcdc10a63dcff4cb6a854e19f7ea22243c4",
+            "2c396444716b590ce59cbbc75a75abfd42772461",
         )
 
     def test_historical_rlm_build_2_review_is_immutable(self) -> None:


### PR DESCRIPTION
Выпуск [v0.8.0](https://github.com/IngvarConsulting/v8-runner-rust/releases/tag/v0.8.0) форка раннера опубликован; этот PR переводит пин на него.

## Что в выпуске

Весь долг раннера под зонтик [#717](https://github.com/IngvarConsulting/unica/issues/717), посчитанный заранее и сделанный одной партией, чтобы не выпускать версию под каждую доработку:

- `infobase restore` — парная операция к `infobase dump`, глагола не было ни в одном режиме;
- `extensions list|info|create|delete|activate` — состав расширений информационной базы;
- `--dry-run` у `launch`, `convert`, `init`, `build`, `load`, `dump`, `artifacts`.

Разблокированы операции словаря `run`: `infobase.restore` (B4), `client.run` (E1), `source.convert` (A3), `infobase.create` (B1), `infobase.build` (B2), `infobase.configuration.load` (B3), `source.dump` (C1), `artifact.build` (D1) и семейство G.

Опубликованное поведение не менялось: голый `extensions` сохранил смысл, существующие результаты получили только всегда присутствующее поле `provider_dispatched`.

## Проверка пина

- три sha256 **посчитаны по скачанным байтам** (`shasum -a 256`) и совпали с манифестом выпуска `v8-runner-assets.json`, а не взяты из него на доверии;
- `sourceCommit` = `2c396444716b590ce59cbbc75a75abfd42772461`, на нём же тег и `origin/master` форка;
- `scripts/ci/build-unica-tools.py --target darwin-arm64` прошёл по новому локу: поставляемый бинарь — `v8-runner 0.8.0`, его sha256 совпадает с локом;
- в поставляемом бинаре проверена вся новая поверхность: `infobase restore`, пять подкоманд `extensions`, `--dry-run` у семи глаголов.

## Попутный дефект реестра

`test_infobase_export_decision_names_the_locked_runner_version` сверял прозу продуктового решения `DEC.2026-09-03.INFOBASE-EXPORT-RUN-SLICE` с текущим `tools.lock.json`. Решение говорит, что было выбрано **на его дату**, и правке не подлежит — реестр требует заводить преемника, а не редактировать. То есть гейт требовал при каждом поднятии раннера либо править неизменяемую запись, либо заменять целое продуктовое решение ради номера версии.

Проверка переведена на литерал `0.7.1`: теперь она охраняет сохранность исторического факта в решении, а не связывает его с движущимся пином. Два других гейта (`test_maintained_v8_runner_release_is_published_at_source`, `test_v8_runner_tool_lock_ref_resolves_to_locked_baseline`) просто переведены на новый коммит — они для этого и написаны.

## Состояние набора

Три гейта пина зелёные. Три падения в `tests/ci` — `test_notifications_do_not_restart_the_aggregate_deadline` (0.66 с против бюджета 0.35), `test_parent_exit_before_snapshot_has_bounded_cleanup_and_reaps_orphan`, `test_unregistered_setsid_child_does_not_block_or_get_claimed` — это известные гонки по стенным часам в зондах провода, к пину отношения не имеют.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the bundled v8-runner tool to version 0.8.0.
  - Refreshed source references and platform-specific checksums to match the new release.
  - Updated attribution and provenance information for the included tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->