### PR TITLE
chore(toolchain): поднять закреплённый v8-runner до 0.8.1

### DIFF
--- a/plugins/unica/ATTRIBUTIONS.md
+++ b/plugins/unica/ATTRIBUTIONS.md
@@ -47,8 +47,8 @@ Unica поставляет LSP-бинарник `bsl-analyzer`. Его лице�
 - Репозиторий: [IngvarConsulting/v8-runner-rust](https://github.com/IngvarConsulting/v8-runner-rust)
 - Автор: [v8-runner contributors](https://github.com/alkoleft/v8-runner-rust/graphs/contributors)
 - Исходный проект: [alkoleft/v8-runner-rust](https://github.com/alkoleft/v8-runner-rust)
-- Закреплённая версия: `0.8.0`, source tag и asset tag `v0.8.0`,
-  commit `2c396444716b590ce59cbbc75a75abfd42772461`
+- Закреплённая версия: `0.8.1`, source tag и asset tag `v0.8.1`,
+  commit `96cab2ea6aa062eab8cc799fd6634b57f9b29ae9`
 - Лицензия: [AGPL-3.0-only](third-party/licenses/v8-runner/LICENSE)
 
 `v8-runner` запускается Unica как отдельный внутренний процесс. На его

--- a/plugins/unica/third-party/tools.lock.json
+++ b/plugins/unica/third-party/tools.lock.json
@@ -58,27 +58,27 @@
     },
     {
       "name": "v8-runner",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "repository": "https://github.com/IngvarConsulting/v8-runner-rust",
-      "sourceTag": "v0.8.0",
-      "sourceCommit": "2c396444716b590ce59cbbc75a75abfd42772461",
+      "sourceTag": "v0.8.1",
+      "sourceCommit": "96cab2ea6aa062eab8cc799fd6634b57f9b29ae9",
       "assetRepository": "https://github.com/IngvarConsulting/v8-runner-rust",
-      "assetTag": "v0.8.0",
+      "assetTag": "v0.8.1",
       "license": "AGPL-3.0-only",
       "assetStrategy": "direct-release-asset",
       "binaryName": "v8-runner",
       "assets": {
         "darwin-arm64": {
           "assetName": "v8-runner-darwin-arm64",
-          "sha256": "376f7b0657dfb9ce461c87fa5667ff96479f6e8f0fbcb755ff03ac911fd051c1"
+          "sha256": "cb38034d0f1c7ce3d0cf586885bd9a18b13065b2a0f72d4e07a403457df18385"
         },
         "linux-x64": {
           "assetName": "v8-runner-linux-x64",
-          "sha256": "f7e3b7b7c5a2b85d696c100b4dcd20aa768c1d88431a39d25236c45cd1c6c614"
+          "sha256": "2aad8d400257e80cad24f2478e5ae168c49bf8ddc0969cd5d7a9e47801ba5082"
         },
         "win-x64": {
           "assetName": "v8-runner-win-x64.exe",
-          "sha256": "88385be792afd8389ebcae7360d0047054cddd8e141dc3d2e27609885b457772"
+          "sha256": "41ae1504b7929c99388a90a9b6f413ed2b34295e8c19bac7d11b36d87278f867"
         }
       }
     },


### PR DESCRIPTION
Патч-выпуск [v0.8.1](https://github.com/IngvarConsulting/v8-runner-rust/releases/tag/v0.8.1) — исход проверочного этапа, который был заложен в план: выпустить одну версию, проверить её в деле, и если найдётся дефект, выпустить патч.

## Что нашла проверка

**Все превью 0.8.0 брали workspace lock.** Замерено на поставляемом бинаре: после четырёх превью в `workPath` лежал `.v8-runner.workspace.lock.system`. Блокировка владеет `workPath`, а превью его не меняет — значит держать её не за что, а вред настоящий: «покажи план» отказывало бы на занятом пространстве, и два одновременных превью выстраивались бы в очередь. `infobase --dry-run` так себя не вёл никогда, то есть новые превью были исключением.

Починено в [v8-runner-rust#85](https://github.com/IngvarConsulting/v8-runner-rust/pull/85): признак режима переехал внутрь самой границы блокировки, а не в помощник рядом — у границы один владелец, и страж архитектуры форка продолжает доказывать, что все адаптеры через неё идут. Он же поймал первую версию правки.

Попутно исправлены две мои формулировки, написанные шире правды: закрытый признак у экспортной формы — `mode`, а не `provider_dispatched` (он там на применении отсутствует, и это замерено), и превью всё-таки оставляет строку в журнале действий — как любой вызов.

## Проверка пина

- три sha256 **посчитаны по скачанным байтам** и совпали с манифестом выпуска;
- `sourceCommit` = `96cab2ea6aa062eab8cc799fd6634b57f9b29ae9`, на нём тег и `origin/master` форка;
- `build-unica-tools.py` прошёл: поставляемый бинарь — `v8-runner 0.8.1`, sha совпадает с локом;
- **дефект проверен закрытым на поставляемом бинаре**: после пяти превью блокировки в `workPath` нет; превью проходит при блокировке, занятой чужим владельцем, применение на ней упирается.

## Обещание #861 выполнено

Этот бамп **не тронул ни одного гейта** — `git diff origin/main -- tests/ scripts/ arch/` пуст, изменены только `tools.lock.json` и проза атрибуции. Ровно то свойство, ради которого источник сборки отделён от номера версии.

## Замечание о дисциплине

Первая попытка этого бампа попала не в ту ветку: я переключил ветку с несохранёнными правками, и они ушли в коммит ветки с запиской. Исправлено встречным коммитом без перезаписи истории; в [#860](https://github.com/IngvarConsulting/unica/pull/860) остаётся только записка.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application’s internal tooling to a newer version.
  - Refreshed associated source metadata and platform-specific integrity information.
  - No changes to exported functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->